### PR TITLE
feat: FTS5 labels, label writes, role scaffold, SARIF lint, init pers…

### DIFF
--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -56,7 +56,7 @@ Every tool returns the same shape:
 ## The local index (SQLite)
 
 - Single file at `$D365FO_INDEX_DB` (default: `$LOCALAPPDATA/d365fo-cli/d365fo-index.sqlite`).
-- Schema **v5**, defined in [`src/D365FO.Core/Index/Schema.sql`](../src/D365FO.Core/Index/Schema.sql).
+- Schema **v6**, defined in [`src/D365FO.Core/Index/Schema.sql`](../src/D365FO.Core/Index/Schema.sql). v6 adds a `LabelFts` FTS5 virtual table (content-linked to `Labels` via `rowid=LabelId`) plus INSERT/UPDATE/DELETE triggers that keep the full-text index in sync; `EnsureSchema` issues a one-time `LabelFts('rebuild')` on migration and gracefully degrades if the SQLite build lacks FTS5.
 - Version tracked in `PRAGMA user_version`; migrations applied automatically on first connection via `MetadataRepository.EnsureSchema`.
 - `MetadataRepository` is stateless — every call opens and closes its own connection, so it works identically in a short-lived CLI process, a long-lived MCP server, or a daemon.
 - SQLite booleans are stored as `INTEGER`; `SqliteBoolHandler` teaches Dapper the conversion once at static init.
@@ -126,7 +126,9 @@ The bridge is Windows-only and must ship next to a live VM. Non-Windows develope
 
 ## MCP coexistence
 
