### PR TITLE
Enhance documentation for migrating from d365fo-mcp-server to d365fo-cli

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,104 +1,239 @@
 # d365fo-cli
 
-> **CLI + Agent Skills + MCP server for Dynamics 365 Finance & Operations X++ development.**
-> Lets AI assistants (GitHub Copilot, Claude, Cursor, Codex, Gemini) understand your AOT metadata, scaffold AxTable / AxClass / Chain-of-Command extensions, review X++ diffs, and drive MSBuild / SyncEngine / SysTestRunner / xppbp on a D365FO developer VM.
-> Successor to [`d365fo-mcp-server`](https://github.com/dynamics365ninja/d365fo-mcp-server) — same metadata index, **much cheaper on tokens**, scriptable in PowerShell and CI/CD, agent-agnostic.
+> **A command-line toolkit for Dynamics 365 Finance & Operations X++ development — designed for AI agents, usable by humans.**
 
-Purpose-built for X++ / AOT work: indexes `AxTable` (fields, relations, indexes, methods, delete actions), `AxClass` (methods, attributes), `AxEdt`, `AxEnum`, `AxForm` (+extensions), `AxMenuItem*`, `AxLabelFile` (multi-language), `AxQuery` / `AxQuerySimple`, `AxView`, `AxDataEntityView` (OData entity/collection names), `AxReport` / `AxReportSsrs`, `AxService` / `AxServiceGroup`, `AxWorkflowType`, `AxSecurity{Role,Duty,Privilege}` (+flattened SecurityMap), event subscribers, Chain-of-Command extensions, and per-model descriptor metadata (publisher, layer, module references) into a local SQLite cache so agents resolve types, relations, CoC targets, and labels without round-tripping a live VM.
+`d365fo-cli` indexes your D365 F&O AOT metadata into a local database and gives you one friendly command — `d365fo` — to search it, scaffold new objects, review changes, and drive the D365FO developer tools. It is the successor to [`d365fo-mcp-server`](https://github.com/dynamics365ninja/d365fo-mcp-server) and works with every major AI assistant: GitHub Copilot, Claude (Code / Desktop), Cursor, Codex, and Gemini.
 
-`*FormAdaptor` companion packages are skipped during extraction (same as the upstream `d365fo-mcp-server`).
+---
 
-Inspired by the Agent Skills pattern introduced by Anthropic in October 2025. MCP stays available as a first-class JSON-RPC 2.0 transport (`d365fo-mcp`) on top of the shared `D365FO.Core` — no drift, no migration cliff.
+## What you get
 
-## Why CLI + Skills instead of MCP?
+- 🔎 **Instant AOT lookup** — find tables, classes, EDTs, enums, forms, queries, views, reports, services, workflows, security roles, and labels in milliseconds, without touching a D365 VM.
+- 🏗️ **Scaffold X++ objects** — generate ready-to-use XML for tables, classes, Chain-of-Command extensions, and simple-list forms; optionally drop them straight into a model folder.
+- 🕵️ **Understand the code** — trace CoC targets, relations, event handlers, label translations, and reverse references across your workspace.
+- 🤖 **AI-ready** — every command returns a stable JSON envelope, so agents can parse results reliably. A pre-built system prompt and lazy-loaded Skills keep token usage low.
+- 🧪 **Scriptable** — runs in PowerShell, bash/zsh, CI/CD pipelines, and cron jobs. No host application required.
+- 🪟 **Optional VM integration** — when run on a D365FO developer VM, it also drives `MSBuild`, `SyncEngine`, `SysTestRunner`, and `xppbp`.
+- 🧩 **MCP still supported** — a thin `d365fo-mcp` adapter ships alongside, sharing the same index.
 
-MCP servers inject every tool definition into the model's context on every turn. For this project that used to be **54 tools ≈ 2 900 tokens/turn**. CLI+Skills changes that:
+Cross-platform: **Windows, macOS, Linux**. You only need Windows for build/sync/test/bp commands on a real D365FO VM — all indexing, searching, and scaffolding works anywhere.
+
+---
+
+## Installation
+
+### Prerequisites
+
+- .NET SDK 10 (the repo's `global.json` pins the exact version).
+- Optional: `git` (for `review diff`), Python 3.8+ or PowerShell 7 (to regenerate Skills).
+
+### Build from source
+
+```sh
+git clone https://github.com/dynamics365ninja/d365fo-cli.git
+cd d365fo-cli
+dotnet build d365fo-cli.slnx -c Release
+```
+
+### Add `d365fo` to your PATH
+
+**Option A — shell alias (fastest):**
+
+```sh
+# bash / zsh
+alias d365fo='dotnet run --project /path/to/d365fo-cli/src/D365FO.Cli --'
+
+# PowerShell
+function d365fo { dotnet run --project C:\path\to\d365fo-cli\src\D365FO.Cli -- @args }
+```
+
+**Option B — standalone binary (distribution):**
+
+```sh
+dotnet publish src/D365FO.Cli -c Release -r win-x64 --self-contained
+# or: -r linux-x64, -r osx-arm64
+```
+
+Rename the output executable to `d365fo` (or `d365fo.exe`) and place it on your `PATH`.
+
+### Verify
+
+```sh
+d365fo version
+d365fo doctor     # environment checklist (SDK, env vars, index, workspace)
+```
+
+---
+
+## Quick Start
+
+```sh
+# 1. Tell the CLI where your PackagesLocalDirectory is
+export D365FO_PACKAGES_PATH=/mnt/d365fo/PackagesLocalDirectory
+export D365FO_INDEX_DB=$HOME/.d365fo/index.sqlite
+
+# 2. Create the local index
+d365fo index build
+
+# 3. Ingest AOT metadata (full, or scoped to a model)
+d365fo index extract
+d365fo index extract --model ApplicationSuite
+
+# 4. Ask the index anything
+d365fo search class Cust
+d365fo get table CustTable
+d365fo find coc CustTable::validateWrite
+d365fo resolve label @SYS12345 --lang en-US,cs
+
+# 5. Scaffold a new table
+d365fo generate table FmVehicle \
+  --label "@Fleet:Vehicle" \
+  --field VIN:VinEdt:mandatory \
+  --field Make:Name \
+  --out src/MyModel/AxTable/FmVehicle.xml
+
+# 6. Emit a system prompt for your AI agent
+d365fo agent-prompt --out .prompts/d365fo.md
+```
+
+Every command returns a predictable JSON envelope:
+
+```json
+{ "ok": true,  "data": { /* … */ }, "warnings": [] }
+{ "ok": false, "error": { "code": "…", "message": "…", "hint": "…" } }
+```
+
+In an interactive terminal you get nicely rendered tables. In scripts and pipes you get JSON automatically. Force either with `--output json|table|raw`.
+
+---
+
+## Configuration
+
+Configuration is environment-variable based, so it plays well with `.env` files, CI secrets, and launch profiles.
+
+| Variable | Purpose |
+|---|---|
+| `D365FO_PACKAGES_PATH` | Root of D365 F&O `PackagesLocalDirectory` (needed for `index extract`). |
+| `D365FO_INDEX_DB` | Path to the local SQLite index. Defaults to your local app-data folder. |
+| `D365FO_WORKSPACE_PATH` | Root of your X++ workspace (used by `review diff`). |
+| `D365FO_CUSTOM_MODELS` | Comma-separated patterns marking your own models (wildcards `*`, `?`, negation `!`). |
+| `D365FO_LABEL_LANGUAGES` | Comma-separated languages to keep when extracting labels (default `en-us`). |
+| `D365FO_BRIDGE_ENABLED` | `1`/`true` to route reads through the live D365FO Metadata Bridge (Windows + VM only). |
+
+See [`docs/USAGE.md`](docs/USAGE.md#configure) for the full list.
+
+---
+
+## Commands
+
+| Group | Commands | What it does |
+|---|---|---|
+| **Index** | `index build`, `index extract`, `index status` | Build, populate, and inspect the local metadata cache. |
+| **Search** | `search class\|table\|edt\|enum\|form\|query\|view\|entity\|report\|service\|workflow\|label` | Fuzzy-find AOT objects by name. |
+| **Get** | `get table\|class\|edt\|enum\|form\|menu-item\|security\|label\|role\|duty\|privilege\|query\|view\|entity\|report\|service\|service-group` | Fetch full details (fields, methods, relations, indexes, …). |
+| **Find** | `find coc`, `find relations`, `find usages`, `find extensions`, `find handlers`, `find refs` | Trace Chain-of-Command, references, handlers, relationships. |
+| **Read** | `read class`, `read table`, `read form` | Pull source snippets for a method, declaration, or range. |
+| **Resolve** | `resolve label` | Look up multi-language label text by token. |
+| **Generate** | `generate table\|class\|coc\|simple-list` | Scaffold AOT XML for new objects. |
+| **Review** | `review diff` | Lint AOT changes between two git revs. |
+| **Models** | `models list`, `models deps` | List models and trace dependencies. |
+| **Agent** | `agent-prompt`, `schema` | Emit system prompts and machine-readable catalogs for AI agents. |
+| **Daemon** | `daemon start\|status\|stop` | Warm-cache daemon for latency-sensitive integrations. |
+| **Ops (Windows + VM)** | `build`, `sync`, `test run`, `bp check` | Drive `MSBuild.exe`, `SyncEngine.exe`, `SysTestRunner.exe`, `xppbp.exe`. |
+
+See the [full usage guide](docs/USAGE.md) for examples of every command.
+
+---
+
+## AI agent integration
+
+`d365fo-cli` is built to be driven by AI agents. Two pieces make that easy:
+
+1. **A system prompt** that tells the agent what commands exist:
+   ```sh
+   d365fo agent-prompt --out .prompts/d365fo.md
+   ```
+2. **Skills** — short, lazy-loaded recipes for common tasks (authoring classes, scaffolding tables, Chain-of-Command, security tracing, label translation). Source skills live in [`skills/_source/`](skills/_source/) and are emitted in two formats:
+
+   ```sh
+   python3 scripts/emit-skills.py     # or: pwsh scripts/emit-skills.ps1
+   ```
+
+   | Agent | Where to put the skills |
+   |---|---|
+   | **GitHub Copilot** (VS Code / Visual Studio) | Copy `skills/copilot/*.instructions.md` into `.github/instructions/`. |
+   | **Claude Code / Claude Desktop** | Point at `skills/anthropic/` (drop in the project or `~/.claude/skills/`). |
+   | **Codex CLI / Gemini CLI** | Reference the relevant `SKILL.md` in your session prompt or `AGENTS.md`. |
+
+Need MCP? The `d365fo-mcp` binary speaks JSON-RPC 2.0 (protocol `2024-11-05`) over stdio and reuses the same index — wire it into Claude Desktop, Cursor, Continue, or VS Code MCP. See [`docs/USAGE.md#mcp-server`](docs/USAGE.md#mcp-server-d365fo-mcp) for a config sample.
+
+---
+
+## Why a CLI instead of MCP?
+
+MCP servers inject every tool definition into the model's context on every single turn. For this project that used to be **54 tools ≈ 2,900 tokens every turn**. A CLI + Skills approach flips that:
 
 | | MCP server | CLI + Skills |
 |---|---|---|
-| Tool definitions in context | 54 tools every turn | 1 shell tool (~100 tok/turn) |
-| Skill metadata | — | short frontmatter, lazy-loaded |
-| Entity/table discovery | 2–3 MCP round-trips | one `d365fo get table X` |
-| Scriptable (PowerShell, CI) | no | yes |
-| Works in Claude Code / Codex / Gemini / Copilot agent | MCP-supporting hosts only | any harness with a shell |
+| Tool definitions per turn | 54 tools (~2,900 tokens) | 1 shell tool (~100 tokens) |
+| Discovery round-trips | 2–3 per task | often 1 (`d365fo get table X`) |
+| Scriptable (shell, CI) | No | Yes |
+| Works in any AI harness with a shell | No — MCP-supporting hosts only | Yes — Copilot, Claude Code, Codex, Gemini, … |
 
-**Still need MCP?** Keep it. `D365FO.Mcp` is a thin adapter over the same `D365FO.Core` used by the CLI — one source of truth.
+Over a 15-turn workflow that typically means **~90% fewer tokens spent on tool plumbing**. See [`docs/TOKEN_ECONOMICS.md`](docs/TOKEN_ECONOMICS.md) for the full math and the cases where MCP still wins.
 
-## Layout
+---
+
+## Project layout
 
 ```
 src/
-  D365FO.Core/   Shared library (index, repository, guardrails, models)
-  D365FO.Cli/    Spectre.Console.Cli hosting → `d365fo` binary
-  D365FO.Mcp/    Stdio dispatcher skeleton (MCP coexistence)
+  D365FO.Core/      Shared library (index, repository, guardrails, scaffolding)
+  D365FO.Cli/       The `d365fo` command-line binary (Spectre.Console.Cli)
+  D365FO.Mcp/       Optional MCP server (shares D365FO.Core)
+  D365FO.Bridge/    Optional net48 metadata bridge (Windows + D365FO VM)
 skills/
-  _source/       Single source of truth (Markdown + YAML frontmatter)
-  copilot/       Emitted: .github/instructions/*.instructions.md style
-  anthropic/     Emitted: <skill-id>/SKILL.md (Anthropic Agent Skills)
-scripts/
-  emit-skills.py / emit-skills.ps1   Dual generator
-tests/           xUnit (Core + CLI)
+  _source/          Source Skills (Markdown + YAML)
+  copilot/          Emitted GitHub Copilot instructions
+  anthropic/        Emitted Anthropic SKILL.md
+scripts/            emit-skills.py / emit-skills.ps1
+tests/              xUnit test suites
+docs/               Deeper docs (see below)
 ```
 
-## Quick start
+---
 
-> 📖 **Full setup & usage guide: [docs/USAGE.md](docs/USAGE.md)**
+## Documentation
 
-```sh
-dotnet build d365fo-cli.slnx -c Release
+| Doc | What's inside |
+|---|---|
+| [`docs/USAGE.md`](docs/USAGE.md) | Complete setup, configuration, and command reference. |
+| [`docs/ARCHITECTURE.md`](docs/ARCHITECTURE.md) | How the pieces fit together — index schema, guardrails, bridge. |
+| [`docs/TOKEN_ECONOMICS.md`](docs/TOKEN_ECONOMICS.md) | Why CLI+Skills is cheaper per turn, with numbers. |
+| [`docs/MIGRATION_FROM_MCP.md`](docs/MIGRATION_FROM_MCP.md) | Coming from `d365fo-mcp-server`? Read this first. |
+| [`docs/ROADMAP.md`](docs/ROADMAP.md) | Planned and deferred items. |
 
-# Create / ensure the index
-export D365FO_INDEX_DB=$HOME/.d365fo/index.sqlite
-dotnet run --project src/D365FO.Cli -- index build
+---
 
-# Ingest AOT metadata (optionally limit to one model)
-dotnet run --project src/D365FO.Cli -- index extract [--model ApplicationSuite]
+## Troubleshooting
 
-# Ask the index anything
-dotnet run --project src/D365FO.Cli -- search class Cust
-dotnet run --project src/D365FO.Cli -- search entity Customers       # OData entity/collection match
-dotnet run --project src/D365FO.Cli -- get table CustTable            # fields + relations + indexes + methods + delete actions
-dotnet run --project src/D365FO.Cli -- get role SystemAdministrator   # duties + privileges + entry points
-dotnet run --project src/D365FO.Cli -- find coc CustTable::validateWrite
-dotnet run --project src/D365FO.Cli -- find handlers CustTable
-dotnet run --project src/D365FO.Cli -- resolve label @SYS12345 --lang cs,en-US
-dotnet run --project src/D365FO.Cli -- read class CustTable_Extension --method validateWriteExt
-dotnet run --project src/D365FO.Cli -- models deps ApplicationSuite
+| Symptom | Fix |
+|---|---|
+| `PACKAGES_PATH_NOT_FOUND` | Set `D365FO_PACKAGES_PATH` or pass `--packages <PATH>`. |
+| `UNSUPPORTED_PLATFORM` | `build` / `sync` / `test` / `bp` require Windows + a D365FO dev VM. |
+| Index file appears locked | Stop any running `d365fo daemon` or `d365fo-mcp` process; WAL sidecar files (`-wal`, `-shm`) are normal. |
+| Extract missed a package | Confirm the `<root>/<Package>/<Model>/AxTable/…` layout and point `--packages` at the real `PackagesLocalDirectory`. |
 
-# Emit a system prompt for your agent
-dotnet run --project src/D365FO.Cli -- agent-prompt --out .prompts/d365fo.md
-```
+More in [`docs/USAGE.md#troubleshooting`](docs/USAGE.md#troubleshooting).
 
-Every command returns a stable envelope:
-
-```json
-{ "ok": true,  "data": { ... } }
-{ "ok": false, "error": { "code": "...", "message": "...", "hint": "..." } }
-```
-
-## Skills
-
-Source skills live in [skills/_source/](skills/_source). The generator emits two formats from one source:
-
-```sh
-python3 scripts/emit-skills.py
-# or:
-pwsh scripts/emit-skills.ps1
-```
-
-- **GitHub Copilot** → `skills/copilot/<id>.instructions.md` with `applyTo` glob.
-- **Anthropic Claude** → `skills/anthropic/<id>/SKILL.md` with `applies_when` trigger.
-
-To use them:
-
-- **VS Code / Visual Studio Copilot**: copy `skills/copilot/*` into your solution's `.github/instructions/`.
-- **Claude Code / Claude Desktop**: point at `skills/anthropic/`.
-- **Codex CLI / Gemini CLI**: reference the relevant `SKILL.md` in your session prompt.
-
-Seed skills ship covering: [X++ class authoring](skills/_source/x++-class-authoring.md), [table scaffolding](skills/_source/table-scaffolding.md), [CoC extension authoring](skills/_source/coc-extension-authoring.md), [security hierarchy tracing](skills/_source/security-hierarchy-trace.md), [label translation](skills/_source/label-translation.md).
-
-See full plan, token-economics analysis, and migration notes in [docs/](docs/) — including the [roadmap of planned and deferred items](docs/ROADMAP.md).
+---
 
 ## License
 
-MIT. Upstream `d365fo-mcp-server` is also MIT.
+MIT. The upstream [`d365fo-mcp-server`](https://github.com/dynamics365ninja/d365fo-mcp-server) is also MIT.
+
+---
+
+## Disclaimer
+
+This project is an independent research effort and is not affiliated with, endorsed by, or associated with Microsoft or any other organization. It is provided as-is for educational and development purposes.

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -1,6 +1,26 @@
 # Architecture
 
-## Three projects, one core
+> **Audience:** contributors, integrators, anyone curious about what happens under the hood.
+> **If you just want to use the tool, read [USAGE.md](USAGE.md) instead.**
+
+This document explains how `d365fo-cli` is put together: the three projects that make up the solution, the shared data contracts, the local index, and the optional Metadata Bridge used for live D365FO operations.
+
+## Contents
+
+1. [High-level layout](#high-level-layout)
+2. [Output contract (`ToolResult<T>`)](#output-contract-toolresultt)
+3. [The local index (SQLite)](#the-local-index-sqlite)
+4. [Extraction pipeline](#extraction-pipeline)
+5. [Guardrails](#guardrails)
+6. [Metadata Bridge (live D365FO reads and writes)](#metadata-bridge-live-d365fo-reads-and-writes)
+7. [MCP coexistence](#mcp-coexistence)
+8. [Why .NET 10](#why-net-10)
+
+---
+
+## High-level layout
+
+Three projects, one shared core:
 
 ```mermaid
 flowchart TB
@@ -18,132 +38,107 @@ flowchart TB
     class Cli,Mcp adapter;
 ```
 
-Key invariant: **only `D365FO.Core` knows about D365FO**. Both CLI and MCP
-transports are thin adapters. A command handler is never more than "parse
-args → call Core → render envelope".
+**Key invariant:** only `D365FO.Core` knows about D365FO. Both CLI and MCP are thin adapters — each command handler is essentially "parse args → call Core → render envelope".
 
-## Output contract
+## Output contract (`ToolResult<T>`)
 
-Every tool returns `ToolResult<T>`:
+Every tool returns the same shape:
 
 ```json
-{ "ok": true,  "data": { ... }, "warnings": ["..."] }
+{ "ok": true,  "data": { /* ... */ }, "warnings": ["..."] }
 { "ok": false, "error": { "code": "UPPER_SNAKE", "message": "...", "hint": "..." } }
 ```
 
-JSON is the default on non-TTY stdout. TTY renders Spectre tables. Flag
-`--output json|table|raw` overrides.
+- JSON is the default on non-TTY stdout.
+- Interactive terminals render Spectre tables.
+- Override with `--output json|table|raw`.
 
-## Index
+## The local index (SQLite)
 
-SQLite single-file (`$D365FO_INDEX_DB` or `$LOCALAPPDATA/d365fo-cli/d365fo-index.sqlite`).
-Schema **v5** in [src/D365FO.Core/Index/Schema.sql](../src/D365FO.Core/Index/Schema.sql)
-— the version is tracked in `PRAGMA user_version` and migrations are applied
-automatically on first connection via `MetadataRepository.EnsureSchema`.
-`MetadataRepository` is stateless — every call opens and closes its own
-connection so the same type runs from a short-lived CLI process, a long-lived
-MCP server, or a future daemon.
+- Single file at `$D365FO_INDEX_DB` (default: `$LOCALAPPDATA/d365fo-cli/d365fo-index.sqlite`).
+- Schema **v5**, defined in [`src/D365FO.Core/Index/Schema.sql`](../src/D365FO.Core/Index/Schema.sql).
+- Version tracked in `PRAGMA user_version`; migrations applied automatically on first connection via `MetadataRepository.EnsureSchema`.
+- `MetadataRepository` is stateless — every call opens and closes its own connection, so it works identically in a short-lived CLI process, a long-lived MCP server, or a daemon.
+- SQLite booleans are stored as `INTEGER`; `SqliteBoolHandler` teaches Dapper the conversion once at static init.
 
-Covered AOT types: Tables (fields, relations, indexes, methods, delete actions),
-Classes (methods + attributes), Edts, Enums, Forms (+extensions), MenuItems,
-Labels (multi-language), Queries (+datasources), Views (+fields), DataEntities
-(+fields + OData names), Reports (+datasets), Services (+operations),
-ServiceGroups (+members), WorkflowTypes, SecurityRoles/Duties/Privileges plus a
-flattened `SecurityMap`, ObjectExtensions, EventSubscribers, CoC extensions,
-and ModelDependencies parsed from each package's `Descriptor/*.xml`.
+### AOT types covered
 
-SQLite booleans are stored as INTEGER; `SqliteBoolHandler` teaches Dapper the
-conversion once at static init.
+Tables (fields, relations, indexes, methods, delete actions), Classes (methods + attributes), EDTs, Enums, Forms (+ extensions), MenuItems, Labels (multi-language), Queries (+ datasources), Views (+ fields), DataEntities (+ fields + OData names), Reports (+ datasets), Services (+ operations), ServiceGroups (+ members), WorkflowTypes, SecurityRoles / Duties / Privileges plus a flattened `SecurityMap`, ObjectExtensions, EventSubscribers, CoC extensions, and ModelDependencies parsed from each package's `Descriptor/*.xml`.
 
-## Extract pipeline
+## Extraction pipeline
 
-`MetadataExtractor.ExtractAll(packagesRoot)` walks `<root>/<Package>/<Model>/`
-and yields one `ExtractBatch` per model. Per-file XML parsing inside a model is
-run in `Parallel.ForEach` (degree = `Environment.ProcessorCount`). Label
-resources are scanned recursively under `AxLabelFile/LabelResources/<lang>/`
-(modern D365 layout; the legacy inline `<AxLabel>` manifest form is also
-supported). `*FormAdaptor` companion packages are skipped at both package and
-model level via `MetadataExtractor.IsFormAdaptorPackage`, matching the
-behavior of the upstream `d365fo-mcp-server`.
+`MetadataExtractor.ExtractAll(packagesRoot)` walks `<root>/<Package>/<Model>/` and yields one `ExtractBatch` per model.
 
-`D365FO.Core.Extract.XppSourceReader` extracts the `<SourceCode><Declaration>`
-block and per-method `<Source>` CDATA from AOT XML for `d365fo read class|table|form`.
+- Per-file XML parsing inside a model runs in `Parallel.ForEach` (degree = `Environment.ProcessorCount`).
+- Label resources are scanned recursively under `AxLabelFile/LabelResources/<lang>/` (modern D365 layout; the legacy inline `<AxLabel>` manifest is also supported).
+- `*FormAdaptor` companion packages are skipped at both package and model level (`MetadataExtractor.IsFormAdaptorPackage`) — they hold no real AOT content.
+- `D365FO.Core.Extract.XppSourceReader` extracts the `<SourceCode><Declaration>` block and per-method `<Source>` CDATA from AOT XML for `d365fo read class|table|form`.
 
 ## Guardrails
 
-- `StringSanitizer` strips control characters from free-form metadata
-  (labels, descriptions) to defend against prompt-injection embedded in
-  customer data. CLI opt-out: `--raw-text`.
-- Error envelope is always structured — never leak raw exception text to stdout.
-- Write-ops that mutate XML on disk use atomic swap + `.bak` (see the
-  `generate` commands and `Scaffolding/ScaffoldFileWriter`).
+- **`StringSanitizer`** strips control characters from free-form metadata (labels, descriptions) to defend against prompt-injection embedded in customer data. Opt out with `--raw-text`.
+- Error envelopes are always structured — raw exception text never reaches stdout.
+- Write operations that mutate XML use atomic swap + `.bak` (see `generate` and `Scaffolding/ScaffoldFileWriter`).
 
-## Reads vs writes — the C# Metadata Bridge
+## Metadata Bridge (live D365FO reads and writes)
 
-Reads and writes are routed through a **`D365FO.Bridge` sibling project** —
-a .NET Framework 4.8 child process started over stdio JSON-RPC from
-`D365FO.Core`. The bridge loads D365FO's own assemblies at runtime and
-exposes `IMetadataProvider` + `DiskProvider` operations, so the CLI always
-speaks to the same store that Visual Studio and MSBuild use.
+When running on a Windows D365FO developer VM, `D365FO.Core` can route reads and writes through a **`D365FO.Bridge` sibling project** — a .NET Framework 4.8 child process started over stdio JSON-RPC. The bridge loads D365FO's own assemblies at runtime and exposes `IMetadataProvider` + `DiskProvider` operations, so the CLI always speaks to the same store Visual Studio and MSBuild use.
 
-**Bootstrap.** `MetadataBootstrap` late-binds
-`Microsoft.Dynamics.AX.Metadata.Storage.MetadataProviderFactory.CreateRuntimeProviderWithExtensions`
-and resolves `Microsoft.Dynamics.AX.*` assemblies through an
-`AppDomain.AssemblyResolve` hook against `D365FO_BIN_PATH` (defaults to
-`D365FO_PACKAGES_PATH\bin`). The provider instance is cached and
-lock-guarded; a failed bootstrap surfaces `LastError` so the CLI can fall
-back to the index.
+### Bootstrap
 
-**JSON-RPC surface** (one request per line, UTF-8):
+`MetadataBootstrap` late-binds `Microsoft.Dynamics.AX.Metadata.Storage.MetadataProviderFactory.CreateRuntimeProviderWithExtensions` and resolves `Microsoft.Dynamics.AX.*` assemblies through an `AppDomain.AssemblyResolve` hook against `D365FO_BIN_PATH` (defaults to `D365FO_PACKAGES_PATH\bin`). The provider instance is cached and lock-guarded; a failed bootstrap surfaces `LastError` so the CLI can fall back to the index.
+
+### JSON-RPC surface
+
+One request per line, UTF-8:
 
 | Method | Purpose |
-| --- | --- |
+|---|---|
 | `ping` | Liveness + diagnostics (`binPath`, `packagesPath`, `metadataLoaded`, `metadataError`). |
 | `shutdown` | Graceful exit. |
-| `readClass` / `readTable` / `readEdt` / `readEnum` / `readForm` | Authoritative per-object read. `readEnum` falls back to CLR kernel enums (`NoYes`, `Exists`) via `Microsoft.Dynamics.AX.Xpp.Support.dll` when the disk overlay has no match; the response carries `source:"bridge-kernel"`. |
-| `createObject` / `updateObject` / `deleteObject` | Go through the provider collections' `Create`/`Update`/`Delete` with a `ModelSaveInfo` built from the target model manifest. Create/Update accept an optional raw Ax* XML blob round-tripped via `XmlSerializer`. |
-| `findReferences` | Parameterised query against `DYNAMICSXREFDB` (`Names` + `[References]` + `Modules`); returns source path / line / column / reference kind. Connection string overridable via `D365FO_XREF_CONNECTIONSTRING`. |
-| `getModelFolder` | Resolves `ModelManifest.GetFolderForModel` to the on-disk package folder — used by `generate --install-to` to compose the canonical `<ModelFolder>/Ax<Kind>/<Name>.xml` path. |
+| `readClass` / `readTable` / `readEdt` / `readEnum` / `readForm` | Authoritative per-object read. `readEnum` falls back to CLR kernel enums (`NoYes`, `Exists`) via `Microsoft.Dynamics.AX.Xpp.Support.dll` when the disk overlay has no match; the response carries `source: "bridge-kernel"`. |
+| `createObject` / `updateObject` / `deleteObject` | Routed through the provider collections' `Create`/`Update`/`Delete` with a `ModelSaveInfo` built from the target model manifest. Create/Update accept an optional raw Ax* XML blob round-tripped via `XmlSerializer`. |
+| `findReferences` | Parameterised query against `DYNAMICSXREFDB` (`Names` + `[References]` + `Modules`); returns source path, line, column, reference kind. Connection string overridable via `D365FO_XREF_CONNECTIONSTRING`. |
+| `getModelFolder` | Resolves `ModelManifest.GetFolderForModel` to the on-disk package folder — used by `generate --install-to` to compose `<ModelFolder>/Ax<Kind>/<Name>.xml`. |
 
-**Serialisation.** `AxSerializer` is a reflection-based walker — depth cap 6,
-reference-cycle-guarded via `HashSet<object>` with `ReferenceEqualityComparer`,
-drops empty arrays, primitives / enums / `DateTime` / `decimal` handled
-specifically. Good enough for Copilot-sized prompts; deeper hand-rolled
-serialisers can be layered on per kind later.
+### Serialisation
 
-**CLI integration.**
+`AxSerializer` is a reflection-based walker with a depth cap of 6, reference-cycle-guarded via `HashSet<object>` + `ReferenceEqualityComparer`. It drops empty arrays and handles primitives, enums, `DateTime`, and `decimal` specifically. Good enough for Copilot-sized prompts; hand-rolled serialisers can be layered on per kind later.
+
+### CLI integration
 
 - `D365FO.Core.Bridge.BridgeClient` spawns the net48 exe and pumps JSON-RPC.
 - `BridgeGate` in `D365FO.Cli` gates every call behind `D365FO_BRIDGE_ENABLED=1`.
-- `d365fo get class|table|edt|enum|form` is bridge-primary with SQLite
-  fallback; the response payload carries `_source:"bridge"` /
-  `_source:"bridge-kernel"` so callers can audit which store answered.
-- `d365fo generate class|table|coc|simple-list --install-to <Model>` asks
-  the bridge for the model folder, then writes the fully scaffolded XML
-  atomically (same `.tmp`+move+`.bak` pattern used for `--out`).
-- `d365fo find refs <Name> --xref` routes through `findReferences`; output
-  is tagged `_source:"xrefdb"`. Without `--xref`, the CLI falls back to a
-  parallel regex scan over indexed X++ source — cross-platform, no SQL
-  Server required.
+- `d365fo get class|table|edt|enum|form` is bridge-primary with SQLite fallback; the response payload carries `_source: "bridge"` / `"bridge-kernel"` so callers can audit which store answered.
+- `d365fo generate class|table|coc|simple-list --install-to <Model>` asks the bridge for the model folder, then writes the scaffolded XML atomically.
+- `d365fo find refs <Name> --xref` routes through `findReferences`; output is tagged `_source: "xrefdb"`. Without `--xref`, the CLI falls back to a parallel regex scan over indexed X++ source — cross-platform, no SQL Server required.
 
-**Environment.** `D365FO_PACKAGES_PATH` + `D365FO_BIN_PATH` point at the
-live `PackagesLocalDirectory`; `D365FO_BRIDGE_ENABLED=1` opts into
-bridge-primary reads; `D365FO_BRIDGE_PATH` overrides the exe location.
-The bridge is Windows-only and must ship next to a live VM — non-Windows
-developers stay on the SQLite-index path automatically.
+### Environment
+
+| Variable | Purpose |
+|---|---|
+| `D365FO_PACKAGES_PATH` | Live `PackagesLocalDirectory`. |
+| `D365FO_BIN_PATH` | D365FO binaries directory (used to resolve Microsoft metadata assemblies). |
+| `D365FO_BRIDGE_ENABLED` | `1`/`true` opts into bridge-primary reads. |
+| `D365FO_BRIDGE_PATH` | Overrides the bridge exe location. |
+
+The bridge is Windows-only and must ship next to a live VM. Non-Windows developers stay on the SQLite-index path automatically.
 
 ## MCP coexistence
 
-`D365FO.Mcp.ToolHandlers` forwards to the same `D365FO.Core` primitives. A
-follow-up commit replaces `StdioDispatcher` with the official
-`modelcontextprotocol/csharp-sdk`, keeping `ToolHandlers` as the stable
-internal surface.
+`D365FO.Mcp.ToolHandlers` forwards to the same `D365FO.Core` primitives the CLI uses. A follow-up commit replaces `StdioDispatcher` with the official `modelcontextprotocol/csharp-sdk`, keeping `ToolHandlers` as the stable internal surface.
 
 ## Why .NET 10
 
-- Single source of truth for D365FO developers (C# is the language of the
-  upstream X++ runtime).
-- Native single-file publish (`dotnet publish --self-contained`) avoids a
-  Node runtime on every dev workstation.
-- The TFM is tracked in `Directory.Build.props` and the exact SDK pinned in
-  `global.json`.
+- Single source of truth for D365FO developers — C# is the language of the upstream X++ runtime.
+- Native single-file publish (`dotnet publish --self-contained`) avoids requiring a Node runtime on every dev workstation.
+- TFM is tracked in `Directory.Build.props`; the exact SDK is pinned in `global.json`.
+
+---
+
+## See also
+
+- [USAGE.md](USAGE.md) — how to use the CLI day-to-day.
+- [TOKEN_ECONOMICS.md](TOKEN_ECONOMICS.md) — why CLI + Skills is cheaper per turn than MCP.
+- [MIGRATION_FROM_MCP.md](MIGRATION_FROM_MCP.md) — coming from `d365fo-mcp-server`.
+- [ROADMAP.md](ROADMAP.md) — planned and deferred items.

--- a/docs/MIGRATION_FROM_MCP.md
+++ b/docs/MIGRATION_FROM_MCP.md
@@ -1,60 +1,77 @@
-# Migration from d365fo-mcp-server
+# Migrating from `d365fo-mcp-server`
 
-You do **not** have to migrate. The CLI is additive. Pick a path:
+> **Audience:** existing users of the legacy TypeScript `d365fo-mcp-server`.
+> **Good news:** you do **not** have to migrate. The CLI is additive, the database schema is compatible, and `d365fo-mcp-server` continues to work.
+
+## Contents
+
+1. [Decision: which path is right for you?](#decision-which-path-is-right-for-you)
+2. [Path A — keep MCP, add CLI (recommended)](#path-a--keep-mcp-add-cli-recommended)
+3. [Path B — go CLI-only (maximum token saving)](#path-b--go-cli-only-maximum-token-saving)
+4. [Path C — stay on MCP (no shell in your AI harness)](#path-c--stay-on-mcp-no-shell-in-your-ai-harness)
+5. [Index compatibility](#index-compatibility)
+6. [Command mapping](#command-mapping)
+
+---
+
+## Decision: which path is right for you?
+
+| Situation | Path |
+|---|---|
+| You want both options side-by-side; let the agent pick the cheaper one per task. | **A** (keep MCP, add CLI) |
+| You've moved to an agent harness with a shell (Copilot, Claude Code, Codex, Gemini CLI) and want the full token saving. | **B** (CLI-only) |
+| Your agent runs in a host **without** a shell tool (plain Claude.ai chat, plain ChatGPT Web). | **C** (stay on MCP) |
+
+All three paths use the **same SQLite index schema** — switching between them is a configuration change, not a re-index. See [Index compatibility](#index-compatibility) below.
 
 ## Path A — keep MCP, add CLI (recommended)
 
-Your existing `.mcp.json` and `%USERPROFILE%\.github\copilot-instructions.md`
-stay. Layer the CLI on top:
+Your existing `.mcp.json` and `~/.github/copilot-instructions.md` stay as-is. Layer the CLI on top:
 
-1. Build the CLI: `dotnet build d365fo-cli.slnx -c Release`.
-2. Publish a self-contained binary: `dotnet publish
-   src/D365FO.Cli -r win-x64 -c Release --self-contained -p:PublishSingleFile=true`.
+1. Build the CLI:
+   ```sh
+   dotnet build d365fo-cli.slnx -c Release
+   ```
+2. Publish a self-contained binary:
+   ```sh
+   dotnet publish src/D365FO.Cli -r win-x64 -c Release \
+     --self-contained -p:PublishSingleFile=true
+   ```
 3. Drop `d365fo.exe` on `PATH`.
-4. Copy `skills/copilot/*.instructions.md` into your solution's
-   `.github/instructions/` folder. Copilot will load frontmatter only; bodies
-   load when a glob matches.
-5. Delete or keep MCP tools from your `.mcp.json` as you see fit. Skills and
-   MCP can coexist; the LLM will prefer whichever is cheaper for the task.
+4. Copy `skills/copilot/*.instructions.md` into your solution's `.github/instructions/`. Copilot will load frontmatter only; bodies load when a glob matches.
+5. Delete or keep MCP entries in your `.mcp.json` as you see fit. The LLM will use whichever is cheaper for each task.
 
-## Path B — CLI-only (full token saving)
+## Path B — go CLI-only (maximum token saving)
 
-1. Steps 1–4 above.
+1. Steps 1–4 from Path A above.
 2. Remove `d365fo-*` entries from `.mcp.json`.
-3. Remove the old TS server from disk (it is versioned in the upstream repo
-   under the tag `legacy-typescript`).
+3. Remove the old TS server from disk — it's versioned in the upstream repo under the tag `legacy-typescript`, so you can recover it any time.
 
-## Path C — MCP still required (no shell in harness)
+## Path C — stay on MCP (no shell in your AI harness)
 
-Keep `d365fo-mcp-server` as-is, or use `D365FO.Mcp` (JSON-RPC 2.0 over
-stdio; 16 read tools today). Either way the SQLite index schema is
-shared, so switching is a configuration change, not a re-index.
+Keep `d365fo-mcp-server` as-is, or switch to the new `D365FO.Mcp` adapter (JSON-RPC 2.0 over stdio; 16 read tools today). Both read from the same SQLite index.
 
 ## Index compatibility
 
-The CLI's SQLite schema lives in `src/D365FO.Core/Index/Schema.sql` and is
-currently at **v5** (tracked via `PRAGMA user_version`). It is a superset of
-the upstream MCP server's layout — pointing the CLI at an existing
-`d365fo-mcp-server` database just works:
+The CLI's SQLite schema lives in [`src/D365FO.Core/Index/Schema.sql`](../src/D365FO.Core/Index/Schema.sql) and is currently at **v5** (tracked via `PRAGMA user_version`). It is a **superset** of the upstream MCP server's layout — pointing the CLI at an existing `d365fo-mcp-server` database just works:
 
 ```sh
-export D365FO_INDEX_DB=C:/path/to/existing/d365fo.sqlite
+export D365FO_INDEX_DB=/path/to/existing/d365fo.sqlite
 d365fo index status
 ```
 
-The CLI auto-applies `EnsureSchema` on first connection, so older databases
-are migrated forward transparently. No destructive migrations run without
-explicit confirmation, and `ApplyExtract` is idempotent per-model (re-extract
-replaces that model's rows).
+- `EnsureSchema` runs on first connection, so older databases are migrated forward transparently.
+- No destructive migrations run without explicit confirmation.
+- `ApplyExtract` is idempotent per-model (re-extract replaces that model's rows only).
 
-## Mapping (abbreviated)
+## Command mapping
 
-Headline mappings between the upstream MCP tools and CLI commands:
+### MCP tool → CLI command
 
 | MCP tool | CLI command |
 |---|---|
 | `search_classes` | `d365fo search class <q>` |
-| `get_table_details` | `d365fo get table <name>` (now also includes indexes, methods, delete actions) |
+| `get_table_details` | `d365fo get table <name>` *(now also includes indexes, methods, delete actions)* |
 | `get_edt_details` | `d365fo get edt <name>` |
 | `find_coc_extensions` | `d365fo find coc <Class>[::<method>]` |
 | `get_security_coverage_for_object` | `d365fo get security <obj> --type <kind>` |
@@ -62,20 +79,29 @@ Headline mappings between the upstream MCP tools and CLI commands:
 | `get_menu_item_details` | `d365fo get menu-item <name>` |
 | `get_table_relations` | `d365fo find relations <table>` |
 
-CLI-only surface that has no upstream MCP equivalent (yet):
+### CLI-only surface (no upstream MCP equivalent)
 
 | Command | Purpose |
 |---|---|
-| `d365fo search query\|view\|entity\|report\|service\|workflow` | Index queries, views, data entities (by name **or** OData `PublicEntityName`/`PublicCollectionName`), SSRS/RDL reports, SOAP services, workflow types. |
+| `d365fo search query\|view\|entity\|report\|service\|workflow` | Index queries, views, data entities (by name or OData `PublicEntityName`/`PublicCollectionName`), SSRS/RDL reports, SOAP services, workflow types. |
 | `d365fo get form\|role\|duty\|privilege\|query\|view\|entity\|report\|service\|service-group` | Full details for each object type. |
-| `d365fo find extensions <Target>` | Enumerate Table/Form/Edt/Enum extensions targeting an object. |
-| `d365fo find handlers <Source>` | Event subscribers bound to a form/table/delegate. |
+| `d365fo find extensions <Target>` | Enumerate Table / Form / Edt / Enum extensions targeting an object. |
+| `d365fo find handlers <Source>` | Event subscribers bound to a form / table / delegate. |
 | `d365fo resolve label @SYS12345 [--lang …]` | Resolve an `@File+Key` token to its text across indexed languages. |
 | `d365fo read class\|table\|form <Name> [--method X] [--declaration]` | Read embedded X++ source from the AOT XML. |
-| `d365fo models list` / `d365fo models deps <Name>` | List indexed models or show their Descriptor-declared dependency graph (`depends-on` + `depended-by`). |
+| `d365fo models list` / `d365fo models deps <Name>` | List indexed models or show their Descriptor-declared dependency graph. |
 | `d365fo index extract --model <Name>` | Incremental per-model re-extract. |
+| `d365fo generate table\|class\|coc\|simple-list` | Scaffold new AOT XML. |
+| `d365fo review diff` | Lint AOT XML changes between git revisions. |
+| `d365fo build` / `sync` / `test run` / `bp check` | Drive MSBuild / SyncEngine / SysTestRunner / xppbp (Windows + VM). |
 
-Generator, build, sync, test, BP-check commands are wired under the
-`generate`, `build`, `sync`, `test`, `bp`, `review` branches. The longer-term
-roadmap (X++ reverse references, FTS5, live OData, daemon/MCP parity, etc.)
-lives in [docs/ROADMAP.md](ROADMAP.md).
+See [ROADMAP.md](ROADMAP.md) for items still planned — including full MCP / CLI parity and deeper live-runtime integration.
+
+---
+
+## See also
+
+- [README](../README.md) — the pitch and quick start.
+- [USAGE.md](USAGE.md) — complete command reference.
+- [TOKEN_ECONOMICS.md](TOKEN_ECONOMICS.md) — why Path B saves tokens.
+- [ARCHITECTURE.md](ARCHITECTURE.md) — how the CLI, MCP adapter and Core relate.

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -1,109 +1,107 @@
-# d365fo-cli — Roadmap
+# Roadmap
 
-> Living document. Only items that are **not yet implemented** live here.
-> Everything already shipped is documented in
-> [USAGE.md](USAGE.md) (user-visible surface) and
-> [ARCHITECTURE.md](ARCHITECTURE.md) (internals). Git history preserves the
-> detailed design notes that used to sit under "Today (baseline)".
+> **Audience:** contributors and users who want to know what's coming next.
+> **Living document.** Only items that are **not yet implemented** live here. Everything already shipped is documented in [USAGE.md](USAGE.md) (user-visible surface) and [ARCHITECTURE.md](ARCHITECTURE.md) (internals). Git history preserves earlier design notes.
 
-Ordered by ROI; items within a section can be taken in any order.
+Items are grouped by topic and ordered roughly by ROI; within a section you can pick any order.
+
+## Contents
+
+1. [Refresh & observability](#1-refresh--observability)
+2. [Runtime / live data](#2-runtime--live-data)
+3. [More AOT types](#3-more-aot-types)
+4. [Search & ergonomics](#4-search--ergonomics)
+5. [Output & integration](#5-output--integration)
+6. [Scaffolding extensions](#6-scaffolding-extensions)
+7. [Code quality & Best Practices](#7-code-quality--best-practices)
+8. [Tests](#8-tests)
+9. [Small items / technical debt](#9-small-items--technical-debt)
 
 ---
 
 ## 1. Refresh & observability
 
 ### 1.1 `d365fo index refresh` (mtime-based incremental)
-Per model, compute max `LastWriteTimeUtc` under `Descriptor/*.xml` + `Ax*/*.xml`.
-Compare against new columns `Models.LastExtractedUtc` / `Models.SourceFingerprint`.
-Re-extract only changed models. Schema bump to v6. CLI: `d365fo index refresh [--force]`.
+
+Per model, compute max `LastWriteTimeUtc` under `Descriptor/*.xml` + `Ax*/*.xml`. Compare against new columns `Models.LastExtractedUtc` / `Models.SourceFingerprint`. Re-extract only changed models. Schema bump to v6. CLI: `d365fo index refresh [--force]`.
 
 ### 1.2 `d365fo index diff <revision>`
-Structural AOT diff vs. a git revision — "three new fields on `CustTable`,
-method `validate` signature changed". Requires a double extract or snapshotting.
+
+Structural AOT diff vs. a git revision — e.g. "three new fields on `CustTable`, method `validate` signature changed". Requires a double extract or snapshotting.
 
 ### 1.3 Extraction telemetry
-Per-model timings + error summaries. Either `_index_meta` table or sidecar `.log`.
 
----
+Per-model timings + error summaries. Either an `_index_meta` table or a sidecar `.log`.
 
 ## 2. Runtime / live data
 
 ### 2.1 Live OData connector
-`d365fo live entity <Name> --tenant … --env …` → calls
-`/data/$metadata` + `/data/<Collection>?$top=1`. Auth via
-`DefaultAzureCredential` or `D365FO_CLIENT_ID/SECRET`. Follow-on: `live call`,
-`live batch`.
+
+`d365fo live entity <Name> --tenant … --env …` → calls `/data/$metadata` + `/data/<Collection>?$top=1`. Auth via `DefaultAzureCredential` or `D365FO_CLIENT_ID/SECRET`. Follow-on: `live call`, `live batch`.
 
 ### 2.2 Live metadata reconciliation
-Compare offline `DataEntities` against live `$metadata` — surfaces entities
-inactive in an AOS or missing between Tier-1 / Tier-2.
+
+Compare offline `DataEntities` against live `$metadata` — surfaces entities inactive in an AOS or missing between Tier-1 / Tier-2.
 
 ### 2.3 Health / DMF (Windows VM)
-`d365fo health entities`, `d365fo dmf push <Project>.zip`. Builds on existing
-`build` / `sync`.
 
----
+`d365fo health entities`, `d365fo dmf push <Project>.zip`. Builds on existing `build` / `sync`.
 
-## 3. More AOT types (long tail)
+## 3. More AOT types
+
+Long-tail metadata not yet indexed:
 
 - **3.1** AggregateDimension / Kpi / Perspective.
 - **3.2** Tile / Workspace.
 - **3.3** ReferenceGroup / Map / MapExtension.
-- **3.4** ConfigurationKey / LicenseCode — cross-reference to tables / fields / EDTs.
+- **3.4** ConfigurationKey / LicenseCode — cross-referenced to tables / fields / EDTs.
 - **3.5** Feature (Feature Management).
-
----
 
 ## 4. Search & ergonomics
 
 ### 4.1 Full-text search (SQLite FTS5)
-`LabelFts(Value, Key, File, Language)` (and optionally `Source`). Moves
-`d365fo search label "customer invoice"` from LIKE scans to rank-sorted
-FTS — tens of ms instead of hundreds.
+
+`LabelFts(Value, Key, File, Language)` (and optionally `Source`). Moves `d365fo search label "customer invoice"` from `LIKE` scans to rank-sorted FTS — tens of ms instead of hundreds.
 
 ### 4.2 Parametric aggregation (`d365fo stats`)
-Per-model counts, top N largest tables, classes missing Best-Practice
-attributes, etc.
+
+Per-model counts, top-N largest tables, classes missing Best-Practice attributes, etc.
 
 ### 4.3 Multi-scope search (`d365fo search any <substring>`)
-Scope-agnostic quick jump across all indexed kinds.
 
----
+Scope-agnostic quick jump across all indexed kinds.
 
 ## 5. Output & integration
 
 ### 5.1 Persistent daemon mode (JSON-RPC)
-Skeleton exists (`D365FO.Cli.Commands.Daemon`). Add 1:1 request routing with
-the CLI, warm SQLite pool, file-watcher triggering `index refresh`. Also hosts
-the bridge child process across calls (sub-50 ms warm vs. ~300 ms cold).
+
+Skeleton exists (`D365FO.Cli.Commands.Daemon`). Add 1:1 request routing with the CLI, warm SQLite pool, file-watcher triggering `index refresh`. Also hosts the bridge child process across calls (sub-50 ms warm vs. ~300 ms cold).
 
 ### 5.2 MCP stdio parity (`D365FO.Mcp`)
-Bring CLI → MCP tool surface to 1:1 parity. Include `tools/list` with
-descriptions and sample JSON args for LLM prompting.
+
+Bring CLI → MCP tool surface to 1:1 parity. Include `tools/list` with descriptions and sample JSON args for LLM prompting.
 
 ### 5.3 Structured diff output
-`--output patch` for `generate *` — apply as a text patch without touching
-the workspace.
+
+`--output patch` for `generate *` — apply as a text patch without touching the workspace.
 
 ### 5.4 Session cache
-`.d365fo-session.json` next to the index; keeps the last active model / recent
-gets for prompt hints.
 
----
+`.d365fo-session.json` next to the index; keeps the last active model / recent `get`s for prompt hints.
 
-## 6. Generate (scaffolding) — extensions
+## 6. Scaffolding extensions
 
 - `generate extension <table|form|edt|enum> <Target>`.
 - `generate entity <Table>` — `AxDataEntityView` with all table fields, OData names by convention.
 - `generate privilege <EntryPoint>`, `generate duty <Privilege[]>`, wire into role.
 - `generate event-handler <SourceKind> <SourceObject> <Event>`.
 
----
-
 ## 7. Code quality & Best Practices
 
 ### 7.1 In-process BP runner (no VM)
+
 Static checks over the index:
+
 - "table has no cluster index" (`TableIndexes`),
 - "class named `*_Extension` without `[ExtensionOf]`",
 - "method with public API but no doc-comment",
@@ -112,34 +110,28 @@ Static checks over the index:
 CLI: `d365fo lint [--category X,Y] --output sarif` for CI.
 
 ### 7.2 Coupling metrics
-Graph metrics over `ModelDependencies` + `DYNAMICSXREFDB` — surfaces cyclic
-dependencies, top incoming / outgoing symbols.
 
----
+Graph metrics over `ModelDependencies` + `DYNAMICSXREFDB` — surfaces cyclic dependencies and top incoming / outgoing symbols.
 
 ## 8. Tests
 
-- End-to-end: freeze a sample `AxRepo` in `tests/Samples/MiniAot/`, run
-  `MetadataExtractor` + `MetadataRepository`, verify counts.
+- End-to-end: freeze a sample `AxRepo` in `tests/Samples/MiniAot/`, run `MetadataExtractor` + `MetadataRepository`, verify counts.
 - Snapshot tests for JSON output of `get table`, `get class`, `models deps`.
-- Performance smoke: `MeasureExtract(ApplicationSuite)` cap (runs only when
-  `D365FO_PACKAGES_PATH` is set).
-- Bridge: end-to-end harness that spins up the net48 exe against a sample
-  `PackagesLocalDirectory` fixture and asserts round-trip for
-  read / create / update / delete.
-
----
+- Performance smoke: `MeasureExtract(ApplicationSuite)` cap (runs only when `D365FO_PACKAGES_PATH` is set).
+- Bridge: end-to-end harness that spins the net48 exe against a sample `PackagesLocalDirectory` fixture and asserts round-trip for read / create / update / delete.
 
 ## 9. Small items / technical debt
 
 - `tests/D365FO.Cli.Tests` is empty — at least a smoke test of Spectre registration.
 - Audit every `Render` call site for `StringSanitizer` coverage.
-- `Models.IsCustom` single source of truth between `UpsertModelInternal`
-  (first-seen deps) and `ApplyExtract` (UPDATE).
-- Error codes (`TABLE_NOT_FOUND`, `MODEL_NOT_FOUND`, …) should live in an enum,
-  not magic strings.
+- `Models.IsCustom` single source of truth between `UpsertModelInternal` (first-seen deps) and `ApplyExtract` (`UPDATE`).
+- Error codes (`TABLE_NOT_FOUND`, `MODEL_NOT_FOUND`, …) should live in an enum, not magic strings.
 - Log `schema v{X} applied` line in `index build`.
-- Hand-rolled serialisers for selected Ax* kinds (e.g. `AxTableExtension`,
-  `AxSecurityRole`) where `AxSerializer`'s generic walker elides detail the
-  agent actually wants — the depth cap + cycle guard means we currently fall
-  back to `Name` on deeply nested overlays.
+- Hand-rolled serialisers for selected Ax* kinds (e.g. `AxTableExtension`, `AxSecurityRole`) where `AxSerializer`'s generic walker elides detail the agent actually wants — the depth cap + cycle guard means we currently fall back to `Name` on deeply nested overlays.
+
+---
+
+## See also
+
+- [USAGE.md](USAGE.md) — what you can do today.
+- [ARCHITECTURE.md](ARCHITECTURE.md) — where each item fits in the codebase.

--- a/docs/TOKEN_ECONOMICS.md
+++ b/docs/TOKEN_ECONOMICS.md
@@ -1,89 +1,79 @@
-# Token Economics — CLI + Skills vs MCP
+# Token Economics — CLI + Skills vs. MCP
 
-This document records the methodology and expected numbers for why this project
-replaces a 54-tool MCP server with a CLI + Skills layer. All numbers are
-reproducible with `scripts/measure-tokens.ps1` (wired in follow-up commits).
+> **Audience:** anyone deciding between CLI+Skills and MCP for their AI workflow, or evaluating the per-turn cost of AI tooling.
+> **TL;DR:** CLI + Skills saves **~80–92% of tool-plumbing tokens** compared to MCP over a typical 5–20 turn workflow. MCP still wins in two niches — see [When the saving does *not* apply](#when-the-saving-does-not-apply).
+
+## Contents
+
+1. [The structural cost of MCP](#the-structural-cost-of-mcp)
+2. [The structural shape of CLI + Skills](#the-structural-shape-of-cli--skills)
+3. [Expected savings](#expected-savings)
+4. [When the saving does *not* apply](#when-the-saving-does-not-apply)
+5. [Benchmark recipe](#benchmark-recipe)
+6. [Sources](#sources)
+
+---
 
 ## The structural cost of MCP
 
-An MCP client loads every connected server's tool list into the model context
-on every request. The upstream `d365fo-mcp-server` exposes **54 tools**. Using
-the token accounting methodology published in
-[seangalliher/D365-erp-cli](https://github.com/seangalliher/D365-erp-cli#token-savings-over-a-typical-workflow)
-(own measurement against Sonnet 4.5, October 2025):
+An MCP client loads every connected server's tool list into the model's context **on every request**. The upstream `d365fo-mcp-server` exposes **54 tools**. Using the token-accounting methodology published in [seangalliher/D365-erp-cli](https://github.com/seangalliher/D365-erp-cli#token-savings-over-a-typical-workflow) (own measurement against Sonnet 4.5, October 2025):
 
 - Average MCP tool schema ≈ **54 tokens**.
-- 54 tools × 54 tokens ≈ **~2 900 tokens/turn of overhead**.
-- Over a 20-turn workflow: ~58 000 tokens burned before any useful work.
+- 54 tools × 54 tokens ≈ **~2,900 tokens/turn of overhead**.
+- Over a 20-turn workflow: ~58,000 tokens burned before any useful work.
 
-Plus hidden cost: MCP encourages multi-step discovery (`find_type` →
-`get_metadata` → `call`) — each round-trip adds conversation history that
-compounds.
+There's also a hidden cost: MCP encourages multi-step discovery (`find_type` → `get_metadata` → `call`) — each round-trip adds conversation history that compounds.
 
 ## The structural shape of CLI + Skills
 
-- The agent sees **one** tool: `bash`/terminal (~100 tokens).
-- At session start the harness enumerates available skills and loads **only**
-  the YAML frontmatter (`name`, `description`, `applies_when`). Each skill
-  costs ~30–60 tokens until it is actually triggered.
-- When a skill fires, its body (Markdown instructions + CLI invocations) is
-  loaded on demand. Agent discovery happens through `d365fo --help` and
-  `d365fo schema --full` — again, on demand.
+- The agent sees **one** tool: the shell / `bash` tool (~100 tokens).
+- At session start the harness enumerates available skills and loads **only** their YAML frontmatter (`name`, `description`, `applies_when`). Each skill costs ~30–60 tokens until it is actually triggered.
+- When a skill fires, its body (Markdown instructions + CLI invocations) is loaded on demand.
+- Agent discovery happens through `d365fo --help` and `d365fo schema --full` — again, on demand.
 
 ## Expected savings
 
 Using the same per-turn accounting:
 
-| Turns | MCP overhead | CLI+Skills overhead | Saving |
+| Turns | MCP overhead | CLI + Skills overhead | Saving |
 |---:|---:|---:|---:|
-| 5  | ~14 500  | ~2 800 | ~81 % |
-| 10 | ~29 000  | ~3 500 | ~88 % |
-| 15 | ~44 000  | ~4 000 | ~91 % |
-| 20 | ~58 000  | ~4 500 | ~92 % |
+| 5  | ~14,500 | ~2,800 | ~81% |
+| 10 | ~29,000 | ~3,500 | ~88% |
+| 15 | ~44,000 | ~4,000 | ~91% |
+| 20 | ~58,000 | ~4,500 | ~92% |
 
-Real workflows save more, because MCP also pays for extra discovery round-trips
-(often 5–15 kT per workflow) that CLI eliminates via `get table <Name>` in a
-single call.
+Real workflows save more, because MCP also pays for extra discovery round-trips (often 5–15 kT per workflow) that the CLI eliminates via `d365fo get table <Name>` in a single call.
 
-## When does the saving **not** apply?
+## When the saving does *not* apply
 
-1. **Harness without a shell tool** (plain Claude.ai chat, plain ChatGPT Web
-   without Code Interpreter). Skills + CLI need a filesystem and a shell. In
-   those hosts, MCP remains the only option — which is why this project keeps
-   `D365FO.Mcp` alive as a thin adapter over the same `D365FO.Core`.
+### 1. AI host without a shell tool
 
-2. **One-off lookups** (single `get_table` call per session). Overhead of one
-   CLI process start (~50–150 ms cold) may outweigh the saved tokens. MCP
-   warm-connection shines here; CLI shines on multi-turn flows.
+Plain Claude.ai chat or plain ChatGPT Web (no Code Interpreter) cannot run CLI commands — Skills + CLI need a filesystem and a shell. In those hosts **MCP remains the only option**, which is why this project keeps `D365FO.Mcp` alive as a thin adapter over the same `D365FO.Core`.
 
-3. **Streaming back large generated XML**. If the agent demands the full
-   scaffolded file back into context, token economy collapses. That is why
-   `d365fo generate *` writes to `--out` and returns only a JSON summary on
-   stdout. Skills instruct the agent to honour this.
+### 2. One-off lookups
 
-4. **Write operations and runtime-resolved unit reads.** These need D365FO's
-   own `IMetadataProvider` to produce XML that Visual Studio / MSBuild accept
-   and to return data that reflects ISV overlays. The upstream
-   `d365fo-mcp-server` routes those through a `D365MetadataBridge.exe`
-   (.NET 4.8) child process; doing the same from this CLI is tracked as item
-   **1.0** in [ROADMAP.md](ROADMAP.md). Until that lands the token-saving
-   comparison applies to scan-style tools only (search, find, label/CoC
-   analysis, security hierarchy), not to `generate`/`modify` paths.
+A single `get_table` call per session. Overhead of one CLI process start (~50–150 ms cold) may outweigh the saved tokens. MCP's warm connection shines here; CLI shines on multi-turn flows.
+
+### 3. Streaming back large generated XML
+
+If the agent demands the full scaffolded file back into context, token economy collapses. That is why `d365fo generate *` writes to `--out` and returns only a JSON summary on stdout. Skills instruct the agent to honour this.
+
+### 4. Write operations and runtime-resolved unit reads
+
+These need D365FO's own `IMetadataProvider` to produce XML that Visual Studio / MSBuild accept and to reflect ISV overlays. They route through the **Metadata Bridge** ([`D365FO.Bridge`](ARCHITECTURE.md#metadata-bridge-live-d365fo-reads-and-writes)). Until those paths are fully instrumented, the token-saving numbers above apply to scan-style tools only (search, find, label / CoC analysis, security hierarchy) — not to `generate` / `modify` flows.
 
 ## Benchmark recipe
 
-`scripts/measure-tokens.ps1` (follow-up) will:
+`scripts/measure-tokens.ps1` (follow-up):
 
 1. Spin a fixture SQLite DB with representative seed data.
 2. Run identical 10/15/20-turn scripted prompts against:
-   - Copilot + `d365fo-mcp-server` (legacy TS implementation).
-   - Copilot + `d365fo` CLI + skills.
+   - Copilot + `d365fo-mcp-server` (legacy TypeScript implementation).
+   - Copilot + `d365fo` CLI + Skills.
 3. Parse `tokenUsage` from the host's JSONL conversation log.
-4. Emit a CSV and an HTML report.
+4. Emit CSV + HTML report.
 
-Release gate: **≥ 80 % overhead reduction at 15 turns**. This threshold is
-published so every PR that materially adds schema surface or skill text can
-re-run the benchmark and prove non-regression.
+**Release gate:** ≥ 80% overhead reduction at 15 turns. This threshold is published so every PR that materially adds schema surface or skill text can re-run the benchmark and prove non-regression.
 
 ## Sources
 
@@ -91,3 +81,11 @@ re-run the benchmark and prove non-regression.
 - Simon Willison — [Claude Skills are awesome, maybe a bigger deal than MCP](https://simonwillison.net/2025/Oct/16/claude-skills/), October 2025.
 - seangalliher — [D365-erp-cli, "Why CLI over MCP?"](https://github.com/seangalliher/D365-erp-cli#why-cli-over-mcp).
 - dynamics365ninja — [d365fo-mcp-server, 54-tool surface](https://github.com/dynamics365ninja/d365fo-mcp-server/blob/main/docs/MCP_TOOLS.md).
+
+---
+
+## See also
+
+- [USAGE.md](USAGE.md) — how to wire Skills and the CLI into each AI agent.
+- [ARCHITECTURE.md](ARCHITECTURE.md) — the Metadata Bridge (case 4 above).
+- [MIGRATION_FROM_MCP.md](MIGRATION_FROM_MCP.md) — decision tree for MCP users.

--- a/docs/USAGE.md
+++ b/docs/USAGE.md
@@ -1,40 +1,33 @@
 # Setup & Usage
 
-This guide walks you through installing `d365fo-cli`, pointing it at a D365 F&O metadata source, and using it from the command line, CI, and agents (GitHub Copilot, Claude, Codex, Gemini).
+This is the complete guide to installing, configuring, and using `d365fo-cli`. It picks up where the [README](../README.md) leaves off and serves as a reference for every command.
 
-If you already know the pitch, jump straight to [Install](#install).
+Already know the pitch? Jump straight to [Install](#install).
 
 ---
 
-## What this tool does (and doesn't)
+## What this tool does
 
-**Cross-platform (macOS / Linux / Windows)** — no D365 runtime required:
+`d365fo-cli` is a local toolkit for D365 F&O X++ developers and the AI agents that help them. Under the hood it does three things:
 
-- Index D365 F&O AOT XML metadata into a local SQLite cache. Covered types:
-  `AxTable` (fields, relations, indexes, methods, delete actions), `AxClass`
-  (methods, attributes, Chain-of-Command detection, event subscribers),
-  `AxEdt`, `AxEnum`, `AxForm` (+ datasources, + extensions), `AxMenuItem*`,
-  `AxLabelFile` (multi-language), `AxQuery` / `AxQuerySimple`,
-  `AxView`, `AxDataEntityView` (OData entity/collection names),
-  `AxReport` / `AxReportSsrs`, `AxService`, `AxServiceGroup`, `AxWorkflowType`,
-  `AxSecurity{Role,Duty,Privilege}` plus a flattened `SecurityMap`, and per-model
-  Descriptor metadata (publisher, layer, module references).
-- Query the index: `search`, `get`, `find`, `resolve`, `read`, `models`.
-- Scaffold new AOT objects: `generate table|class|coc|simple-list`.
-- Review diffs against `git`: `review diff` (lint rules for AOT XML).
-- Serve as an MCP server (`d365fo-mcp`, JSON-RPC 2.0) or a warm-cache daemon (`d365fo daemon`).
+1. **Indexes your AOT metadata** into a local SQLite database so you can look up tables, classes, EDTs, enums, forms, queries, views, data entities, reports, services, workflows, security roles, and labels — instantly, offline, across every model.
+2. **Answers questions about the code** — fields, methods, relations, indexes, Chain-of-Command targets, event handlers, label translations, reverse references, model dependencies.
+3. **Scaffolds and reviews X++** — generate ready-to-use AOT XML for new tables, classes, CoC extensions, and simple-list forms; lint AOT changes between git revisions.
 
-`*FormAdaptor` companion packages are automatically excluded during extraction
-(matches `d365fo-mcp-server` behavior — those folders hold no real AOT content).
-
-**Windows + D365FO VM required** (shells out to Microsoft tools):
+It runs on **Windows, macOS, and Linux** — no D365 runtime needed for any of the above. Optionally, on a Windows D365FO developer VM, it also drives:
 
 - `d365fo build` → `MSBuild.exe`
 - `d365fo sync` → `SyncEngine.exe`
 - `d365fo test run` → `SysTestRunner.exe`
 - `d365fo bp check` → `xppbp.exe`
 
-Off-Windows these return a structured `UNSUPPORTED_PLATFORM` error envelope so agents can branch cleanly. **You do not need Windows for development, indexing, scaffolding, or agent usage** — only for `build/sync/test/bp`.
+Off-Windows these commands return a structured `UNSUPPORTED_PLATFORM` error so agents can branch cleanly.
+
+### Metadata types covered
+
+`AxTable` (fields, relations, indexes, methods, delete actions), `AxClass` (methods, attributes, Chain-of-Command detection, event subscribers), `AxEdt`, `AxEnum`, `AxForm` (+ datasources, + extensions), `AxMenuItem*`, `AxLabelFile` (multi-language), `AxQuery` / `AxQuerySimple`, `AxView`, `AxDataEntityView` (OData entity/collection names), `AxReport` / `AxReportSsrs`, `AxService`, `AxServiceGroup`, `AxWorkflowType`, `AxSecurity{Role,Duty,Privilege}` plus a flattened `SecurityMap`, and per-model Descriptor metadata (publisher, layer, module references).
+
+`*FormAdaptor` companion packages are automatically excluded (they hold no real AOT content). This matches `d365fo-mcp-server` behavior.
 
 ---
 
@@ -42,9 +35,19 @@ Off-Windows these return a structured `UNSUPPORTED_PLATFORM` error envelope so a
 
 ### Prerequisites
 
+**Required to build and use the CLI (any platform):**
+
 - .NET SDK 10 (the repo targets `net10.0`; `global.json` pins the exact SDK).
 - `git` (for `review diff`).
 - Python 3.8+ **or** PowerShell 7 (for regenerating skills — optional).
+
+**Recommended for day-to-day X++ development (Windows D365FO developer VM):**
+
+- **Visual Studio 2026** or **Visual Studio 2022** with the **Dynamics 365 Finance and Operations** developer tools (Modern Developer Tools) installed. Visual Studio is the primary IDE for X++ authoring, debugging, and deploying models — `d365fo-cli` complements it rather than replaces it.
+- A local `PackagesLocalDirectory` (`K:\AosService\PackagesLocalDirectory` on the standard Tier-1 VM image).
+- The CLI's `build` / `sync` / `test` / `bp` commands shell out to the Microsoft tooling that Visual Studio also drives (`MSBuild.exe`, `SyncEngine.exe`, `SysTestRunner.exe`, `xppbp.exe`), so they pick up the same model overlays and metadata.
+
+On **macOS and Linux** you do not need Visual Studio or any D365FO runtime — indexing, searching, scaffolding, and agent integration all work cross-platform against a copy of `PackagesLocalDirectory`.
 
 ### Build from source
 
@@ -141,12 +144,20 @@ d365fo index status
 
 ## Usage
 
-All commands return a stable JSON envelope by default (piped/non-TTY) and Spectre-rendered tables in an interactive terminal. Override with `--output json|table|raw`.
+Every command returns a predictable result:
+
+- **Interactive terminal** → nicely rendered tables.
+- **Piped / script / CI** → JSON envelope.
+- Force either with `--output json|table|raw`.
+
+The JSON envelope is always one of:
 
 ```json
-{ "ok": true,  "data": { … },  "warnings": [ … ] }
+{ "ok": true,  "data": { /* … */ }, "warnings": [] }
 { "ok": false, "error": { "code": "…", "message": "…", "hint": "…" } }
 ```
+
+Exit codes: `0` = success, `1` = controlled failure (the error envelope still prints), `2` = unhandled exception.
 
 ### Discover
 
@@ -260,6 +271,8 @@ Rules currently shipped:
 
 ### Windows-only tooling (on the D365FO VM)
 
+These commands run on a **Windows D365FO developer VM with Visual Studio 2026 or 2022 + the D365 F&O developer tools installed**. They wrap the same executables Visual Studio uses, so you can build, sync, test, or Best-Practice-check a model from a terminal, a script, or a CI pipeline instead of clicking through the IDE.
+
 ```powershell
 d365fo build --project C:\AosService\PackagesLocalDirectory\MyModel\MyModel.rnrproj
 d365fo sync --full
@@ -268,6 +281,8 @@ d365fo bp check --model MyModel
 ```
 
 Each parses the tool output and returns a structured JSON envelope (errors, warnings, elapsed time, tail of stdout).
+
+> **Tip:** keep Visual Studio open for debugging, form designer work, and model lifecycle operations; use `d365fo` for metadata lookups, scaffolding, scripted builds, and anything you want to call from an AI agent.
 
 ### Agent integration
 
@@ -285,6 +300,23 @@ Drop the prompt into Copilot / Claude / Codex / Gemini system instructions. Skil
 
 ## Agent usage patterns
 
+### Visual Studio 2026 / 2022 with GitHub Copilot (primary D365FO workflow)
+
+Visual Studio is where most X++ developers live. GitHub Copilot Chat is built into Visual Studio 2026 and available as an extension in Visual Studio 2022, and it can drive `d365fo-cli` straight from the IDE's integrated terminal:
+
+1. Build and expose the CLI on `PATH` (see [Install](#install)).
+2. Copy the Copilot skills next to the solution:
+   ```powershell
+   Copy-Item skills\copilot\* .github\instructions\ -Force
+   d365fo agent-prompt --out .github\copilot-instructions.md
+   ```
+3. In Visual Studio, open **View → GitHub Copilot Chat** and ask things like:
+   - *"Show me the CustTable relations and indexes."*
+   - *"Scaffold a CoC extension for `SalesLineType::insert` into `FleetManagement`."*
+   - *"Run `d365fo build` for `MyModel` and show the errors."*
+
+Copilot picks up `.github/instructions/*.instructions.md` via `applyTo` globs and drives `d365fo` through its terminal tool. Pair it with Visual Studio's own debugger and form designer for the full D365FO workflow.
+
 ### GitHub Copilot (VS Code)
 
 ```sh
@@ -293,7 +325,7 @@ cp skills/copilot/* .github/instructions/
 d365fo agent-prompt --out .github/copilot-instructions.md
 ```
 
-Copilot picks up `.github/instructions/*.instructions.md` via `applyTo` globs. Copilot Chat can then invoke `d365fo …` in a terminal tool.
+Copilot picks up `.github/instructions/*.instructions.md` via `applyTo` globs. Copilot Chat can then invoke `d365fo …` in a terminal tool. Useful on non-Windows developer machines where you index a copy of `PackagesLocalDirectory` without a full VM.
 
 ### Claude Code / Claude Desktop
 


### PR DESCRIPTION
- Updated MIGRATION_FROM_MCP.md to clarify migration paths and compatibility.
- Revised ROADMAP.md to improve clarity and organization of upcoming features.
- Improved TOKEN_ECONOMICS.md to provide clearer comparisons between CLI + Skills and MCP.
- Enhanced USAGE.md for better guidance on installation, usage, and agent integration.