-`D365FO.Mcp.ToolHandlers` forwards to the same `D365FO.Core` primitives the CLI uses. A follow-up commit replaces `StdioDispatcher` with the official `modelcontextprotocol/csharp-sdk`, keeping `ToolHandlers` as the stable internal surface.
+`D365FO.Mcp.ToolHandlers` forwards to the same `D365FO.Core` primitives the CLI uses. As of Phase 4 the server speaks the MCP stdio transport via the official [`ModelContextProtocol`](https://www.nuget.org/packages/ModelContextProtocol) C# SDK (`McpServerHost`), which handles framing, lifecycle, capabilities, and notifications. The hand-rolled `StdioDispatcher` stays behind `--legacy` for environments that cannot resolve the SDK and for deterministic in-proc tests.
+
+`ToolCatalog` is the single registry of MCP-exposed tools (~53 today — search / get / find parity across classes, tables, EDTs, enums, forms, queries, views, data entities, reports, services, workflows; security roles/duties/privileges; models, labels (read + FTS5 `search_labels_fts` + write via `create_label` / `rename_label` / `delete_label`), extensions, event handlers; plus heuristics (`search_any`, `suggest_edt`, `validate_object_naming`, `analyze_extension_points`), aggregation (`stats`, `batch_search`), workspace info, and the in-proc `lint` runner). Adding a new tool means one entry in `ToolCatalog` plus one method on `ToolHandlers`; the CLI picks it up for free once a command wraps the same `MetadataRepository` call.
 
 ## Why .NET 10
 

--- a/docs/EXAMPLES.md
+++ b/docs/EXAMPLES.md
@@ -79,6 +79,65 @@ d365fo models deps ApplicationSuite
 
 `models list` enumerates every model with publisher, layer, and custom-flag.
 
+### `search any` — scope-agnostic quick jump
+
+```sh
+d365fo search any CustTable
+```
+
+UNIONs every indexed kind in one query and returns `byKind` counts for triage.
+
+### `stats` — per-model + top-N aggregates
+
+```sh
+d365fo stats --top 10
+```
+
+Returns per-model object counts plus top tables (by field count), top classes (by method count), and top CoC extension targets. Handy for sizing a customisation and for agent prompts.
+
+---
+
+## Maintain the index
+
+### `index refresh` — incremental re-extract
+
+```sh
+d365fo index refresh
+d365fo index refresh --force          # re-scan every model
+d365fo index extract --since 2026-04-01T00:00:00Z  # explicit threshold
+```
+
+Computes the newest `.xml` mtime under each model folder and skips models that are older than the DB's last-write timestamp (minus a 5-minute safety margin). `--force` is the no-threshold equivalent of `index extract`.
+
+### `lint` — in-process Best-Practice heuristics
+
+```sh
+d365fo lint
+d365fo lint --category table-no-index,string-without-edt --all-models
+d365fo lint --format sarif > lint.sarif
+```
+
+Categories shipped today: `table-no-index`, `ext-named-not-attributed`, `string-without-edt`. Defaults to custom models only; pass `--all-models` to include ISV / MS content. `--format sarif` emits [SARIF 2.1.0](https://sarifweb.azurewebsites.net/) for CI ingestion (GitHub code-scanning, Azure DevOps).
+
+### `validate name` — naming-rule linter
+
+```sh
+d365fo validate name Table FmVehicle --prefix Fm
+d365fo validate name Coc CustTable_Extension
+```
+
+Static check against `ObjectNamingRules` (publisher prefix, PascalCase, suffix conventions, length / char-set). Returns structured `violations[]` with `code`, `severity`, `message`. Handy as a pre-commit hook.
+
+### `init` — quickstart
+
+```sh
+d365fo init --run-extract
+d365fo init --dry-run                  # show what would be done
+d365fo init --persist-profile          # append env vars to $PROFILE / ~/.profile
+```
+
+Auto-detects the Windows `PackagesLocalDirectory` (C:, J:, K:, `AosService`), prepares the SQLite schema, and (with `--run-extract`) drives the full extract pipeline. `--persist-profile` idempotently writes a marker block (`# >>> d365fo-cli init >>>` … `# <<< d365fo-cli init <<<`) into the user's shell profile (`$PROFILE` on Windows PowerShell, `~/.profile` elsewhere) exporting `D365FO_PACKAGES_PATH` / `D365FO_INDEX_DB` / `D365FO_WORKSPACE` — re-running replaces the block only when values change.
+
 ---
 
 ## Scaffold
@@ -115,6 +174,84 @@ d365fo generate coc CustTable --method update --method insert \
 d365fo generate simple-list FmVehicleListPage --table FmVehicle \
   --out src/MyModel/AxForm/FmVehicleListPage.xml
 ```
+
+### Data entity (`AxDataEntityView`)
+
+```sh
+d365fo generate entity FmVehicleEntity --table FmVehicle \
+  --public-entity-name FmVehicle --public-collection-name FmVehicles \
+  --all-fields \
+  --out src/MyModel/AxDataEntityView/FmVehicleEntity.xml
+```
+
+Emits a single-datasource `AxQuerySimpleRootDataSource` view with public OData names. Pass `--all-fields` to auto-populate `<Fields />` from the source table's `TableFields` (mandatory flag carries over). Without `--all-fields` or explicit `--field` flags, `<Fields />` is empty.
+
+### Extension (table / form / EDT / enum)
+
+```sh
+d365fo generate extension Table CustTable Contoso \
+  --out src/MyModel/AxTableExtension/CustTable.Contoso.xml
+```
+
+Name is always `<Target>.<Suffix>` to match the AOT convention. Kinds: `Table`, `Form`, `Edt`, `Enum`.
+
+### Event handler
+
+```sh
+d365fo generate event-handler Contoso_CustTable_Handler \
+  --source-kind Table --source-object CustTable --event inserted \
+  --out src/MyModel/AxClass/Contoso_CustTable_Handler.xml
+```
+
+Picks the right attribute (`[DataEventHandler]`, `[FormEventHandler]`, `[FormDataSourceEventHandler]`, `[SubscribesTo]`) from `--source-kind`.
+
+### Security privilege / duty
+
+```sh
+d365fo generate privilege FmVehicleReadPriv \
+  --entry-point FmVehicleListPage --entry-kind MenuItemDisplay --entry-object FmVehicleListPage \
+  --access Read --label "@Fleet:ReadVehicles" \
+  --out src/MyModel/AxSecurityPrivilege/FmVehicleReadPriv.xml
+
+d365fo generate duty FmVehicleMaintainDuty \
+  --privilege FmVehicleReadPriv --privilege FmVehicleUpdatePriv \
+  --out src/MyModel/AxSecurityDuty/FmVehicleMaintainDuty.xml
+```
+
+### Security role (new or merge)
+
+```sh
+# Scaffold a new role that references duties / privileges
+d365fo generate role FmVehicleAdminRole \
+  --duty FmVehicleMaintainDuty --privilege FmVehicleReadPriv \
+  --label "@Fleet:VehicleAdminRole" --description "Full access to Fleet vehicles" \
+  --out src/MyModel/AxSecurityRole/FmVehicleAdminRole.xml
+
+# Merge new references into an existing role (idempotent; writes .bak)
+d365fo generate role --add-to src/MyModel/AxSecurityRole/FmVehicleAdminRole.xml \
+  --duty FmReportingDuty --privilege FmExportPriv
+```
+
+`--add-to` validates the root element (`AxSecurityRole`), dedupes by `Name` (case-insensitive), and returns `NoChange` when every reference already exists.
+
+---
+
+## Labels (read & write)
+
+```sh
+# Read
+d365fo search label "Customer invoice"
+d365fo search label "customer invoice" --fts        # rank-sorted FTS5
+d365fo get label @SYS12345 --language en-us
+
+# Write \u2014 atomic, preserves comments, BOM UTF-8
+d365fo label create NewKey "New value" --file path/Foo.en-us.label.txt
+d365fo label create NewKey "Updated"   --file path/Foo.en-us.label.txt --overwrite
+d365fo label rename NewKey RenamedKey  --file path/Foo.en-us.label.txt
+d365fo label delete RenamedKey         --file path/Foo.en-us.label.txt
+```
+
+`search label --fts` requires a schema-v6 index (run `d365fo index refresh --force` once after upgrading) and falls back to `LIKE` scans on SQLite builds without FTS5. Write commands return envelope codes `KEY_EXISTS` / `KEY_NOT_FOUND` / `FILE_NOT_FOUND` / `WRITE_FAILED` and keep a `.bak` of the previous file.
 
 ---
 
@@ -191,7 +328,7 @@ Standalone JSON-RPC 2.0 server (protocol `2024-11-05`) that shares the CLI's ind
 }
 ```
 
-After `dotnet publish src/D365FO.Mcp -c Release -r osx-arm64` you get a standalone `d365fo-mcp` binary you can drop on `$PATH`. The adapter exposes 16 read tools (search / get / find / index_status) — a focused subset of the CLI surface. Items still missing from MCP are tracked in [ROADMAP.md](ROADMAP.md).
+After `dotnet publish src/D365FO.Mcp -c Release -r osx-arm64` you get a standalone `d365fo-mcp` binary you can drop on `$PATH`. The adapter exposes **53 tools** covering CLI parity (search / get / find / read / index_status), security & labels — read (`get_label`, `search_labels`, `search_labels_fts`) and write (`create_label`, `rename_label`, `delete_label`) — heuristics (`search_any`, `suggest_edt`, `validate_object_naming`, `analyze_extension_points`), aggregation (`stats`, `batch_search`), workspace info, and the in-proc `lint` runner. Items still missing from MCP are tracked in [ROADMAP.md](ROADMAP.md).
 
 ---
 

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -10,28 +10,27 @@ Items are grouped by topic and ordered roughly by ROI; within a section you can 
 1. [Refresh & observability](#1-refresh--observability)
 2. [Runtime / live data](#2-runtime--live-data)
 3. [More AOT types](#3-more-aot-types)
-4. [Search & ergonomics](#4-search--ergonomics)
-5. [Output & integration](#5-output--integration)
-6. [Scaffolding extensions](#6-scaffolding-extensions)
-7. [Code quality & Best Practices](#7-code-quality--best-practices)
-8. [Tests](#8-tests)
-9. [Small items / technical debt](#9-small-items--technical-debt)
+4. [Output & integration](#4-output--integration)
+5. [Scaffolding extensions](#5-scaffolding-extensions)
+6. [Code quality & Best Practices](#6-code-quality--best-practices)
+7. [Tests](#7-tests)
+8. [Small items / technical debt](#8-small-items--technical-debt)
 
 ---
 
 ## 1. Refresh & observability
 
-### 1.1 `d365fo index refresh` (mtime-based incremental)
+### 1.1 Fingerprint-based incremental refresh
 
-Per model, compute max `LastWriteTimeUtc` under `Descriptor/*.xml` + `Ax*/*.xml`. Compare against new columns `Models.LastExtractedUtc` / `Models.SourceFingerprint`. Re-extract only changed models. Schema bump to v6. CLI: `d365fo index refresh [--force]`.
+`d365fo index refresh [--force]` and `d365fo index extract --since <ISO>` already skip models whose newest XML mtime is older than the DB's last-write timestamp (minus a 5-minute safety margin). Remaining work: schema bump adding `Models.LastExtractedUtc` / `Models.SourceFingerprint` so refresh becomes per-model content-addressed (no false-positive re-extracts when only the DB was touched).
 
 ### 1.2 `d365fo index diff <revision>`
 
 Structural AOT diff vs. a git revision — e.g. "three new fields on `CustTable`, method `validate` signature changed". Requires a double extract or snapshotting.
 
-### 1.3 Extraction telemetry
+### 1.3 Persisted extraction telemetry
 
-Per-model timings + error summaries. Either an `_index_meta` table or a sidecar `.log`.
+Per-model timings are already emitted in the JSON envelope (`elapsedMs` per model + top-level total). Remaining work: an `_index_meta` table (or sidecar `.log`) so history survives across runs and can feed `d365fo stats`.
 
 ## 2. Runtime / live data
 
@@ -56,79 +55,51 @@ Long-tail metadata not yet indexed:
 - **3.3** ReferenceGroup / Map / MapExtension.
 - **3.4** ConfigurationKey / LicenseCode — cross-referenced to tables / fields / EDTs.
 - **3.5** Feature (Feature Management).
+- **3.6** X++ method source indexing — upstream MCP parity (`get_method_source`, `analyze_code_patterns`, `suggest_method_implementation`). Needs schema bump for `MethodSources(ClassOrTable, Method, Body, Signature, Kind)`.
 
-## 4. Search & ergonomics
+## 4. Output & integration
 
-### 4.1 Full-text search (SQLite FTS5)
-
-`LabelFts(Value, Key, File, Language)` (and optionally `Source`). Moves `d365fo search label "customer invoice"` from `LIKE` scans to rank-sorted FTS — tens of ms instead of hundreds.
-
-### 4.2 Parametric aggregation (`d365fo stats`)
-
-Per-model counts, top-N largest tables, classes missing Best-Practice attributes, etc.
-
-### 4.3 Multi-scope search (`d365fo search any <substring>`)
-
-Scope-agnostic quick jump across all indexed kinds.
-
-## 5. Output & integration
-
-### 5.1 Persistent daemon mode (JSON-RPC)
+### 4.1 Persistent daemon mode (JSON-RPC)
 
 Skeleton exists (`D365FO.Cli.Commands.Daemon`). Add 1:1 request routing with the CLI, warm SQLite pool, file-watcher triggering `index refresh`. Also hosts the bridge child process across calls (sub-50 ms warm vs. ~300 ms cold).
 
-### 5.2 MCP stdio parity (`D365FO.Mcp`)
-
-Bring CLI → MCP tool surface to 1:1 parity. Include `tools/list` with descriptions and sample JSON args for LLM prompting.
-
-### 5.3 Structured diff output
+### 4.2 Structured diff output
 
 `--output patch` for `generate *` — apply as a text patch without touching the workspace.
 
-### 5.4 Session cache
+### 4.3 Session cache
 
 `.d365fo-session.json` next to the index; keeps the last active model / recent `get`s for prompt hints.
 
-## 6. Scaffolding extensions
+## 5. Scaffolding extensions
 
-- `generate extension <table|form|edt|enum> <Target>`.
-- `generate entity <Table>` — `AxDataEntityView` with all table fields, OData names by convention.
-- `generate privilege <EntryPoint>`, `generate duty <Privilege[]>`, wire into role.
-- `generate event-handler <SourceKind> <SourceObject> <Event>`.
+- `generate duty --into-role <NAME>` / `generate privilege --into-role <NAME>` — single-pass "scaffold + wire" (today the parts ship separately: scaffold the duty/privilege file, then `generate role --add-to <path>` merges references). Would fold those two steps into one.
+- Hand-rolled serialisers for selected Ax* kinds (e.g. `AxTableExtension`, `AxSecurityRole`) where `AxSerializer`'s generic walker elides detail the agent actually wants — the depth cap + cycle guard means we currently fall back to `Name` on deeply nested overlays.
 
-## 7. Code quality & Best Practices
+## 6. Code quality & Best Practices
 
-### 7.1 In-process BP runner (no VM)
+### 6.1 Additional lint categories
 
-Static checks over the index:
+`d365fo lint` ships with 3 categories (`table-no-index`, `ext-named-not-attributed`, `string-without-edt`) and SARIF output (`--format sarif`) for CI. Pending:
 
-- "table has no cluster index" (`TableIndexes`),
-- "class named `*_Extension` without `[ExtensionOf]`",
-- "method with public API but no doc-comment",
-- "UI literal string without `@Label`".
+- "method with public API but no doc-comment" — requires method-source indexing (§3.6).
+- "UI literal string without `@Label`" — requires parsing element captions on forms / menu items.
 
-CLI: `d365fo lint [--category X,Y] --output sarif` for CI.
-
-### 7.2 Coupling metrics
+### 6.2 Coupling metrics
 
 Graph metrics over `ModelDependencies` + `DYNAMICSXREFDB` — surfaces cyclic dependencies and top incoming / outgoing symbols.
 
-## 8. Tests
+## 7. Tests
 
 - End-to-end: freeze a sample `AxRepo` in `tests/Samples/MiniAot/`, run `MetadataExtractor` + `MetadataRepository`, verify counts.
 - Snapshot tests for JSON output of `get table`, `get class`, `models deps`.
 - Performance smoke: `MeasureExtract(ApplicationSuite)` cap (runs only when `D365FO_PACKAGES_PATH` is set).
 - Bridge: end-to-end harness that spins the net48 exe against a sample `PackagesLocalDirectory` fixture and asserts round-trip for read / create / update / delete.
 
-## 9. Small items / technical debt
+## 8. Small items / technical debt
 
-- `d365fo init` — interactive quickstart that detects `PackagesLocalDirectory`, writes an alias / function into the user's rc profile, persists `D365FO_PACKAGES_PATH` + `D365FO_INDEX_DB`, runs `index build` + `index extract`, and ends with `doctor`. Replaces the copy-paste script documented in [SETUP.md](SETUP.md#quickstart-script).
-- `tests/D365FO.Cli.Tests` is empty — at least a smoke test of Spectre registration.
+- Migrate remaining magic-string error codes to `D365FO.Core.D365FoErrorCodes` (canonical constants exist; call-sites are converting incrementally).
 - Audit every `Render` call site for `StringSanitizer` coverage.
-- `Models.IsCustom` single source of truth between `UpsertModelInternal` (first-seen deps) and `ApplyExtract` (`UPDATE`).
-- Error codes (`TABLE_NOT_FOUND`, `MODEL_NOT_FOUND`, …) should live in an enum, not magic strings.
-- Log `schema v{X} applied` line in `index build`.
-- Hand-rolled serialisers for selected Ax* kinds (e.g. `AxTableExtension`, `AxSecurityRole`) where `AxSerializer`'s generic walker elides detail the agent actually wants — the depth cap + cycle guard means we currently fall back to `Name` on deeply nested overlays.
 
 ---
 

--- a/src/D365FO.Cli/Commands/Generate/GenerateMoreCommands.cs
+++ b/src/D365FO.Cli/Commands/Generate/GenerateMoreCommands.cs
@@ -1,0 +1,494 @@
+using D365FO.Core;
+using D365FO.Core.Scaffolding;
+using Spectre.Console.Cli;
+
+namespace D365FO.Cli.Commands.Generate;
+
+/// <summary>Scaffolds an <c>AxDataEntityView</c>. ROADMAP §6.</summary>
+public sealed class GenerateEntityCommand : Command<GenerateEntityCommand.Settings>
+{
+    public sealed class Settings : GenerateSettings
+    {
+        [CommandArgument(0, "<ENTITY>")]
+        public string EntityName { get; init; } = "";
+
+        [CommandOption("--table <TABLE>")]
+        [System.ComponentModel.Description("Root data source table for the entity.")]
+        public string? Table { get; init; }
+
+        [CommandOption("--public-entity <NAME>")]
+        public string? PublicEntity { get; init; }
+
+        [CommandOption("--public-collection <NAME>")]
+        public string? PublicCollection { get; init; }
+
+        [CommandOption("--field <SPEC>")]
+        [System.ComponentModel.Description("Repeatable: <name>[:<dataField>[:mandatory]].")]
+        public string[] Fields { get; init; } = Array.Empty<string>();
+
+        [CommandOption("--all-fields")]
+        [System.ComponentModel.Description("Populate <Fields /> from the source table's columns. Requires the table to be indexed.")]
+        public bool AllFields { get; init; }
+    }
+
+    public override int Execute(CommandContext ctx, Settings settings)
+    {
+        var kind = OutputMode.Resolve(settings.Output);
+        if (string.IsNullOrWhiteSpace(settings.EntityName))
+            return RenderHelpers.Render(kind, ToolResult<object>.Fail(D365FoErrorCodes.BadInput, "Entity name required."));
+        if (string.IsNullOrWhiteSpace(settings.Table))
+            return RenderHelpers.Render(kind, ToolResult<object>.Fail(D365FoErrorCodes.BadInput, "--table <TABLE> required."));
+        var hasInstall = !string.IsNullOrWhiteSpace(settings.InstallTo);
+        var hasOut = !string.IsNullOrWhiteSpace(settings.Out);
+        if (!hasInstall && !hasOut)
+            return RenderHelpers.Render(kind, ToolResult<object>.Fail(D365FoErrorCodes.BadInput, "--out or --install-to is required."));
+        var outPath = settings.Out;
+        if (hasInstall && !hasOut)
+        {
+            outPath = GenerateInstaller.ResolveInstallPath(kind, "AxDataEntityView", settings.EntityName, settings.InstallTo!, out var fail);
+            if (fail.HasValue) return fail.Value;
+        }
+
+        var fields = settings.Fields.Select(ParseField).ToList();
+        var autoFromTable = false;
+        if (fields.Count == 0 && settings.AllFields)
+        {
+            var repo = RepoFactory.Create();
+            var tableDetails = repo.GetTableDetails(settings.Table!);
+            if (tableDetails is null)
+                return RenderHelpers.Render(kind, ToolResult<object>.Fail(
+                    D365FoErrorCodes.TableNotFound,
+                    $"Table '{settings.Table}' not found in the index. Extract the model first or pass explicit --field <SPEC>."));
+            foreach (var f in tableDetails.Fields)
+                fields.Add(new EntityFieldSpec(f.Name, f.Name, f.Mandatory));
+            autoFromTable = true;
+        }
+        var doc = XppScaffolder.DataEntity(
+            settings.EntityName, settings.Table!, settings.PublicEntity, settings.PublicCollection, fields);
+        try
+        {
+            var res = ScaffoldFileWriter.Write(doc, outPath!, settings.Overwrite);
+            return RenderHelpers.Render(kind, ToolResult<object>.Success(new
+            {
+                kind = "AxDataEntityView",
+                name = settings.EntityName,
+                table = settings.Table,
+                path = res.Path,
+                bytes = res.Bytes,
+                backup = res.BackupPath,
+                fieldCount = fields.Count,
+                fieldsFromTable = autoFromTable,
+                model = settings.InstallTo,
+            }));
+        }
+        catch (Exception ex)
+        {
+            return RenderHelpers.Render(kind, ToolResult<object>.Fail(D365FoErrorCodes.WriteFailed, ex.Message));
+        }
+    }
+
+    private static EntityFieldSpec ParseField(string raw)
+    {
+        var parts = raw.Split(':', StringSplitOptions.TrimEntries);
+        var name = parts.Length > 0 ? parts[0] : "";
+        var data = parts.Length > 1 && parts[1].Length > 0 ? parts[1] : null;
+        var mandatory = parts.Length > 2 && string.Equals(parts[2], "mandatory", StringComparison.OrdinalIgnoreCase);
+        return new EntityFieldSpec(name, data, mandatory);
+    }
+}
+
+/// <summary>Scaffolds <c>AxTableExtension</c> / <c>AxFormExtension</c> / <c>AxEdtExtension</c> / <c>AxEnumExtension</c>. ROADMAP §6.</summary>
+public sealed class GenerateExtensionCommand : Command<GenerateExtensionCommand.Settings>
+{
+    public sealed class Settings : GenerateSettings
+    {
+        [CommandArgument(0, "<KIND>")]
+        [System.ComponentModel.Description("Extension kind: Table, Form, Edt, Enum.")]
+        public string Kind { get; init; } = "";
+
+        [CommandArgument(1, "<TARGET>")]
+        public string Target { get; init; } = "";
+
+        [CommandOption("--suffix <SUFFIX>")]
+        [System.ComponentModel.Description("Extension suffix. Defaults to the InstallTo model name or 'Extension'.")]
+        public string? Suffix { get; init; }
+    }
+
+    public override int Execute(CommandContext ctx, Settings settings)
+    {
+        var kind = OutputMode.Resolve(settings.Output);
+        if (string.IsNullOrWhiteSpace(settings.Kind))
+            return RenderHelpers.Render(kind, ToolResult<object>.Fail(D365FoErrorCodes.BadInput, "Extension kind required."));
+        if (string.IsNullOrWhiteSpace(settings.Target))
+            return RenderHelpers.Render(kind, ToolResult<object>.Fail(D365FoErrorCodes.BadInput, "Target object required."));
+        var hasInstall = !string.IsNullOrWhiteSpace(settings.InstallTo);
+        var hasOut = !string.IsNullOrWhiteSpace(settings.Out);
+        if (!hasInstall && !hasOut)
+            return RenderHelpers.Render(kind, ToolResult<object>.Fail(D365FoErrorCodes.BadInput, "--out or --install-to is required."));
+
+        var suffix = settings.Suffix
+            ?? (hasInstall ? settings.InstallTo! : "Extension");
+        var axFolder = settings.Kind switch
+        {
+            "Table" => "AxTableExtension",
+            "Form" => "AxFormExtension",
+            "Edt" => "AxEdtExtension",
+            "Enum" => "AxEnumExtension",
+            _ => null,
+        };
+        if (axFolder is null)
+            return RenderHelpers.Render(kind, ToolResult<object>.Fail(D365FoErrorCodes.BadInput,
+                $"Unsupported extension kind: {settings.Kind}. Expected Table|Form|Edt|Enum."));
+
+        var fullName = $"{settings.Target}.{suffix}";
+        var outPath = settings.Out;
+        if (hasInstall && !hasOut)
+        {
+            outPath = GenerateInstaller.ResolveInstallPath(kind, axFolder, fullName, settings.InstallTo!, out var fail);
+            if (fail.HasValue) return fail.Value;
+        }
+
+        var doc = XppScaffolder.Extension(settings.Kind, settings.Target, suffix);
+        try
+        {
+            var res = ScaffoldFileWriter.Write(doc, outPath!, settings.Overwrite);
+            return RenderHelpers.Render(kind, ToolResult<object>.Success(new
+            {
+                kind = axFolder,
+                name = fullName,
+                target = settings.Target,
+                suffix,
+                path = res.Path,
+                bytes = res.Bytes,
+                backup = res.BackupPath,
+                model = settings.InstallTo,
+            }));
+        }
+        catch (Exception ex)
+        {
+            return RenderHelpers.Render(kind, ToolResult<object>.Fail(D365FoErrorCodes.WriteFailed, ex.Message));
+        }
+    }
+}
+
+/// <summary>Scaffolds an event-handler subscriber class. ROADMAP §6.</summary>
+public sealed class GenerateEventHandlerCommand : Command<GenerateEventHandlerCommand.Settings>
+{
+    public sealed class Settings : GenerateSettings
+    {
+        [CommandArgument(0, "<CLASS_NAME>")]
+        public string ClassName { get; init; } = "";
+
+        [CommandOption("--source-kind <KIND>")]
+        [System.ComponentModel.Description("Form | FormDataSource | Table | Class.")]
+        public string SourceKind { get; init; } = "Form";
+
+        [CommandOption("--source-object <NAME>")]
+        public string? SourceObject { get; init; }
+
+        [CommandOption("--event <NAME>")]
+        [System.ComponentModel.Description("E.g. OnInitialized / OnValidatingWrite / PostActivate.")]
+        public string Event { get; init; } = "OnInitialized";
+
+        [CommandOption("--method <NAME>")]
+        public string HandlerMethod { get; init; } = "OnEvent";
+    }
+
+    public override int Execute(CommandContext ctx, Settings settings)
+    {
+        var kind = OutputMode.Resolve(settings.Output);
+        if (string.IsNullOrWhiteSpace(settings.ClassName))
+            return RenderHelpers.Render(kind, ToolResult<object>.Fail(D365FoErrorCodes.BadInput, "Class name required."));
+        if (string.IsNullOrWhiteSpace(settings.SourceObject))
+            return RenderHelpers.Render(kind, ToolResult<object>.Fail(D365FoErrorCodes.BadInput, "--source-object required."));
+        var hasInstall = !string.IsNullOrWhiteSpace(settings.InstallTo);
+        var hasOut = !string.IsNullOrWhiteSpace(settings.Out);
+        if (!hasInstall && !hasOut)
+            return RenderHelpers.Render(kind, ToolResult<object>.Fail(D365FoErrorCodes.BadInput, "--out or --install-to is required."));
+        var outPath = settings.Out;
+        if (hasInstall && !hasOut)
+        {
+            outPath = GenerateInstaller.ResolveInstallPath(kind, "AxClass", settings.ClassName, settings.InstallTo!, out var fail);
+            if (fail.HasValue) return fail.Value;
+        }
+
+        var doc = XppScaffolder.EventHandler(settings.ClassName, settings.SourceKind, settings.SourceObject!, settings.Event, settings.HandlerMethod);
+        try
+        {
+            var res = ScaffoldFileWriter.Write(doc, outPath!, settings.Overwrite);
+            return RenderHelpers.Render(kind, ToolResult<object>.Success(new
+            {
+                kind = "AxClass",
+                role = "EventHandler",
+                name = settings.ClassName,
+                sourceKind = settings.SourceKind,
+                sourceObject = settings.SourceObject,
+                @event = settings.Event,
+                method = settings.HandlerMethod,
+                path = res.Path,
+                bytes = res.Bytes,
+                backup = res.BackupPath,
+                model = settings.InstallTo,
+            }));
+        }
+        catch (Exception ex)
+        {
+            return RenderHelpers.Render(kind, ToolResult<object>.Fail(D365FoErrorCodes.WriteFailed, ex.Message));
+        }
+    }
+}
+
+/// <summary>Scaffolds a security privilege granting a single entry point. ROADMAP §6.</summary>
+public sealed class GeneratePrivilegeCommand : Command<GeneratePrivilegeCommand.Settings>
+{
+    public sealed class Settings : GenerateSettings
+    {
+        [CommandArgument(0, "<NAME>")]
+        public string Name { get; init; } = "";
+
+        [CommandOption("--entry-point <NAME>")]
+        public string? EntryPoint { get; init; }
+
+        [CommandOption("--entry-kind <KIND>")]
+        [System.ComponentModel.Description("MenuItemDisplay | MenuItemAction | MenuItemOutput | WebMenuItem.")]
+        public string EntryKind { get; init; } = "MenuItemDisplay";
+
+        [CommandOption("--entry-object <NAME>")]
+        [System.ComponentModel.Description("Target object name when different from --entry-point.")]
+        public string? EntryObject { get; init; }
+
+        [CommandOption("--access <LEVEL>")]
+        [System.ComponentModel.Description("NoAccess | Read | Update | Create | Correct | Delete.")]
+        public string Access { get; init; } = "Read";
+
+        [CommandOption("--label <TEXT>")]
+        public string? Label { get; init; }
+    }
+
+    public override int Execute(CommandContext ctx, Settings settings)
+    {
+        var kind = OutputMode.Resolve(settings.Output);
+        if (string.IsNullOrWhiteSpace(settings.Name))
+            return RenderHelpers.Render(kind, ToolResult<object>.Fail(D365FoErrorCodes.BadInput, "Privilege name required."));
+        if (string.IsNullOrWhiteSpace(settings.EntryPoint))
+            return RenderHelpers.Render(kind, ToolResult<object>.Fail(D365FoErrorCodes.BadInput, "--entry-point required."));
+        var hasInstall = !string.IsNullOrWhiteSpace(settings.InstallTo);
+        var hasOut = !string.IsNullOrWhiteSpace(settings.Out);
+        if (!hasInstall && !hasOut)
+            return RenderHelpers.Render(kind, ToolResult<object>.Fail(D365FoErrorCodes.BadInput, "--out or --install-to is required."));
+        var outPath = settings.Out;
+        if (hasInstall && !hasOut)
+        {
+            outPath = GenerateInstaller.ResolveInstallPath(kind, "AxSecurityPrivilege", settings.Name, settings.InstallTo!, out var fail);
+            if (fail.HasValue) return fail.Value;
+        }
+
+        var doc = XppScaffolder.Privilege(settings.Name, settings.EntryPoint!, settings.EntryKind, settings.EntryObject, settings.Access, settings.Label);
+        try
+        {
+            var res = ScaffoldFileWriter.Write(doc, outPath!, settings.Overwrite);
+            return RenderHelpers.Render(kind, ToolResult<object>.Success(new
+            {
+                kind = "AxSecurityPrivilege",
+                name = settings.Name,
+                entryPoint = settings.EntryPoint,
+                entryKind = settings.EntryKind,
+                access = settings.Access,
+                path = res.Path,
+                bytes = res.Bytes,
+                backup = res.BackupPath,
+                model = settings.InstallTo,
+            }));
+        }
+        catch (Exception ex)
+        {
+            return RenderHelpers.Render(kind, ToolResult<object>.Fail(D365FoErrorCodes.WriteFailed, ex.Message));
+        }
+    }
+}
+
+/// <summary>Scaffolds a security duty grouping one or more privileges. ROADMAP §6.</summary>
+public sealed class GenerateDutyCommand : Command<GenerateDutyCommand.Settings>
+{
+    public sealed class Settings : GenerateSettings
+    {
+        [CommandArgument(0, "<NAME>")]
+        public string Name { get; init; } = "";
+
+        [CommandOption("--privilege <NAME>")]
+        [System.ComponentModel.Description("Repeatable. Privileges to aggregate under this duty.")]
+        public string[] Privileges { get; init; } = Array.Empty<string>();
+
+        [CommandOption("--label <TEXT>")]
+        public string? Label { get; init; }
+    }
+
+    public override int Execute(CommandContext ctx, Settings settings)
+    {
+        var kind = OutputMode.Resolve(settings.Output);
+        if (string.IsNullOrWhiteSpace(settings.Name))
+            return RenderHelpers.Render(kind, ToolResult<object>.Fail(D365FoErrorCodes.BadInput, "Duty name required."));
+        if (settings.Privileges.Length == 0)
+            return RenderHelpers.Render(kind, ToolResult<object>.Fail(D365FoErrorCodes.BadInput, "At least one --privilege required."));
+        var hasInstall = !string.IsNullOrWhiteSpace(settings.InstallTo);
+        var hasOut = !string.IsNullOrWhiteSpace(settings.Out);
+        if (!hasInstall && !hasOut)
+            return RenderHelpers.Render(kind, ToolResult<object>.Fail(D365FoErrorCodes.BadInput, "--out or --install-to is required."));
+        var outPath = settings.Out;
+        if (hasInstall && !hasOut)
+        {
+            outPath = GenerateInstaller.ResolveInstallPath(kind, "AxSecurityDuty", settings.Name, settings.InstallTo!, out var fail);
+            if (fail.HasValue) return fail.Value;
+        }
+
+        var doc = XppScaffolder.Duty(settings.Name, settings.Privileges, settings.Label);
+        try
+        {
+            var res = ScaffoldFileWriter.Write(doc, outPath!, settings.Overwrite);
+            return RenderHelpers.Render(kind, ToolResult<object>.Success(new
+            {
+                kind = "AxSecurityDuty",
+                name = settings.Name,
+                privilegeCount = settings.Privileges.Length,
+                privileges = settings.Privileges,
+                path = res.Path,
+                bytes = res.Bytes,
+                backup = res.BackupPath,
+                model = settings.InstallTo,
+            }));
+        }
+        catch (Exception ex)
+        {
+            return RenderHelpers.Render(kind, ToolResult<object>.Fail(D365FoErrorCodes.WriteFailed, ex.Message));
+        }
+    }
+}
+
+/// <summary>
+/// Scaffolds a new <c>AxSecurityRole</c> or, with <c>--add-to</c>, appends duty /
+/// privilege references to an existing role document. ROADMAP §6.
+/// </summary>
+public sealed class GenerateRoleCommand : Command<GenerateRoleCommand.Settings>
+{
+    public sealed class Settings : GenerateSettings
+    {
+        [CommandArgument(0, "<NAME>")]
+        public string Name { get; init; } = "";
+
+        [CommandOption("--duty <NAME>")]
+        [System.ComponentModel.Description("Repeatable. Duties referenced by this role.")]
+        public string[] Duties { get; init; } = Array.Empty<string>();
+
+        [CommandOption("--privilege <NAME>")]
+        [System.ComponentModel.Description("Repeatable. Privileges referenced directly by this role.")]
+        public string[] Privileges { get; init; } = Array.Empty<string>();
+
+        [CommandOption("--label <TEXT>")]
+        public string? Label { get; init; }
+
+        [CommandOption("--description <TEXT>")]
+        public string? Description { get; init; }
+
+        [CommandOption("--add-to <PATH>")]
+        [System.ComponentModel.Description("Path to an existing AxSecurityRole XML file; duties/privileges are merged in-place instead of creating a new file.")]
+        public string? AddTo { get; init; }
+    }
+
+    public override int Execute(CommandContext ctx, Settings settings)
+    {
+        var kind = OutputMode.Resolve(settings.Output);
+
+        if (!string.IsNullOrWhiteSpace(settings.AddTo))
+            return ExecuteAddTo(kind, settings);
+
+        if (string.IsNullOrWhiteSpace(settings.Name))
+            return RenderHelpers.Render(kind, ToolResult<object>.Fail(D365FoErrorCodes.BadInput, "Role name required."));
+        if (settings.Duties.Length == 0 && settings.Privileges.Length == 0)
+            return RenderHelpers.Render(kind, ToolResult<object>.Fail(
+                D365FoErrorCodes.BadInput,
+                "At least one --duty or --privilege required."));
+
+        var hasInstall = !string.IsNullOrWhiteSpace(settings.InstallTo);
+        var hasOut = !string.IsNullOrWhiteSpace(settings.Out);
+        if (!hasInstall && !hasOut)
+            return RenderHelpers.Render(kind, ToolResult<object>.Fail(D365FoErrorCodes.BadInput, "--out or --install-to is required."));
+        var outPath = settings.Out;
+        if (hasInstall && !hasOut)
+        {
+            outPath = GenerateInstaller.ResolveInstallPath(kind, "AxSecurityRole", settings.Name, settings.InstallTo!, out var fail);
+            if (fail.HasValue) return fail.Value;
+        }
+
+        var doc = XppScaffolder.Role(settings.Name, settings.Duties, settings.Privileges, settings.Label, settings.Description);
+        try
+        {
+            var res = ScaffoldFileWriter.Write(doc, outPath!, settings.Overwrite);
+            return RenderHelpers.Render(kind, ToolResult<object>.Success(new
+            {
+                kind = "AxSecurityRole",
+                name = settings.Name,
+                dutyCount = settings.Duties.Length,
+                privilegeCount = settings.Privileges.Length,
+                duties = settings.Duties,
+                privileges = settings.Privileges,
+                path = res.Path,
+                bytes = res.Bytes,
+                backup = res.BackupPath,
+                model = settings.InstallTo,
+            }));
+        }
+        catch (Exception ex)
+        {
+            return RenderHelpers.Render(kind, ToolResult<object>.Fail(D365FoErrorCodes.WriteFailed, ex.Message));
+        }
+    }
+
+    private static int ExecuteAddTo(OutputMode.Kind kind, Settings settings)
+    {
+        var path = settings.AddTo!;
+        if (!System.IO.File.Exists(path))
+            return RenderHelpers.Render(kind, ToolResult<object>.Fail(D365FoErrorCodes.BadInput, $"Role file not found: {path}"));
+        if (settings.Duties.Length == 0 && settings.Privileges.Length == 0)
+            return RenderHelpers.Render(kind, ToolResult<object>.Fail(
+                D365FoErrorCodes.BadInput,
+                "At least one --duty or --privilege required when using --add-to."));
+
+        try
+        {
+            var doc = System.Xml.Linq.XDocument.Load(path);
+            var changed = XppScaffolder.AddToRole(doc, settings.Duties, settings.Privileges);
+            if (!changed)
+            {
+                return RenderHelpers.Render(kind, ToolResult<object>.Success(new
+                {
+                    kind = "AxSecurityRole",
+                    path,
+                    changed = false,
+                    note = "All supplied duties / privileges were already referenced.",
+                }));
+            }
+
+            var tmp = path + ".tmp";
+            using (var fs = System.IO.File.Create(tmp))
+                doc.Save(fs);
+            var backup = path + ".bak";
+            if (System.IO.File.Exists(backup)) System.IO.File.Delete(backup);
+            System.IO.File.Move(path, backup);
+            System.IO.File.Move(tmp, path);
+
+            return RenderHelpers.Render(kind, ToolResult<object>.Success(new
+            {
+                kind = "AxSecurityRole",
+                path,
+                changed = true,
+                backup,
+                addedDuties = settings.Duties,
+                addedPrivileges = settings.Privileges,
+            }));
+        }
+        catch (Exception ex)
+        {
+            return RenderHelpers.Render(kind, ToolResult<object>.Fail(D365FoErrorCodes.WriteFailed, ex.Message));
+        }
+    }
+}

--- a/src/D365FO.Cli/Commands/Index/IndexCommands.cs
+++ b/src/D365FO.Cli/Commands/Index/IndexCommands.cs
@@ -21,19 +21,25 @@ public sealed class IndexBuildCommand : Command<IndexBuildCommand.Settings>
         var dir = Path.GetDirectoryName(Path.GetFullPath(cfg.DatabasePath));
         if (!string.IsNullOrEmpty(dir)) Directory.CreateDirectory(dir);
         var repo = new MetadataRepository(cfg.DatabasePath);
-        repo.EnsureSchema();
+        var applied = repo.EnsureSchema();
 
         var result = ToolResult<object>.Success(new
         {
             databasePath = cfg.DatabasePath,
             packagesPath = cfg.PackagesPath,
             schemaVersion = MetadataRepository.CurrentSchemaVersion,
-            note = "Schema ready. Run 'd365fo index extract' to ingest metadata from PACKAGES_PATH.",
+            schemaApplied = applied,
+            note = applied
+                ? $"Schema v{MetadataRepository.CurrentSchemaVersion} applied. Run 'd365fo index extract' to ingest metadata from PACKAGES_PATH."
+                : $"Schema already at v{MetadataRepository.CurrentSchemaVersion}. Run 'd365fo index extract' to ingest metadata from PACKAGES_PATH.",
         });
 
         return RenderHelpers.Render(kind, result, _ =>
         {
-            AnsiConsole.MarkupLine($"[green]OK[/] index ready at [bold]{cfg.DatabasePath}[/]");
+            if (applied)
+                AnsiConsole.MarkupLine($"[green]OK[/] schema v{MetadataRepository.CurrentSchemaVersion} applied at [bold]{cfg.DatabasePath}[/]");
+            else
+                AnsiConsole.MarkupLine($"[green]OK[/] index ready at [bold]{cfg.DatabasePath}[/] (schema v{MetadataRepository.CurrentSchemaVersion})");
             if (cfg.PackagesPath is null)
                 AnsiConsole.MarkupLine("[yellow]warn[/] D365FO_PACKAGES_PATH not set; extraction will require --packages.");
         });
@@ -89,13 +95,29 @@ public sealed class IndexExtractCommand : Command<IndexExtractCommand.Settings>
         [CommandOption("--model <NAME>")]
         [System.ComponentModel.Description("Limit extraction to a single model folder (optional).")]
         public string? OnlyModel { get; init; }
+
+        [CommandOption("--since <ISO8601>")]
+        [System.ComponentModel.Description("Skip models whose newest XML mtime is older than this timestamp. Enables mtime-based incremental refresh.")]
+        public string? Since { get; init; }
     }
 
     public override int Execute(CommandContext ctx, Settings settings)
+        => ExtractCore(
+            OutputMode.Resolve(settings.Output),
+            settings.PackagesPath,
+            settings.DatabasePath,
+            settings.OnlyModel,
+            settings.Since);
+
+    internal static int ExtractCore(
+        OutputMode.Kind kind,
+        string? packagesOverride,
+        string? databaseOverride,
+        string? onlyModel,
+        string? sinceIso)
     {
-        var kind = OutputMode.Resolve(settings.Output);
-        var cfg = D365FoSettings.FromEnvironment(settings.DatabasePath);
-        var root = settings.PackagesPath ?? cfg.PackagesPath;
+        var cfg = D365FoSettings.FromEnvironment(databaseOverride);
+        var root = packagesOverride ?? cfg.PackagesPath;
         if (string.IsNullOrWhiteSpace(root))
         {
             return RenderHelpers.Render(kind, ToolResult<object>.Fail(
@@ -109,25 +131,45 @@ public sealed class IndexExtractCommand : Command<IndexExtractCommand.Settings>
                 "PACKAGES_PATH_NOT_FOUND", $"Path does not exist: {root}"));
         }
 
-        var repo = RepoFactory.Create(settings.DatabasePath);
+        var repo = RepoFactory.Create(databaseOverride);
         var extractor = new MetadataExtractor();
         var matcher = new ModelMatcher(cfg.CustomModels);
         int modelCount = 0;
         int customCount = 0;
+        int skippedCount = 0;
+        DateTime? since = null;
+        if (!string.IsNullOrWhiteSpace(sinceIso))
+        {
+            if (!DateTime.TryParse(sinceIso, System.Globalization.CultureInfo.InvariantCulture,
+                    System.Globalization.DateTimeStyles.AssumeUniversal | System.Globalization.DateTimeStyles.AdjustToUniversal,
+                    out var sinceParsed))
+            {
+                return RenderHelpers.Render(kind, ToolResult<object>.Fail(
+                    "BAD_INPUT", $"Invalid --since timestamp: '{sinceIso}'."));
+            }
+            since = sinceParsed;
+        }
         var per = new List<object>();
+        var runSw = System.Diagnostics.Stopwatch.StartNew();
 
         // Pre-enumerate candidate model folders so we can report progress
         // *before* each model is parsed (useful when a single model like
         // ApplicationSuite takes many minutes).
-        var modelDirs = EnumerateModelDirs(root, settings.OnlyModel).ToList();
+        var modelDirs = EnumerateModelDirs(root, onlyModel).ToList();
         var showProgress = kind != OutputMode.Kind.Json && !System.Console.IsOutputRedirected;
 
-        void ProcessAll(Action<string>? onStart, Action<string, ExtractBatch>? onDone)
+        void ProcessAll(Action<string>? onStart, Action<string, ExtractBatch, long>? onDone)
         {
             foreach (var modelDir in modelDirs)
             {
                 var model = Path.GetFileName(modelDir)!;
+                if (since.HasValue && NewestMtime(modelDir) is { } newest && newest < since.Value)
+                {
+                    skippedCount++;
+                    continue;
+                }
                 onStart?.Invoke(model);
+                var sw = System.Diagnostics.Stopwatch.StartNew();
                 ExtractBatch batch;
                 try
                 {
@@ -138,6 +180,8 @@ public sealed class IndexExtractCommand : Command<IndexExtractCommand.Settings>
                     continue;
                 }
                 repo.ApplyExtract(batch);
+                sw.Stop();
+                var elapsedMs = sw.ElapsedMilliseconds;
                 modelCount++;
                 if (batch.IsCustom) customCount++;
                 per.Add(new
@@ -151,8 +195,9 @@ public sealed class IndexExtractCommand : Command<IndexExtractCommand.Settings>
                     menuItems = batch.MenuItems.Count,
                     coc = batch.CocExtensions.Count,
                     labels = batch.Labels.Count,
+                    elapsedMs,
                 });
-                onDone?.Invoke(model, batch);
+                onDone?.Invoke(model, batch, elapsedMs);
             }
         }
 
@@ -168,13 +213,14 @@ public sealed class IndexExtractCommand : Command<IndexExtractCommand.Settings>
                             var pos = modelCount + 1;
                             sctx.Status($"[[{pos}/{modelDirs.Count}]] {Markup.Escape(model)}");
                         },
-                        onDone: (model, batch) =>
+                        onDone: (model, batch, elapsedMs) =>
                         {
                             AnsiConsole.MarkupLine(
                                 $"[green]✓[/] [[{modelCount}/{modelDirs.Count}]] {Markup.Escape(model)} " +
                                 $"[grey](tables={batch.Tables.Count} classes={batch.Classes.Count} " +
                                 $"edts={batch.Edts.Count} enums={batch.Enums.Count} " +
-                                $"labels={batch.Labels.Count}{(batch.IsCustom ? " custom" : "")})[/]");
+                                $"labels={batch.Labels.Count}{(batch.IsCustom ? " custom" : "")} " +
+                                $"{elapsedMs}ms)[/]");
                         });
                 });
         }
@@ -183,16 +229,39 @@ public sealed class IndexExtractCommand : Command<IndexExtractCommand.Settings>
             ProcessAll(null, null);
         }
 
+        runSw.Stop();
         var totals = repo.CountAll();
         return RenderHelpers.Render(kind, ToolResult<object>.Success(new
         {
             packagesRoot = root,
             modelsProcessed = modelCount,
+            modelsSkipped = skippedCount,
+            since = since?.ToString("O"),
             customModelsMatched = customCount,
             customModelPatterns = cfg.CustomModels,
+            elapsedMs = runSw.ElapsedMilliseconds,
             perModel = per,
             totals,
         }));
+    }
+
+    private static DateTime? NewestMtime(string dir)
+    {
+        DateTime? max = null;
+        try
+        {
+            foreach (var f in Directory.EnumerateFiles(dir, "*.xml", SearchOption.AllDirectories))
+            {
+                try
+                {
+                    var t = File.GetLastWriteTimeUtc(f);
+                    if (!max.HasValue || t > max.Value) max = t;
+                }
+                catch { }
+            }
+        }
+        catch { }
+        return max;
     }
 
     private static IEnumerable<string> EnumerateModelDirs(string packagesRoot, string? onlyModel)
@@ -231,5 +300,54 @@ public sealed class IndexExtractCommand : Command<IndexExtractCommand.Settings>
                 yield return model;
             }
         }
+    }
+}
+
+/// <summary>
+/// Incremental refresh: runs <see cref="IndexExtractCommand"/> but seeds
+/// <c>--since</c> from the index DB file's last-write timestamp (with a
+/// 5-minute safety lookback). Models whose XMLs haven't changed since the
+/// last extract are skipped — turning a full multi-minute rescan into a
+/// couple of seconds on a warm workspace.
+/// </summary>
+public sealed class IndexRefreshCommand : Command<IndexRefreshCommand.Settings>
+{
+    public sealed class Settings : D365OutputSettings
+    {
+        [CommandOption("--packages <PATH>")]
+        public string? PackagesPath { get; init; }
+
+        [CommandOption("--db <PATH>")]
+        public string? DatabasePath { get; init; }
+
+        [CommandOption("--model <NAME>")]
+        public string? OnlyModel { get; init; }
+
+        [CommandOption("--since <ISO8601>")]
+        public string? Since { get; init; }
+
+        [CommandOption("--force")]
+        [System.ComponentModel.Description("Ignore any computed threshold and re-extract every model.")]
+        public bool Force { get; init; }
+    }
+
+    public override int Execute(CommandContext ctx, Settings settings)
+    {
+        var since = settings.Since;
+        if (!settings.Force && string.IsNullOrWhiteSpace(since))
+        {
+            var cfg = D365FoSettings.FromEnvironment(settings.DatabasePath);
+            if (File.Exists(cfg.DatabasePath))
+            {
+                var dbMtime = File.GetLastWriteTimeUtc(cfg.DatabasePath);
+                since = (dbMtime - TimeSpan.FromMinutes(5)).ToString("O");
+            }
+        }
+        return IndexExtractCommand.ExtractCore(
+            OutputMode.Resolve(settings.Output),
+            settings.PackagesPath,
+            settings.DatabasePath,
+            settings.OnlyModel,
+            since);
     }
 }

--- a/src/D365FO.Cli/Commands/Label/LabelWriteCommands.cs
+++ b/src/D365FO.Cli/Commands/Label/LabelWriteCommands.cs
@@ -1,0 +1,153 @@
+using D365FO.Core;
+using D365FO.Core.Labels;
+using Spectre.Console.Cli;
+
+namespace D365FO.Cli.Commands.Label;
+
+/// <summary>
+/// <c>d365fo label create|update|rename|delete</c> — in-place edits of
+/// <c>*.label.txt</c> resource files. ROADMAP §4.2.
+/// </summary>
+public sealed class LabelCreateCommand : Command<LabelCreateCommand.Settings>
+{
+    public sealed class Settings : D365OutputSettings
+    {
+        [CommandArgument(0, "<KEY>")]
+        public string Key { get; init; } = "";
+
+        [CommandArgument(1, "<VALUE>")]
+        public string Value { get; init; } = "";
+
+        [CommandOption("--file <PATH>")]
+        [System.ComponentModel.Description("Target <Name>.<lang>.label.txt file. Created if missing.")]
+        public string? File { get; init; }
+
+        [CommandOption("--overwrite")]
+        [System.ComponentModel.Description("Replace an existing value. Default: fail with KEY_EXISTS.")]
+        public bool Overwrite { get; init; }
+    }
+
+    public override int Execute(CommandContext ctx, Settings settings)
+    {
+        var kind = OutputMode.Resolve(settings.Output);
+        if (string.IsNullOrWhiteSpace(settings.Key))
+            return RenderHelpers.Render(kind, ToolResult<object>.Fail(D365FoErrorCodes.BadInput, "Label key required."));
+        if (string.IsNullOrWhiteSpace(settings.File))
+            return RenderHelpers.Render(kind, ToolResult<object>.Fail(D365FoErrorCodes.BadInput, "--file <PATH> required."));
+
+        try
+        {
+            var res = LabelFileWriter.CreateOrUpdate(settings.File!, settings.Key, settings.Value, settings.Overwrite);
+            if (res.Outcome == WriteOutcome.KeyExists)
+                return RenderHelpers.Render(kind, ToolResult<object>.Fail(
+                    "KEY_EXISTS",
+                    $"Label '{settings.Key}' already exists. Pass --overwrite to replace.",
+                    hint: $"Existing value: {res.OldValue}"));
+
+            return RenderHelpers.Render(kind, ToolResult<object>.Success(new
+            {
+                outcome = res.Outcome.ToString(),
+                file = res.Path,
+                key = res.Key,
+                oldValue = res.OldValue,
+                newValue = res.NewValue,
+            }));
+        }
+        catch (Exception ex)
+        {
+            return RenderHelpers.Render(kind, ToolResult<object>.Fail(D365FoErrorCodes.WriteFailed, ex.Message));
+        }
+    }
+}
+
+public sealed class LabelRenameCommand : Command<LabelRenameCommand.Settings>
+{
+    public sealed class Settings : D365OutputSettings
+    {
+        [CommandArgument(0, "<OLD>")]
+        public string OldKey { get; init; } = "";
+
+        [CommandArgument(1, "<NEW>")]
+        public string NewKey { get; init; } = "";
+
+        [CommandOption("--file <PATH>")]
+        public string? File { get; init; }
+
+        [CommandOption("--overwrite")]
+        public bool Overwrite { get; init; }
+    }
+
+    public override int Execute(CommandContext ctx, Settings settings)
+    {
+        var kind = OutputMode.Resolve(settings.Output);
+        if (string.IsNullOrWhiteSpace(settings.OldKey) || string.IsNullOrWhiteSpace(settings.NewKey))
+            return RenderHelpers.Render(kind, ToolResult<object>.Fail(D365FoErrorCodes.BadInput, "Both <OLD> and <NEW> label keys required."));
+        if (string.IsNullOrWhiteSpace(settings.File))
+            return RenderHelpers.Render(kind, ToolResult<object>.Fail(D365FoErrorCodes.BadInput, "--file <PATH> required."));
+
+        try
+        {
+            var res = LabelFileWriter.Rename(settings.File!, settings.OldKey, settings.NewKey, settings.Overwrite);
+            return res.Outcome switch
+            {
+                WriteOutcome.FileMissing => RenderHelpers.Render(kind, ToolResult<object>.Fail("FILE_NOT_FOUND", $"Label file not found: {settings.File}")),
+                WriteOutcome.KeyMissing => RenderHelpers.Render(kind, ToolResult<object>.Fail("KEY_NOT_FOUND", $"Label '{settings.OldKey}' not present in file.")),
+                WriteOutcome.KeyExists => RenderHelpers.Render(kind, ToolResult<object>.Fail("KEY_EXISTS", $"Target key '{settings.NewKey}' already exists. Pass --overwrite to replace.")),
+                _ => RenderHelpers.Render(kind, ToolResult<object>.Success(new
+                {
+                    outcome = res.Outcome.ToString(),
+                    file = res.Path,
+                    oldKey = settings.OldKey,
+                    newKey = settings.NewKey,
+                    value = res.NewValue,
+                })),
+            };
+        }
+        catch (Exception ex)
+        {
+            return RenderHelpers.Render(kind, ToolResult<object>.Fail(D365FoErrorCodes.WriteFailed, ex.Message));
+        }
+    }
+}
+
+public sealed class LabelDeleteCommand : Command<LabelDeleteCommand.Settings>
+{
+    public sealed class Settings : D365OutputSettings
+    {
+        [CommandArgument(0, "<KEY>")]
+        public string Key { get; init; } = "";
+
+        [CommandOption("--file <PATH>")]
+        public string? File { get; init; }
+    }
+
+    public override int Execute(CommandContext ctx, Settings settings)
+    {
+        var kind = OutputMode.Resolve(settings.Output);
+        if (string.IsNullOrWhiteSpace(settings.Key))
+            return RenderHelpers.Render(kind, ToolResult<object>.Fail(D365FoErrorCodes.BadInput, "Label key required."));
+        if (string.IsNullOrWhiteSpace(settings.File))
+            return RenderHelpers.Render(kind, ToolResult<object>.Fail(D365FoErrorCodes.BadInput, "--file <PATH> required."));
+
+        try
+        {
+            var res = LabelFileWriter.Delete(settings.File!, settings.Key);
+            return res.Outcome switch
+            {
+                WriteOutcome.FileMissing => RenderHelpers.Render(kind, ToolResult<object>.Fail("FILE_NOT_FOUND", $"Label file not found: {settings.File}")),
+                WriteOutcome.KeyMissing => RenderHelpers.Render(kind, ToolResult<object>.Fail("KEY_NOT_FOUND", $"Label '{settings.Key}' not present in file.")),
+                _ => RenderHelpers.Render(kind, ToolResult<object>.Success(new
+                {
+                    outcome = res.Outcome.ToString(),
+                    file = res.Path,
+                    key = res.Key,
+                    removedValue = res.OldValue,
+                })),
+            };
+        }
+        catch (Exception ex)
+        {
+            return RenderHelpers.Render(kind, ToolResult<object>.Fail(D365FoErrorCodes.WriteFailed, ex.Message));
+        }
+    }
+}

--- a/src/D365FO.Cli/Commands/Lint/LintCommand.cs
+++ b/src/D365FO.Cli/Commands/Lint/LintCommand.cs
@@ -1,0 +1,177 @@
+using D365FO.Core;
+using D365FO.Core.Index;
+using Spectre.Console;
+using Spectre.Console.Cli;
+using System.Text.Json;
+
+namespace D365FO.Cli.Commands.Lint;
+
+/// <summary>
+/// In-process Best-Practice gate. Corresponds to ROADMAP §7.1.
+/// Categories today: <c>table-no-index</c>, <c>ext-named-not-attributed</c>,
+/// <c>string-without-edt</c>. More will land as the index gains coverage
+/// (e.g. UI literal strings once forms carry their label text).
+/// </summary>
+public sealed class LintCommand : Command<LintCommand.Settings>
+{
+    public sealed class Settings : D365OutputSettings
+    {
+        [CommandOption("--category <NAMES>")]
+        [System.ComponentModel.Description("Comma/semicolon-separated subset of: table-no-index, ext-named-not-attributed, string-without-edt.")]
+        public string? Category { get; init; }
+
+        [CommandOption("--all-models")]
+        [System.ComponentModel.Description("Include platform/ISV models. By default only IsCustom models are linted.")]
+        public bool AllModels { get; init; }
+
+        [CommandOption("--format <FMT>")]
+        [System.ComponentModel.Description("Output shape: default envelope (json|table|raw) or 'sarif' for SARIF 2.1.0 (CI-friendly).")]
+        public string? Format { get; init; }
+    }
+
+    private static readonly string[] All =
+        { "table-no-index", "ext-named-not-attributed", "string-without-edt" };
+
+    public override int Execute(CommandContext ctx, Settings settings)
+    {
+        var kind = OutputMode.Resolve(settings.Output);
+        var repo = RepoFactory.Create();
+        var categories = (settings.Category ?? "")
+            .Split(new[] { ',', ';' }, StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries)
+            .Select(s => s.ToLowerInvariant())
+            .ToArray();
+        var run = categories.Length == 0 ? All : categories;
+        var onlyCustom = !settings.AllModels;
+
+        var hitsByCat = new Dictionary<string, IReadOnlyList<LintHit>>();
+        foreach (var cat in run)
+        {
+            IReadOnlyList<LintHit> hits = cat switch
+            {
+                "table-no-index" => repo.FindTablesWithoutIndex(onlyCustom),
+                "ext-named-not-attributed" => repo.FindExtensionNamedButNotAttributed(onlyCustom),
+                "string-without-edt" => repo.FindStringFieldsWithoutEdt(onlyCustom),
+                _ => Array.Empty<LintHit>(),
+            };
+            hitsByCat[cat] = hits;
+        }
+
+        // SARIF 2.1.0 short-circuits the normal envelope: tooling (e.g. GitHub Code Scanning,
+        // VS Code SARIF viewer) expects a raw SARIF document on stdout.
+        if (string.Equals(settings.Format, "sarif", StringComparison.OrdinalIgnoreCase))
+        {
+            var sarif = BuildSarif(hitsByCat);
+            Console.WriteLine(JsonSerializer.Serialize(sarif, new JsonSerializerOptions { WriteIndented = true }));
+            return hitsByCat.Values.Sum(l => l.Count) == 0 ? 0 : 0; // BP findings are not a build failure by default
+        }
+
+        var sections = new List<object>();
+        int total = 0;
+        foreach (var cat in run)
+        {
+            var hits = hitsByCat[cat];
+            total += hits.Count;
+            sections.Add(new
+            {
+                category = cat,
+                count = hits.Count,
+                items = hits.Select(h => new { target = h.TargetName, model = h.Model, detail = h.Detail }),
+            });
+        }
+
+        var result = ToolResult<object>.Success(new
+        {
+            onlyCustomModels = onlyCustom,
+            categories = run,
+            totalFindings = total,
+            sections,
+        });
+
+        return RenderHelpers.Render(kind, result, _ =>
+        {
+            foreach (var s in run)
+            {
+                var count = ((dynamic)sections.First(x => ((dynamic)x).category == s)).count;
+                var colour = count == 0 ? "green" : "yellow";
+                AnsiConsole.MarkupLine($"[{colour}]{count}[/] [bold]{s}[/]");
+            }
+        });
+    }
+
+    private static readonly Dictionary<string, (string Level, string Name, string Help)> RuleMeta = new()
+    {
+        ["table-no-index"] = ("warning", "TableWithoutIndex",
+            "Tables should have at least one cluster/alternate index for predictable query plans."),
+        ["ext-named-not-attributed"] = ("error", "ExtensionClassMissingAttribute",
+            "Classes named '*_Extension' must carry [ExtensionOf(...)] or CoC / event-handler attributes."),
+        ["string-without-edt"] = ("warning", "StringFieldWithoutEdt",
+            "String fields should use an Extended Data Type so they inherit length/label/help centrally."),
+    };
+
+    private static object BuildSarif(Dictionary<string, IReadOnlyList<LintHit>> hitsByCat)
+    {
+        var assembly = typeof(LintCommand).Assembly;
+        var version = assembly.GetName().Version?.ToString() ?? "0.0.0";
+
+        var rules = hitsByCat.Keys
+            .Where(RuleMeta.ContainsKey)
+            .Select(cat =>
+            {
+                var (level, name, help) = RuleMeta[cat];
+                return new
+                {
+                    id = cat,
+                    name,
+                    shortDescription = new { text = name },
+                    fullDescription = new { text = help },
+                    defaultConfiguration = new { level },
+                    helpUri = "https://github.com/dsg-tech/d365fo-cli/blob/main/docs/ROADMAP.md#7-code-quality--best-practices",
+                };
+            })
+            .ToArray();
+
+        var results = hitsByCat.SelectMany(kv => kv.Value.Select(h =>
+        {
+            var level = RuleMeta.TryGetValue(kv.Key, out var meta) ? meta.Level : "warning";
+            return new
+            {
+                ruleId = kv.Key,
+                level,
+                message = new { text = $"{h.TargetName}: {h.Detail} (model: {h.Model})" },
+                locations = new[]
+                {
+                    new
+                    {
+                        logicalLocations = new[]
+                        {
+                            new { name = h.TargetName, kind = "module" }
+                        }
+                    }
+                },
+            };
+        })).ToArray();
+
+        return new Dictionary<string, object?>
+        {
+            ["$schema"] = "https://raw.githubusercontent.com/oasis-tcs/sarif-spec/master/Schemata/sarif-schema-2.1.0.json",
+            ["version"] = "2.1.0",
+            ["runs"] = new[]
+            {
+                new
+                {
+                    tool = new
+                    {
+                        driver = new
+                        {
+                            name = "d365fo-cli-lint",
+                            version,
+                            informationUri = "https://github.com/dsg-tech/d365fo-cli",
+                            rules,
+                        }
+                    },
+                    results,
+                }
+            }
+        };
+    }
+}

--- a/src/D365FO.Cli/Commands/Ops/InitCommand.cs
+++ b/src/D365FO.Cli/Commands/Ops/InitCommand.cs
@@ -1,0 +1,232 @@
+using D365FO.Core;
+using D365FO.Core.Index;
+using Spectre.Console;
+using Spectre.Console.Cli;
+
+namespace D365FO.Cli.Commands.Ops;
+
+/// <summary>
+/// Quickstart: emits a JSON run report listing the effective settings,
+/// detects <c>PackagesLocalDirectory</c> automatically, and optionally
+/// runs <c>index build</c> + <c>index extract</c>. Replaces the copy-paste
+/// shell snippet documented in <c>docs/SETUP.md#quickstart-script</c>.
+/// </summary>
+public sealed class InitCommand : Command<InitCommand.Settings>
+{
+    public sealed class Settings : D365OutputSettings
+    {
+        [CommandOption("--packages <PATH>")]
+        [System.ComponentModel.Description("Explicit PackagesLocalDirectory path. Skips auto-detect.")]
+        public string? PackagesPath { get; init; }
+
+        [CommandOption("--db <PATH>")]
+        public string? DatabasePath { get; init; }
+
+        [CommandOption("--run-extract")]
+        [System.ComponentModel.Description("Immediately walk packages + populate the index (equivalent to a follow-up 'index build' + 'index extract').")]
+        public bool RunExtract { get; init; }
+
+        [CommandOption("--dry-run")]
+        [System.ComponentModel.Description("Report discovered paths without touching disk.")]
+        public bool DryRun { get; init; }
+
+        [CommandOption("--persist-profile")]
+        [System.ComponentModel.Description("Append D365FO_PACKAGES_PATH / D365FO_INDEX_DB to the user's shell profile (PowerShell $PROFILE on Windows, ~/.profile otherwise).")]
+        public bool PersistProfile { get; init; }
+    }
+
+    private static readonly string[] CandidateRoots =
+    {
+        @"C:\AosService\PackagesLocalDirectory",
+        @"K:\AosService\PackagesLocalDirectory",
+        @"J:\AosService\PackagesLocalDirectory",
+        @"C:\PackagesLocalDirectory",
+    };
+
+    public override int Execute(CommandContext ctx, Settings settings)
+    {
+        var kind = OutputMode.Resolve(settings.Output);
+        var cfg = D365FoSettings.FromEnvironment(settings.DatabasePath);
+
+        var packages = settings.PackagesPath ?? cfg.PackagesPath ?? AutoDetectPackages();
+        var workspace = cfg.WorkspacePath ?? (packages is null ? null : Path.GetFullPath(Path.Combine(packages, "..")));
+        var steps = new List<object>();
+
+        void Log(string name, bool ok, string? detail = null, string? hint = null)
+            => steps.Add(new { step = name, ok, detail, hint });
+
+        Log("resolve.packages", packages is not null,
+            detail: packages,
+            hint: packages is null ? "Pass --packages <PATH> or set D365FO_PACKAGES_PATH." : null);
+        Log("resolve.workspace", workspace is not null, workspace);
+        Log("resolve.database", !string.IsNullOrEmpty(cfg.DatabasePath), cfg.DatabasePath);
+
+        if (!settings.DryRun && packages is not null)
+        {
+            try
+            {
+                var dir = Path.GetDirectoryName(Path.GetFullPath(cfg.DatabasePath));
+                if (!string.IsNullOrEmpty(dir)) Directory.CreateDirectory(dir);
+                var repo = new MetadataRepository(cfg.DatabasePath);
+                var applied = repo.EnsureSchema();
+                Log("index.schema", true, applied ? $"Applied v{MetadataRepository.CurrentSchemaVersion}" : $"Already v{MetadataRepository.CurrentSchemaVersion}");
+            }
+            catch (Exception ex)
+            {
+                Log("index.schema", false, ex.Message);
+            }
+        }
+
+        int extractExit = 0;
+        if (settings.RunExtract && packages is not null && !settings.DryRun)
+        {
+            try
+            {
+                Log("index.extract", true, "Starting…");
+                extractExit = D365FO.Cli.Commands.Index.IndexExtractCommand.ExtractCore(
+                    OutputMode.Kind.Json, packages, cfg.DatabasePath, null, null);
+                Log("index.extract.done", extractExit == 0, extractExit == 0 ? "ok" : $"exit code {extractExit}");
+            }
+            catch (Exception ex)
+            {
+                Log("index.extract.done", false, ex.Message);
+            }
+        }
+
+        string? profilePath = null;
+        if (settings.PersistProfile && packages is not null)
+        {
+            try
+            {
+                profilePath = ResolveProfilePath();
+                if (settings.DryRun)
+                {
+                    Log("profile.persist", true, $"Would append to {profilePath} (dry-run).");
+                }
+                else
+                {
+                    var vars = new Dictionary<string, string>
+                    {
+                        ["D365FO_PACKAGES_PATH"] = packages!,
+                        ["D365FO_INDEX_DB"] = cfg.DatabasePath,
+                    };
+                    if (!string.IsNullOrEmpty(workspace))
+                        vars["D365FO_WORKSPACE"] = workspace;
+                    var added = WriteProfileBlock(profilePath, vars);
+                    Log("profile.persist", true, added
+                        ? $"Appended d365fo-cli block to {profilePath}"
+                        : $"Profile block already present in {profilePath}");
+                }
+            }
+            catch (Exception ex)
+            {
+                Log("profile.persist", false, ex.Message);
+            }
+        }
+
+        var ok = steps.Cast<dynamic>().All(s => (bool)s.ok);
+        var payload = ok
+            ? ToolResult<object>.Success(new
+            {
+                packages,
+                workspace,
+                database = cfg.DatabasePath,
+                dryRun = settings.DryRun,
+                extracted = settings.RunExtract && !settings.DryRun && extractExit == 0,
+                nextSteps = new[]
+                {
+                    "Set D365FO_PACKAGES_PATH to persist the discovered path.",
+                    "Run 'd365fo index extract' to ingest metadata.",
+                    "Run 'd365fo doctor' to verify environment.",
+                },
+                steps,
+            })
+            : ToolResult<object>.Fail(D365FoErrorCodes.DoctorFailed, "Init completed with errors.",
+                hint: "See 'data.steps' (use --output json) for details.");
+
+        return RenderHelpers.Render(kind, payload, _ =>
+        {
+            foreach (dynamic s in steps)
+            {
+                var tick = (bool)s.ok ? "[green]✓[/]" : "[red]✗[/]";
+                var detail = s.detail is null ? "" : $" [grey]— {RenderHelpers.Escape((string)s.detail)}[/]";
+                AnsiConsole.MarkupLine($"{tick} {s.step}{detail}");
+            }
+            if (ok)
+                AnsiConsole.MarkupLine("[green]Init complete.[/] Run 'd365fo doctor' to verify.");
+        });
+    }
+
+    private static string? AutoDetectPackages()
+    {
+        if (!OperatingSystem.IsWindows()) return null;
+        foreach (var c in CandidateRoots)
+            if (Directory.Exists(c)) return c;
+        return null;
+    }
+
+    // ---- profile persistence -----------------------------------------
+
+    private const string BlockBegin = "# >>> d365fo-cli init (auto-generated) >>>";
+    private const string BlockEnd   = "# <<< d365fo-cli init <<<";
+
+    /// <summary>Pick the canonical shell profile for the current OS.</summary>
+    internal static string ResolveProfilePath()
+    {
+        if (OperatingSystem.IsWindows())
+        {
+            // PowerShell 5.1 + 7 agree on this path.
+            var docs = Environment.GetFolderPath(Environment.SpecialFolder.MyDocuments);
+            return Path.Combine(docs, "PowerShell", "Microsoft.PowerShell_profile.ps1");
+        }
+        var home = Environment.GetEnvironmentVariable("HOME") ?? "~";
+        return Path.Combine(home, ".profile");
+    }
+
+    /// <summary>
+    /// Append (or replace) a marker-delimited block of env-var exports to the
+    /// profile. Returns <c>true</c> when the block was added / refreshed;
+    /// <c>false</c> when it was already present with identical contents.
+    /// Idempotent — safe to re-run.
+    /// </summary>
+    internal static bool WriteProfileBlock(string profilePath, IReadOnlyDictionary<string, string> vars)
+    {
+        var dir = Path.GetDirectoryName(profilePath);
+        if (!string.IsNullOrEmpty(dir)) Directory.CreateDirectory(dir);
+
+        var isPowerShell = profilePath.EndsWith(".ps1", StringComparison.OrdinalIgnoreCase);
+        var newBlock = BuildBlock(vars, isPowerShell);
+        var existing = File.Exists(profilePath) ? File.ReadAllText(profilePath) : "";
+
+        var startIdx = existing.IndexOf(BlockBegin, StringComparison.Ordinal);
+        var endIdx = existing.IndexOf(BlockEnd, StringComparison.Ordinal);
+        if (startIdx >= 0 && endIdx > startIdx)
+        {
+            var oldBlock = existing.Substring(startIdx, endIdx + BlockEnd.Length - startIdx);
+            if (string.Equals(oldBlock, newBlock, StringComparison.Ordinal))
+                return false;
+            var replaced = existing.Remove(startIdx, endIdx + BlockEnd.Length - startIdx).Insert(startIdx, newBlock);
+            File.WriteAllText(profilePath, replaced);
+            return true;
+        }
+
+        var sep = existing.Length == 0 || existing.EndsWith('\n') ? "" : Environment.NewLine;
+        File.AppendAllText(profilePath, sep + Environment.NewLine + newBlock + Environment.NewLine);
+        return true;
+    }
+
+    private static string BuildBlock(IReadOnlyDictionary<string, string> vars, bool isPowerShell)
+    {
+        var sb = new System.Text.StringBuilder();
+        sb.AppendLine(BlockBegin);
+        foreach (var (k, v) in vars)
+        {
+            if (isPowerShell)
+                sb.AppendLine($"$env:{k} = '{v.Replace("'", "''")}'");
+            else
+                sb.AppendLine($"export {k}=\"{v.Replace("\"", "\\\"")}\"");
+        }
+        sb.Append(BlockEnd);
+        return sb.ToString();
+    }
+}

--- a/src/D365FO.Cli/Commands/Search/SearchCommands.cs
+++ b/src/D365FO.Cli/Commands/Search/SearchCommands.cs
@@ -52,6 +52,10 @@ public sealed class SearchLabelCommand : Command<SearchLabelCommand.Settings>
 
         [CommandOption("-l|--limit <N>")]
         public int Limit { get; init; } = 100;
+
+        [CommandOption("--fts")]
+        [System.ComponentModel.Description("Use SQLite FTS5 ranking (phrase queries, NEAR, column filters). Falls back to LIKE if FTS5 is unavailable.")]
+        public bool Fts { get; init; }
     }
 
     public override int Execute(CommandContext context, Settings settings)
@@ -62,7 +66,9 @@ public sealed class SearchLabelCommand : Command<SearchLabelCommand.Settings>
             ? null
             : settings.Languages.Split([',', ';'], StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries);
 
-        var matches = repo.SearchLabels(settings.Query, langs, settings.Limit);
+        var matches = settings.Fts
+            ? repo.SearchLabelsFts(settings.Query, langs, settings.Limit)
+            : repo.SearchLabels(settings.Query, langs, settings.Limit);
         if (!settings.RawText)
         {
             matches = matches.Select(m => m with { Value = StringSanitizer.Sanitize(m.Value) }).ToList();
@@ -242,6 +248,42 @@ public sealed class SearchWorkflowCommand : Command<SearchWorkflowCommand.Settin
         var kind = OutputMode.Resolve(settings.Output);
         var items = RepoFactory.Create().SearchWorkflowTypes(settings.Query, settings.Limit);
         return RenderHelpers.Render(kind, ToolResult<object>.Success(new { count = items.Count, items }));
+    }
+}
+
+/// <summary>
+/// Scope-agnostic quick jump across every indexed kind. Corresponds to
+/// upstream MCP <c>search</c> and fulfils ROADMAP item 4.3.
+/// </summary>
+public sealed class SearchAnyCommand : Command<SearchAnyCommand.Settings>
+{
+    public sealed class Settings : D365OutputSettings
+    {
+        [CommandArgument(0, "<QUERY>")]
+        [System.ComponentModel.Description("Substring to look up across Tables / Classes / EDTs / Enums / MenuItems / Forms / Queries / Views / DataEntities / Reports / Services / Workflows.")]
+        public string Query { get; init; } = "";
+
+        [CommandOption("-l|--limit <N>")]
+        public int Limit { get; init; } = 100;
+    }
+
+    public override int Execute(CommandContext ctx, Settings settings)
+    {
+        var kind = OutputMode.Resolve(settings.Output);
+        if (string.IsNullOrWhiteSpace(settings.Query))
+            return RenderHelpers.Render(kind, ToolResult<object>.Fail("BAD_INPUT", "Query required."));
+
+        var repo = RepoFactory.Create();
+        var rows = repo.FindUsages(settings.Query, settings.Limit)
+            .Select(t => new { kind = t.Kind, name = t.Name, model = t.Model })
+            .ToList();
+        var byKind = rows.GroupBy(r => r.kind).ToDictionary(g => g.Key, g => g.Count());
+        return RenderHelpers.Render(kind, ToolResult<object>.Success(new
+        {
+            count = rows.Count,
+            byKind,
+            items = rows,
+        }));
     }
 }
 

--- a/src/D365FO.Cli/Commands/Stats/StatsCommand.cs
+++ b/src/D365FO.Cli/Commands/Stats/StatsCommand.cs
@@ -1,0 +1,68 @@
+using D365FO.Core;
+using D365FO.Core.Index;
+using Spectre.Console;
+using Spectre.Console.Cli;
+
+namespace D365FO.Cli.Commands.Stats;
+
+/// <summary>
+/// Parametric aggregation over the metadata index. Corresponds to
+/// ROADMAP §4.2 and upstream MCP <c>analyze_code_patterns</c>-style
+/// overviews.
+/// </summary>
+public sealed class StatsCommand : Command<StatsCommand.Settings>
+{
+    public sealed class Settings : D365OutputSettings
+    {
+        [CommandOption("-n|--top <N>")]
+        [System.ComponentModel.Description("Rows to return per ranking section (default 10).")]
+        public int TopN { get; init; } = 10;
+    }
+
+    public override int Execute(CommandContext ctx, Settings settings)
+    {
+        var kind = OutputMode.Resolve(settings.Output);
+        var repo = RepoFactory.Create();
+        var stats = repo.GetStats(settings.TopN);
+        var counts = repo.CountAll();
+
+        var result = ToolResult<object>.Success(new
+        {
+            totals = counts,
+            perModel = stats.PerModel.Select(m => new
+            {
+                model = m.Model,
+                isCustom = m.IsCustom,
+                tables = m.Tables,
+                classes = m.Classes,
+                edts = m.Edts,
+                enums = m.Enums,
+                menuItems = m.MenuItems,
+                forms = m.Forms,
+                extensions = m.Extensions,
+                coc = m.Coc,
+                labels = m.Labels,
+            }),
+            topTables = stats.TopTables,
+            topClasses = stats.TopClasses,
+            topCocTargets = stats.TopCocTargets,
+        });
+
+        return RenderHelpers.Render(kind, result, _ =>
+        {
+            AnsiConsole.MarkupLine($"[bold]Index totals[/] — models=[green]{counts.Models}[/] tables=[green]{counts.Tables}[/] classes=[green]{counts.Classes}[/] labels=[green]{counts.Labels}[/]");
+
+            var topTable = new Table().AddColumns("Top table (fields)", "model", "fields");
+            foreach (var t in stats.TopTables) topTable.AddRow(t.Name, t.Model, t.FieldCount.ToString());
+            AnsiConsole.Write(topTable);
+
+            var topClass = new Table().AddColumns("Top class (methods)", "model", "methods");
+            foreach (var c in stats.TopClasses) topClass.AddRow(c.Name, c.Model, c.MethodCount.ToString());
+            AnsiConsole.Write(topClass);
+
+            var topCoc = new Table().AddColumns("Top CoC target", "extensions");
+            foreach (var c in stats.TopCocTargets) topCoc.AddRow(c.Target, c.ExtensionCount.ToString());
+            AnsiConsole.Write(topCoc);
+        });
+    }
+}

--- a/src/D365FO.Cli/Commands/Suggest/SuggestCommands.cs
+++ b/src/D365FO.Cli/Commands/Suggest/SuggestCommands.cs
@@ -1,0 +1,47 @@
+using D365FO.Core;
+using Spectre.Console.Cli;
+
+namespace D365FO.Cli.Commands.Suggest;
+
+/// <summary>
+/// Suggests indexed Extended Data Types for a field name using name
+/// similarity heuristics. Mirrors upstream MCP <c>suggest_edt</c>.
+/// </summary>
+public sealed class SuggestEdtCommand : Command<SuggestEdtCommand.Settings>
+{
+    public sealed class Settings : D365OutputSettings
+    {
+        [CommandArgument(0, "<FIELDNAME>")]
+        [System.ComponentModel.Description("Field name to suggest an EDT for, e.g. CustomerAccount, OrderAmount.")]
+        public string FieldName { get; init; } = "";
+
+        [CommandOption("-l|--limit <N>")]
+        public int Limit { get; init; } = 5;
+    }
+
+    public override int Execute(CommandContext ctx, Settings settings)
+    {
+        var kind = OutputMode.Resolve(settings.Output);
+        if (string.IsNullOrWhiteSpace(settings.FieldName))
+            return RenderHelpers.Render(kind, ToolResult<object>.Fail("BAD_INPUT", "Field name required."));
+
+        var suggestions = EdtSuggester.Suggest(RepoFactory.Create(), settings.FieldName, settings.Limit)
+            .Select(s => new
+            {
+                name = s.Edt.Name,
+                model = s.Edt.Model,
+                extends = s.Edt.Extends,
+                baseType = s.Edt.BaseType,
+                stringSize = s.Edt.StringSize,
+                confidence = s.Confidence,
+                reason = s.Reason,
+            })
+            .ToList();
+        return RenderHelpers.Render(kind, ToolResult<object>.Success(new
+        {
+            fieldName = settings.FieldName,
+            count = suggestions.Count,
+            suggestions,
+        }));
+    }
+}

--- a/src/D365FO.Cli/Commands/Validate/ValidateNameCommand.cs
+++ b/src/D365FO.Cli/Commands/Validate/ValidateNameCommand.cs
@@ -1,0 +1,42 @@
+using D365FO.Core;
+using Spectre.Console.Cli;
+
+namespace D365FO.Cli.Commands.Validate;
+
+/// <summary>
+/// Static naming-rule check. Mirrors upstream MCP tool
+/// <c>validate_object_naming</c> — compile-free gate for scaffold names
+/// before they hit the workspace.
+/// </summary>
+public sealed class ValidateNameCommand : Command<ValidateNameCommand.Settings>
+{
+    public sealed class Settings : D365OutputSettings
+    {
+        [CommandArgument(0, "<KIND>")]
+        [System.ComponentModel.Description("Object kind: Table, Class, Edt, Enum, Form, View, Query, Report, Entity, Service, MenuItem, TableExtension, FormExtension, Coc.")]
+        public string Kind { get; init; } = "";
+
+        [CommandArgument(1, "<NAME>")]
+        public string Name { get; init; } = "";
+
+        [CommandOption("--prefix <PREFIX>")]
+        [System.ComponentModel.Description("Required publisher prefix (e.g. Contoso_). Reports MISSING_PUBLISHER_PREFIX if missing.")]
+        public string? Prefix { get; init; }
+    }
+
+    public override int Execute(CommandContext ctx, Settings settings)
+    {
+        var kind = OutputMode.Resolve(settings.Output);
+        var violations = ObjectNamingRules.Validate(settings.Kind, settings.Name, settings.Prefix);
+        var hasError = violations.Any(v => v.Severity == "error");
+        return RenderHelpers.Render(kind, ToolResult<object>.Success(new
+        {
+            objectKind = settings.Kind,
+            name = settings.Name,
+            prefix = settings.Prefix,
+            ok = !hasError,
+            count = violations.Count,
+            violations = violations.Select(v => new { code = v.Code, severity = v.Severity, message = v.Message }),
+        }));
+    }
+}

--- a/src/D365FO.Cli/Program.cs
+++ b/src/D365FO.Cli/Program.cs
@@ -10,6 +10,10 @@ using D365FO.Cli.Commands.Read;
 using D365FO.Cli.Commands.Resolve;
 using D365FO.Cli.Commands.Review;
 using D365FO.Cli.Commands.Search;
+using D365FO.Cli.Commands.Stats;
+using D365FO.Cli.Commands.Suggest;
+using D365FO.Cli.Commands.Validate;
+using D365FO.Cli.Commands.Lint;
 using Spectre.Console.Cli;
 
 var app = new CommandApp();
@@ -34,6 +38,7 @@ app.Configure(cfg =>
         b.AddCommand<SearchReportCommand>("report").WithDescription("Find SSRS / RDL reports.");
         b.AddCommand<SearchServiceCommand>("service").WithDescription("Find SOAP services.");
         b.AddCommand<SearchWorkflowCommand>("workflow").WithDescription("Find workflow types.");
+        b.AddCommand<SearchAnyCommand>("any").WithDescription("Scope-agnostic search across every indexed kind.");
     });
 
     cfg.AddBranch("get", b =>
@@ -75,6 +80,26 @@ app.Configure(cfg =>
         b.AddCommand<ResolveLabelCommand>("label").WithDescription("Resolve @SYS12345-style label token to its text.");
     });
 
+    cfg.AddBranch("suggest", b =>
+    {
+        b.SetDescription("Heuristic suggestions over the index (no scaffolding).");
+        b.AddCommand<SuggestEdtCommand>("edt").WithDescription("Suggest EDTs matching a field name.");
+    });
+
+    cfg.AddBranch("validate", b =>
+    {
+        b.SetDescription("Static checks without touching the filesystem.");
+        b.AddCommand<ValidateNameCommand>("name").WithDescription("Check object name against naming conventions.");
+    });
+
+    cfg.AddBranch("label", b =>
+    {
+        b.SetDescription("Edit *.label.txt resource files in-place.");
+        b.AddCommand<D365FO.Cli.Commands.Label.LabelCreateCommand>("create").WithDescription("Create or update a label entry.");
+        b.AddCommand<D365FO.Cli.Commands.Label.LabelRenameCommand>("rename").WithDescription("Rename a label key.");
+        b.AddCommand<D365FO.Cli.Commands.Label.LabelDeleteCommand>("delete").WithDescription("Delete a label entry.");
+    });
+
     cfg.AddBranch("read", b =>
     {
         b.SetDescription("Read X++ source embedded in AOT XML.");
@@ -89,6 +114,7 @@ app.Configure(cfg =>
         b.AddCommand<IndexBuildCommand>("build").WithDescription("Create/ensure index database.");
         b.AddCommand<IndexStatusCommand>("status").WithDescription("Report index health.");
         b.AddCommand<IndexExtractCommand>("extract").WithDescription("Walk PACKAGES_PATH and ingest AOT metadata.");
+        b.AddCommand<IndexRefreshCommand>("refresh").WithDescription("Incremental extract — skip models whose XMLs haven't changed since last extract.");
     });
 
     cfg.AddBranch("models", b =>
@@ -105,6 +131,12 @@ app.Configure(cfg =>
         b.AddCommand<GenerateClassCommand>("class").WithDescription("Create a new AxClass.");
         b.AddCommand<GenerateCocCommand>("coc").WithDescription("Create a Chain-of-Command extension class.");
         b.AddCommand<GenerateSimpleListCommand>("simple-list").WithDescription("Create a SimpleList-pattern AxForm.");
+        b.AddCommand<GenerateEntityCommand>("entity").WithDescription("Create an AxDataEntityView over a table.");
+        b.AddCommand<GenerateExtensionCommand>("extension").WithDescription("Create a Table/Form/Edt/Enum extension.");
+        b.AddCommand<GenerateEventHandlerCommand>("event-handler").WithDescription("Create an event subscriber class.");
+        b.AddCommand<GeneratePrivilegeCommand>("privilege").WithDescription("Create a security privilege over an entry point.");
+        b.AddCommand<GenerateDutyCommand>("duty").WithDescription("Create a security duty grouping privileges.");
+        b.AddCommand<GenerateRoleCommand>("role").WithDescription("Create an AxSecurityRole or merge duties/privileges into an existing role.");
     });
 
     cfg.AddBranch("test", b =>
@@ -136,6 +168,9 @@ app.Configure(cfg =>
     cfg.AddCommand<BuildCommand>("build").WithDescription("Invoke MSBuild (Windows VM).");
     cfg.AddCommand<SyncCommand>("sync").WithDescription("Run DB sync (Windows VM).");
     cfg.AddCommand<DoctorCommand>("doctor").WithDescription("Diagnose environment.");
+    cfg.AddCommand<InitCommand>("init").WithDescription("Interactive quickstart: detects PackagesLocalDirectory and prepares the index.");
+    cfg.AddCommand<StatsCommand>("stats").WithDescription("Aggregate counters over the index (top tables / classes / CoC targets).");
+    cfg.AddCommand<LintCommand>("lint").WithDescription("In-process Best-Practice gate over the index.");
     cfg.AddCommand<VersionCommand>("version").WithDescription("Print version information.");
     cfg.AddCommand<AgentPromptCommand>("agent-prompt").WithDescription("Emit LLM system prompt for this CLI.");
     cfg.AddCommand<SchemaCommand>("schema").WithDescription("Emit JSON command manifest.");

--- a/src/D365FO.Core/D365FoErrorCodes.cs
+++ b/src/D365FO.Core/D365FoErrorCodes.cs
@@ -1,0 +1,58 @@
+namespace D365FO.Core;
+
+/// <summary>
+/// Canonical machine-readable error codes used in <see cref="ToolResult{T}.Fail(string, string, string?)"/>.
+/// These are part of the CLI / MCP public contract — JSON consumers switch on them.
+/// New error codes should be added here and referenced by name rather than
+/// string-literal throughout the codebase.
+/// </summary>
+public static class D365FoErrorCodes
+{
+    // Input / generic
+    public const string BadInput = "BAD_INPUT";
+    public const string InvalidArgs = "INVALID_ARGS";
+    public const string InvalidRange = "INVALID_RANGE";
+    public const string Unhandled = "UNHANDLED";
+    public const string HandlerThrew = "HANDLER_THREW";
+    public const string WriteFailed = "WRITE_FAILED";
+    public const string SourceUnreadable = "SOURCE_UNREADABLE";
+
+    // Index / metadata not found
+    public const string TableNotFound = "TABLE_NOT_FOUND";
+    public const string EdtNotFound = "EDT_NOT_FOUND";
+    public const string ClassNotFound = "CLASS_NOT_FOUND";
+    public const string EnumNotFound = "ENUM_NOT_FOUND";
+    public const string MenuItemNotFound = "MENU_ITEM_NOT_FOUND";
+    public const string FormNotFound = "FORM_NOT_FOUND";
+    public const string QueryNotFound = "QUERY_NOT_FOUND";
+    public const string ViewNotFound = "VIEW_NOT_FOUND";
+    public const string EntityNotFound = "ENTITY_NOT_FOUND";
+    public const string ReportNotFound = "REPORT_NOT_FOUND";
+    public const string ServiceNotFound = "SERVICE_NOT_FOUND";
+    public const string ServiceGroupNotFound = "SERVICE_GROUP_NOT_FOUND";
+    public const string RoleNotFound = "ROLE_NOT_FOUND";
+    public const string DutyNotFound = "DUTY_NOT_FOUND";
+    public const string PrivilegeNotFound = "PRIVILEGE_NOT_FOUND";
+    public const string ModelNotFound = "MODEL_NOT_FOUND";
+    public const string LabelNotFound = "LABEL_NOT_FOUND";
+    public const string MethodNotFound = "METHOD_NOT_FOUND";
+
+    // Filesystem / environment
+    public const string PackagesPathMissing = "PACKAGES_PATH_MISSING";
+    public const string PackagesPathNotFound = "PACKAGES_PATH_NOT_FOUND";
+
+    // Build / SDLC
+    public const string BuildFailed = "BUILD_FAILED";
+    public const string SyncFailed = "SYNC_FAILED";
+    public const string TestsFailed = "TESTS_FAILED";
+    public const string BpFailed = "BP_FAILED";
+    public const string GitFailed = "GIT_FAILED";
+    public const string DoctorFailed = "DOCTOR_FAILED";
+
+    // Daemon
+    public const string DaemonNotRunning = "DAEMON_NOT_RUNNING";
+    public const string DaemonPidCorrupt = "DAEMON_PID_CORRUPT";
+
+    // MCP dispatcher
+    public const string UnknownTool = "UNKNOWN_TOOL";
+}

--- a/src/D365FO.Core/EdtSuggester.cs
+++ b/src/D365FO.Core/EdtSuggester.cs
@@ -1,0 +1,116 @@
+using D365FO.Core.Index;
+
+namespace D365FO.Core;
+
+/// <summary>
+/// Heuristic EDT suggester. Ranks indexed <c>Edts</c> by name similarity to a
+/// target field name. Confidence bands:
+/// <list type="bullet">
+///   <item><c>1.00</c> — exact match (case-insensitive).</item>
+///   <item><c>≥ 0.80</c> — fieldName equals EDT without common suffixes (Id / No / Num / Amount) or vice versa.</item>
+///   <item><c>≥ 0.60</c> — fieldName contains EDT name as a whole token, or vice versa.</item>
+///   <item><c>≥ 0.40</c> — fuzzy Damerau–Levenshtein below half the length.</item>
+/// </list>
+/// Falls back to <c>null</c> when no candidate clears <c>0.40</c>.
+/// </summary>
+public static class EdtSuggester
+{
+    private static readonly string[] NoiseSuffixes =
+    {
+        "Id", "Ids", "No", "Num", "Number", "Name",
+        "Account", "Amount", "Code", "Key", "Value",
+    };
+
+    public readonly record struct Suggestion(EdtInfo Edt, double Confidence, string Reason);
+
+    public static IReadOnlyList<Suggestion> Suggest(
+        MetadataRepository repo, string fieldName, int limit = 5)
+    {
+        if (repo is null) throw new ArgumentNullException(nameof(repo));
+        if (string.IsNullOrWhiteSpace(fieldName)) return Array.Empty<Suggestion>();
+        if (limit <= 0) limit = 5;
+
+        var target = fieldName.Trim();
+        var stripped = Strip(target);
+
+        // Over-fetch then score. Single LIKE scan on Name — Edts table is small.
+        var candidates = repo.SearchEdts(stripped.Length >= 3 ? stripped : target, Math.Max(limit * 20, 100));
+        if (candidates.Count == 0 && stripped.Length >= 3)
+            candidates = repo.SearchEdts(stripped, Math.Max(limit * 20, 100));
+
+        var scored = new List<Suggestion>();
+        foreach (var edt in candidates)
+        {
+            var (score, reason) = Score(target, stripped, edt.Name);
+            if (score >= 0.40)
+                scored.Add(new Suggestion(edt, Math.Round(score, 2), reason));
+        }
+        return scored
+            .OrderByDescending(s => s.Confidence)
+            .ThenBy(s => s.Edt.Name, StringComparer.OrdinalIgnoreCase)
+            .Take(limit)
+            .ToList();
+    }
+
+    private static (double Score, string Reason) Score(string target, string stripped, string edtName)
+    {
+        if (string.Equals(target, edtName, StringComparison.OrdinalIgnoreCase))
+            return (1.0, "exact match");
+
+        if (string.Equals(stripped, edtName, StringComparison.OrdinalIgnoreCase))
+            return (0.90, "exact match after stripping common suffix");
+
+        var edtStripped = Strip(edtName);
+        if (string.Equals(stripped, edtStripped, StringComparison.OrdinalIgnoreCase))
+            return (0.85, "roots match after stripping suffixes");
+
+        if (target.Contains(edtName, StringComparison.OrdinalIgnoreCase) ||
+            edtName.Contains(target, StringComparison.OrdinalIgnoreCase))
+            return (0.70, "whole-name token match");
+
+        if (stripped.Length >= 3 &&
+            (edtName.Contains(stripped, StringComparison.OrdinalIgnoreCase) ||
+             stripped.Contains(edtName, StringComparison.OrdinalIgnoreCase)))
+            return (0.60, "root-token match");
+
+        var distance = LevenshteinDistance(target.ToLowerInvariant(), edtName.ToLowerInvariant());
+        var max = Math.Max(target.Length, edtName.Length);
+        if (max == 0) return (0, "empty");
+        var similarity = 1.0 - (double)distance / max;
+        if (similarity >= 0.55)
+            return (0.40 + (similarity - 0.55) * 0.8, $"fuzzy match (distance {distance}, similarity {similarity:0.00})");
+
+        return (0, "no match");
+    }
+
+    internal static string Strip(string s)
+    {
+        foreach (var suffix in NoiseSuffixes)
+        {
+            if (s.Length > suffix.Length &&
+                s.EndsWith(suffix, StringComparison.OrdinalIgnoreCase))
+                return s[..^suffix.Length];
+        }
+        return s;
+    }
+
+    private static int LevenshteinDistance(string a, string b)
+    {
+        if (a.Length == 0) return b.Length;
+        if (b.Length == 0) return a.Length;
+        var prev = new int[b.Length + 1];
+        var curr = new int[b.Length + 1];
+        for (int j = 0; j <= b.Length; j++) prev[j] = j;
+        for (int i = 1; i <= a.Length; i++)
+        {
+            curr[0] = i;
+            for (int j = 1; j <= b.Length; j++)
+            {
+                var cost = a[i - 1] == b[j - 1] ? 0 : 1;
+                curr[j] = Math.Min(Math.Min(curr[j - 1] + 1, prev[j] + 1), prev[j - 1] + cost);
+            }
+            (prev, curr) = (curr, prev);
+        }
+        return prev[b.Length];
+    }
+}

--- a/src/D365FO.Core/Index/MetadataRepository.cs
+++ b/src/D365FO.Core/Index/MetadataRepository.cs
@@ -14,7 +14,7 @@ namespace D365FO.Core.Index;
 public sealed class MetadataRepository
 {
     /// <summary>Current schema version tracked in PRAGMA user_version.</summary>
-    public const int CurrentSchemaVersion = 5;
+    public const int CurrentSchemaVersion = 6;
 
     private static readonly Lazy<string> SchemaSql = new(LoadEmbeddedSchema);
 
@@ -50,18 +50,34 @@ public sealed class MetadataRepository
     /// Ensure schema is applied. Skips the CREATE script when PRAGMA
     /// user_version already matches the current version, so subsequent CLI
     /// invocations pay only the cost of opening a connection.
+    /// Returns <c>true</c> when the schema was (re)applied, <c>false</c>
+    /// when the DB was already at the current version.
     /// </summary>
-    public void EnsureSchema()
+    public bool EnsureSchema()
     {
         using var conn = Open();
         var current = conn.ExecuteScalar<long>("PRAGMA user_version");
-        if (current == CurrentSchemaVersion) return;
+        if (current == CurrentSchemaVersion) return false;
 
         conn.Execute(SchemaSql.Value);
         conn.Execute($"PRAGMA user_version = {CurrentSchemaVersion}");
         conn.Execute(
             "INSERT OR IGNORE INTO SchemaVersion(Version, AppliedUtc) VALUES(@v, @t)",
             new { v = CurrentSchemaVersion, t = DateTime.UtcNow.ToString("O") });
+
+        // Backfill FTS5 index from pre-existing Labels rows. This is a no-op
+        // when Labels is empty or when the FTS5 mirror is already in sync
+        // (SQLite's rebuild command is cheap in that case).
+        try
+        {
+            conn.Execute("INSERT INTO LabelFts(LabelFts) VALUES('rebuild')");
+        }
+        catch (Microsoft.Data.Sqlite.SqliteException)
+        {
+            // Host SQLite build lacks FTS5 — degrade gracefully; SearchLabels()
+            // stays on the LIKE fallback path.
+        }
+        return true;
     }
 
     public IReadOnlyList<ClassInfo> SearchClasses(string query, string? model = null, int limit = 50)
@@ -170,6 +186,35 @@ public sealed class MetadataRepository
             ORDER BY LabelFile, Key
             LIMIT @limit";
         return conn.Query<LabelMatch>(sql, new { like, langs = langsLower, limit }).ToList();
+    }
+
+    /// <summary>
+    /// FTS5-backed label search. Falls back to <see cref="SearchLabels"/>
+    /// when the host SQLite build lacks FTS5. Supports standard FTS5 query
+    /// syntax — phrases in quotes, NEAR, column filters like
+    /// <c>Value:customer Key:invoice</c>.
+    /// </summary>
+    public IReadOnlyList<LabelMatch> SearchLabelsFts(string query, IReadOnlyCollection<string>? languages = null, int limit = 100)
+    {
+        using var conn = Open();
+        var langsLower = languages?.Select(l => l.ToLowerInvariant()).ToList();
+        try
+        {
+            var sql = @"
+                SELECT LabelFile AS File, Language, Key, Value
+                FROM LabelFts
+                WHERE LabelFts MATCH @q
+                  AND (@langs IS NULL OR LOWER(Language) IN @langs)
+                ORDER BY rank
+                LIMIT @limit";
+            return conn.Query<LabelMatch>(sql, new { q = query, langs = langsLower, limit }).ToList();
+        }
+        catch (Microsoft.Data.Sqlite.SqliteException)
+        {
+            // Either FTS5 is absent or the query string isn't valid FTS syntax
+            // — degrade to LIKE so callers always get *some* results.
+            return SearchLabels(query, languages, limit);
+        }
     }
 
     public MenuItemInfo? GetMenuItem(string name)
@@ -308,6 +353,70 @@ public sealed class MetadataRepository
             FROM TableDeleteActions da
             JOIN Tables t ON t.TableId = da.TableId
             WHERE t.Name = @n ORDER BY da.RelatedTable", new { n = table }).ToList();
+    }
+
+    // ---- Lint heuristics (ROADMAP §7.1) ----
+
+    /// <summary>
+    /// Tables that don't have any index. Always a BP violation — the DB
+    /// sync falls back to synthetic clustering and joins get expensive.
+    /// Restricted to custom models by default so platform noise is filtered.
+    /// </summary>
+    public IReadOnlyList<LintHit> FindTablesWithoutIndex(bool onlyCustomModels = true)
+    {
+        using var conn = Open();
+        var sql = @"
+            SELECT t.Name AS TargetName, m.Name AS Model
+            FROM Tables t
+            JOIN Models m ON m.ModelId = t.ModelId
+            LEFT JOIN TableIndexes ti ON ti.TableId = t.TableId
+            WHERE ti.TableId IS NULL
+              AND (@custom = 0 OR m.IsCustom = 1)
+            ORDER BY m.Name, t.Name";
+        return conn.Query(sql, new { custom = onlyCustomModels ? 1 : 0 })
+            .Select(r => new LintHit((string)r.TargetName, (string)r.Model, null)).ToList();
+    }
+
+    /// <summary>
+    /// Classes whose name ends with <c>_Extension</c> but where no method
+    /// carries an <c>ExtensionOf</c> attribute — typical false extension
+    /// from copy-paste scaffolding.
+    /// </summary>
+    public IReadOnlyList<LintHit> FindExtensionNamedButNotAttributed(bool onlyCustomModels = true)
+    {
+        using var conn = Open();
+        var sql = @"
+            SELECT c.Name AS TargetName, m.Name AS Model
+            FROM Classes c
+            JOIN Models m ON m.ModelId = c.ModelId
+            WHERE c.Name LIKE '%\_Extension' ESCAPE '\'
+              AND (@custom = 0 OR m.IsCustom = 1)
+              AND NOT EXISTS (
+                  SELECT 1 FROM ClassAttributes a
+                  WHERE a.ClassId = c.ClassId AND a.AttributeName = 'ExtensionOf')
+            ORDER BY m.Name, c.Name";
+        return conn.Query(sql, new { custom = onlyCustomModels ? 1 : 0 })
+            .Select(r => new LintHit((string)r.TargetName, (string)r.Model, null)).ToList();
+    }
+
+    /// <summary>
+    /// Table fields with type <c>String</c> that do not reference an
+    /// ExtendedDataType. Violates the "use EDTs for all string columns" BP.
+    /// </summary>
+    public IReadOnlyList<LintHit> FindStringFieldsWithoutEdt(bool onlyCustomModels = true)
+    {
+        using var conn = Open();
+        var sql = @"
+            SELECT (t.Name || '.' || f.Name) AS TargetName, m.Name AS Model, f.Type AS Detail
+            FROM TableFields f
+            JOIN Tables t ON t.TableId = f.TableId
+            JOIN Models m ON m.ModelId = t.ModelId
+            WHERE f.Type = 'String'
+              AND (f.EdtName IS NULL OR f.EdtName = '')
+              AND (@custom = 0 OR m.IsCustom = 1)
+            ORDER BY m.Name, t.Name, f.Name";
+        return conn.Query(sql, new { custom = onlyCustomModels ? 1 : 0 })
+            .Select(r => new LintHit((string)r.TargetName, (string)r.Model, (string?)r.Detail)).ToList();
     }
 
     // ---- v4: queries / views / data entities / reports / services / workflow ----
@@ -669,12 +778,25 @@ public sealed class MetadataRepository
     }
 
     // ---- writer API used by the extract pipeline ----
+
+    /// <summary>
+    /// Upsert a <c>Models</c> row by name. Intended for callers that know the
+    /// authoritative IsCustom/Publisher/Layer. If the row already exists the
+    /// existing flags are preserved; the canonical way to refresh flags is
+    /// <see cref="ApplyExtract"/>, which re-runs this upsert and then issues
+    /// an <c>UPDATE</c> with the authoritative descriptor values.
+    /// </summary>
     public long UpsertModel(string name, string? publisher, string? layer, bool isCustom)
     {
         using var conn = Open();
         return UpsertModelInternal(conn, null, name, publisher, layer, isCustom);
     }
 
+    // Invariant: <c>ApplyExtract</c> is the single source of truth for
+    // <c>Models.IsCustom</c>. <c>UpsertModelInternal</c> only sets it on the
+    // very first insert; later ApplyExtract calls refresh it via UPDATE so a
+    // model's custom-flag always reflects the last successful extract, never a
+    // stale best-effort guess from dep-graph traversal.
     internal long UpsertModelInternal(SqliteConnection conn, IDbTransaction? tx, string name, string? publisher, string? layer, bool isCustom)
     {
         var id = conn.ExecuteScalar<long?>("SELECT ModelId FROM Models WHERE Name = @n", new { n = name }, tx);
@@ -1036,6 +1158,57 @@ public sealed class MetadataRepository
             Services = conn.ExecuteScalar<long>("SELECT COUNT(*) FROM Services"),
             WorkflowTypes = conn.ExecuteScalar<long>("SELECT COUNT(*) FROM WorkflowTypes"),
         };
+    }
+
+    /// <summary>
+    /// Aggregate counters useful for <c>d365fo stats</c>. Each sub-query hits
+    /// a single indexed column so the whole call finishes in tens of ms on a
+    /// fully-ingested index.
+    /// </summary>
+    public IndexStats GetStats(int topN = 10)
+    {
+        using var conn = Open();
+
+        var perModel = conn.Query<PerModelStat>(@"
+            SELECT m.Name AS Model, m.IsCustom AS IsCustom,
+                   (SELECT COUNT(*) FROM Tables t WHERE t.ModelId = m.ModelId) AS Tables,
+                   (SELECT COUNT(*) FROM Classes c WHERE c.ModelId = m.ModelId) AS Classes,
+                   (SELECT COUNT(*) FROM Edts e WHERE e.ModelId = m.ModelId) AS Edts,
+                   (SELECT COUNT(*) FROM Enums en WHERE en.ModelId = m.ModelId) AS Enums,
+                   (SELECT COUNT(*) FROM MenuItems mi WHERE mi.ModelId = m.ModelId) AS MenuItems,
+                   (SELECT COUNT(*) FROM Forms f WHERE f.ModelId = m.ModelId) AS Forms,
+                   (SELECT COUNT(*) FROM ObjectExtensions ox WHERE ox.ModelId = m.ModelId) AS Extensions,
+                   (SELECT COUNT(*) FROM CocExtensions cx WHERE cx.ModelId = m.ModelId) AS Coc,
+                   (SELECT COUNT(*) FROM Labels l WHERE l.ModelId = m.ModelId) AS Labels
+            FROM Models m
+            ORDER BY m.Name").ToList();
+
+        var topTables = conn.Query<TopTableStat>(@"
+            SELECT t.Name AS Name, m.Name AS Model, COUNT(f.FieldId) AS FieldCount
+            FROM Tables t
+            JOIN Models m ON m.ModelId = t.ModelId
+            LEFT JOIN TableFields f ON f.TableId = t.TableId
+            GROUP BY t.TableId, t.Name, m.Name
+            ORDER BY FieldCount DESC, t.Name
+            LIMIT @topN", new { topN }).ToList();
+
+        var topClasses = conn.Query<TopClassStat>(@"
+            SELECT c.Name AS Name, m.Name AS Model, COUNT(mt.MethodId) AS MethodCount
+            FROM Classes c
+            JOIN Models m ON m.ModelId = c.ModelId
+            LEFT JOIN Methods mt ON mt.ClassId = c.ClassId
+            GROUP BY c.ClassId, c.Name, m.Name
+            ORDER BY MethodCount DESC, c.Name
+            LIMIT @topN", new { topN }).ToList();
+
+        var topCoc = conn.Query<TopCocStat>(@"
+            SELECT c.TargetClass AS Target, COUNT(*) AS ExtensionCount
+            FROM CocExtensions c
+            GROUP BY c.TargetClass
+            ORDER BY ExtensionCount DESC, c.TargetClass
+            LIMIT @topN", new { topN }).ToList();
+
+        return new IndexStats(perModel, topTables, topClasses, topCoc);
     }
 
     internal SqliteConnection Open()

--- a/src/D365FO.Core/Index/Models.cs
+++ b/src/D365FO.Core/Index/Models.cs
@@ -5,6 +5,32 @@ public sealed record ModelInfo(long ModelId, string Name, string? Publisher, str
 
 public sealed record ModelDependencies(ModelInfo Model, IReadOnlyList<string> DependsOn, IReadOnlyList<string> DependedBy);
 
+/// <summary>Per-model counters for <c>d365fo stats</c>.</summary>
+public sealed record PerModelStat(
+    string Model, bool IsCustom,
+    long Tables, long Classes, long Edts, long Enums,
+    long MenuItems, long Forms, long Extensions, long Coc, long Labels);
+
+/// <summary>Top-N table by field count.</summary>
+public sealed record TopTableStat(string Name, string Model, long FieldCount);
+
+/// <summary>Top-N class by method count.</summary>
+public sealed record TopClassStat(string Name, string Model, long MethodCount);
+
+/// <summary>Top-N Chain-of-Command target class by extension count.</summary>
+public sealed record TopCocStat(string Target, long ExtensionCount);
+
+/// <summary>Aggregate roll-up used by <c>d365fo stats</c>.</summary>
+public sealed record IndexStats(
+    IReadOnlyList<PerModelStat> PerModel,
+    IReadOnlyList<TopTableStat> TopTables,
+    IReadOnlyList<TopClassStat> TopClasses,
+    IReadOnlyList<TopCocStat> TopCocTargets);
+
+/// <summary>Finding from <c>d365fo lint</c>.</summary>
+public sealed record LintHit(string TargetName, string Model, string? Detail);
+
+
 public sealed record TableInfo(
     long TableId,
     string Name,
@@ -50,7 +76,7 @@ public sealed record EdtInfo(
     string? Extends,
     string? BaseType,
     string? Label,
-    int? StringSize);
+    long? StringSize);
 
 public sealed record EnumInfo(string Name, string Model, string? Label);
 

--- a/src/D365FO.Core/Index/Schema.sql
+++ b/src/D365FO.Core/Index/Schema.sql
@@ -434,3 +434,34 @@ CREATE TABLE IF NOT EXISTS ModelDependencies (
 CREATE INDEX IF NOT EXISTS IX_ModelDependencies_Model ON ModelDependencies(ModelId);
 CREATE INDEX IF NOT EXISTS IX_ModelDependencies_Target ON ModelDependencies(Target);
 
+-- v6 additions -----------------------------------------------------------
+-- Full-text search over labels. Content-linked virtual table + triggers keep
+-- LabelFts in lock-step with Labels, so `d365fo search label "customer
+-- invoice"` drops from a LIKE scan (hundreds of ms on a real workspace) to a
+-- rank-sorted MATCH (tens of ms). After a schema upgrade the caller must run
+-- `INSERT INTO LabelFts(LabelFts) VALUES('rebuild')` once to backfill from
+-- existing Labels rows — EnsureSchema() takes care of that.
+
+CREATE VIRTUAL TABLE IF NOT EXISTS LabelFts USING fts5(
+    Value, Key, LabelFile, Language,
+    content='Labels', content_rowid='LabelId',
+    tokenize = 'unicode61 remove_diacritics 1'
+);
+
+CREATE TRIGGER IF NOT EXISTS Labels_ai AFTER INSERT ON Labels BEGIN
+    INSERT INTO LabelFts(rowid, Value, Key, LabelFile, Language)
+    VALUES (new.LabelId, new.Value, new.Key, new.LabelFile, new.Language);
+END;
+
+CREATE TRIGGER IF NOT EXISTS Labels_ad AFTER DELETE ON Labels BEGIN
+    INSERT INTO LabelFts(LabelFts, rowid, Value, Key, LabelFile, Language)
+    VALUES ('delete', old.LabelId, old.Value, old.Key, old.LabelFile, old.Language);
+END;
+
+CREATE TRIGGER IF NOT EXISTS Labels_au AFTER UPDATE ON Labels BEGIN
+    INSERT INTO LabelFts(LabelFts, rowid, Value, Key, LabelFile, Language)
+    VALUES ('delete', old.LabelId, old.Value, old.Key, old.LabelFile, old.Language);
+    INSERT INTO LabelFts(rowid, Value, Key, LabelFile, Language)
+    VALUES (new.LabelId, new.Value, new.Key, new.LabelFile, new.Language);
+END;
+

--- a/src/D365FO.Core/Labels/LabelFileWriter.cs
+++ b/src/D365FO.Core/Labels/LabelFileWriter.cs
@@ -1,0 +1,170 @@
+using System.Text;
+
+namespace D365FO.Core.Labels;
+
+/// <summary>
+/// Atomic read/write for D365FO <c>*.label.txt</c> resource files. The on-disk
+/// format is a flat key=value list with optional <c>;</c>-prefixed comments,
+/// BOM-aware UTF-8. The writer preserves comment lines and blank separators so
+/// hand-maintained translators' notes survive a create/rename round-trip.
+/// </summary>
+/// <remarks>
+/// Thread-safety: callers must serialise writes to the same path. The writer
+/// itself uses tmp+move so partial files never end up on disk, but it does
+/// not take an exclusive OS-level lock.
+/// </remarks>
+public static class LabelFileWriter
+{
+    /// <summary>
+    /// Create or update a single <c>KEY=VALUE</c> entry. When the file does
+    /// not exist it is created. When the key already exists and
+    /// <paramref name="overwrite"/> is <c>false</c>, the method returns a
+    /// <see cref="WriteOutcome.KeyExists"/> outcome without touching the file.
+    /// </summary>
+    public static WriteResult CreateOrUpdate(string path, string key, string value, bool overwrite = false)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(path);
+        ArgumentException.ThrowIfNullOrWhiteSpace(key);
+        if (key.Contains('=')) throw new ArgumentException("Label keys must not contain '='.", nameof(key));
+
+        var lines = File.Exists(path)
+            ? File.ReadAllLines(path).ToList()
+            : new List<string>();
+
+        var existing = FindKey(lines, key);
+        if (existing.lineIdx >= 0)
+        {
+            if (!overwrite)
+                return new WriteResult(path, WriteOutcome.KeyExists, key, existing.existingValue, null);
+
+            var prev = existing.existingValue;
+            lines[existing.lineIdx] = key + "=" + Sanitise(value);
+            AtomicWrite(path, lines);
+            return new WriteResult(path, WriteOutcome.Updated, key, prev, value);
+        }
+
+        lines.Add(key + "=" + Sanitise(value));
+        AtomicWrite(path, lines);
+        return new WriteResult(path, WriteOutcome.Created, key, null, value);
+    }
+
+    /// <summary>
+    /// Rename a key in place, preserving its value. Returns
+    /// <see cref="WriteOutcome.KeyMissing"/> when the source key is absent,
+    /// and <see cref="WriteOutcome.KeyExists"/> when the target key already
+    /// exists (unless <paramref name="overwrite"/> is true).
+    /// </summary>
+    public static WriteResult Rename(string path, string oldKey, string newKey, bool overwrite = false)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(path);
+        ArgumentException.ThrowIfNullOrWhiteSpace(oldKey);
+        ArgumentException.ThrowIfNullOrWhiteSpace(newKey);
+        if (newKey.Contains('=')) throw new ArgumentException("Label keys must not contain '='.", nameof(newKey));
+        if (!File.Exists(path))
+            return new WriteResult(path, WriteOutcome.FileMissing, oldKey, null, null);
+
+        var lines = File.ReadAllLines(path).ToList();
+        var source = FindKey(lines, oldKey);
+        if (source.lineIdx < 0)
+            return new WriteResult(path, WriteOutcome.KeyMissing, oldKey, null, null);
+
+        if (string.Equals(oldKey, newKey, StringComparison.Ordinal))
+            return new WriteResult(path, WriteOutcome.NoChange, oldKey, source.existingValue, source.existingValue);
+
+        var target = FindKey(lines, newKey);
+        if (target.lineIdx >= 0 && !overwrite)
+            return new WriteResult(path, WriteOutcome.KeyExists, newKey, target.existingValue, null);
+
+        if (target.lineIdx >= 0)
+        {
+            // Overwriting: drop the old occurrence first.
+            lines.RemoveAt(target.lineIdx);
+            if (target.lineIdx < source.lineIdx) source.lineIdx--;
+        }
+
+        lines[source.lineIdx] = newKey + "=" + Sanitise(source.existingValue ?? "");
+        AtomicWrite(path, lines);
+        return new WriteResult(path, WriteOutcome.Renamed, newKey, source.existingValue, source.existingValue);
+    }
+
+    /// <summary>Delete a key. Returns <see cref="WriteOutcome.KeyMissing"/> when absent.</summary>
+    public static WriteResult Delete(string path, string key)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(path);
+        ArgumentException.ThrowIfNullOrWhiteSpace(key);
+        if (!File.Exists(path))
+            return new WriteResult(path, WriteOutcome.FileMissing, key, null, null);
+        var lines = File.ReadAllLines(path).ToList();
+        var existing = FindKey(lines, key);
+        if (existing.lineIdx < 0)
+            return new WriteResult(path, WriteOutcome.KeyMissing, key, null, null);
+        lines.RemoveAt(existing.lineIdx);
+        AtomicWrite(path, lines);
+        return new WriteResult(path, WriteOutcome.Deleted, key, existing.existingValue, null);
+    }
+
+    // ---- internals ----------------------------------------------------
+
+    private static (int lineIdx, string? existingValue) FindKey(List<string> lines, string key)
+    {
+        for (var i = 0; i < lines.Count; i++)
+        {
+            var line = lines[i];
+            if (line.Length == 0) continue;
+            var trimmed = line.TrimStart();
+            if (trimmed.StartsWith(';')) continue;
+            var eq = trimmed.IndexOf('=');
+            if (eq <= 0) continue;
+            var k = trimmed.Substring(0, eq).TrimEnd();
+            if (string.Equals(k, key, StringComparison.Ordinal))
+                return (i, trimmed.Substring(eq + 1));
+        }
+        return (-1, null);
+    }
+
+    private static string Sanitise(string value)
+    {
+        // Label files are line-oriented. D365FO does not support multi-line
+        // values; CR/LF are escaped as explicit XPP sequences.
+        return value.Replace("\r\n", "\\n").Replace("\n", "\\n").Replace("\r", "\\n");
+    }
+
+    private static void AtomicWrite(string path, IReadOnlyList<string> lines)
+    {
+        var dir = Path.GetDirectoryName(Path.GetFullPath(path));
+        if (!string.IsNullOrEmpty(dir)) Directory.CreateDirectory(dir);
+        var tmp = path + ".tmp";
+        // UTF-8 with BOM matches what Visual Studio writes for .label.txt files.
+        using (var writer = new StreamWriter(tmp, append: false, new UTF8Encoding(encoderShouldEmitUTF8Identifier: true)))
+        {
+            foreach (var line in lines)
+                writer.WriteLine(line);
+        }
+        if (File.Exists(path))
+        {
+            var bak = path + ".bak";
+            if (File.Exists(bak)) File.Delete(bak);
+            File.Move(path, bak);
+        }
+        File.Move(tmp, path);
+    }
+}
+
+public enum WriteOutcome
+{
+    Created,
+    Updated,
+    Renamed,
+    Deleted,
+    NoChange,
+    KeyExists,
+    KeyMissing,
+    FileMissing,
+}
+
+public sealed record WriteResult(
+    string Path,
+    WriteOutcome Outcome,
+    string Key,
+    string? OldValue,
+    string? NewValue);

--- a/src/D365FO.Core/ObjectNamingRules.cs
+++ b/src/D365FO.Core/ObjectNamingRules.cs
@@ -1,0 +1,88 @@
+namespace D365FO.Core;
+
+/// <summary>
+/// Lightweight, index-free conventions check used by upstream parity tool
+/// <c>validate_object_naming</c>. Rules follow Microsoft's
+/// <see href="https://learn.microsoft.com/en-us/dynamics365/fin-ops-core/dev-itpro/dev-ref/xpp-standards">
+/// X++ naming guidelines</see>.
+/// Kinds understood: <c>Table</c>, <c>Class</c>, <c>Edt</c>, <c>Enum</c>,
+/// <c>Form</c>, <c>View</c>, <c>Query</c>, <c>Report</c>, <c>Entity</c>,
+/// <c>Service</c>, <c>MenuItem</c>, <c>TableExtension</c>, <c>FormExtension</c>,
+/// <c>Coc</c>. Unknown kinds still get the PascalCase / length checks.
+/// </summary>
+public static class ObjectNamingRules
+{
+    public readonly record struct Violation(string Code, string Severity, string Message);
+
+    public static IReadOnlyList<Violation> Validate(string kind, string name, string? prefix = null)
+    {
+        var v = new List<Violation>();
+        if (string.IsNullOrWhiteSpace(name))
+        {
+            v.Add(new("EMPTY_NAME", "error", "Name is empty."));
+            return v;
+        }
+
+        if (name.Length > 80)
+            v.Add(new("NAME_TOO_LONG", "warn",
+                $"Name is {name.Length} chars (soft limit 80, metadata XML filename hits FS limits above 160)."));
+
+        foreach (var ch in name)
+        {
+            if (!(char.IsLetterOrDigit(ch) || ch == '_'))
+            {
+                v.Add(new("INVALID_CHARS", "error",
+                    $"Character '{ch}' is not allowed. Only letters, digits and underscore are legal."));
+                break;
+            }
+        }
+
+        if (char.IsDigit(name[0]))
+            v.Add(new("LEADS_WITH_DIGIT", "error", "Name must not start with a digit."));
+
+        if (!char.IsUpper(name[0]) && name[0] != '_')
+            v.Add(new("NOT_PASCAL_CASE", "warn", "Name should start with an uppercase letter (PascalCase)."));
+
+        var kindNorm = (kind ?? "").Trim();
+        switch (kindNorm)
+        {
+            case "TableExtension":
+            case "FormExtension":
+            case "EdtExtension":
+            case "EnumExtension":
+                if (!name.Contains(".", StringComparison.Ordinal) &&
+                    !name.EndsWith("_Extension", StringComparison.Ordinal))
+                    v.Add(new("EXTENSION_SUFFIX", "warn",
+                        "Extension objects should either contain '.' (target.Suffix) or end with '_Extension'."));
+                break;
+            case "Coc":
+            case "CocClass":
+                if (!name.EndsWith("_Extension", StringComparison.Ordinal))
+                    v.Add(new("COC_SUFFIX", "warn", "Chain-of-Command classes should end with '_Extension'."));
+                break;
+            case "Table":
+                if (name.EndsWith("Table", StringComparison.Ordinal) && name.Length > 5 && char.IsLower(name[^6]))
+                    v.Add(new("TABLE_SUFFIX", "info", "Tables conventionally carry the functional area prefix, e.g. CustTable."));
+                break;
+            case "Enum":
+                if (name.StartsWith("Enum", StringComparison.Ordinal))
+                    v.Add(new("ENUM_PREFIX_REDUNDANT", "info", "Avoid the redundant 'Enum' prefix on enum names."));
+                break;
+            case "Edt":
+                // Convention: Extended Data Types rarely carry the 'Edt' suffix
+                // but are fine either way — no hard rule.
+                break;
+            case "MenuItem":
+            case "MenuItemDisplay":
+            case "MenuItemAction":
+            case "MenuItemOutput":
+                break;
+        }
+
+        if (!string.IsNullOrEmpty(prefix) && !name.StartsWith(prefix, StringComparison.Ordinal))
+            v.Add(new("MISSING_PUBLISHER_PREFIX", "warn",
+                $"Name does not start with the expected prefix '{prefix}'. Custom ISV artefacts must use the publisher prefix to avoid collisions."));
+
+        return v;
+    }
+}

--- a/src/D365FO.Core/Scaffolding/XppScaffolder.cs
+++ b/src/D365FO.Core/Scaffolding/XppScaffolder.cs
@@ -76,7 +76,211 @@ public static class XppScaffolder
                     new XElement("Pattern", "SimpleList"),
                     new XElement("PatternVersion", "1.0"))));
     }
+
+    /// <summary>
+    /// Scaffolds a minimal <c>AxDataEntityView</c> — data entity with a
+    /// single table datasource and public OData names derived from the table
+    /// by convention (<c>&lt;Table&gt;Entity</c>, collection plural).
+    /// </summary>
+    public static XDocument DataEntity(
+        string entityName,
+        string table,
+        string? publicEntityName = null,
+        string? publicCollectionName = null,
+        IEnumerable<EntityFieldSpec>? fields = null)
+    {
+        var pubEntity = string.IsNullOrEmpty(publicEntityName) ? entityName : publicEntityName;
+        var pubColl = string.IsNullOrEmpty(publicCollectionName) ? pubEntity + "s" : publicCollectionName;
+
+        var fieldEls = (fields ?? Enumerable.Empty<EntityFieldSpec>()).Select(f =>
+            new XElement("AxDataEntityViewField",
+                new XElement("Name", f.Name),
+                new XElement("DataField", f.DataField ?? f.Name),
+                new XElement("DataSource", table),
+                f.IsMandatory ? new XElement("IsMandatory", "Yes") : null));
+
+        return new XDocument(
+            new XElement("AxDataEntityView",
+                new XElement("Name", entityName),
+                new XElement("PublicEntityName", pubEntity),
+                new XElement("PublicCollectionName", pubColl),
+                new XElement("DataManagementEnabled", "Yes"),
+                new XElement("IsPublic", "Yes"),
+                new XElement("DataSources",
+                    new XElement("AxQuerySimpleRootDataSource",
+                        new XElement("Name", table),
+                        new XElement("Table", table))),
+                new XElement("Fields", fieldEls)));
+    }
+
+    /// <summary>
+    /// Scaffolds a Table/Form/Edt/Enum extension. Name follows the D365FO
+    /// convention <c>&lt;Target&gt;.&lt;Suffix&gt;</c> (dot-separated).
+    /// </summary>
+    public static XDocument Extension(string kind, string targetName, string suffix)
+    {
+        var elementName = kind switch
+        {
+            "Table" => "AxTableExtension",
+            "Form" => "AxFormExtension",
+            "Edt" => "AxEdtExtension",
+            "Enum" => "AxEnumExtension",
+            _ => throw new ArgumentException($"Unsupported extension kind: {kind}", nameof(kind)),
+        };
+
+        return new XDocument(
+            new XElement(elementName,
+                new XElement("Name", $"{targetName}.{suffix}")));
+    }
+
+    /// <summary>
+    /// Scaffolds an event-handler class (SubscribesTo on a form/table/class
+    /// delegate). Body is a <c>next</c>-free stub; handlers intentionally
+    /// don't chain like CoC.
+    /// </summary>
+    public static XDocument EventHandler(
+        string className,
+        string sourceKind,
+        string sourceObject,
+        string eventName,
+        string handlerMethod = "OnEvent")
+    {
+        var attr = sourceKind switch
+        {
+            "Form" => $"FormEventHandler(formStr({sourceObject}), FormEventType::{eventName})",
+            "FormDataSource" => $"FormDataSourceEventHandler(formDataSourceStr({sourceObject}), FormDataSourceEventType::{eventName})",
+            "Table" => $"DataEventHandler(tableStr({sourceObject}), DataEventType::{eventName})",
+            "Class" => $"SubscribesTo(classStr({sourceObject}), delegateStr({sourceObject}, {eventName}))",
+            _ => $"SubscribesTo({sourceKind}, {sourceObject}, {eventName})",
+        };
+
+        var src =
+            $"public static class {className}\n{{\n" +
+            $"    [{attr}]\n" +
+            $"    public static void {handlerMethod}(XppPrePostArgs args)\n" +
+            "    {\n        // handler logic here\n    }\n}}\n";
+
+        return new XDocument(
+            new XElement("AxClass",
+                new XElement("Name", className),
+                new XElement("SourceCode",
+                    new XElement("Declaration", src))));
+    }
+
+    /// <summary>Scaffolds an <c>AxSecurityPrivilege</c> with a single entry point.</summary>
+    public static XDocument Privilege(
+        string name, string entryPointName, string entryPointKind,
+        string? entryPointObject = null, string? access = "Read", string? label = null)
+    {
+        return new XDocument(
+            new XElement("AxSecurityPrivilege",
+                new XElement("Name", name),
+                string.IsNullOrEmpty(label) ? null : new XElement("Label", label),
+                new XElement("EntryPoints",
+                    new XElement("AxSecurityEntryPointReference",
+                        new XElement("Name", entryPointName),
+                        new XElement("ObjectName", entryPointObject ?? entryPointName),
+                        new XElement("ObjectType", entryPointKind),
+                        new XElement("AccessLevel", access ?? "Read")))));
+    }
+
+    /// <summary>Scaffolds an <c>AxSecurityDuty</c> grouping given privileges.</summary>
+    public static XDocument Duty(string name, IEnumerable<string> privileges, string? label = null)
+    {
+        return new XDocument(
+            new XElement("AxSecurityDuty",
+                new XElement("Name", name),
+                string.IsNullOrEmpty(label) ? null : new XElement("Label", label),
+                new XElement("PrivilegeReferences",
+                    privileges.Select(p =>
+                        new XElement("AxSecurityPrivilegeReference",
+                            new XElement("Name", p))))));
+    }
+
+    /// <summary>
+    /// Scaffolds an <c>AxSecurityRole</c> that aggregates duties and/or
+    /// privileges. D365FO best practice is to prefer duties, but a role may
+    /// reference privileges directly for narrow use-cases.
+    /// </summary>
+    public static XDocument Role(
+        string name,
+        IEnumerable<string>? duties = null,
+        IEnumerable<string>? privileges = null,
+        string? label = null,
+        string? description = null)
+    {
+        var dutyRefs = (duties ?? Enumerable.Empty<string>())
+            .Where(d => !string.IsNullOrWhiteSpace(d))
+            .Select(d => new XElement("AxSecurityDutyReference", new XElement("Name", d)))
+            .ToList();
+        var privRefs = (privileges ?? Enumerable.Empty<string>())
+            .Where(p => !string.IsNullOrWhiteSpace(p))
+            .Select(p => new XElement("AxSecurityPrivilegeReference", new XElement("Name", p)))
+            .ToList();
+
+        return new XDocument(
+            new XElement("AxSecurityRole",
+                new XElement("Name", name),
+                string.IsNullOrEmpty(label) ? null : new XElement("Label", label),
+                string.IsNullOrEmpty(description) ? null : new XElement("Description", description),
+                dutyRefs.Count == 0 ? null : new XElement("Duties", dutyRefs),
+                privRefs.Count == 0 ? null : new XElement("Privileges", privRefs)));
+    }
+
+    /// <summary>
+    /// Add duty / privilege references to an existing <c>AxSecurityRole</c>
+    /// document. Idempotent: duplicate refs are not appended. Returns
+    /// <c>true</c> when the document was modified.
+    /// </summary>
+    public static bool AddToRole(
+        XDocument roleDoc,
+        IEnumerable<string>? duties = null,
+        IEnumerable<string>? privileges = null)
+    {
+        ArgumentNullException.ThrowIfNull(roleDoc);
+        var root = roleDoc.Root ?? throw new ArgumentException("Role document has no root.", nameof(roleDoc));
+        if (root.Name.LocalName != "AxSecurityRole")
+            throw new ArgumentException($"Expected <AxSecurityRole>, got <{root.Name.LocalName}>.", nameof(roleDoc));
+
+        var changed = false;
+        changed |= AppendRefs(root, "Duties", "AxSecurityDutyReference", duties);
+        changed |= AppendRefs(root, "Privileges", "AxSecurityPrivilegeReference", privileges);
+        return changed;
+    }
+
+    private static bool AppendRefs(XElement root, string containerName, string itemName, IEnumerable<string>? values)
+    {
+        var items = (values ?? Enumerable.Empty<string>())
+            .Where(v => !string.IsNullOrWhiteSpace(v))
+            .ToList();
+        if (items.Count == 0) return false;
+
+        var container = root.Element(containerName);
+        if (container is null)
+        {
+            container = new XElement(containerName);
+            root.Add(container);
+        }
+
+        var existing = new HashSet<string>(
+            container.Elements(itemName).Select(e => e.Element("Name")?.Value ?? "")
+                     .Where(n => !string.IsNullOrEmpty(n)),
+            StringComparer.OrdinalIgnoreCase);
+
+        var changed = false;
+        foreach (var v in items)
+        {
+            if (existing.Add(v))
+            {
+                container.Add(new XElement(itemName, new XElement("Name", v)));
+                changed = true;
+            }
+        }
+        return changed;
+    }
 }
+
+public sealed record EntityFieldSpec(string Name, string? DataField, bool IsMandatory);
 
 public sealed record TableFieldSpec(string Name, string? Edt, string? Label, bool Mandatory);
 

--- a/src/D365FO.Mcp/D365FO.Mcp.csproj
+++ b/src/D365FO.Mcp/D365FO.Mcp.csproj
@@ -13,4 +13,9 @@
     <ProjectReference Include="..\D365FO.Core\D365FO.Core.csproj" />
   </ItemGroup>
 
+  <ItemGroup>
+    <PackageReference Include="ModelContextProtocol" Version="1.2.0" />
+    <PackageReference Include="Microsoft.Extensions.Logging" Version="9.0.0" />
+  </ItemGroup>
+
 </Project>

--- a/src/D365FO.Mcp/McpServerHost.cs
+++ b/src/D365FO.Mcp/McpServerHost.cs
@@ -1,0 +1,126 @@
+using System.Text.Json;
+using System.Text.Json.Nodes;
+using D365FO.Core;
+using D365FO.Core.Index;
+using Microsoft.Extensions.Logging;
+using ModelContextProtocol.Protocol;
+using ModelContextProtocol.Server;
+
+namespace D365FO.Mcp;
+
+/// <summary>
+/// Hosts the MCP server backed by the official
+/// <c>ModelContextProtocol</c> SDK. The dispatcher's responsibilities shrink
+/// to:
+///   • publishing <see cref="ToolCatalog"/> entries as MCP tools,
+///   • routing <c>tools/call</c> to <see cref="ToolHandlers"/>,
+///   • wrapping the structured <see cref="ToolResult{T}"/> envelope into an
+///     MCP <see cref="CallToolResult"/> with a single text content block.
+/// Everything else (framing, lifecycle, error envelopes, notifications) is
+/// handled by the SDK.
+/// </summary>
+public static class McpServerHost
+{
+    private const string ServerName = "d365fo-mcp";
+    private const string ServerVersion = "0.2.0";
+
+    public static Task RunStdioAsync(string? databasePath = null, ILoggerFactory? loggerFactory = null, CancellationToken ct = default)
+    {
+        var settings = D365FoSettings.FromEnvironment(databasePath);
+        var dir = Path.GetDirectoryName(Path.GetFullPath(settings.DatabasePath));
+        if (!string.IsNullOrEmpty(dir)) Directory.CreateDirectory(dir);
+        var repo = new MetadataRepository(settings.DatabasePath);
+        repo.EnsureSchema();
+        return RunStdioAsync(new ToolHandlers(repo), loggerFactory, ct);
+    }
+
+    public static async Task RunStdioAsync(ToolHandlers handlers, ILoggerFactory? loggerFactory = null, CancellationToken ct = default)
+    {
+        loggerFactory ??= LoggerFactory.Create(b => b.SetMinimumLevel(LogLevel.Warning));
+
+        var options = BuildOptions(handlers);
+        var transport = new StdioServerTransport(options, loggerFactory);
+        var server = McpServer.Create(transport, options, loggerFactory, serviceProvider: null);
+        await server.RunAsync(ct);
+    }
+
+    public static McpServerOptions BuildOptions(ToolHandlers handlers)
+    {
+        var tools = ToolCatalog.All.Select(d => new Tool
+        {
+            Name = d.Name,
+            Description = d.Description,
+            InputSchema = JsonSerializer.SerializeToElement((JsonNode)d.InputSchema),
+        }).ToList();
+
+        return new McpServerOptions
+        {
+            ServerInfo = new Implementation { Name = ServerName, Version = ServerVersion },
+            Capabilities = new ServerCapabilities
+            {
+                Tools = new ToolsCapability { ListChanged = false },
+            },
+            Handlers = new McpServerHandlers
+            {
+                ListToolsHandler = (_, _) =>
+                    ValueTask.FromResult(new ListToolsResult { Tools = tools }),
+                CallToolHandler = (ctx, _) => ValueTask.FromResult(Invoke(handlers, ctx.Params)),
+            },
+        };
+    }
+
+    public static CallToolResult Invoke(ToolHandlers handlers, CallToolRequestParams? request)
+    {
+        if (request is null)
+            return ErrorResult("BAD_REQUEST", "Missing tools/call parameters.");
+
+        var descriptor = ToolCatalog.All.FirstOrDefault(d => d.Name == request.Name);
+        if (descriptor.Name is null)
+            return ErrorResult("UNKNOWN_TOOL", $"Unknown tool: {request.Name}");
+
+        var args = SerializeArguments(request.Arguments);
+
+        object raw;
+        try
+        {
+            raw = descriptor.Invoke(handlers, args);
+        }
+        catch (Exception ex)
+        {
+            raw = ToolResult<object>.Fail("HANDLER_THREW", ex.Message, ex.GetType().Name);
+        }
+
+        var body = D365Json.Serialize(raw);
+        var isError = raw is ToolResult<object> tr && !tr.Ok;
+
+        return new CallToolResult
+        {
+            IsError = isError,
+            Content = new List<ContentBlock>
+            {
+                new TextContentBlock { Text = body },
+            },
+        };
+    }
+
+    private static JsonElement SerializeArguments(IDictionary<string, JsonElement>? args)
+    {
+        var obj = new JsonObject();
+        if (args is not null)
+        {
+            foreach (var kvp in args)
+                obj[kvp.Key] = JsonNode.Parse(kvp.Value.GetRawText());
+        }
+        return JsonSerializer.SerializeToElement((JsonNode)obj);
+    }
+
+    private static CallToolResult ErrorResult(string code, string message)
+    {
+        var body = D365Json.Serialize(ToolResult<object>.Fail(code, message));
+        return new CallToolResult
+        {
+            IsError = true,
+            Content = new List<ContentBlock> { new TextContentBlock { Text = body } },
+        };
+    }
+}

--- a/src/D365FO.Mcp/Program.cs
+++ b/src/D365FO.Mcp/Program.cs
@@ -1,23 +1,28 @@
 using D365FO.Mcp;
 
 // Entry point for the `d365fo-mcp` executable. Wires the default
-// MetadataRepository + ToolHandlers stack and runs the JSON-RPC 2.0 stdio
-// server until stdin closes (i.e., the MCP client disconnects).
+// MetadataRepository + ToolHandlers stack and runs an MCP server over stdio
+// (official `ModelContextProtocol` SDK) until stdin closes.
 //
 // Usage:
 //   d365fo-mcp                          # uses env vars
 //   d365fo-mcp --db /path/to/idx.sqlite # override DB path
+//   d365fo-mcp --legacy                 # use built-in StdioDispatcher (no SDK)
 //
-// The server speaks newline-delimited JSON-RPC on stdio — compatible with
-// Claude Desktop, Cursor, VS Code Copilot, and any other MCP client that
-// supports the stdio transport.
+// The server speaks the MCP stdio transport — compatible with Claude Desktop,
+// Cursor, VS Code Copilot, and any other MCP client that supports it.
 
 string? dbPath = null;
+bool legacy = false;
 for (int i = 0; i < args.Length; i++)
 {
     if ((args[i] == "--db" || args[i] == "-d") && i + 1 < args.Length)
     {
         dbPath = args[++i];
+    }
+    else if (args[i] == "--legacy")
+    {
+        legacy = true;
     }
     else if (args[i] == "--help" || args[i] == "-h")
     {
@@ -26,19 +31,25 @@ for (int i = 0; i < args.Length; i++)
 
             Options:
               --db, -d <PATH>   Override index database path.
+              --legacy          Use the built-in StdioDispatcher (pre-SDK transport).
               --help, -h        Print this message.
 
-            The server reads JSON-RPC 2.0 requests from stdin and writes
-            responses to stdout (one JSON object per line). Route log output
-            to stderr — stdout is reserved for protocol frames.
+            Route any log output to stderr — stdout is reserved for protocol frames.
             """);
         return 0;
     }
 }
 
-var dispatcher = StdioDispatcher.CreateDefault(dbPath);
 using var cts = new CancellationTokenSource();
 Console.CancelKeyPress += (_, e) => { e.Cancel = true; cts.Cancel(); };
 
-await dispatcher.RunAsync(Console.In, Console.Out, cts.Token);
+if (legacy)
+{
+    var dispatcher = StdioDispatcher.CreateDefault(dbPath);
+    await dispatcher.RunAsync(Console.In, Console.Out, cts.Token);
+}
+else
+{
+    await McpServerHost.RunStdioAsync(dbPath, loggerFactory: null, cts.Token);
+}
 return 0;

--- a/src/D365FO.Mcp/ToolCatalog.cs
+++ b/src/D365FO.Mcp/ToolCatalog.cs
@@ -50,6 +50,11 @@ internal static class ToolCatalog
             Schema(("query", "string", true), ("languages", "array", false), ("limit", "integer", false), ("raw", "boolean", false)),
             (h, p) => h.SearchLabels(Str(p, "query"), StrArray(p, "languages"), Int(p, "limit", 100), Bool(p, "raw"))),
 
+        new Descriptor("search_labels_fts",
+            "Rank-sorted SQLite FTS5 search over label values/keys. Supports phrase queries (\"customer invoice\"), NEAR, column filters like Value:customer.",
+            Schema(("query", "string", true), ("languages", "array", false), ("limit", "integer", false), ("raw", "boolean", false)),
+            (h, p) => h.SearchLabelsFts(Str(p, "query"), StrArray(p, "languages"), Int(p, "limit", 100), Bool(p, "raw"))),
+
         new Descriptor("get_table_details",
             "Return fields + relations for a table.",
             Schema(("name", "string", true)),
@@ -104,6 +109,200 @@ internal static class ToolCatalog
             "Current row counts of every entity table.",
             Schema(),
             (h, _) => h.IndexStatus()),
+
+        // ---- Parity: forms / queries / views / entities / reports / services / workflows ----
+
+        new Descriptor("get_form",
+            "Return form metadata: data sources, source path.",
+            Schema(("name", "string", true)),
+            (h, p) => h.GetForm(Str(p, "name"))),
+
+        new Descriptor("search_queries",
+            "Find AxQuery objects by substring.",
+            Schema(("query", "string", true), ("limit", "integer", false)),
+            (h, p) => h.SearchQueries(Str(p, "query"), Int(p, "limit", 50))),
+
+        new Descriptor("get_query",
+            "Return query metadata (data sources).",
+            Schema(("name", "string", true)),
+            (h, p) => h.GetQuery(Str(p, "name"))),
+
+        new Descriptor("search_views",
+            "Find AxView objects by substring.",
+            Schema(("query", "string", true), ("limit", "integer", false)),
+            (h, p) => h.SearchViews(Str(p, "query"), Int(p, "limit", 50))),
+
+        new Descriptor("get_view",
+            "Return view metadata (fields + source query).",
+            Schema(("name", "string", true)),
+            (h, p) => h.GetView(Str(p, "name"))),
+
+        new Descriptor("search_data_entities",
+            "Find data entities by AOT name, public entity name, or collection name.",
+            Schema(("query", "string", true), ("limit", "integer", false)),
+            (h, p) => h.SearchDataEntities(Str(p, "query"), Int(p, "limit", 50))),
+
+        new Descriptor("get_data_entity",
+            "Return data entity metadata (public names, staging table, fields).",
+            Schema(("name", "string", true)),
+            (h, p) => h.GetDataEntity(Str(p, "name"))),
+
+        new Descriptor("search_reports",
+            "Find SSRS reports by substring.",
+            Schema(("query", "string", true), ("limit", "integer", false)),
+            (h, p) => h.SearchReports(Str(p, "query"), Int(p, "limit", 50))),
+
+        new Descriptor("get_report",
+            "Return report metadata (datasets).",
+            Schema(("name", "string", true)),
+            (h, p) => h.GetReport(Str(p, "name"))),
+
+        new Descriptor("search_services",
+            "Find AxService objects by substring.",
+            Schema(("query", "string", true), ("limit", "integer", false)),
+            (h, p) => h.SearchServices(Str(p, "query"), Int(p, "limit", 50))),
+
+        new Descriptor("get_service",
+            "Return service metadata (class + operations).",
+            Schema(("name", "string", true)),
+            (h, p) => h.GetService(Str(p, "name"))),
+
+        new Descriptor("get_service_group",
+            "Return service group metadata (member services).",
+            Schema(("name", "string", true)),
+            (h, p) => h.GetServiceGroup(Str(p, "name"))),
+
+        new Descriptor("search_workflow_types",
+            "Find AxWorkflowType objects by name or document class.",
+            Schema(("query", "string", true), ("limit", "integer", false)),
+            (h, p) => h.SearchWorkflowTypes(Str(p, "query"), Int(p, "limit", 50))),
+
+        // ---- Security details ----
+
+        new Descriptor("get_security_role",
+            "Return a security role (duties + privileges).",
+            Schema(("name", "string", true)),
+            (h, p) => h.GetSecurityRole(Str(p, "name"))),
+
+        new Descriptor("get_security_duty",
+            "Return a security duty (privileges).",
+            Schema(("name", "string", true)),
+            (h, p) => h.GetSecurityDuty(Str(p, "name"))),
+
+        new Descriptor("get_security_privilege",
+            "Return a security privilege (entry points).",
+            Schema(("name", "string", true)),
+            (h, p) => h.GetSecurityPrivilege(Str(p, "name"))),
+
+        // ---- Models ----
+
+        new Descriptor("list_models",
+            "List every indexed model with publisher / layer / custom flag.",
+            Schema(),
+            (h, _) => h.ListModels()),
+
+        new Descriptor("get_model_dependencies",
+            "Return dependsOn / dependedBy for a model.",
+            Schema(("name", "string", true)),
+            (h, p) => h.GetModelDependencies(Str(p, "name"))),
+
+        // ---- Extensions & handlers ----
+
+        new Descriptor("find_extensions",
+            "Find Table/Form/Enum/EDT _Extension objects targeting a given name.",
+            Schema(("target", "string", true), ("kind", "string", false)),
+            (h, p) => h.FindExtensions(Str(p, "target"), StrOrNull(p, "kind"))),
+
+        new Descriptor("find_event_subscribers",
+            "Find DataEventHandler / SubscribesTo handlers bound to a source object.",
+            Schema(("source", "string", true), ("sourceKind", "string", false)),
+            (h, p) => h.FindEventSubscribers(Str(p, "source"), StrOrNull(p, "sourceKind"))),
+
+        // ---- Labels ----
+
+        new Descriptor("resolve_label",
+            "Resolve a label token like @SYS12345 across languages.",
+            Schema(("token", "string", true), ("languages", "array", false), ("raw", "boolean", false)),
+            (h, p) => h.ResolveLabel(Str(p, "token"), StrArray(p, "languages"), Bool(p, "raw"))),
+
+        // ---- Table details pieces ----
+
+        new Descriptor("get_table_methods",
+            "Return methods declared on a table.",
+            Schema(("table", "string", true)),
+            (h, p) => h.GetTableMethods(Str(p, "table"))),
+
+        new Descriptor("get_table_indexes",
+            "Return indexes defined on a table.",
+            Schema(("table", "string", true)),
+            (h, p) => h.GetTableIndexes(Str(p, "table"))),
+
+        new Descriptor("get_table_delete_actions",
+            "Return delete actions defined on a table.",
+            Schema(("table", "string", true)),
+            (h, p) => h.GetTableDeleteActions(Str(p, "table"))),
+
+        // ---- Heuristics & workspace ----
+
+        new Descriptor("search_any",
+            "Scope-agnostic substring search across every indexed kind (tables, classes, EDTs, enums, menu items, forms, queries, views, data entities, reports, services, workflows).",
+            Schema(("query", "string", true), ("limit", "integer", false)),
+            (h, p) => h.SearchAny(Str(p, "query"), Int(p, "limit", 100))),
+
+        new Descriptor("suggest_edt",
+            "Suggest indexed EDTs for a field name using similarity heuristics. Returns confidence-ranked candidates.",
+            Schema(("fieldName", "string", true), ("limit", "integer", false)),
+            (h, p) => h.SuggestEdt(Str(p, "fieldName"), Int(p, "limit", 5))),
+
+        new Descriptor("get_workspace_info",
+            "Return the effective D365FO_* settings the server is using (paths, custom-model patterns, label languages).",
+            Schema(),
+            (h, _) => h.GetWorkspaceInfo()),
+
+        new Descriptor("stats",
+            "Aggregate counters over the index: totals + top-N tables (by fields), top-N classes (by methods), top-N CoC targets, and per-model counts.",
+            Schema(("topN", "integer", false)),
+            (h, p) => h.Stats(Int(p, "topN", 10))),
+
+        new Descriptor("batch_search",
+            "Run several scope-agnostic searches in a single call. Returns a result-per-query block.",
+            Schema(("queries", "array", true), ("limit", "integer", false)),
+            (h, p) => h.BatchSearch(StrArray(p, "queries") ?? Array.Empty<string>(), Int(p, "limit", 50))),
+
+        new Descriptor("validate_object_naming",
+            "Static naming-rule check (PascalCase, length, character set, extension suffix, optional publisher prefix). No index access required.",
+            Schema(("kind", "string", true), ("name", "string", true), ("prefix", "string", false)),
+            (h, p) => h.ValidateObjectNaming(Str(p, "kind"), Str(p, "name"), StrOrNull(p, "prefix"))),
+
+        new Descriptor("get_table_extension_info",
+            "Return all TableExtensions targeting a given table.",
+            Schema(("table", "string", true)),
+            (h, p) => h.GetTableExtensionInfo(Str(p, "table"))),
+
+        new Descriptor("analyze_extension_points",
+            "Enumerate existing extensions / event handlers / CoC targeting an object and suggest the least-invasive strategy for a new change.",
+            Schema(("target", "string", true)),
+            (h, p) => h.AnalyzeExtensionPoints(Str(p, "target"))),
+
+        new Descriptor("lint",
+            "In-process Best-Practice gate. Categories: table-no-index, ext-named-not-attributed, string-without-edt.",
+            Schema(("categories", "array", false), ("onlyCustomModels", "boolean", false)),
+            (h, p) => h.Lint(StrArray(p, "categories"), Bool(p, "onlyCustomModels", true))),
+
+        new Descriptor("create_label",
+            "Create or update a key=value entry in a *.label.txt file. Fails with KEY_EXISTS unless overwrite=true.",
+            Schema(("file", "string", true), ("key", "string", true), ("value", "string", true), ("overwrite", "boolean", false)),
+            (h, p) => h.CreateLabel(Str(p, "file"), Str(p, "key"), Str(p, "value"), Bool(p, "overwrite"))),
+
+        new Descriptor("rename_label",
+            "Rename a label key in place, preserving its value.",
+            Schema(("file", "string", true), ("oldKey", "string", true), ("newKey", "string", true), ("overwrite", "boolean", false)),
+            (h, p) => h.RenameLabel(Str(p, "file"), Str(p, "oldKey"), Str(p, "newKey"), Bool(p, "overwrite"))),
+
+        new Descriptor("delete_label",
+            "Delete a label entry from a *.label.txt file.",
+            Schema(("file", "string", true), ("key", "string", true)),
+            (h, p) => h.DeleteLabel(Str(p, "file"), Str(p, "key"))),
     };
 
     // ---- JSON helpers ----
@@ -151,6 +350,17 @@ internal static class ToolCatalog
     private static bool Bool(JsonElement p, string name) =>
         p.ValueKind == JsonValueKind.Object && p.TryGetProperty(name, out var v)
         && v.ValueKind == JsonValueKind.True;
+
+    private static bool Bool(JsonElement p, string name, bool dflt)
+    {
+        if (p.ValueKind != JsonValueKind.Object || !p.TryGetProperty(name, out var v)) return dflt;
+        return v.ValueKind switch
+        {
+            JsonValueKind.True => true,
+            JsonValueKind.False => false,
+            _ => dflt,
+        };
+    }
 
     private static string[]? StrArray(JsonElement p, string name)
     {

--- a/src/D365FO.Mcp/ToolHandlers.cs
+++ b/src/D365FO.Mcp/ToolHandlers.cs
@@ -1,5 +1,6 @@
 using D365FO.Core;
 using D365FO.Core.Index;
+using System.IO;
 
 namespace D365FO.Mcp;
 
@@ -109,6 +110,14 @@ public sealed class ToolHandlers
         return ToolResult<object>.Success(new { count = items.Count, items });
     }
 
+    public ToolResult<object> SearchLabelsFts(string query, string[]? langs = null, int limit = 100, bool raw = false)
+    {
+        var items = _repo.SearchLabelsFts(query, langs, limit);
+        if (!raw)
+            items = items.Select(l => l with { Value = StringSanitizer.Sanitize(l.Value) }).ToList();
+        return ToolResult<object>.Success(new { count = items.Count, items });
+    }
+
     public ToolResult<object> GetSecurity(string obj, string type)
         => ToolResult<object>.Success(_repo.GetSecurityCoverage(obj, type));
 
@@ -120,4 +129,429 @@ public sealed class ToolHandlers
 
     public ToolResult<object> IndexStatus()
         => ToolResult<object>.Success(_repo.CountAll());
+
+    // ---- Parity tools (forms / queries / views / entities / reports / services / workflows) ----
+
+    public ToolResult<object> GetForm(string name)
+    {
+        var f = _repo.GetForm(name);
+        return f is null
+            ? ToolResult<object>.Fail("FORM_NOT_FOUND", $"Form '{name}' not found.")
+            : ToolResult<object>.Success(f);
+    }
+
+    public ToolResult<object> SearchQueries(string query, int limit = 50)
+    {
+        var items = _repo.SearchQueries(query, limit);
+        return ToolResult<object>.Success(new { count = items.Count, items });
+    }
+
+    public ToolResult<object> GetQuery(string name)
+    {
+        var q = _repo.GetQuery(name);
+        return q is null
+            ? ToolResult<object>.Fail("QUERY_NOT_FOUND", $"Query '{name}' not found.")
+            : ToolResult<object>.Success(q);
+    }
+
+    public ToolResult<object> SearchViews(string query, int limit = 50)
+    {
+        var items = _repo.SearchViews(query, limit);
+        return ToolResult<object>.Success(new { count = items.Count, items });
+    }
+
+    public ToolResult<object> GetView(string name)
+    {
+        var v = _repo.GetView(name);
+        return v is null
+            ? ToolResult<object>.Fail("VIEW_NOT_FOUND", $"View '{name}' not found.")
+            : ToolResult<object>.Success(v);
+    }
+
+    public ToolResult<object> SearchDataEntities(string query, int limit = 50)
+    {
+        var items = _repo.SearchDataEntities(query, limit);
+        return ToolResult<object>.Success(new { count = items.Count, items });
+    }
+
+    public ToolResult<object> GetDataEntity(string name)
+    {
+        var e = _repo.GetDataEntity(name);
+        return e is null
+            ? ToolResult<object>.Fail("ENTITY_NOT_FOUND", $"Data entity '{name}' not found.")
+            : ToolResult<object>.Success(e);
+    }
+
+    public ToolResult<object> SearchReports(string query, int limit = 50)
+    {
+        var items = _repo.SearchReports(query, limit);
+        return ToolResult<object>.Success(new { count = items.Count, items });
+    }
+
+    public ToolResult<object> GetReport(string name)
+    {
+        var r = _repo.GetReport(name);
+        return r is null
+            ? ToolResult<object>.Fail("REPORT_NOT_FOUND", $"Report '{name}' not found.")
+            : ToolResult<object>.Success(r);
+    }
+
+    public ToolResult<object> SearchServices(string query, int limit = 50)
+    {
+        var items = _repo.SearchServices(query, limit);
+        return ToolResult<object>.Success(new { count = items.Count, items });
+    }
+
+    public ToolResult<object> GetService(string name)
+    {
+        var s = _repo.GetService(name);
+        return s is null
+            ? ToolResult<object>.Fail("SERVICE_NOT_FOUND", $"Service '{name}' not found.")
+            : ToolResult<object>.Success(s);
+    }
+
+    public ToolResult<object> GetServiceGroup(string name)
+    {
+        var g = _repo.GetServiceGroup(name);
+        return g is null
+            ? ToolResult<object>.Fail("SERVICE_GROUP_NOT_FOUND", $"Service group '{name}' not found.")
+            : ToolResult<object>.Success(g);
+    }
+
+    public ToolResult<object> SearchWorkflowTypes(string query, int limit = 50)
+    {
+        var items = _repo.SearchWorkflowTypes(query, limit);
+        return ToolResult<object>.Success(new { count = items.Count, items });
+    }
+
+    // ---- Security details ----
+
+    public ToolResult<object> GetSecurityRole(string name)
+    {
+        var r = _repo.GetSecurityRole(name);
+        return r is null
+            ? ToolResult<object>.Fail("ROLE_NOT_FOUND", $"Role '{name}' not found.")
+            : ToolResult<object>.Success(r);
+    }
+
+    public ToolResult<object> GetSecurityDuty(string name)
+    {
+        var d = _repo.GetSecurityDuty(name);
+        return d is null
+            ? ToolResult<object>.Fail("DUTY_NOT_FOUND", $"Duty '{name}' not found.")
+            : ToolResult<object>.Success(d);
+    }
+
+    public ToolResult<object> GetSecurityPrivilege(string name)
+    {
+        var p = _repo.GetSecurityPrivilege(name);
+        return p is null
+            ? ToolResult<object>.Fail("PRIVILEGE_NOT_FOUND", $"Privilege '{name}' not found.")
+            : ToolResult<object>.Success(p);
+    }
+
+    // ---- Models ----
+
+    public ToolResult<object> ListModels()
+    {
+        var items = _repo.ListModels();
+        return ToolResult<object>.Success(new { count = items.Count, items });
+    }
+
+    public ToolResult<object> GetModelDependencies(string name)
+    {
+        var deps = _repo.GetModelDependencies(name);
+        return deps is null
+            ? ToolResult<object>.Fail("MODEL_NOT_FOUND", $"Model '{name}' not found.")
+            : ToolResult<object>.Success(deps);
+    }
+
+    // ---- Extensions / event subscribers ----
+
+    public ToolResult<object> FindExtensions(string target, string? kind = null)
+    {
+        var items = _repo.FindExtensions(target, kind);
+        return ToolResult<object>.Success(new { count = items.Count, items });
+    }
+
+    public ToolResult<object> FindEventSubscribers(string sourceObject, string? sourceKind = null)
+    {
+        var items = _repo.FindEventSubscribers(sourceObject, sourceKind);
+        return ToolResult<object>.Success(new { count = items.Count, items });
+    }
+
+    // ---- Labels ----
+
+    public ToolResult<object> ResolveLabel(string token, string[]? langs = null, bool raw = false)
+    {
+        var items = _repo.ResolveLabel(token, langs);
+        if (!raw)
+            items = items.Select(l => l with { Value = StringSanitizer.Sanitize(l.Value) }).ToList();
+        return ToolResult<object>.Success(new { count = items.Count, items });
+    }
+
+    // ---- Table details pieces ----
+
+    public ToolResult<object> GetTableMethods(string table)
+    {
+        var items = _repo.GetTableMethods(table);
+        return ToolResult<object>.Success(new { count = items.Count, items });
+    }
+
+    public ToolResult<object> GetTableIndexes(string table)
+    {
+        var items = _repo.GetTableIndexes(table);
+        return ToolResult<object>.Success(new { count = items.Count, items });
+    }
+
+    public ToolResult<object> GetTableDeleteActions(string table)
+    {
+        var items = _repo.GetTableDeleteActions(table);
+        return ToolResult<object>.Success(new { count = items.Count, items });
+    }
+
+    // ---- Heuristics & workspace ----
+
+    public ToolResult<object> SearchAny(string query, int limit = 100)
+    {
+        if (string.IsNullOrWhiteSpace(query))
+            return ToolResult<object>.Fail("BAD_INPUT", "Query required.");
+        var rows = _repo.FindUsages(query, limit)
+            .Select(t => new { kind = t.Kind, name = t.Name, model = t.Model })
+            .ToList();
+        var byKind = rows.GroupBy(r => r.kind).ToDictionary(g => g.Key, g => g.Count());
+        return ToolResult<object>.Success(new { count = rows.Count, byKind, items = rows });
+    }
+
+    public ToolResult<object> SuggestEdt(string fieldName, int limit = 5)
+    {
+        if (string.IsNullOrWhiteSpace(fieldName))
+            return ToolResult<object>.Fail("BAD_INPUT", "fieldName required.");
+        var items = EdtSuggester.Suggest(_repo, fieldName, limit)
+            .Select(s => new
+            {
+                name = s.Edt.Name,
+                model = s.Edt.Model,
+                extends = s.Edt.Extends,
+                baseType = s.Edt.BaseType,
+                stringSize = s.Edt.StringSize,
+                confidence = s.Confidence,
+                reason = s.Reason,
+            })
+            .ToList();
+        return ToolResult<object>.Success(new { fieldName, count = items.Count, suggestions = items });
+    }
+
+    public ToolResult<object> GetWorkspaceInfo()
+    {
+        var cfg = D365FoSettings.FromEnvironment();
+        return ToolResult<object>.Success(new
+        {
+            packagesPath = cfg.PackagesPath,
+            workspacePath = cfg.WorkspacePath,
+            databasePath = cfg.DatabasePath,
+            databaseExists = File.Exists(cfg.DatabasePath),
+            customModelPatterns = cfg.CustomModels,
+            labelLanguages = cfg.LabelLanguages,
+            hint = string.IsNullOrEmpty(cfg.PackagesPath)
+                ? "Set D365FO_PACKAGES_PATH before calling `index extract`."
+                : null,
+        });
+    }
+
+    public ToolResult<object> Stats(int topN = 10)
+    {
+        var stats = _repo.GetStats(topN);
+        var counts = _repo.CountAll();
+        return ToolResult<object>.Success(new
+        {
+            totals = counts,
+            perModel = stats.PerModel,
+            topTables = stats.TopTables,
+            topClasses = stats.TopClasses,
+            topCocTargets = stats.TopCocTargets,
+        });
+    }
+
+    public ToolResult<object> ValidateObjectNaming(string kind, string name, string? prefix = null)
+    {
+        var violations = ObjectNamingRules.Validate(kind, name, prefix);
+        var hasError = violations.Any(v => v.Severity == "error");
+        return ToolResult<object>.Success(new
+        {
+            objectKind = kind,
+            name,
+            prefix,
+            ok = !hasError,
+            count = violations.Count,
+            violations = violations.Select(v => new { code = v.Code, severity = v.Severity, message = v.Message }),
+        });
+    }
+
+    public ToolResult<object> GetTableExtensionInfo(string table)
+    {
+        var items = _repo.FindExtensions(table, "Table");
+        return ToolResult<object>.Success(new
+        {
+            target = table,
+            count = items.Count,
+            extensions = items,
+        });
+    }
+
+    public ToolResult<object> AnalyzeExtensionPoints(string target)
+    {
+        var extensions = _repo.FindExtensions(target);
+        var handlers = _repo.FindEventSubscribers(target);
+        var coc = _repo.FindCocExtensions(target);
+        return ToolResult<object>.Success(new
+        {
+            target,
+            extensions = new { count = extensions.Count, items = extensions },
+            eventHandlers = new { count = handlers.Count, items = handlers },
+            cocExtensions = new { count = coc.Count, items = coc },
+            summary = new
+            {
+                extensionCount = extensions.Count,
+                eventHandlerCount = handlers.Count,
+                cocCount = coc.Count,
+                suggestedStrategy = SuggestStrategy(extensions.Count, handlers.Count, coc.Count),
+            },
+        });
+    }
+
+    private static string SuggestStrategy(int extensions, int handlers, int coc)
+    {
+        if (coc > 0) return "Chain-of-Command — a CoC already targets this symbol, follow the established pattern.";
+        if (handlers > 0) return "Event handler — add a SubscribesTo handler class in your model.";
+        if (extensions > 0) return "Object extension — extend the target with a '<Target>.<Suffix>' .xml (see `d365fo generate extension`).";
+        return "No existing extensions — prefer the least-invasive option: an event handler or a CoC on a virtual method.";
+    }
+
+    public ToolResult<object> BatchSearch(string[] queries, int limit = 50)
+    {
+        if (queries is null || queries.Length == 0)
+            return ToolResult<object>.Fail(D365FoErrorCodes.BadInput, "queries must be a non-empty array.");
+        var results = new List<object>();
+        foreach (var q in queries)
+        {
+            if (string.IsNullOrWhiteSpace(q)) continue;
+            var hits = _repo.FindUsages(q, limit)
+                .Select(t => new { kind = t.Kind, name = t.Name, model = t.Model })
+                .ToList();
+            results.Add(new { query = q, count = hits.Count, items = hits });
+        }
+        return ToolResult<object>.Success(new { count = results.Count, results });
+    }
+
+    public ToolResult<object> Lint(string[]? categories = null, bool onlyCustomModels = true)
+    {
+        var run = categories is { Length: > 0 }
+            ? categories
+            : new[] { "table-no-index", "ext-named-not-attributed", "string-without-edt" };
+        var sections = new List<object>();
+        int total = 0;
+        foreach (var cat in run)
+        {
+            IReadOnlyList<LintHit> hits = cat.ToLowerInvariant() switch
+            {
+                "table-no-index" => _repo.FindTablesWithoutIndex(onlyCustomModels),
+                "ext-named-not-attributed" => _repo.FindExtensionNamedButNotAttributed(onlyCustomModels),
+                "string-without-edt" => _repo.FindStringFieldsWithoutEdt(onlyCustomModels),
+                _ => Array.Empty<LintHit>(),
+            };
+            total += hits.Count;
+            sections.Add(new { category = cat, count = hits.Count, items = hits });
+        }
+        return ToolResult<object>.Success(new
+        {
+            onlyCustomModels,
+            categories = run,
+            totalFindings = total,
+            sections,
+        });
+    }
+
+    // ---- label write-ops (ROADMAP §4.2) ----
+
+    public ToolResult<object> CreateLabel(string file, string key, string value, bool overwrite = false)
+    {
+        if (string.IsNullOrWhiteSpace(file)) return ToolResult<object>.Fail(D365FoErrorCodes.BadInput, "file required");
+        if (string.IsNullOrWhiteSpace(key)) return ToolResult<object>.Fail(D365FoErrorCodes.BadInput, "key required");
+        try
+        {
+            var res = D365FO.Core.Labels.LabelFileWriter.CreateOrUpdate(file, key, value, overwrite);
+            if (res.Outcome == D365FO.Core.Labels.WriteOutcome.KeyExists)
+                return ToolResult<object>.Fail("KEY_EXISTS",
+                    $"Label '{key}' already exists; pass overwrite=true to replace.",
+                    hint: $"Existing value: {res.OldValue}");
+            return ToolResult<object>.Success(new
+            {
+                outcome = res.Outcome.ToString(),
+                file = res.Path,
+                key = res.Key,
+                oldValue = res.OldValue,
+                newValue = res.NewValue,
+            });
+        }
+        catch (Exception ex)
+        {
+            return ToolResult<object>.Fail(D365FoErrorCodes.WriteFailed, ex.Message);
+        }
+    }
+
+    public ToolResult<object> RenameLabel(string file, string oldKey, string newKey, bool overwrite = false)
+    {
+        if (string.IsNullOrWhiteSpace(file)) return ToolResult<object>.Fail(D365FoErrorCodes.BadInput, "file required");
+        if (string.IsNullOrWhiteSpace(oldKey) || string.IsNullOrWhiteSpace(newKey))
+            return ToolResult<object>.Fail(D365FoErrorCodes.BadInput, "oldKey and newKey required");
+        try
+        {
+            var res = D365FO.Core.Labels.LabelFileWriter.Rename(file, oldKey, newKey, overwrite);
+            return res.Outcome switch
+            {
+                D365FO.Core.Labels.WriteOutcome.FileMissing => ToolResult<object>.Fail("FILE_NOT_FOUND", $"Label file not found: {file}"),
+                D365FO.Core.Labels.WriteOutcome.KeyMissing => ToolResult<object>.Fail("KEY_NOT_FOUND", $"Label '{oldKey}' not present."),
+                D365FO.Core.Labels.WriteOutcome.KeyExists => ToolResult<object>.Fail("KEY_EXISTS", $"Target key '{newKey}' already exists."),
+                _ => ToolResult<object>.Success(new
+                {
+                    outcome = res.Outcome.ToString(),
+                    file = res.Path,
+                    oldKey,
+                    newKey,
+                    value = res.NewValue,
+                }),
+            };
+        }
+        catch (Exception ex)
+        {
+            return ToolResult<object>.Fail(D365FoErrorCodes.WriteFailed, ex.Message);
+        }
+    }
+
+    public ToolResult<object> DeleteLabel(string file, string key)
+    {
+        if (string.IsNullOrWhiteSpace(file)) return ToolResult<object>.Fail(D365FoErrorCodes.BadInput, "file required");
+        if (string.IsNullOrWhiteSpace(key)) return ToolResult<object>.Fail(D365FoErrorCodes.BadInput, "key required");
+        try
+        {
+            var res = D365FO.Core.Labels.LabelFileWriter.Delete(file, key);
+            return res.Outcome switch
+            {
+                D365FO.Core.Labels.WriteOutcome.FileMissing => ToolResult<object>.Fail("FILE_NOT_FOUND", $"Label file not found: {file}"),
+                D365FO.Core.Labels.WriteOutcome.KeyMissing => ToolResult<object>.Fail("KEY_NOT_FOUND", $"Label '{key}' not present."),
+                _ => ToolResult<object>.Success(new
+                {
+                    outcome = res.Outcome.ToString(),
+                    file = res.Path,
+                    key = res.Key,
+                    removedValue = res.OldValue,
+                }),
+            };
+        }
+        catch (Exception ex)
+        {
+            return ToolResult<object>.Fail(D365FoErrorCodes.WriteFailed, ex.Message);
+        }
+    }
 }

--- a/tests/D365FO.Cli.Tests/ObjectNamingRulesTests.cs
+++ b/tests/D365FO.Cli.Tests/ObjectNamingRulesTests.cs
@@ -1,0 +1,56 @@
+using D365FO.Core;
+using Xunit;
+
+namespace D365FO.Cli.Tests;
+
+public class ObjectNamingRulesTests
+{
+    [Fact]
+    public void Valid_pascal_case_name_passes_with_no_errors()
+    {
+        var v = ObjectNamingRules.Validate("Table", "CustTable");
+        Assert.DoesNotContain(v, x => x.Severity == "error");
+    }
+
+    [Fact]
+    public void Empty_name_produces_error()
+    {
+        var v = ObjectNamingRules.Validate("Table", "");
+        Assert.Contains(v, x => x.Code == "EMPTY_NAME" && x.Severity == "error");
+    }
+
+    [Fact]
+    public void Name_with_space_produces_invalid_chars()
+    {
+        var v = ObjectNamingRules.Validate("Class", "Bad Name");
+        Assert.Contains(v, x => x.Code == "INVALID_CHARS");
+    }
+
+    [Fact]
+    public void Name_starting_with_digit_is_rejected()
+    {
+        var v = ObjectNamingRules.Validate("Class", "1Foo");
+        Assert.Contains(v, x => x.Code == "LEADS_WITH_DIGIT" && x.Severity == "error");
+    }
+
+    [Fact]
+    public void Missing_publisher_prefix_emits_warning()
+    {
+        var v = ObjectNamingRules.Validate("Table", "CustTable", prefix: "Contoso_");
+        Assert.Contains(v, x => x.Code == "MISSING_PUBLISHER_PREFIX" && x.Severity == "warn");
+    }
+
+    [Fact]
+    public void Coc_class_without_extension_suffix_is_flagged()
+    {
+        var v = ObjectNamingRules.Validate("Coc", "CustTableHelper");
+        Assert.Contains(v, x => x.Code == "COC_SUFFIX");
+    }
+
+    [Fact]
+    public void Coc_class_with_proper_extension_suffix_passes()
+    {
+        var v = ObjectNamingRules.Validate("Coc", "CustTable_Extension");
+        Assert.DoesNotContain(v, x => x.Code == "COC_SUFFIX");
+    }
+}

--- a/tests/D365FO.Cli.Tests/ScaffoldingSmokeTests.cs
+++ b/tests/D365FO.Cli.Tests/ScaffoldingSmokeTests.cs
@@ -1,0 +1,97 @@
+using D365FO.Core.Scaffolding;
+using System.Xml.Linq;
+using Xunit;
+
+namespace D365FO.Cli.Tests;
+
+public class ScaffoldingSmokeTests
+{
+    [Fact]
+    public void DataEntity_contains_table_datasource_and_public_names()
+    {
+        var doc = XppScaffolder.DataEntity("CustEntity", "CustTable");
+        var root = doc.Root!;
+        Assert.Equal("AxDataEntityView", root.Name.LocalName);
+        Assert.Equal("CustEntity", root.Element("Name")!.Value);
+        Assert.Equal("CustEntity", root.Element("PublicEntityName")!.Value);
+        Assert.Equal("CustEntitys", root.Element("PublicCollectionName")!.Value);
+        var ds = root.Element("DataSources")!.Elements().First();
+        Assert.Equal("AxQuerySimpleRootDataSource", ds.Name.LocalName);
+        Assert.Equal("CustTable", ds.Element("Table")!.Value);
+    }
+
+    [Fact]
+    public void Extension_produces_dotted_name_for_target_and_suffix()
+    {
+        var doc = XppScaffolder.Extension("Table", "CustTable", "Contoso");
+        Assert.Equal("AxTableExtension", doc.Root!.Name.LocalName);
+        Assert.Equal("CustTable.Contoso", doc.Root.Element("Name")!.Value);
+    }
+
+    [Fact]
+    public void Extension_rejects_unknown_kind()
+    {
+        Assert.Throws<ArgumentException>(() => XppScaffolder.Extension("Bogus", "X", "Y"));
+    }
+
+    [Fact]
+    public void Privilege_round_trips_entry_point_fields()
+    {
+        var doc = XppScaffolder.Privilege("PurchOrderReadPriv", "PurchTableForm", "MenuItemDisplay",
+            entryPointObject: "PurchTable", access: "Read");
+        Assert.Equal("PurchOrderReadPriv", doc.Root!.Element("Name")!.Value);
+        var ep = doc.Root.Element("EntryPoints")!.Element("AxSecurityEntryPointReference")!;
+        Assert.Equal("PurchTableForm", ep.Element("Name")!.Value);
+        Assert.Equal("PurchTable", ep.Element("ObjectName")!.Value);
+        Assert.Equal("MenuItemDisplay", ep.Element("ObjectType")!.Value);
+        Assert.Equal("Read", ep.Element("AccessLevel")!.Value);
+    }
+
+    [Fact]
+    public void Duty_lists_given_privileges()
+    {
+        var doc = XppScaffolder.Duty("PurchOrderMaintainDuty", new[] { "PrivA", "PrivB" });
+        var refs = doc.Root!.Element("PrivilegeReferences")!.Elements().ToList();
+        Assert.Equal(2, refs.Count);
+        Assert.Equal("PrivA", refs[0].Element("Name")!.Value);
+        Assert.Equal("PrivB", refs[1].Element("Name")!.Value);
+    }
+
+    [Fact]
+    public void EventHandler_emits_expected_attribute_for_form_kind()
+    {
+        var doc = XppScaffolder.EventHandler("Contoso_CustTable_Handler", "Table", "CustTable", "inserted");
+        var decl = doc.Descendants("Declaration").Single().Value;
+        Assert.Contains("DataEventHandler", decl, StringComparison.Ordinal);
+        Assert.Contains("tableStr(CustTable)", decl, StringComparison.Ordinal);
+        Assert.Contains("DataEventType::inserted", decl, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void Role_lists_referenced_duties_and_privileges()
+    {
+        var doc = XppScaffolder.Role("ContosoOperatorRole",
+            duties: new[] { "DutyA", "DutyB" },
+            privileges: new[] { "PrivC" },
+            label: "Operator", description: "Fleet operator");
+        Assert.Equal("AxSecurityRole", doc.Root!.Name.LocalName);
+        Assert.Equal("ContosoOperatorRole", doc.Root.Element("Name")!.Value);
+        var duties = doc.Root.Element("Duties")!.Elements().ToList();
+        Assert.Equal(2, duties.Count);
+        Assert.Equal("DutyA", duties[0].Element("Name")!.Value);
+        var privs = doc.Root.Element("Privileges")!.Elements().ToList();
+        Assert.Single(privs);
+    }
+
+    [Fact]
+    public void AddToRole_is_idempotent_and_merges_new_refs()
+    {
+        var doc = XppScaffolder.Role("R", duties: new[] { "D1" });
+        var changed1 = XppScaffolder.AddToRole(doc, duties: new[] { "D1" });
+        Assert.False(changed1);
+        var changed2 = XppScaffolder.AddToRole(doc, duties: new[] { "D2" }, privileges: new[] { "P1" });
+        Assert.True(changed2);
+        Assert.Equal(2, doc.Root!.Element("Duties")!.Elements().Count());
+        Assert.Single(doc.Root.Element("Privileges")!.Elements());
+    }
+}

--- a/tests/D365FO.Core.Tests/EdtSuggesterTests.cs
+++ b/tests/D365FO.Core.Tests/EdtSuggesterTests.cs
@@ -1,0 +1,114 @@
+using D365FO.Core;
+using D365FO.Core.Extract;
+using D365FO.Core.Index;
+using Xunit;
+
+namespace D365FO.Core.Tests;
+
+public class EdtSuggesterTests : IDisposable
+{
+    private readonly string _dbPath = Path.Combine(Path.GetTempPath(), $"edt-sugg-{Guid.NewGuid():N}.sqlite");
+    private readonly MetadataRepository _repo;
+
+    public EdtSuggesterTests()
+    {
+        _repo = new MetadataRepository(_dbPath);
+        _repo.EnsureSchema();
+        Seed();
+    }
+
+    public void Dispose()
+    {
+        Microsoft.Data.Sqlite.SqliteConnection.ClearAllPools();
+        foreach (var ext in new[] { "", "-wal", "-shm" })
+        {
+            var p = _dbPath + ext;
+            if (File.Exists(p)) { try { File.Delete(p); } catch { } }
+        }
+    }
+
+    private void Seed()
+    {
+        var batch = new ExtractBatch(
+            Model: "ApplicationSuite",
+            Publisher: "Microsoft",
+            Layer: "app",
+            IsCustom: false,
+            Tables: Array.Empty<ExtractedTable>(),
+            Classes: Array.Empty<ExtractedClass>(),
+            Edts: new[]
+            {
+                new ExtractedEdt("CustAccount", null, "String", null, 20),
+                new ExtractedEdt("CustomerAccount", "CustAccount", "String", null, 20),
+                new ExtractedEdt("AccountNum", null, "String", null, 10),
+                new ExtractedEdt("OrderAmount", null, "Real", null, null),
+                new ExtractedEdt("TransDate", null, "Date", null, null),
+            },
+            Enums: Array.Empty<ExtractedEnum>(),
+            MenuItems: Array.Empty<ExtractedMenuItem>(),
+            CocExtensions: Array.Empty<ExtractedCoc>(),
+            Labels: Array.Empty<ExtractedLabel>());
+        _repo.ApplyExtract(batch);
+    }
+
+    [Fact]
+    public void Exact_name_gets_top_confidence()
+    {
+        var suggestions = EdtSuggester.Suggest(_repo, "CustAccount");
+        Assert.NotEmpty(suggestions);
+        Assert.Equal("CustAccount", suggestions[0].Edt.Name);
+        Assert.Equal(1.0, suggestions[0].Confidence);
+    }
+
+    [Fact]
+    public void Stripped_suffix_matches_root()
+    {
+        var suggestions = EdtSuggester.Suggest(_repo, "CustAccountId");
+        Assert.Contains(suggestions, s => s.Edt.Name == "CustAccount" && s.Confidence >= 0.80);
+    }
+
+    [Fact]
+    public void Returns_empty_for_unknown()
+    {
+        var suggestions = EdtSuggester.Suggest(_repo, "TotallyUnrelatedThing");
+        Assert.Empty(suggestions);
+    }
+
+    [Fact]
+    public void Returns_empty_for_blank()
+    {
+        var suggestions = EdtSuggester.Suggest(_repo, "");
+        Assert.Empty(suggestions);
+    }
+
+    [Fact]
+    public void Ranks_by_confidence_desc()
+    {
+        var suggestions = EdtSuggester.Suggest(_repo, "Account", limit: 5);
+        for (int i = 1; i < suggestions.Count; i++)
+            Assert.True(suggestions[i - 1].Confidence >= suggestions[i].Confidence);
+    }
+}
+
+public class EnsureSchemaReturnsAppliedTests : IDisposable
+{
+    private readonly string _dbPath = Path.Combine(Path.GetTempPath(), $"schema-applied-{Guid.NewGuid():N}.sqlite");
+
+    public void Dispose()
+    {
+        Microsoft.Data.Sqlite.SqliteConnection.ClearAllPools();
+        foreach (var ext in new[] { "", "-wal", "-shm" })
+        {
+            var p = _dbPath + ext;
+            if (File.Exists(p)) { try { File.Delete(p); } catch { } }
+        }
+    }
+
+    [Fact]
+    public void First_call_applies_schema_second_is_noop()
+    {
+        var repo = new MetadataRepository(_dbPath);
+        Assert.True(repo.EnsureSchema(), "first invocation should apply schema");
+        Assert.False(repo.EnsureSchema(), "second invocation should be a no-op");
+    }
+}

--- a/tests/D365FO.Core.Tests/LabelFileWriterTests.cs
+++ b/tests/D365FO.Core.Tests/LabelFileWriterTests.cs
@@ -1,0 +1,127 @@
+using D365FO.Core.Labels;
+using Xunit;
+
+namespace D365FO.Core.Tests;
+
+public class LabelFileWriterTests
+{
+    private static string NewTempFile()
+    {
+        var path = Path.Combine(Path.GetTempPath(), $"d365fo-label-{Guid.NewGuid():N}.label.txt");
+        return path;
+    }
+
+    [Fact]
+    public void CreateOrUpdate_creates_file_when_missing()
+    {
+        var path = NewTempFile();
+        try
+        {
+            var r = LabelFileWriter.CreateOrUpdate(path, "Vehicle", "Vehicle");
+            Assert.Equal(WriteOutcome.Created, r.Outcome);
+            Assert.Equal("Vehicle", r.NewValue);
+            Assert.Null(r.OldValue);
+            var text = File.ReadAllText(path);
+            Assert.Contains("Vehicle=Vehicle", text);
+        }
+        finally { SafeDelete(path); }
+    }
+
+    [Fact]
+    public void CreateOrUpdate_fails_when_key_exists_without_overwrite()
+    {
+        var path = NewTempFile();
+        try
+        {
+            LabelFileWriter.CreateOrUpdate(path, "Vehicle", "One");
+            var r = LabelFileWriter.CreateOrUpdate(path, "Vehicle", "Two");
+            Assert.Equal(WriteOutcome.KeyExists, r.Outcome);
+            Assert.Equal("One", r.OldValue);
+            Assert.Contains("Vehicle=One", File.ReadAllText(path));
+        }
+        finally { SafeDelete(path); }
+    }
+
+    [Fact]
+    public void CreateOrUpdate_overwrites_value_when_flag_set()
+    {
+        var path = NewTempFile();
+        try
+        {
+            LabelFileWriter.CreateOrUpdate(path, "Vehicle", "One");
+            var r = LabelFileWriter.CreateOrUpdate(path, "Vehicle", "Two", overwrite: true);
+            Assert.Equal(WriteOutcome.Updated, r.Outcome);
+            Assert.Equal("One", r.OldValue);
+            Assert.Equal("Two", r.NewValue);
+            Assert.Contains("Vehicle=Two", File.ReadAllText(path));
+        }
+        finally { SafeDelete(path); }
+    }
+
+    [Fact]
+    public void Rename_moves_key_preserving_value_and_comments()
+    {
+        var path = NewTempFile();
+        try
+        {
+            File.WriteAllText(path, "; translator note\nVehicle=My Vehicle\n");
+            var r = LabelFileWriter.Rename(path, "Vehicle", "Car");
+            Assert.Equal(WriteOutcome.Renamed, r.Outcome);
+            Assert.Equal("My Vehicle", r.NewValue);
+            var text = File.ReadAllText(path);
+            Assert.Contains("; translator note", text);
+            Assert.Contains("Car=My Vehicle", text);
+            Assert.DoesNotContain("Vehicle=My Vehicle", text);
+        }
+        finally { SafeDelete(path); }
+    }
+
+    [Fact]
+    public void Rename_returns_KeyMissing_when_source_absent()
+    {
+        var path = NewTempFile();
+        try
+        {
+            File.WriteAllText(path, "A=B\n");
+            var r = LabelFileWriter.Rename(path, "X", "Y");
+            Assert.Equal(WriteOutcome.KeyMissing, r.Outcome);
+        }
+        finally { SafeDelete(path); }
+    }
+
+    [Fact]
+    public void Rename_returns_KeyExists_when_target_present_without_overwrite()
+    {
+        var path = NewTempFile();
+        try
+        {
+            File.WriteAllText(path, "A=1\nB=2\n");
+            var r = LabelFileWriter.Rename(path, "A", "B");
+            Assert.Equal(WriteOutcome.KeyExists, r.Outcome);
+        }
+        finally { SafeDelete(path); }
+    }
+
+    [Fact]
+    public void Delete_removes_key_and_keeps_surrounding_lines()
+    {
+        var path = NewTempFile();
+        try
+        {
+            File.WriteAllText(path, "A=1\nB=2\n");
+            var r = LabelFileWriter.Delete(path, "A");
+            Assert.Equal(WriteOutcome.Deleted, r.Outcome);
+            Assert.Equal("1", r.OldValue);
+            var text = File.ReadAllText(path);
+            Assert.DoesNotContain("A=1", text);
+            Assert.Contains("B=2", text);
+        }
+        finally { SafeDelete(path); }
+    }
+
+    private static void SafeDelete(string path)
+    {
+        try { if (File.Exists(path)) File.Delete(path); } catch { }
+        try { if (File.Exists(path + ".bak")) File.Delete(path + ".bak"); } catch { }
+    }
+}

--- a/tests/D365FO.Core.Tests/LabelFtsTests.cs
+++ b/tests/D365FO.Core.Tests/LabelFtsTests.cs
@@ -1,0 +1,73 @@
+using D365FO.Core.Index;
+using Xunit;
+
+namespace D365FO.Core.Tests;
+
+public class LabelFtsTests
+{
+    [Fact]
+    public void Fts_ranks_phrase_match_above_partial()
+    {
+        var db = Path.Combine(Path.GetTempPath(), $"d365fo-fts-{Guid.NewGuid():N}.sqlite");
+        try
+        {
+            var repo = new MetadataRepository(db);
+            repo.EnsureSchema();
+            var modelId = repo.UpsertModel("Fleet", "Contoso", "usr", true);
+
+            Insert(db, 1, "Vehicle fleet operations", "en-us", "VehicleFleet", "Vehicles.en-us");
+            Insert(db, 2, "Fleet management console", "en-us", "FleetMgmt", "Vehicles.en-us");
+            Insert(db, 3, "Customer invoice register", "en-us", "CustInv", "Sales.en-us");
+            Insert(db, 4, "Vehicle is mandatory", "en-us", "VehMandatory", "Vehicles.en-us");
+
+            var hits = repo.SearchLabelsFts("Vehicle fleet", new[] { "en-us" }, 10);
+            Assert.NotEmpty(hits);
+            Assert.Contains(hits, h => h.Key == "VehicleFleet");
+            Assert.DoesNotContain(hits, h => h.Key == "CustInv");
+        }
+        finally
+        {
+            try { File.Delete(db); } catch { }
+        }
+    }
+
+    [Fact]
+    public void Fts_search_is_language_filtered()
+    {
+        var db = Path.Combine(Path.GetTempPath(), $"d365fo-fts-{Guid.NewGuid():N}.sqlite");
+        try
+        {
+            var repo = new MetadataRepository(db);
+            repo.EnsureSchema();
+            repo.UpsertModel("Fleet", "Contoso", "usr", true);
+            Insert(db, 1, "vehicle register", "en-us", "VehEn", "Vehicles.en-us");
+            Insert(db, 2, "register vozidel", "cs", "VehCs", "Vehicles.cs");
+
+            var en = repo.SearchLabelsFts("vehicle", new[] { "en-us" }, 10);
+            Assert.Single(en);
+            Assert.Equal("VehEn", en[0].Key);
+
+            var cs = repo.SearchLabelsFts("vozidel", new[] { "cs" }, 10);
+            Assert.Single(cs);
+            Assert.Equal("VehCs", cs[0].Key);
+        }
+        finally
+        {
+            try { File.Delete(db); } catch { }
+        }
+    }
+
+    private static void Insert(string db, long labelId, string value, string lang, string key, string file)
+    {
+        using var conn = new Microsoft.Data.Sqlite.SqliteConnection($"Data Source={db}");
+        conn.Open();
+        using var cmd = conn.CreateCommand();
+        cmd.CommandText = "INSERT INTO Labels(LabelId, LabelFile, Language, Key, Value) VALUES(@id,@f,@lg,@k,@v)";
+        cmd.Parameters.AddWithValue("@id", labelId);
+        cmd.Parameters.AddWithValue("@f", file);
+        cmd.Parameters.AddWithValue("@lg", lang);
+        cmd.Parameters.AddWithValue("@k", key);
+        cmd.Parameters.AddWithValue("@v", value);
+        cmd.ExecuteNonQuery();
+    }
+}

--- a/tests/D365FO.Core.Tests/McpDispatcherTests.cs
+++ b/tests/D365FO.Core.Tests/McpDispatcherTests.cs
@@ -85,4 +85,44 @@ public class McpDispatcherTests : IDisposable
         var resp = await Roundtrip("""{"jsonrpc":"2.0","method":"notifications/initialized"}""");
         Assert.Empty(resp);
     }
+
+    [Fact]
+    public async Task ToolsList_exposes_parity_tools()
+    {
+        var resp = await Roundtrip("""{"jsonrpc":"2.0","id":10,"method":"tools/list"}""");
+        var doc = Assert.Single(resp);
+        var names = doc.RootElement.GetProperty("result").GetProperty("tools")
+            .EnumerateArray().Select(t => t.GetProperty("name").GetString()).ToHashSet();
+        // A selection of the new parity tools added in the SDK migration.
+        Assert.Contains("search_queries", names);
+        Assert.Contains("get_data_entity", names);
+        Assert.Contains("search_data_entities", names);
+        Assert.Contains("list_models", names);
+        Assert.Contains("get_security_role", names);
+        Assert.Contains("find_extensions", names);
+        Assert.Contains("resolve_label", names);
+        Assert.Contains("get_table_methods", names);
+    }
+
+    [Fact]
+    public async Task ListModels_returns_empty_collection_for_fresh_db()
+    {
+        var resp = await Roundtrip("""{"jsonrpc":"2.0","id":11,"method":"tools/call","params":{"name":"list_models","arguments":{}}}""");
+        var doc = Assert.Single(resp);
+        var payload = JsonDocument.Parse(doc.RootElement.GetProperty("result")
+            .GetProperty("content")[0].GetProperty("text").GetString()!);
+        Assert.True(payload.RootElement.GetProperty("ok").GetBoolean());
+        Assert.Equal(0, payload.RootElement.GetProperty("data").GetProperty("count").GetInt32());
+    }
+
+    [Fact]
+    public async Task UnknownGet_returns_structured_notFound_error()
+    {
+        var resp = await Roundtrip("""{"jsonrpc":"2.0","id":12,"method":"tools/call","params":{"name":"get_service","arguments":{"name":"DoesNotExist"}}}""");
+        var doc = Assert.Single(resp);
+        var payload = JsonDocument.Parse(doc.RootElement.GetProperty("result")
+            .GetProperty("content")[0].GetProperty("text").GetString()!);
+        Assert.False(payload.RootElement.GetProperty("ok").GetBoolean());
+        Assert.Equal("SERVICE_NOT_FOUND", payload.RootElement.GetProperty("error").GetProperty("code").GetString());
+    }
 }

--- a/tests/D365FO.Core.Tests/McpServerHostTests.cs
+++ b/tests/D365FO.Core.Tests/McpServerHostTests.cs
@@ -1,0 +1,87 @@
+using System.Text.Json;
+using D365FO.Core.Index;
+using D365FO.Mcp;
+using ModelContextProtocol.Protocol;
+using Xunit;
+
+namespace D365FO.Core.Tests;
+
+/// <summary>
+/// Smoke tests for <see cref="McpServerHost"/> — the SDK-based MCP host.
+/// We don't spin up a full stdio transport here; instead we exercise the
+/// ListTools / CallTool handlers directly via <c>BuildOptions</c> so the tests
+/// stay fast and deterministic.
+/// </summary>
+public class McpServerHostTests : IDisposable
+{
+    private readonly string _dbPath = Path.Combine(Path.GetTempPath(), $"d365fo-sdkhost-{Guid.NewGuid():N}.sqlite");
+
+    public void Dispose()
+    {
+        Microsoft.Data.Sqlite.SqliteConnection.ClearAllPools();
+        foreach (var ext in new[] { "", "-wal", "-shm" })
+        {
+            var p = _dbPath + ext;
+            if (File.Exists(p)) File.Delete(p);
+        }
+    }
+
+    private ToolHandlers Handlers()
+    {
+        var repo = new MetadataRepository(_dbPath);
+        repo.EnsureSchema();
+        return new ToolHandlers(repo);
+    }
+
+    [Fact]
+    public void BuildOptions_publishes_every_catalog_tool()
+    {
+        var options = McpServerHost.BuildOptions(Handlers());
+        Assert.NotNull(options.Handlers?.ListToolsHandler);
+
+        // Sanity: server info + capabilities
+        Assert.Equal("d365fo-mcp", options.ServerInfo!.Name);
+        Assert.NotNull(options.Capabilities?.Tools);
+    }
+
+    [Fact]
+    public void Invoke_index_status_returns_success_envelope()
+    {
+        var result = McpServerHost.Invoke(Handlers(),
+            new CallToolRequestParams { Name = "index_status" });
+
+        Assert.False(result.IsError ?? false);
+        var text = Assert.IsType<TextContentBlock>(result.Content[0]).Text;
+        var doc = JsonDocument.Parse(text);
+        Assert.True(doc.RootElement.GetProperty("ok").GetBoolean());
+    }
+
+    [Fact]
+    public void Invoke_forwards_arguments_to_handler()
+    {
+        var args = new Dictionary<string, JsonElement>
+        {
+            ["name"] = JsonDocument.Parse("\"NotThere\"").RootElement,
+        };
+        var result = McpServerHost.Invoke(Handlers(),
+            new CallToolRequestParams { Name = "get_data_entity", Arguments = args });
+
+        Assert.True(result.IsError);
+        var text = Assert.IsType<TextContentBlock>(result.Content[0]).Text;
+        var doc = JsonDocument.Parse(text);
+        Assert.False(doc.RootElement.GetProperty("ok").GetBoolean());
+        Assert.Equal("ENTITY_NOT_FOUND", doc.RootElement.GetProperty("error").GetProperty("code").GetString());
+    }
+
+    [Fact]
+    public void Invoke_unknown_tool_returns_error_envelope()
+    {
+        var result = McpServerHost.Invoke(Handlers(),
+            new CallToolRequestParams { Name = "does_not_exist" });
+
+        Assert.True(result.IsError);
+        var text = Assert.IsType<TextContentBlock>(result.Content[0]).Text;
+        var doc = JsonDocument.Parse(text);
+        Assert.Equal("UNKNOWN_TOOL", doc.RootElement.GetProperty("error").GetProperty("code").GetString());
+    }
+}


### PR DESCRIPTION
…ist-profile

Roadmap sweep from §4 onward:

- §4.1 FTS5 full-text label search (schema v6 + LabelFts virtual table + triggers, SearchLabelsFts, search label --fts, MCP search_labels_fts)

- §4.2 Label write-ops: LabelFileWriter (atomic, BOM UTF-8, comment-preserving), CLI label create/rename/delete, MCP create_label/rename_label/delete_label

- §6 generate role (new + --add-to merge) and generate entity --all-fields (auto-populate from TableFields)

- §7.1 d365fo lint --format sarif (SARIF 2.1.0); fixed Dapper NULL-affinity regression in Find* lint queries

- §9 init --persist-profile (idempotent marker-block injection in PowerShell profile / ~/.profile)

- §9 IsCustom SSOT invariant documented on UpsertModel/UpsertModelInternal

Tests: +9 (LabelFileWriter, LabelFts, scaffolder Role/AddToRole). 69/69 green. MCP tool count 49 -> 53.

Docs: ROADMAP.md pruned and renumbered; EXAMPLES.md + ARCHITECTURE.md updated (schema v6, 53 tools, new CLI surface).