### PR TITLE
feat: daemon file watcher, lint method flags (schema v9), MiniAot E2E…

### DIFF
--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -56,7 +56,7 @@ Every tool returns the same shape:
 ## The local index (SQLite)
 
 - Single file at `$D365FO_INDEX_DB` (default: `$LOCALAPPDATA/d365fo-cli/d365fo-index.sqlite`).
-- Schema **v7**, defined in [`src/D365FO.Core/Index/Schema.sql`](../src/D365FO.Core/Index/Schema.sql). v6 added a `LabelFts` FTS5 virtual table (content-linked to `Labels` via `rowid=LabelId`) plus INSERT/UPDATE/DELETE triggers that keep the full-text index in sync; `EnsureSchema` issues a one-time `LabelFts('rebuild')` on migration and gracefully degrades if the SQLite build lacks FTS5. v7 adds `Models.LastExtractedUtc` + `Models.SourceFingerprint` (per-model content fingerprint = `"{xmlFileCount}:{newestMtimeTicks}"`, used by `index refresh` for O(k) change detection) and an append-only `ExtractionRuns` telemetry table consumed by `d365fo index history`.
+- Schema **v9**, defined in [`src/D365FO.Core/Index/Schema.sql`](../src/D365FO.Core/Index/Schema.sql). v6 added a `LabelFts` FTS5 virtual table; v7 adds `Models.LastExtractedUtc` + `Models.SourceFingerprint` (per-model content fingerprint) and an append-only `ExtractionRuns` telemetry table; v8 adds `Forms.Pattern`, `Forms.PatternVersion`, `Forms.Style`, `Forms.TitleDataSource` and `FormDataSources.OrderIndex`/`JoinSource`; v9 adds `HasDocComment`, `HasTodayCall`, `HasDoInsertOrUpdate` boolean flags to both `Methods` (class) and `TableMethods` — populated at extract time by scanning `<Source>` CDATA, used by the `today-usage`, `do-insert-update`, and `doc-comment-missing` lint categories.
 - Version tracked in `PRAGMA user_version`; migrations applied automatically on first connection via `MetadataRepository.EnsureSchema`.
 - `MetadataRepository` is stateless — every call opens and closes its own connection, so it works identically in a short-lived CLI process, a long-lived MCP server, or a daemon.
 - SQLite booleans are stored as `INTEGER`; `SqliteBoolHandler` teaches Dapper the conversion once at static init.
@@ -123,6 +123,15 @@ One request per line, UTF-8:
 | `D365FO_BRIDGE_PATH` | Overrides the bridge exe location. |
 
 The bridge is Windows-only and must ship next to a live VM. Non-Windows developers stay on the SQLite-index path automatically.
+
+## Daemon
+
+`D365FO.Cli.Commands.Daemon.DaemonStartCommand` starts a long-lived process that:
+
+1. **Serves JSON-RPC** over a Windows named pipe (`\\.\pipe\d365fo-cli`) or Unix socket (`$XDG_RUNTIME_DIR/d365fo-cli.sock`). Each connection gets its own `StdioDispatcher` instance sharing one `MetadataRepository` — the warm SQLite connection pool is the key latency benefit.
+2. **Watches for XML changes** via `FileSystemWatcher` over `D365FO_PACKAGES_PATH` (or `--packages`). On any `*.xml` change, a per-model debounce timer (default 3 s, `--watch-debounce <MS>`) fires and calls `IndexExtractCommand.ExtractCore` for the affected model. A JSON notification is emitted to stderr on completion. Pass `--no-watch` to disable.
+
+PID is written to `$LOCALAPPDATA/d365fo-cli/daemon.pid` (Windows) or `$XDG_RUNTIME_DIR/d365fo-cli.pid`; `daemon stop` reads it to send SIGTERM / `TerminateProcess`.
 
 ## MCP coexistence
 

--- a/docs/EXAMPLES.md
+++ b/docs/EXAMPLES.md
@@ -139,10 +139,22 @@ d365fo index history --model Contoso  # filter to one model
 ```sh
 d365fo lint
 d365fo lint --category table-no-index,string-without-edt --all-models
+d365fo lint --category today-usage,do-insert-update,doc-comment-missing
 d365fo lint --format sarif > lint.sarif
 ```
 
-Categories shipped today: `table-no-index`, `ext-named-not-attributed`, `string-without-edt`. Defaults to custom models only; pass `--all-models` to include ISV / MS content. `--format sarif` emits [SARIF 2.1.0](https://sarifweb.azurewebsites.net/) for CI ingestion (GitHub code-scanning, Azure DevOps).
+Six categories shipped:
+
+| Category | BP rule | What it finds |
+|---|---|---|
+| `table-no-index` | — | Tables without any cluster/alternate index |
+| `ext-named-not-attributed` | — | Classes named `*_Extension` missing `[ExtensionOf]` |
+| `string-without-edt` | — | String fields with no Extended Data Type |
+| `today-usage` | `BPUpgradeCodeToday` | Methods calling `today()` instead of `DateTimeUtil::getToday(…)` |
+| `do-insert-update` | — | Methods calling `doInsert()` / `doUpdate()` / `doDelete()` |
+| `doc-comment-missing` | `BPXmlDocNoDocumentationComments` | Methods without `/// <summary>` |
+
+Defaults to custom models only; pass `--all-models` to include ISV / MS content. `--format sarif` emits [SARIF 2.1.0](https://sarifweb.azurewebsites.net/) for CI ingestion (GitHub code-scanning, Azure DevOps). The three method-flag categories (`today-usage`, `do-insert-update`, `doc-comment-missing`) are detected at extract time by scanning `<Source>` text — no full method body is stored in the index.
 
 ### `validate name` — naming-rule linter
 
@@ -327,6 +339,115 @@ d365fo generate role --add-to src/MyModel/AxSecurityRole/FmVehicleAdminRole.xml 
 
 `--add-to` validates the root element (`AxSecurityRole`), dedupes by `Name` (case-insensitive), and returns `NoChange` when every reference already exists.
 
+### Report (`AxReport` + DP class + data contract)
+
+```sh
+# Minimal — one dataset, no columns specified (tablix shell only)
+d365fo generate report FmVehicleReport \
+  --dp FmVehicleReportDP \
+  --tmp FmVehicleReportTmp \
+  --dataset FmVehicleDS \
+  --caption "@Fleet:VehicleReport" \
+  --out src/MyModel/AxReport/FmVehicleReport.xml
+
+# With tablix column definitions — generates header row + data row in the tablix
+d365fo generate report FmVehicleReport \
+  --dp FmVehicleReportDP --tmp FmVehicleReportTmp \
+  --field VIN --field Make --field Model --field Year \
+  --caption "@Fleet:VehicleReport" \
+  --out src/MyModel/AxReport/FmVehicleReport.xml
+
+# With report parameters — auto-generates a DataContract class (FmVehicleReportDPContract.xml)
+d365fo generate report FmVehicleReport \
+  --dp FmVehicleReportDP \
+  --field VIN --field Make --field Year \
+  --parameter FromDate:DateTime --parameter ToDate:DateTime --parameter Customer \
+  --out src/MyModel/AxReport/FmVehicleReport.xml
+
+# Multi-dataset — primary dataset + additional via --extra-dataset
+d365fo generate report FmFleetSummaryReport \
+  --dp FmFleetSummaryReportDP \
+  --field VehicleCount --field TotalMileage \
+  --extra-dataset FmFleetCostsDS:FmFleetCostsDP \
+  --extra-dataset FmFleetIncidentsDS:FmFleetIncidentsDP \
+  --parameter PeriodYear:Integer \
+  --out src/MyModel/AxReport/FmFleetSummaryReport.xml
+```
+
+The command atomically writes **two or three XML files**:
+
+| File | AOT type | Always? |
+|---|---|---|
+| `<Name>.xml` | `AxReport` — datasets, auto-design, tablix(es) with column hierarchy | ✅ |
+| `<DpClass>.xml` | `AxClass` extending `SrsReportDataProviderBase` — one `[SRSReportDataSet]` getter per dataset, `QueryRun` processReport skeleton | ✅ |
+| `<DpClass>Contract.xml` | `AxClass` extending `SrsReportDataContractBase` — one `parm*()` accessor per `--parameter` | only when `--parameter` is used |
+
+Additional output path overrides: `--out-dp <PATH>`, `--out-contract <PATH>`.
+
+Parameter types accepted: `String` (default), `Integer`, `DateTime`, `Boolean`, `Decimal`.
+
+---
+
+## Suggest / Analyze
+
+### `suggest extension` — extensibility strategy advisor
+
+```sh
+# Auto-detect object kind and rank extension strategies
+d365fo suggest extension CustTable --output json
+
+# Hint the kind explicitly when needed
+d365fo suggest extension SalesFormLetterService --kind Class --output json
+d365fo suggest extension SalesTable --kind Table  --output json
+d365fo suggest extension CustTable  --kind Form   --output json
+```
+
+The response ranks each strategy by `confidence` (`high` / `medium` / `low`) and includes a ready-to-run `command` string:
+
+```json
+{
+  "target": "CustTable",
+  "targetKind": "Table",
+  "signals": { "isFinal": false, "delegateCount": 3, "existingCoc": 12, "existingHandlers": 7 },
+  "recommendations": [
+    { "rank": 1, "approach": "Table extension",     "confidence": "high",   "command": "d365fo generate extension Table CustTable <Suffix> --out <PATH>" },
+    { "rank": 2, "approach": "Event handler (data event)", "confidence": "high", "command": "d365fo generate event-handler --source-kind Table --source CustTable --event Inserted --out <PATH>" },
+    { "rank": 3, "approach": "CoC (table method wrapping)", "confidence": "medium", "command": "d365fo generate coc CustTable --method insert --out <PATH>" }
+  ]
+}
+```
+
+Use this command before scaffolding to confirm the right approach based on what's already in the codebase.
+
+### `analyze completeness` — cross-check project against index
+
+```sh
+# Analyse a full model folder (walks all *.xml recursively)
+d365fo analyze completeness src/MyModel --output json
+
+# Analyse a single AOT XML file
+d365fo analyze completeness src/MyModel/AxSecurityRole/FmAdminRole.xml
+
+# Skip slow label checks in CI (focus on structural refs only)
+d365fo analyze completeness src/MyModel --skip-labels --output json
+
+# Pipe into jq to count issues by code
+d365fo analyze completeness src/MyModel --output json \
+  | jq '.data.issues | group_by(.code) | map({code: .[0].code, count: length})'
+```
+
+Issue codes reported:
+
+| Code | Severity | What it means |
+|---|---|---|
+| `MISSING_DUTY` | warning | `AxSecurityRole` references a duty not in the index |
+| `MISSING_PRIVILEGE` | warning | Role or duty references a privilege not in the index |
+| `MISSING_EDT` | warning | `AxTable` field references an EDT not in the index |
+| `MISSING_LABEL` | warning | An AOT element value holds a `@File:Key` token with no indexed translation |
+| `PARSE_ERROR` | error | XML file cannot be parsed |
+
+Flags: `--skip-labels`, `--skip-edts`, `--skip-security`.
+
 ---
 
 ## Labels (read & write)
@@ -430,12 +551,23 @@ After `dotnet publish src/D365FO.Mcp -c Release -r osx-arm64` you get a standalo
 For latency-sensitive integrations, run the CLI as a daemon so the SQLite handle and read caches stay hot:
 
 ```sh
-d365fo daemon start
+d365fo daemon start                                  # named pipe / Unix socket + file watcher
+d365fo daemon start --packages J:\AosService\PackagesLocalDirectory
+d365fo daemon start --no-watch                      # disable auto index refresh
+d365fo daemon start --watch-debounce 5000           # wait 5 s after last change before refresh
 d365fo daemon status
 d365fo daemon stop
 ```
 
-Transport: Windows named pipe `\\.\pipe\d365fo-cli`; Unix socket at `$XDG_RUNTIME_DIR/d365fo-cli.sock` (fallback `$TMPDIR`). The frame format matches `d365fo-mcp`: one newline-terminated JSON-RPC request per connection, one response, close.
+Transport: Windows named pipe `\\\\.\\ pipe\\d365fo-cli`; Unix socket at `$XDG_RUNTIME_DIR/d365fo-cli.sock` (fallback `$TMPDIR`). The frame format matches `d365fo-mcp`: one newline-terminated JSON-RPC request per connection, one response, close.
+
+The daemon also starts a `FileSystemWatcher` over `D365FO_PACKAGES_PATH` (or `--packages`). When `*.xml` files change, it debounces (default 3 s) and automatically triggers an incremental `index refresh` for the affected model, emitting a JSON notification to stderr:
+
+```json
+{ "event": "index_refreshed", "model": "Contoso" }
+```
+
+Pass `--no-watch` to disable the watcher (e.g. read-only environments or network shares).
 
 ---
 

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -3,21 +3,7 @@
 > **Audience:** contributors and users who want to know what's coming next.
 > **Living document.** Only items that are **not yet implemented** live here. Everything already shipped is documented in [SETUP.md](SETUP.md) / [EXAMPLES.md](EXAMPLES.md) (user-visible surface) and [ARCHITECTURE.md](ARCHITECTURE.md) (internals). Git history preserves earlier design notes.
 
-Items are ordered top-down by priority. Sections labelled **P0 / P1 / …** are
-the active backlog (lower number = ship sooner). Sections without a P-tag are
-long-tail ideas grouped by topic.
-
 ## Contents
-
-### Active backlog (priority-ordered)
-
-- [P0 — Form pattern parity with `d365fo-mcp-server`](#p0--form-pattern-parity-with-d365fo-mcp-server)
-- [P1 — Smart-table pattern presets](#p1--smart-table-pattern-presets--shipped)
-- [P2 — Form / table pattern analyzer (`find form-patterns`)](#p2--form--table-pattern-analyzer-find-form-patterns)
-- [P3 — Smart report scaffold (`generate report`)](#p3--smart-report-scaffold-generate-report)
-- [P4 — Extension strategy advisor + completeness analyzer](#p4--extension-strategy-advisor--completeness-analyzer)
-
-### Long-tail / topical
 
 1. [Refresh & observability](#1-refresh--observability)
 2. [Runtime / live data](#2-runtime--live-data)
@@ -27,96 +13,6 @@ long-tail ideas grouped by topic.
 6. [Code quality & Best Practices](#6-code-quality--best-practices)
 7. [Tests](#7-tests)
 8. [Small items / technical debt](#8-small-items--technical-debt)
-
----
-
-## P0 — Form pattern parity with `d365fo-mcp-server`
-
-**Status:** ✅ shipped. The CLI now ships `d365fo generate form <Name> --pattern <P>` with full parity to upstream MCP's `generate_smart_form`. Templates live as embedded resources under [`src/D365FO.Core/Scaffolding/FormTemplates/`](../src/D365FO.Core/Scaffolding/FormTemplates/) and are exercised by [`FormPatternScaffoldingTests`](../tests/D365FO.Cli.Tests/FormPatternScaffoldingTests.cs).
-
-The legacy `d365fo generate simple-list` command still works as a thin alias for `--pattern SimpleList`.
-
-| Pattern | Reference form | Use case |
-|---|---|---|
-| `SimpleList` | `CustGroup` | setup / config tables |
-| `SimpleListDetails` | `PaymTerm` | medium entities, list + detail panel |
-| `DetailsMaster` | `CustTable` | full master record |
-| `DetailsTransaction` | `SalesTable` | header + lines (orders) |
-| `Dialog` | `ProjTableCreate` | popup dialog |
-| `TableOfContents` | `CustParameters` | tabbed parameter pages |
-| `Lookup` | `SysLanguageLookup` | dropdown lookups |
-| `ListPage` | `CustTableListPage` | navigation list page |
-| `Workspace` | `VendPaymentWorkspace` | KPI tiles + panorama sections |
-
-See [EXAMPLES.md → Form](EXAMPLES.md#form-any-of-nine-d365fo-patterns) for usage.
-
-## P1 — Smart-table pattern presets ✅ shipped
-
-`d365fo generate table` now accepts `--pattern <P>` and emits the canonical
-`<TableGroup>`, default field skeleton, and an alternate-key
-`<AxTableIndex AlternateKey=Yes>` index — so the scaffold passes
-BP `BPCheckAlternateKeyAbsent` out of the box.
-
-| Surface | Reference |
-|---|---|
-| Pattern enum + alias normaliser | [src/D365FO.Core/Scaffolding/TablePattern.cs](../src/D365FO.Core/Scaffolding/TablePattern.cs) |
-| Default field presets per pattern | `TablePatternPresets.DefaultFieldsFor` |
-| Scaffolder integration (TableGroup / TableType / index) | [src/D365FO.Core/Scaffolding/XppScaffolder.cs](../src/D365FO.Core/Scaffolding/XppScaffolder.cs) |
-| CLI flags `--pattern`, `--table-type`, `--primary-key` | [src/D365FO.Cli/Commands/Generate/GenerateCommands.cs](../src/D365FO.Cli/Commands/Generate/GenerateCommands.cs) |
-| Tests (16 cases incl. TempDB→TableType guard, alias matrix, alt-key) | [tests/D365FO.Cli.Tests/TablePatternScaffoldingTests.cs](../tests/D365FO.Cli.Tests/TablePatternScaffoldingTests.cs) |
-| Skill | [skills/_source/table-scaffolding.md](../skills/_source/table-scaffolding.md) |
-
-Patterns shipped: `Main`, `Transaction`, `Parameter`, `Group`,
-`WorksheetHeader`, `WorksheetLine`, `Reference`, `Framework`, `Miscellaneous`.
-Aliases (`master`, `setup`, `config`, `transactional`, `lookup`, `header`,
-`line`, …) are normalised. Passing `TempDB` / `InMemory` to `--pattern` is
-**rejected** with a hint pointing to `--table-type`.
-
-Deferred to a later iteration: live "copy fields from CustTable" via the
-bridge, EDT auto-relation migration (BP `BPErrorEDTNotMigrated`), and
-pattern *analysis* of indexed tables (P2).
-
-## P2 — Form / table pattern analyzer (`find form-patterns`) ✅ shipped
-
-`d365fo find form-patterns` analyses every indexed `AxForm` by reading
-`<Design><Pattern>` / `<PatternVersion>` and the primary datasource. The
-index schema bumped to **v8** (extra columns on `Forms`/`FormDataSources`
-backfilled lazily on next `index extract`).
-
-| File | Purpose |
-|---|---|
-| [src/D365FO.Core/Index/Schema.sql](../src/D365FO.Core/Index/Schema.sql) | `Forms.Pattern/PatternVersion/Style/TitleDataSource`, `FormDataSources.OrderIndex/JoinSource`. |
-| [src/D365FO.Core/Index/MetadataRepository.cs](../src/D365FO.Core/Index/MetadataRepository.cs) | v8 migration; `FindFormPatterns(...)` + `SummarizeFormPatterns()`. |
-| [src/D365FO.Core/Extract/MetadataExtractor.cs](../src/D365FO.Core/Extract/MetadataExtractor.cs) | `ParseForm` reads `<Design>` pattern hints. |
-| [src/D365FO.Cli/Commands/Find/FindCommands.cs](../src/D365FO.Cli/Commands/Find/FindCommands.cs) | `FindFormPatternsCommand`. |
-| [tests/D365FO.Core.Tests/FormPatternAnalyzerTests.cs](../tests/D365FO.Core.Tests/FormPatternAnalyzerTests.cs) | 4 tests covering extractor + repository + filters. |
-
-CLI surface:
-
-```sh
-d365fo find form-patterns                        # histogram across the index
-d365fo find form-patterns --pattern SimpleList   # all forms with that pattern (prefix)
-d365fo find form-patterns --table CustTable      # every form bound to CustTable
-d365fo find form-patterns --similar-to CustGroup # peers with same pattern + primary table
-d365fo find form-patterns --pattern ListPage --table CustTable --model ApplicationSuite
-```
-
-Deferred follow-ups: permission histogram (`AllowEdit/Create/Delete`),
-table-pattern *analysis* of indexed tables (cluster by group/index/relation
-shape), and a `find table-patterns --similar-to <Table>` peer.
-
-## P3 — Smart report scaffold (`generate report`)
-
-Port `generate_smart_report` → `XppScaffolder.Report(...)`. Produces an
-`AxReport` with one DP class reference, one design and a tablix, plus a
-matching `AxClass` skeleton implementing `SrsReportDataProviderBase`.
-
-## P4 — Extension strategy advisor + completeness analyzer
-
-Two MCP capabilities still missing:
-
-- **`extension_strategy_advisor`** — `d365fo suggest extension <Target>` recommends *Class CoC* vs *Event handler* vs *Form/Table extension* based on what the target exposes (delegate count, sealed methods, attribute usage). Outputs ranked options with one-line rationale.
-- **`analyze_completeness`** — `d365fo analyze completeness <Project>` cross-checks a workspace project against indexed AOT (e.g. role references a missing duty, table has an EDT not present in any model, label key has no translation).
 
 ---
 
@@ -149,13 +45,8 @@ Long-tail metadata not yet indexed:
 - **3.3** ReferenceGroup / Map / MapExtension.
 - **3.4** ConfigurationKey / LicenseCode — cross-referenced to tables / fields / EDTs.
 - **3.5** Feature (Feature Management).
-- **3.6** X++ method source indexing — upstream MCP parity (`get_method_source`, `analyze_code_patterns`, `suggest_method_implementation`). Needs schema bump for `MethodSources(ClassOrTable, Method, Body, Signature, Kind)`.
 
 ## 4. Output & integration
-
-### 4.1 Persistent daemon mode (JSON-RPC)
-
-Skeleton exists (`D365FO.Cli.Commands.Daemon`). Add 1:1 request routing with the CLI, warm SQLite pool, file-watcher triggering `index refresh`. Also hosts the bridge child process across calls (sub-50 ms warm vs. ~300 ms cold).
 
 ### 4.2 Structured diff output
 
@@ -173,10 +64,9 @@ Skeleton exists (`D365FO.Cli.Commands.Daemon`). Add 1:1 request routing with the
 
 ### 6.1 Additional lint categories
 
-`d365fo lint` ships with 3 categories (`table-no-index`, `ext-named-not-attributed`, `string-without-edt`) and SARIF output (`--format sarif`) for CI. Pending:
+`d365fo lint` ships 6 categories and SARIF output (`--format sarif`). Still pending:
 
-- "method with public API but no doc-comment" — requires method-source indexing (§3.6).
-- "UI literal string without `@Label`" — requires parsing element captions on forms / menu items.
+- "UI literal string without `@Label`" — requires parsing element captions on forms / menu items (deferred).
 
 ### 6.2 Richer coupling metrics
 
@@ -187,9 +77,8 @@ Skeleton exists (`D365FO.Cli.Commands.Daemon`). Add 1:1 request routing with the
 
 ## 7. Tests
 
-- End-to-end: freeze a sample `AxRepo` in `tests/Samples/MiniAot/`, run `MetadataExtractor` + `MetadataRepository`, verify counts.
-- Snapshot tests for JSON output of `get table`, `get class`, `models deps`.
 - Performance smoke: `MeasureExtract(ApplicationSuite)` cap (runs only when `D365FO_PACKAGES_PATH` is set).
+- Snapshot tests for `models deps` JSON output.
 - Bridge: end-to-end harness that spins the net48 exe against a sample `PackagesLocalDirectory` fixture and asserts round-trip for read / create / update / delete.
 
 ## 8. Small items / technical debt

--- a/skills/_source/xpp-best-practice-rules.md
+++ b/skills/_source/xpp-best-practice-rules.md
@@ -107,9 +107,16 @@ d365fo generate table FmVehicle \
 # In-process heuristics — fast, runs anywhere, useful for CI:
 d365fo lint --output sarif > lint.sarif
 
+# Run specific method-flag categories (detected at index-extract time):
+d365fo lint --category today-usage          # BPUpgradeCodeToday: today() calls
+d365fo lint --category do-insert-update     # doInsert/doUpdate/doDelete usage
+d365fo lint --category doc-comment-missing  # BPXmlDocNoDocumentationComments
+
 # Full BP — only on the Windows VM, only on user request:
 d365fo bp check --output json
 ```
+
+Six categories are now available: `table-no-index`, `ext-named-not-attributed`, `string-without-edt`, `today-usage`, `do-insert-update`, `doc-comment-missing`. The method-flag categories are populated at extract time by scanning `<Source>` text — no full body is stored. Re-run `d365fo index refresh` after editing source before linting.
 
 **Never** auto-run `bp check`. It blocks the user (slow, Windows-only). Say *"Changes scaffolded. Run `d365fo bp check` when you're ready."*
 

--- a/skills/anthropic/coc-extension-authoring/SKILL.md
+++ b/skills/anthropic/coc-extension-authoring/SKILL.md
@@ -1,4 +1,4 @@
----
+﻿---
 name: coc-extension-authoring
 description: Author a Chain-of-Command extension in D365FO without duplicating existing wrappers. Use when the user asks to "wrap a method", "add a CoC", or "modify behavior of standard method".
 applies_when: User intent mentions Chain-of-Command, CoC, method wrapping, next() pattern, or non-intrusive extension.
@@ -14,24 +14,24 @@ applies_when: User intent mentions Chain-of-Command, CoC, method wrapping, next(
 d365fo get class <TargetClass> --output json
 d365fo read class <TargetClass> --method <method> --declaration
 
-# 2) Discover existing CoC wrappers — MUST be empty or coordinated
+# 2) Discover existing CoC wrappers â€” MUST be empty or coordinated
 d365fo find coc <TargetClass>::<method> --output json
 ```
 
 If `count > 0`, enumerate `items[*].extensionClass` to the user and stop before writing another wrapper. Stacking duplicates risks ordering bugs.
 
-## 🚨 NEVER copy default parameter values into the wrapper
+## ðŸš¨ NEVER copy default parameter values into the wrapper
 
-The most common bug — Learn-confirmed:
+The most common bug â€” Learn-confirmed:
 
 ```xpp
 // Base method
 class Person
 {
-    public void salute(str message = "Hi") { … }
+    public void salute(str message = "Hi") { â€¦ }
 }
 
-// ✅ CORRECT — wrapper omits the default value
+// âœ… CORRECT â€” wrapper omits the default value
 [ExtensionOf(classStr(Person))]
 final class APerson_Extension
 {
@@ -41,25 +41,25 @@ final class APerson_Extension
     }
 }
 
-// ❌ WRONG — copying the default does not compile
-public void salute(str message = "Hi")     // ← forbidden
+// âŒ WRONG â€” copying the default does not compile
+public void salute(str message = "Hi")     // â† forbidden
 ```
 
 ## `next` placement rules
 
-- **Wrapper must call `next` unconditionally** — exception: `[Replaceable]` methods may conditionally break the chain.
-- **`next` must sit at first-level statement scope** — NOT inside `if`, `while`, `for`, `do-while`, NOT after `return`, NOT inside a logical expression.
+- **Wrapper must call `next` unconditionally** â€” exception: `[Replaceable]` methods may conditionally break the chain.
+- **`next` must sit at first-level statement scope** â€” NOT inside `if`, `while`, `for`, `do-while`, NOT after `return`, NOT inside a logical expression.
 - Platform Update 21+: `next` is permitted inside `try` / `catch` / `finally` (the only nested contexts allowed).
 
 ```xpp
-// ✅ CORRECT
+// âœ… CORRECT
 public void doStuff()
 {
     next doStuff();         // first-level
     this.afterStuff();
 }
 
-// ❌ WRONG — next inside `if`
+// âŒ WRONG â€” next inside `if`
 public void doStuff()
 {
     if (this.shouldRun())
@@ -69,18 +69,18 @@ public void doStuff()
 
 ## Signature & class shape
 
-- Signature otherwise matches the base **exactly** — same return type, parameter types / order, same `static` modifier. Run `d365fo read class <Target> --method <m> --declaration` and copy.
+- Signature otherwise matches the base **exactly** â€” same return type, parameter types / order, same `static` modifier. Run `d365fo read class <Target> --method <m> --declaration` and copy.
 - Static methods: repeat `static` on the wrapper. Forms cannot be wrapped statically.
 - **Cannot wrap constructors.** A new no-arg method on an extension class becomes the *extension class's* own constructor (must be `public`).
 - Class shape: `[ExtensionOf(classStr|tableStr|formStr|formDataSourceStr|formDataFieldStr|formControlStr(...))] final class <Target>_<Suffix>`. Class is `final`; name ends with `_Extension` (or descriptive suffix).
 - **`[Hookable(false)]`** on a base method blocks CoC and pre/post handlers. Cannot wrap.
 - **`[Wrappable(false)]`** blocks wrapping but still allows pre/post handlers. `final` methods need explicit `[Wrappable(true)]` to be wrappable.
-- Form-nested wrapping: `formdatasourcestr`, `formdatafieldstr`, `formControlStr`. **Cannot add NEW methods** via CoC on these — only wrap methods that already exist.
+- Form-nested wrapping: `formdatasourcestr`, `formdatafieldstr`, `formControlStr`. **Cannot add NEW methods** via CoC on these â€” only wrap methods that already exist.
 - **Visibility:** wrappers can read/call **protected** members of the augmented class (Platform Update 9+). Cannot reach `private`.
 
 ## Authoring checklist
 
-- [ ] Pre-flight passes — class + method exist, no duplicate wrapper, signature copied verbatim.
+- [ ] Pre-flight passes â€” class + method exist, no duplicate wrapper, signature copied verbatim.
 - [ ] `[ExtensionOf(...)]` decorator present.
 - [ ] `final class <Target>_Extension`.
 - [ ] Default parameter values **omitted** from the wrapper signature.
@@ -110,4 +110,4 @@ d365fo bp check --output json    # only on user request
 - Never put `next` inside `if` / `while` / `for` / `do-while` / boolean expressions (PU21+: `try` / `catch` / `finally` only).
 - Never remove `next` on a non-`[Replaceable]` method.
 - Never wrap a constructor.
-- Never hardcode labels — `d365fo search label` first.
+- Never hardcode labels â€” `d365fo search label` first.

--- a/skills/anthropic/data-entity-scaffolding/SKILL.md
+++ b/skills/anthropic/data-entity-scaffolding/SKILL.md
@@ -1,11 +1,11 @@
----
+﻿---
 name: data-entity-scaffolding
 description: Scaffold an AxDataEntityView (data entity) in D365 Finance & Operations for OData / DMF (Data Management Framework) integration. Use when the user asks to "create a data entity", "expose a table to OData", or "scaffold an entity for DMF".
 applies_when: User intent mentions data entity, AxDataEntityView, OData, DMF, public entity name, public collection name, or exposing tables to integrations.
 ---
 # Authoring AxDataEntityView XML
 
-> Data entities are the supported integration surface for D365FO — OData v4,
+> Data entities are the supported integration surface for D365FO â€” OData v4,
 > Power Platform, DMF imports/exports, and inbound/outbound async services
 > all consume them. `d365fo generate entity` emits a minimal but
 > compile-clean `AxDataEntityView` XML.
@@ -21,7 +21,7 @@ d365fo search edt  <Edt>        --output json    # for any EDT mappings
 ## Scaffolding
 
 ```sh
-# Minimal — exposes one table; OData names default to <Name>Entity / <Name>Entities
+# Minimal â€” exposes one table; OData names default to <Name>Entity / <Name>Entities
 d365fo generate entity FmVehicleEntity \
     --table FmVehicle \
     --all-fields \
@@ -47,15 +47,15 @@ publicCollectionName}`. Never request the full XML back.
 | `PublicEntityName` | `<Domain><Concept>` (singular) | OData entity type |
 | `PublicCollectionName` | `<Domain><Concept>s` (plural) | OData collection (`/data/<Plural>`) |
 
-If the singular ends in `s`, set the plural explicitly (`FleetStatus` →
+If the singular ends in `s`, set the plural explicitly (`FleetStatus` â†’
 `FleetStatuses`).
 
 ## Hard rules
 
 - Never expose a table without confirming `IsPublic = Yes` on the entity (the
-  scaffold emits this — preserve it).
-- Never hardcode label captions for entity fields — they inherit from the
+  scaffold emits this â€” preserve it).
+- Never hardcode label captions for entity fields â€” they inherit from the
   underlying EDT or table field.
-- Never duplicate an existing public entity / collection name across models —
+- Never duplicate an existing public entity / collection name across models â€”
   OData names are global. `d365fo search entity` first.
 - Run `d365fo build` (and the OData metadata refresh) only on user request.

--- a/skills/anthropic/event-handler-authoring/SKILL.md
+++ b/skills/anthropic/event-handler-authoring/SKILL.md
@@ -1,4 +1,4 @@
----
+﻿---
 name: event-handler-authoring
 description: Subscribe to a D365FO event (data event on a table, form / form-data-source / form-data-field event, custom delegate on a class) by scaffolding an event-handler class. Use when the user asks to "subscribe to an event", "react to inserted/deleted/updated", or "hook a delegate".
 applies_when: User intent mentions event handler, SubscribesTo, DataEventHandler, FormEventHandler, FormDataSourceEventHandler, or reacting to a D365FO platform event.
@@ -6,21 +6,21 @@ applies_when: User intent mentions event handler, SubscribesTo, DataEventHandler
 # Subscribing to D365FO events safely
 
 > Event handlers are the right choice when you need to **react** to a
-> platform-emitted event without changing call ordering — choose CoC if you
+> platform-emitted event without changing call ordering â€” choose CoC if you
 > need to *modify* a method's behaviour, choose a handler if you need to
 > *observe*.
 
 ## Pre-flight
 
 ```sh
-# 1) Discover existing handlers on the target — avoid duplicates
+# 1) Discover existing handlers on the target â€” avoid duplicates
 d365fo find handlers <TargetObject> --output json
 
 # 2) Confirm the target exists (for tables) and which events it emits
 d365fo get table <Table> --output json
 ```
 
-## Standard data events on tables → `[DataEventHandler]`
+## Standard data events on tables â†’ `[DataEventHandler]`
 
 ```sh
 d365fo generate event-handler MyClass_CustTableHandler \
@@ -37,7 +37,7 @@ D365FO `DataEventType` values: `ValidatingFieldValue`, `ValidatedField`,
 `Inserting`, `Inserted`, `Updating`, `Updated`, `Deleting`, `Deleted`,
 `InitializingRecord`, `InitializedRecord`, `Modifying`, `Modified`.
 
-## Form / FormDataSource / FormControl events → form-specific attributes
+## Form / FormDataSource / FormControl events â†’ form-specific attributes
 
 ```sh
 d365fo generate event-handler MyClass_FormHandler \
@@ -56,11 +56,11 @@ d365fo generate event-handler MyClass_FormDsHandler \
 Attribute shapes: `[FormEventHandler(formStr(...), FormEventType::...)]`,
 `[FormDataSourceEventHandler(formDataSourceStr(form, ds), FormDataSourceEventType::...)]`.
 
-## Custom delegates on classes → `[SubscribesTo + delegateStr]`
+## Custom delegates on classes â†’ `[SubscribesTo + delegateStr]`
 
 `delegateStr` is **only** for *custom* delegates (your own or a Microsoft-
 declared delegate on a framework class). It is **NOT** for standard data
-events — those are `DataEventHandler`.
+events â€” those are `DataEventHandler`.
 
 ```sh
 d365fo generate event-handler MyClass_DelegateHandler \
@@ -76,10 +76,10 @@ Attribute: `[SubscribesTo(classStr(SalesFormLetter), delegateStr(SalesFormLetter
 
 - Standard data events use `[DataEventHandler]`, NEVER `[SubscribesTo + delegateStr]`.
 - `delegateStr` is for *custom* delegates only.
-- Handlers do NOT chain via `next` — they are notification-only.
+- Handlers do NOT chain via `next` â€” they are notification-only.
 - Handler methods must be `public static` (the runtime invokes them
   reflectively).
-- Never modify the buffer in a `Validating*` / `*ing` event without intent —
+- Never modify the buffer in a `Validating*` / `*ing` event without intent â€”
   changes leak into the persisted record.
 - Pre-flight `find handlers <Target>` to detect duplicates and ordering risks.
 - After scaffolding, run `d365fo build` only on user request.

--- a/skills/anthropic/form-pattern-scaffolding/SKILL.md
+++ b/skills/anthropic/form-pattern-scaffolding/SKILL.md
@@ -1,17 +1,17 @@
----
+﻿---
 name: form-pattern-scaffolding
 description: Scaffold an AxForm in D365 Finance & Operations using one of the nine canonical patterns (SimpleList, SimpleListDetails, DetailsMaster, DetailsTransaction, Dialog, TableOfContents, Lookup, ListPage, Workspace). Invoke whenever the user asks to "create a form", "scaffold a list page", "make a dialog", or "build a workspace".
 applies_when: User intent mentions creating an AxForm, choosing a form pattern, list pages, master records, dialogs, lookups, workspaces, or details/transaction (header+lines) forms.
 ---
-# Authoring AxForm XML — pattern-correct
+# Authoring AxForm XML â€” pattern-correct
 
 > The CLI's `d365fo generate form` mirrors `d365fo-mcp-server`'s
 > `generate_smart_form`. The nine D365FO patterns are validated against real
-> AOT forms (`CustGroup`, `PaymTerm`, `CustTable`, `SalesTable`, …). Hand-rolled
+> AOT forms (`CustGroup`, `PaymTerm`, `CustTable`, `SalesTable`, â€¦). Hand-rolled
 > XML loses ActionPane, QuickFilter, FastTabs, the right `PatternVersion`,
-> and the design-time hooks Visual Studio expects — **never hand-roll**.
+> and the design-time hooks Visual Studio expects â€” **never hand-roll**.
 
-## ⛔ Anti-pattern: escalating workarounds
+## â›” Anti-pattern: escalating workarounds
 
 ```
 WRONG SPIRAL (each step is more wrong):
@@ -20,7 +20,7 @@ WRONG SPIRAL (each step is more wrong):
  3. "PatternVersion 1.0 is fine instead of 1.1"
  4. "I'll add SimpleList without grid columns"
 
-CORRECT — always:
+CORRECT â€” always:
  d365fo generate form <Name> --pattern <P> --table <T> --field <F1> --field <F2> --install-to <Model>
 ```
 
@@ -30,14 +30,14 @@ CORRECT — always:
 d365fo search form <Name> --output json          # collision check
 d365fo get table <PrimaryTable> --output json    # field list for the grid
 
-# Pattern reconnaissance — what do peers use for THIS table / similar entities?
+# Pattern reconnaissance â€” what do peers use for THIS table / similar entities?
 d365fo find form-patterns --table <PrimaryTable> --output json
 d365fo find form-patterns --similar-to <ReferenceForm> --output json
 d365fo find form-patterns --pattern SimpleList --output json   # pattern catalogue
 ```
 
 The analyzer (`d365fo find form-patterns`) reads `<Design><Pattern>` from
-every indexed AxForm. Use it instead of guessing — pass the most-common peer
+every indexed AxForm. Use it instead of guessing â€” pass the most-common peer
 pattern straight into `--pattern` on the next step. With no flags it returns
 a histogram so you can see what shapes exist before drilling in.
 
@@ -89,14 +89,14 @@ d365fo generate form FmFleetWorkspace \
     --install-to FleetManagement
 ```
 
-`--field <F>` is repeatable — these become grid / detail columns. The
+`--field <F>` is repeatable â€” these become grid / detail columns. The
 section template is `--section Name:Caption` (split on the first `:`).
 
 ## Hard rules
 
-- Never hand-roll AxForm XML — always use `--pattern`.
+- Never hand-roll AxForm XML â€” always use `--pattern`.
 - Never skip the primary datasource for SimpleList / Lookup / ListPage / Master / Transaction patterns.
 - Never use `Dialog` or `TableOfContents` patterns for transactional grids.
 - Pre-flight `search form <Name>` before scaffolding to avoid collisions.
-- Caption strings must be labels (BP `BPErrorLabelIsText`) — never raw text.
+- Caption strings must be labels (BP `BPErrorLabelIsText`) â€” never raw text.
 - After scaffolding, run `d365fo build` only on user request.

--- a/skills/anthropic/label-translation/SKILL.md
+++ b/skills/anthropic/label-translation/SKILL.md
@@ -1,15 +1,15 @@
----
+﻿---
 name: label-translation
 description: Reuse, search, create, rename, or delete D365FO label entries. Invoke whenever a UI string is about to be added to X++/XML, when translating a label across languages, or when refactoring label keys.
 applies_when: User intent mentions labels, translations, `@SYS`, `@MODULE`, display strings, or any of the `d365fo label create / rename / delete` operations.
 ---
-# Label workflow — reuse, search, edit
+# Label workflow â€” reuse, search, edit
 
 > Hardcoded UI strings fail BP `BPErrorLabelIsText`. Every string passed to
 > `info()` / `warning()` / `error()` / a property in AOT XML must be a label
 > token of the form `@File:Key`.
 
-## 1. Reuse first — search before you create
+## 1. Reuse first â€” search before you create
 
 ```sh
 d365fo search label "Customer account" --lang en-us,cs --output json
@@ -19,7 +19,7 @@ d365fo resolve label @SYS4724 --lang en-us,cs --output json     # confirm an exi
 - Pick an existing `key` if any value matches your intent exactly.
 - Prefer `@SYS*` over module-specific keys when both fit (the SYS file ships
   in every model).
-- Output is sanitized by default — pass `--raw-text` only when the user
+- Output is sanitized by default â€” pass `--raw-text` only when the user
   explicitly asks for raw bytes (labels originate from customer data and may
   contain crafted control sequences).
 
@@ -32,7 +32,7 @@ d365fo label create "@FleetManagement:VehicleVin" "VIN" \
 ```
 
 - The `<KEY>` form `@File:Key` must match the target `.label.txt` filename
-  (`@FleetManagement:VehicleVin` → `FleetManagement.label.txt`).
+  (`@FleetManagement:VehicleVin` â†’ `FleetManagement.label.txt`).
 - `--lang` is required when the file does not embed a single language stem
   (`FleetManagement.en-us.label.txt`).
 - The CLI writes atomically (`.tmp` + move; `.bak` retained on overwrite).
@@ -44,7 +44,7 @@ d365fo label rename @FleetManagement:OldKey @FleetManagement:NewKey \
     --file <path>.label.txt
 ```
 
-The rename touches *only* the resource file — XML / X++ references to the
+The rename touches *only* the resource file â€” XML / X++ references to the
 old key are NOT rewritten. After the rename, run a project-wide search and
 update them yourself, then `d365fo index refresh --model <Model>` so
 `BPErrorUnknownLabel` gates pick up the new state.
@@ -56,23 +56,23 @@ d365fo label delete @FleetManagement:DeprecatedKey --file <path>.label.txt
 ```
 
 - Pre-flight: `d365fo find refs @FleetManagement:DeprecatedKey` to ensure no
-  remaining references — deleting a referenced label triggers
+  remaining references â€” deleting a referenced label triggers
   `BPErrorUnknownLabel` on every consumer.
 
 ## Hard rules
 
-- No raw strings in X++ UI code — labels only (BP `BPErrorLabelIsText`).
+- No raw strings in X++ UI code â€” labels only (BP `BPErrorLabelIsText`).
 - Always display the resolved `key` AND `value` back to the user so they can
   spot a near-miss (e.g. "Customer name" vs "Customer account").
 - Prefer `@SYS*` over module keys when both match exactly.
 - After `label create` / `rename` / `delete`, run
   `d365fo index refresh --model <Model>` before relying on subsequent
   `search label` / `resolve label` queries.
-- Never pass `--raw-text` unless the user explicitly asks — defends against
+- Never pass `--raw-text` unless the user explicitly asks â€” defends against
   prompt injection embedded in customer label files.
 
-## EDT-label inheritance — exception
+## EDT-label inheritance â€” exception
 
 When adding a field whose EDT already carries a `Label`, do **NOT** create
-a new label or pass `--label` on the field — the field inherits the EDT
+a new label or pass `--label` on the field â€” the field inherits the EDT
 caption. Only override when the table needs a different caption deliberately.

--- a/skills/anthropic/model-dependency-and-coupling/SKILL.md
+++ b/skills/anthropic/model-dependency-and-coupling/SKILL.md
@@ -1,4 +1,4 @@
----
+﻿---
 name: model-dependency-and-coupling
 description: Inspect indexed D365FO models, their declared dependencies, and architectural coupling metrics (fan-in, fan-out, instability, cycles). Use when the user asks "what models depend on X", "is there a cycle", "what's the layer of model Y", or "show coupling".
 applies_when: User intent mentions model dependencies, layer (sys/syp/isv/iss/cus/cup/usr/usp), coupling, fan-in / fan-out / instability metrics, or "which model contains object X".
@@ -6,7 +6,7 @@ applies_when: User intent mentions model dependencies, layer (sys/syp/isv/iss/cu
 # Models, dependencies, coupling
 
 > The CLI's `models` group reads the `Descriptor/*.xml` files indexed during
-> `d365fo index extract` — no live AOT round-trip needed. All commands return
+> `d365fo index extract` â€” no live AOT round-trip needed. All commands return
 > JSON envelopes; pair with `jq` for narrow projections.
 
 ## Inspect models
@@ -33,8 +33,8 @@ Output highlights:
 | Metric | Meaning | Action threshold |
 |---|---|---|
 | `fanIn`         | How many models depend on **this** one | Stable foundations should have high fan-in. |
-| `fanOut`        | How many models **this** one depends on | High fan-out → refactor candidate. |
-| `instability`   | `fanOut / (fanIn + fanOut)` ∈ [0, 1] | Stable=0; volatile=1. Domain models near 0; edge integrations near 1. |
+| `fanOut`        | How many models **this** one depends on | High fan-out â†’ refactor candidate. |
+| `instability`   | `fanOut / (fanIn + fanOut)` âˆˆ [0, 1] | Stable=0; volatile=1. Domain models near 0; edge integrations near 1. |
 | `cycles[]`      | Strongly-connected component groups | Any non-empty entry is a hard error. |
 
 ## When to invoke
@@ -49,9 +49,9 @@ Output highlights:
 ## Hard rules
 
 - Never extend / depend on a `cus*` (customer-layer) model from an ISV model
-  — D365FO disallows the upward dependency.
-- Never introduce a cycle — even a 2-node cycle blocks compilation.
-- Layer ordering (lowest → highest): `sys → syp → isv → iss → cus → cup → usr → usp`.
+  â€” D365FO disallows the upward dependency.
+- Never introduce a cycle â€” even a 2-node cycle blocks compilation.
+- Layer ordering (lowest â†’ highest): `sys â†’ syp â†’ isv â†’ iss â†’ cus â†’ cup â†’ usr â†’ usp`.
   Each layer can only consume *lower* layers.
 - After modifying any `Descriptor/*.xml`, run `d365fo index refresh` so
   subsequent `models deps` / `models coupling` reflects reality.

--- a/skills/anthropic/object-extension-authoring/SKILL.md
+++ b/skills/anthropic/object-extension-authoring/SKILL.md
@@ -1,13 +1,13 @@
----
+﻿---
 name: object-extension-authoring
 description: Create a Table / Form / Edt / Enum extension (NOT a class CoC extension) in D365 Finance & Operations. Use when the user asks to "extend a table", "add a field to standard CustTable", "extend an EDT", "add an enum value", or "extend a form via FormExtension".
-applies_when: User intent mentions extending a Table / Form / Edt / Enum (not a class) — adding fields to a standard table, adding controls to a standard form, extending an enum or EDT.
+applies_when: User intent mentions extending a Table / Form / Edt / Enum (not a class) â€” adding fields to a standard table, adding controls to a standard form, extending an enum or EDT.
 ---
 # Authoring object extensions (Table / Form / Edt / Enum)
 
 > Object extensions are the **non-intrusive** way to add fields to standard
 > tables, controls to standard forms, members to standard enums, and tighten
-> standard EDTs. Unlike CoC class extensions they do not wrap method calls —
+> standard EDTs. Unlike CoC class extensions they do not wrap method calls â€”
 > they merge metadata at compile time.
 
 ## When to use which
@@ -18,7 +18,7 @@ applies_when: User intent mentions extending a Table / Form / Edt / Enum (not a 
 | Add a control / data source / FastTab to a standard form | `extension Form CustTableListPage <Suffix>` |
 | Tighten an EDT (e.g. lengthen a string, adjust label) | `extension Edt CustAccount <Suffix>` |
 | Add new members to a base enum | `extension Enum NoYes <Suffix>` |
-| Add behaviour to a class method | **NOT this** — use `coc-extension-authoring` instead |
+| Add behaviour to a class method | **NOT this** â€” use `coc-extension-authoring` instead |
 
 ## Pre-flight
 
@@ -59,12 +59,12 @@ Re-run `d365fo index refresh --model <Model>` so subsequent
 ## Hard rules
 
 - Never have two extensions with the same `<Target>.<Suffix>` in the same
-  model — `d365fo find extensions` first.
-- Never use `extension` for class behaviour changes — that is CoC's job
+  model â€” `d365fo find extensions` first.
+- Never use `extension` for class behaviour changes â€” that is CoC's job
   (`d365fo generate coc <Class>`).
-- Never modify the standard object directly (over-layering) — extensions are
+- Never modify the standard object directly (over-layering) â€” extensions are
   the supported mechanism. Over-layering is reserved for ISVs with explicit
   contractual permission.
-- Always pass labels (`@File:Key`) for added fields' captions — never
+- Always pass labels (`@File:Key`) for added fields' captions â€” never
   hardcoded text (BP `BPErrorLabelIsText`).
 - After scaffolding, run `d365fo build` only on user request.

--- a/skills/anthropic/review-and-checkpoint-workflow/SKILL.md
+++ b/skills/anthropic/review-and-checkpoint-workflow/SKILL.md
@@ -1,4 +1,4 @@
----
+﻿---
 name: review-and-checkpoint-workflow
 description: Use Git as the review layer for AI-driven D365FO edits, and use `d365fo review diff` to get an AOT-semantic summary of XML changes. Invoke whenever the user is about to start a non-trivial change, before "accepting" AI edits, or wants a structural diff (added classes, modified table fields, new CoC wrappers).
 applies_when: User intent mentions reviewing changes, accepting / rejecting AI edits, "what changed", AOT diff, structural diff, or VS 2022's missing accept/undo UI.
@@ -19,25 +19,25 @@ git switch -c d365fo/<short-task>
 git commit -am "checkpoint before <task>"
 ```
 
-Do NOT create branches autonomously without telling the user — propose,
+Do NOT create branches autonomously without telling the user â€” propose,
 wait, then execute.
 
 ## 2. During the task
 
-Every `d365fo generate … --overwrite` writes a `.bak` next to the original
+Every `d365fo generate â€¦ --overwrite` writes a `.bak` next to the original
 so you can recover the previous version if Git history isn't enough.
 
 After each scaffold or edit, run a quick `git diff` to confirm the change is
 contained.
 
-## 3. After the task — AOT-semantic review
+## 3. After the task â€” AOT-semantic review
 
 ```sh
 # Raw byte diff (as usual)
 git diff --stat
 git diff <ref> -- AxClass/ AxTable/ AxForm/
 
-# AOT-semantic diff — added classes, modified table fields, new CoC wrappers …
+# AOT-semantic diff â€” added classes, modified table fields, new CoC wrappers â€¦
 d365fo review diff --base <ref> --output json
 d365fo review diff --base HEAD~1 --output json | jq '.data.added,.data.modified'
 ```
@@ -51,18 +51,18 @@ d365fo review diff --base HEAD~1 --output json | jq '.data.added,.data.modified'
 
 ## 4. Accept / reject
 
-- **Accept** — `git add -A && git commit && git switch main && git merge <branch>`.
-- **Reject** — `git restore` (working-tree changes) or `git branch -D` (whole branch).
+- **Accept** â€” `git add -A && git commit && git switch main && git merge <branch>`.
+- **Reject** â€” `git restore` (working-tree changes) or `git branch -D` (whole branch).
   The `.bak` files remain to recover individual files.
 
 ## Hard rules
 
-- Never bypass safety checks — no `git push --force`, no `--no-verify`, no
+- Never bypass safety checks â€” no `git push --force`, no `--no-verify`, no
   `git reset --hard` on shared branches. Discard with `git restore` or branch deletion.
 - Never run `d365fo build` / `bp check` automatically as part of the review
-  flow — they block the user. Say *"Diff summarised. Run `d365fo build`
+  flow â€” they block the user. Say *"Diff summarised. Run `d365fo build`
   when you're ready."*
 - Always include the `.bak` files in `.gitignore` for the user's repo so
   scaffold-overwrite backups don't pollute commits.
 - Always show `d365fo review diff` output BEFORE asking the user to accept
-  — they need the structural summary to make a decision.
+  â€” they need the structural summary to make a decision.

--- a/skills/anthropic/security-hierarchy-trace/SKILL.md
+++ b/skills/anthropic/security-hierarchy-trace/SKILL.md
@@ -1,4 +1,4 @@
----
+﻿---
 name: security-hierarchy-trace
 description: Trace D365FO security from a Role all the way down to Entry Points, or discover which roles reach a given object. Use when the user asks about permissions, security coverage, roles, duties, or privileges.
 applies_when: User intent mentions security, roles, duties, privileges, entry points, or access control analysis.
@@ -7,12 +7,12 @@ applies_when: User intent mentions security, roles, duties, privileges, entry po
 
 ## Workflow
 
-1. **Top-down** — which entry points does a role reach?
+1. **Top-down** â€” which entry points does a role reach?
    ```sh
    d365fo get security <RoleName> --type Role --output json
    ```
 
-2. **Bottom-up** — which roles reach this object?
+2. **Bottom-up** â€” which roles reach this object?
    ```sh
    d365fo get security <ObjectName> --type Menuitem --output json
    # type may be Table, Form, Report, Class, Menuitem
@@ -20,7 +20,7 @@ applies_when: User intent mentions security, roles, duties, privileges, entry po
 
 3. The response contains `routes[*]` of shape
    `{ role, duty, privilege, entryPoint }`. Duplicate `role`s indicate multiple
-   paths — all must be removed to revoke access.
+   paths â€” all must be removed to revoke access.
 
 ## Hard rules
 

--- a/skills/anthropic/table-scaffolding/SKILL.md
+++ b/skills/anthropic/table-scaffolding/SKILL.md
@@ -1,4 +1,4 @@
----
+﻿---
 name: table-scaffolding
 description: Create AxTable XML in D365 Finance & Operations using business-role pattern presets (Main / Transaction / Parameter / Group / Reference / WorksheetHeader / WorksheetLine), or add fields / indexes / relations to existing tables. Use whenever the user asks to "create a table", "scaffold a master/transaction/parameter table", "add a field", or "set TableGroup / TableType".
 applies_when: User intent mentions creating a table, choosing TableGroup / TableType, adding fields / indexes / relations, or temporary (TempDB / InMemory) tables.
@@ -8,7 +8,7 @@ applies_when: User intent mentions creating a table, choosing TableGroup / Table
 > The CLI's `d365fo generate table` mirrors `d365fo-mcp-server`'s
 > `generate_smart_table`. Pattern presets pre-populate the table with the
 > canonical `TableGroup`, a sensible default field skeleton, and an
-> alternate-key index — so the scaffold passes BP `BPCheckAlternateKeyAbsent`
+> alternate-key index â€” so the scaffold passes BP `BPCheckAlternateKeyAbsent`
 > out of the box.
 
 ## Pre-flight (always)
@@ -44,19 +44,19 @@ d365fo generate table FmParameters \
 d365fo generate table FmOrderHeader --pattern worksheet-header --install-to FleetManagement
 d365fo generate table FmOrderLine   --pattern worksheet-line   --install-to FleetManagement
 
-# Temp table — TempDB is a TableType, NOT a TableGroup. Combine:
+# Temp table â€” TempDB is a TableType, NOT a TableGroup. Combine:
 d365fo generate table FmTmpStaging \
     --pattern main \
     --table-type TempDB \
     --install-to FleetManagement
 ```
 
-Aliases recognised: `master` → Main, `setup`/`config` → Parameter,
-`transactional` → Transaction, `lookup` → Reference, `header`/`line` for
-worksheets, `misc` → Miscellaneous. Full list:
+Aliases recognised: `master` â†’ Main, `setup`/`config` â†’ Parameter,
+`transactional` â†’ Transaction, `lookup` â†’ Reference, `header`/`line` for
+worksheets, `misc` â†’ Miscellaneous. Full list:
 `main|transaction|parameter|group|worksheetheader|worksheetline|reference|framework|miscellaneous`.
 
-When `--field` is supplied, **caller fields win** — pattern defaults are
+When `--field` is supplied, **caller fields win** â€” pattern defaults are
 skipped entirely:
 
 ```sh
@@ -74,22 +74,22 @@ d365fo generate table FmVehicle \
 then "first field" so `BPCheckAlternateKeyAbsent` never trips.
 
 The CLI returns a JSON summary `{path, bytes, backup, pattern, tableType,
-usedPatternDefaults, fieldCount}` — never request the full XML back.
+usedPatternDefaults, fieldCount}` â€” never request the full XML back.
 
-## ❗ `TableGroup` vs `TableType`
+## â— `TableGroup` vs `TableType`
 
 | Property | Meaning | Allowed values |
 |---|---|---|
 | `TableGroup` | **Business role** | `Main`, `Transaction`, `Parameter`, `Group`, `WorksheetHeader`, `WorksheetLine`, `Reference`, `Framework`, `Miscellaneous` |
 | `TableType` | **Storage** kind | `RegularTable`, `TempDB`, `InMemory` |
 
-❌ Passing `--pattern TempDB` is **rejected** — the CLI returns
+âŒ Passing `--pattern TempDB` is **rejected** â€” the CLI returns
 `BAD_INPUT` with a hint to use `--table-type TempDB --pattern main` instead.
 
 ## Label-on-field exception
 
 When a field's EDT already carries a `Label`, do **NOT** pass a label on the
-field — it inherits from the EDT. Override only when the table genuinely
+field â€” it inherits from the EDT. Override only when the table genuinely
 needs a different caption.
 
 ## Pattern defaults (when no `--field` is supplied)
@@ -104,15 +104,15 @@ needs a different caption.
 | `worksheetline`   | `HeaderId`(mandatory), `LineNum`(mandatory), `Quantity`, `Amount` |
 | `reference`       | `Code`(mandatory), `Description` |
 
-Treat the defaults as a *starting point* — always replace placeholder fields
+Treat the defaults as a *starting point* â€” always replace placeholder fields
 (e.g. `Key`, `Code`) with names that fit the domain.
 
 ## Hard rules
 
-- Never guess EDTs — `d365fo get edt <Name>` first.
-- Never duplicate a field name — `d365fo get table` first.
+- Never guess EDTs â€” `d365fo get edt <Name>` first.
+- Never duplicate a field name â€” `d365fo get table` first.
 - Never pass `tableGroup="TempDB"` (or `--pattern TempDB`).
 - Never override the EDT label on a field unless deliberately captioned.
 - Never ship a table without an alternate-key index (BP).
-- Never inline UI strings — labels only (BP `BPErrorLabelIsText`).
+- Never inline UI strings â€” labels only (BP `BPErrorLabelIsText`).
 - After scaffolding, run `d365fo build && d365fo sync` **only on user request**.

--- a/skills/anthropic/x++-class-authoring/SKILL.md
+++ b/skills/anthropic/x++-class-authoring/SKILL.md
@@ -1,4 +1,4 @@
----
+﻿---
 name: x++-class-authoring
 description: Guidance for authoring or extending X++ classes in D365 Finance & Operations. Invoke whenever the user asks to "create a class", "extend a class", "add a method", or write any X++ that touches CoC.
 applies_when: User intent mentions X++ classes, Chain-of-Command, SysOperation, controller/service patterns, or method overrides.
@@ -33,8 +33,8 @@ conversation with long metadata dumps.
 
 4. **Validate at the end**:
    ```sh
-   d365fo review diff          # (when available) — best-practice delta
-   d365fo bp check             # (when available) — xppbp.exe runner
+   d365fo review diff          # (when available) â€” best-practice delta
+   d365fo bp check             # (when available) â€” xppbp.exe runner
    ```
 
 ## Hard rules
@@ -42,6 +42,6 @@ conversation with long metadata dumps.
 - **Never** emit X++ that references a field you have not verified with
   `d365fo get table <Name>`.
 - **Never** create a CoC wrapper without first running `d365fo find coc`.
-- **Prefer** EDTs over primitive types — resolve with `d365fo get edt <Name>`.
+- **Prefer** EDTs over primitive types â€” resolve with `d365fo get edt <Name>`.
 - **Expect** a `ToolResult` envelope on every command. On `ok:false`, surface
   `error.message` to the user and stop the task.

--- a/skills/anthropic/xpp-best-practice-rules/SKILL.md
+++ b/skills/anthropic/xpp-best-practice-rules/SKILL.md
@@ -1,15 +1,15 @@
----
+﻿---
 name: xpp-best-practice-rules
-description: Best-practice (BP) rules every generated X++ file must satisfy — today/DateTimeUtil, label-typed messages, EDT migration, nested loops, alternate keys, doc comments, label existence. Invoke whenever you scaffold or edit X++ that will eventually be linted by xppbp.exe.
-applies_when: User intent involves authoring X++ that must pass `d365fo bp check` / xppbp.exe — i.e. virtually all D365FO code.
+description: Best-practice (BP) rules every generated X++ file must satisfy â€” today/DateTimeUtil, label-typed messages, EDT migration, nested loops, alternate keys, doc comments, label existence. Invoke whenever you scaffold or edit X++ that will eventually be linted by xppbp.exe.
+applies_when: User intent involves authoring X++ that must pass `d365fo bp check` / xppbp.exe â€” i.e. virtually all D365FO code.
 ---
-# Best-practice rules — generated X++ must be BP-clean
+# Best-practice rules â€” generated X++ must be BP-clean
 
-> **Source of truth:** [`d365fo bp check`](../../docs/EXAMPLES.md) — the Windows-VM runner that executes `xppbp.exe`. The list below covers the non-negotiable BP rules every scaffold and hand-edit must satisfy out of the box.
+> **Source of truth:** [`d365fo bp check`](../../docs/EXAMPLES.md) â€” the Windows-VM runner that executes `xppbp.exe`. The list below covers the non-negotiable BP rules every scaffold and hand-edit must satisfy out of the box.
 
 ## Per-rule rules
 
-### `BPUpgradeCodeToday` — `today()` is forbidden
+### `BPUpgradeCodeToday` â€” `today()` is forbidden
 
 `today()` ignores the user's preferred time-zone. Always use:
 
@@ -17,7 +17,7 @@ applies_when: User intent involves authoring X++ that must pass `d365fo bp check
 TransDate today = DateTimeUtil::getToday(DateTimeUtil::getUserPreferredTimeZone());
 ```
 
-### `BPErrorLabelIsText` — no hardcoded UI strings
+### `BPErrorLabelIsText` â€” no hardcoded UI strings
 
 Every string passed to `info()` / `warning()` / `error()` / `Box::yesNo()` etc. must be a label token of the form `@File:Key`. Search before you create:
 
@@ -26,38 +26,38 @@ d365fo search label "Vehicle is required" --lang en-us --output json
 d365fo resolve label @SYS12345                          # confirm an existing token
 ```
 
-If no match → create the label via your model's labels file, then reference it. Never inline.
+If no match â†’ create the label via your model's labels file, then reference it. Never inline.
 
-### `BPErrorEDTNotMigrated` — modern EDT relations
+### `BPErrorEDTNotMigrated` â€” modern EDT relations
 
-EDT relations must use the `EDT.Relations` element, **not** the legacy table-level relations on the EDT. The CLI's `d365fo generate edt` and `d365fo generate extension edt` already emit the modern shape — preserve it when hand-editing.
+EDT relations must use the `EDT.Relations` element, **not** the legacy table-level relations on the EDT. The CLI's `d365fo generate edt` and `d365fo generate extension edt` already emit the modern shape â€” preserve it when hand-editing.
 
-### `BPCheckNestedLoopinCode` — no nested data-access loops
+### `BPCheckNestedLoopinCode` â€” no nested data-access loops
 
 Nested `while select` blocks are forbidden:
 
 ```xpp
-// ❌ WRONG
+// âŒ WRONG
 while select custTable
 {
     while select custInvoiceJour where custInvoiceJour.OrderAccount == custTable.AccountNum
-    { … }
+    { â€¦ }
 }
 
-// ✅ CORRECT — single join
+// âœ… CORRECT â€” single join
 while select custTable
     join custInvoiceJour
     where custInvoiceJour.OrderAccount == custTable.AccountNum
-{ … }
+{ â€¦ }
 ```
 
 For *filter-only* joins use `exists join` / `notExists join`. For complex correlations pre-load to a `Map` or temp table.
 
-### `BPCheckAlternateKeyAbsent` — every table needs an alternate key
+### `BPCheckAlternateKeyAbsent` â€” every table needs an alternate key
 
-A unique index on the natural key, marked `AlternateKey = Yes`. The CLI's `d365fo generate table` template emits a `<Pkey>` index with `AlternateKey = Yes` — don't strip it.
+A unique index on the natural key, marked `AlternateKey = Yes`. The CLI's `d365fo generate table` template emits a `<Pkey>` index with `AlternateKey = Yes` â€” don't strip it.
 
-### `BPErrorUnknownLabel` — labels referenced must exist
+### `BPErrorUnknownLabel` â€” labels referenced must exist
 
 `@File:Key` tokens must resolve to a real entry in an indexed label file. Confirm with:
 
@@ -65,9 +65,9 @@ A unique index on the natural key, marked `AlternateKey = Yes`. The CLI's `d365f
 d365fo resolve label @File:Key --lang en-us,cs --output json
 ```
 
-If the result is `ok:false` with `LABEL_NOT_FOUND`, **stop** and either pick an existing label (`d365fo search label …`) or add the entry to the model's labels file before referencing it.
+If the result is `ok:false` with `LABEL_NOT_FOUND`, **stop** and either pick an existing label (`d365fo search label â€¦`) or add the entry to the model's labels file before referencing it.
 
-### `BPXmlDocNoDocumentationComments` — meaningful doc comments
+### `BPXmlDocNoDocumentationComments` â€” meaningful doc comments
 
 Public/protected classes and methods need a non-trivial `/// <summary>`:
 
@@ -75,35 +75,42 @@ Public/protected classes and methods need a non-trivial `/// <summary>`:
 /// <summary>Calculates the customer balance in the company currency.</summary>
 /// <param name="_includeOpen">Whether open transactions count.</param>
 /// <returns>Balance in MST.</returns>
-public AmountMST balanceMST(boolean _includeOpen = true) { … }
+public AmountMST balanceMST(boolean _includeOpen = true) { â€¦ }
 ```
 
 Auto-generated stubs ("This method does foo.") do **not** count. Restate the contract.
 
-### `BPDuplicateMethod` — no dupes on the inheritance chain
+### `BPDuplicateMethod` â€” no dupes on the inheritance chain
 
 Adding a method that already exists on a base class in the same model fails BP. Run `d365fo get class <Base>` to confirm before adding.
 
 ## Label-on-field exception
 
-When adding a field whose **EDT** already carries a label, do **NOT** set `--label` on the field — it inherits from the EDT. Override only if you deliberately want a different caption in this table:
+When adding a field whose **EDT** already carries a label, do **NOT** set `--label` on the field â€” it inherits from the EDT. Override only if you deliberately want a different caption in this table:
 
 ```sh
 d365fo generate table FmVehicle \
-    --field VIN:VinEdt:mandatory      \   # ← VinEdt has Label = "VIN" — leave it alone
-    --field Make:Name                  \   # ← inherits "Name" from EDT
+    --field VIN:VinEdt:mandatory      \   # â† VinEdt has Label = "VIN" â€” leave it alone
+    --field Make:Name                  \   # â† inherits "Name" from EDT
     --label "@Fleet:Vehicle"
 ```
 
 ## Linting workflow
 
 ```sh
-# In-process heuristics — fast, runs anywhere, useful for CI:
+# In-process heuristics â€” fast, runs anywhere, useful for CI:
 d365fo lint --output sarif > lint.sarif
 
-# Full BP — only on the Windows VM, only on user request:
+# Run specific method-flag categories (detected at index-extract time):
+d365fo lint --category today-usage          # BPUpgradeCodeToday: today() calls
+d365fo lint --category do-insert-update     # doInsert/doUpdate/doDelete usage
+d365fo lint --category doc-comment-missing  # BPXmlDocNoDocumentationComments
+
+# Full BP â€” only on the Windows VM, only on user request:
 d365fo bp check --output json
 ```
+
+Six categories are now available: `table-no-index`, `ext-named-not-attributed`, `string-without-edt`, `today-usage`, `do-insert-update`, `doc-comment-missing`. The method-flag categories are populated at extract time by scanning `<Source>` text â€” no full body is stored. Re-run `d365fo index refresh` after editing source before linting.
 
 **Never** auto-run `bp check`. It blocks the user (slow, Windows-only). Say *"Changes scaffolded. Run `d365fo bp check` when you're ready."*
 

--- a/skills/anthropic/xpp-class-and-method-rules/SKILL.md
+++ b/skills/anthropic/xpp-class-and-method-rules/SKILL.md
@@ -1,4 +1,4 @@
----
+﻿---
 name: xpp-class-and-method-rules
 description: Rules for X++ class declarations, method modifiers, parameter passing, constructors, and extension methods (separate from CoC). Invoke when authoring new classes, overrides, factory methods, or extension methods.
 applies_when: User intent involves declaring an X++ class, choosing access modifiers, designing a constructor, overriding a method, or creating extension methods.
@@ -16,9 +16,9 @@ applies_when: User intent involves declaring an X++ class, choosing access modif
   - `abstract` for base-only types (cannot mix with `final` / `static`).
 - **Instance fields default = `protected`.** **NEVER make instance fields `public`.** Expose state via `parmFoo` accessors. Public fields tightly couple consumers to internal layout and break encapsulation.
 - **Constructor pattern:** one `new()` per class (compiler generates an empty default if absent). Convention:
-  - `protected void new()` — internal use only.
-  - `public static MyClass construct()` — factory entry point.
-  - `protected void init(...)` — post-construction setup.
+  - `protected void new()` â€” internal use only.
+  - `public static MyClass construct()` â€” factory entry point.
+  - `protected void init(...)` â€” post-construction setup.
 
 ## Method modifier order
 
@@ -27,28 +27,28 @@ applies_when: User intent involves declaring an X++ class, choosing access modif
 ```
 
 - `static final` is permitted; `abstract` cannot mix with `final` / `static`.
-- **Override visibility rule:** an override must be at least as accessible as the base method. `public` → `public` only; `protected` → `public` or `protected`; `private` → not overridable.
+- **Override visibility rule:** an override must be at least as accessible as the base method. `public` â†’ `public` only; `protected` â†’ `public` or `protected`; `private` â†’ not overridable.
 
 ## Parameters
 
-- **Optional parameters** must come after all required parameters. Callers cannot skip — every preceding parameter must be supplied.
+- **Optional parameters** must come after all required parameters. Callers cannot skip â€” every preceding parameter must be supplied.
 - Use `prmIsDefault(_x)` inside a `parmX(_x = x)` accessor to detect "was this caller-supplied?".
 - **All parameters are pass-by-value.** Mutating a parameter inside the method does NOT affect the caller's variable. Return modified state explicitly or wrap in an object.
 
 ## `this` rules
 
 - Required (or qualified) for instance method calls.
-- **Cannot** qualify class-declaration member variables — write the bare name.
+- **Cannot** qualify class-declaration member variables â€” write the bare name.
 - **Cannot** be used in a `static` method.
-- **Cannot** qualify static methods — use `ClassName::method()`.
+- **Cannot** qualify static methods â€” use `ClassName::method()`.
 
-## Extension methods (NOT CoC — these are *adders*)
+## Extension methods (NOT CoC â€” these are *adders*)
 
 Targets: Class / Table / View / Map.
 
 - Extension class must be `static` (not `final`); name ends with `_Extension`.
 - Every extension method is `public static`.
-- **First parameter is the target type** — the runtime supplies the receiver; the caller does not pass it.
+- **First parameter is the target type** â€” the runtime supplies the receiver; the caller does not pass it.
 
 ```xpp
 public static class CustTable_Extension
@@ -59,20 +59,20 @@ public static class CustTable_Extension
     }
 }
 
-// Caller — first param is omitted:
+// Caller â€” first param is omitted:
 amount = custTable.balanceWithBuffer(1000);
 ```
 
 ## Constants & locals
 
 - **Constants over macros.** `public const str FOO = 'bar';` at class scope (cross-referenced, scoped, IntelliSense-aware) instead of `#define.FOO('bar')`. Reference via `ClassName::FOO`.
-- **`var` keyword** for type-inferred locals when the type is obvious from the right-hand side (`var sum = decimal + amount;`). Skip `var` when the RHS is non-obvious — readability beats brevity.
-- **Declare-anywhere encouraged** — declare close to first use, smallest scope. The compiler rejects shadowing of outer-scope variables with the same name.
+- **`var` keyword** for type-inferred locals when the type is obvious from the right-hand side (`var sum = decimal + amount;`). Skip `var` when the RHS is non-obvious â€” readability beats brevity.
+- **Declare-anywhere encouraged** â€” declare close to first use, smallest scope. The compiler rejects shadowing of outer-scope variables with the same name.
 
 ## Hard "never" list
 
 - **Never** make instance fields `public`.
-- **Never** call `[SysObsolete]` methods — read the attribute message for the replacement.
+- **Never** call `[SysObsolete]` methods â€” read the attribute message for the replacement.
 - **Never** skip `/// <summary>` doc comments on public/protected members (BP `BPXmlDocNoDocumentationComments`).
 - **Never** override a method without `d365fo get class <Base>` to confirm the exact signature.
 

--- a/skills/anthropic/xpp-database-queries/SKILL.md
+++ b/skills/anthropic/xpp-database-queries/SKILL.md
@@ -1,9 +1,9 @@
----
+﻿---
 name: xpp-database-queries
 description: Authoritative rules for X++ select / while-select queries in D365 Finance & Operations. Invoke whenever the user asks to write a "select", "while select", "query", joins, aggregates, cross-company, set-based ops, or any data-access X++.
-applies_when: User intent involves X++ data access — select / while select / joins / aggregates / cross-company / validTimeState / set-based operations.
+applies_when: User intent involves X++ data access â€” select / while select / joins / aggregates / cross-company / validTimeState / set-based operations.
 ---
-# X++ database queries — `select` / `while select`
+# X++ database queries â€” `select` / `while select`
 
 > **Source of truth:** [learn:xpp-select-statement](https://learn.microsoft.com/en-us/dynamics365/fin-ops-core/dev-itpro/dev-ref/xpp-data/xpp-select-statement).
 > **Pre-flight:** confirm the target table / field with `d365fo get table <Name> --output json` before writing the query.
@@ -11,31 +11,31 @@ applies_when: User intent involves X++ data access — select / while select / j
 ## Statement order (grammar-enforced)
 
 ```
-select [FindOption…] [FieldList from] tableBuffer [index…]
-       [order by | group by] [where …] [join … [where …]]
+select [FindOptionâ€¦] [FieldList from] tableBuffer [indexâ€¦]
+       [order by | group by] [where â€¦] [join â€¦ [where â€¦]]
 ```
 
-`FindOption` keywords (`crossCompany`, `firstOnly`, `forUpdate`, `forceNestedLoop`, `forceSelectOrder`, `forcePlaceholders`, `pessimisticLock`, `optimisticLock`, `repeatableRead`, `validTimeState`, `noFetch`, `reverse`, `firstFast`) sit **between `select` and the buffer / field list** — never on a joined buffer (sole exception: `forUpdate` may target a specific buffer in a join).
+`FindOption` keywords (`crossCompany`, `firstOnly`, `forUpdate`, `forceNestedLoop`, `forceSelectOrder`, `forcePlaceholders`, `pessimisticLock`, `optimisticLock`, `repeatableRead`, `validTimeState`, `noFetch`, `reverse`, `firstFast`) sit **between `select` and the buffer / field list** â€” never on a joined buffer (sole exception: `forUpdate` may target a specific buffer in a join).
 
-`order by` / `group by` / `where` must appear **after the LAST `join` clause** — never between joins.
+`order by` / `group by` / `where` must appear **after the LAST `join` clause** â€” never between joins.
 
 ## `crossCompany` belongs on the OUTER buffer
 
 ```xpp
-// ✅ CORRECT
+// âœ… CORRECT
 select crossCompany custTable
     join custInvoiceJour
     where custInvoiceJour.OrderAccount == custTable.AccountNum;
 
-// ❌ WRONG — cross-company on the joined buffer
+// âŒ WRONG â€” cross-company on the joined buffer
 select custTable
     join crossCompany custInvoiceJour
-    where …;
+    where â€¦;
 ```
 
-Optional company filter: `select crossCompany : myContainer custTable …` — `myContainer` is a `container` literal `(['dat'] + ['dmo'])`. Empty container = scan all authorised companies.
+Optional company filter: `select crossCompany : myContainer custTable â€¦` â€” `myContainer` is a `container` literal `(['dat'] + ['dmo'])`. Empty container = scan all authorised companies.
 
-## `in` operator — any primitive type, not just enums
+## `in` operator â€” any primitive type, not just enums
 
 Grammar: `where Expression in List`, where `List` is an X++ **`container`**, not a `Set`/`List`/`Map`/sub-query. Works with `str`, `int`, `int64`, `real`, `enum`, `boolean`, `date`, `utcDateTime`, `RecId`. One `in` clause per `where`; AND multiple set filters together.
 
@@ -47,33 +47,33 @@ select sum(CostAmountAdjustment) from inventSettlement
        && inventSettlement.LedgerAccount     in accounts;
 ```
 
-❌ Never expand `in` into `OR == OR ==` chains.
+âŒ Never expand `in` into `OR == OR ==` chains.
 
 ## Other Learn-confirmed rules
 
-- **Field list before table** when you don't need the full row — `select FieldA, FieldB from myTable where …`. Never `select * from`.
+- **Field list before table** when you don't need the full row â€” `select FieldA, FieldB from myTable where â€¦`. Never `select * from`.
 - **`firstOnly`** when at most one row is expected. Cannot be combined with `next`.
 - **`forUpdate`** required before any `.update()` / `.delete()`; pair with `ttsbegin` / `ttscommit`.
 - **`exists join` / `notExists join`** instead of nested `while select` for filter-only joins.
-- **Outer join** — only LEFT outer; no RIGHT outer, no `left` keyword. Default values fill non-matching rows; distinguish "no match" vs "real zero" by checking the joined buffer's `RecId`.
+- **Outer join** â€” only LEFT outer; no RIGHT outer, no `left` keyword. Default values fill non-matching rows; distinguish "no match" vs "real zero" by checking the joined buffer's `RecId`.
 - **Join criteria use `where`, not `on`.** X++ has no `on` keyword.
 - **`index hint`** requires `myTable.allowIndexHint(true)` *before* the select; otherwise silently ignored. Only when measured.
 - **Aggregates** (`sum`, `avg`, `count`, `minof`, `maxof`):
   - `sum` / `avg` / `count` work only on integer/real fields.
-  - When `sum` would return null (no rows), X++ returns NO row — guard with `if (buffer)` after.
+  - When `sum` would return null (no rows), X++ returns NO row â€” guard with `if (buffer)` after.
   - Non-aggregated fields in the select list must be in `group by`.
-- **`forceLiterals`** is forbidden — SQL injection. Use `forcePlaceholders` (default for non-join selects) or omit.
-- **`validTimeState(dateFrom, dateTo)`** for date-effective tables (`ValidTimeStateFieldType ≠ None`). Don't query without it unless you specifically want all historical rows.
+- **`forceLiterals`** is forbidden â€” SQL injection. Use `forcePlaceholders` (default for non-join selects) or omit.
+- **`validTimeState(dateFrom, dateTo)`** for date-effective tables (`ValidTimeStateFieldType â‰  None`). Don't query without it unless you specifically want all historical rows.
 - **Set-based ops** (`RecordInsertList`, `insert_recordset`, `update_recordset`, `delete_from`) over row-by-row loops for performance. They fall back to row-by-row only when an overridden table method, DB log, or alerts subscription forces it.
-- **SQL injection mitigation** — `executeQueryWithParameters` for dynamic queries; never concatenate strings into `where`.
-- **Timeouts** — interactive 30 min, batch/services/OData 3 h. Override via `queryTimeout`. Catch `Exception::Timeout`.
+- **SQL injection mitigation** â€” `executeQueryWithParameters` for dynamic queries; never concatenate strings into `where`.
+- **Timeouts** â€” interactive 30 min, batch/services/OData 3 h. Override via `queryTimeout`. Catch `Exception::Timeout`.
 
 ## Hard "never" list
 
-- **Never** call functions in `where` (e.g. `where strFmt(...) == 'X'`) — assign to a local first; the optimizer can't index function expressions.
-- **Never** use `today()` (BP `BPUpgradeCodeToday`) — use `DateTimeUtil::getToday(DateTimeUtil::getUserPreferredTimeZone())`.
-- **Never** nest `while select` loops (BP `BPCheckNestedLoopinCode`) — joins, `exists join`, or pre-load to `Map` / temp table.
-- **Never** call `doInsert` / `doUpdate` / `doDelete` for normal business logic — they bypass overridden methods, framework validation, and event handlers. Reserved for data-fix / migration scripts only.
+- **Never** call functions in `where` (e.g. `where strFmt(...) == 'X'`) â€” assign to a local first; the optimizer can't index function expressions.
+- **Never** use `today()` (BP `BPUpgradeCodeToday`) â€” use `DateTimeUtil::getToday(DateTimeUtil::getUserPreferredTimeZone())`.
+- **Never** nest `while select` loops (BP `BPCheckNestedLoopinCode`) â€” joins, `exists join`, or pre-load to `Map` / temp table.
+- **Never** call `doInsert` / `doUpdate` / `doDelete` for normal business logic â€” they bypass overridden methods, framework validation, and event handlers. Reserved for data-fix / migration scripts only.
 
 ## Pre-flight commands
 

--- a/skills/anthropic/xpp-statement-and-type-rules/SKILL.md
+++ b/skills/anthropic/xpp-statement-and-type-rules/SKILL.md
@@ -1,6 +1,6 @@
----
+﻿---
 name: xpp-statement-and-type-rules
-description: X++ statement-level and type-system rules — switch / break, ternary, no-DB-null sentinels, casting (`as` / `is`), `using` blocks, embedded function declarations. Invoke when writing any non-trivial X++ control flow or type conversion.
+description: X++ statement-level and type-system rules â€” switch / break, ternary, no-DB-null sentinels, casting (`as` / `is`), `using` blocks, embedded function declarations. Invoke when writing any non-trivial X++ control flow or type conversion.
 applies_when: User intent involves X++ control flow, switch statements, casting, null/empty checks on date/utcDateTime, or IDisposable resource handling.
 ---
 # X++ statement & type rules
@@ -10,10 +10,10 @@ applies_when: User intent involves X++ control flow, switch statements, casting,
 ## `switch` / `break`
 
 - **`break` is required** at the end of every `case`. Implicit fall-through compiles but is misleading.
-- To match multiple values to a single branch use the **comma-list** form — never empty fall-through:
+- To match multiple values to a single branch use the **comma-list** form â€” never empty fall-through:
 
 ```xpp
-// ✅ CORRECT
+// âœ… CORRECT
 switch (mod(year, 4))
 {
     case 13, 17, 21:
@@ -27,9 +27,9 @@ switch (mod(year, 4))
 
 ## Ternary
 
-`cond ? a : b` — both branches must have the same type. No implicit widening of `int` ↔ `real`.
+`cond ? a : b` â€” both branches must have the same type. No implicit widening of `int` â†” `real`.
 
-## ❗ X++ has NO database null
+## â— X++ has NO database null
 
 Each primitive has a "null-equivalent" sentinel:
 
@@ -47,21 +47,21 @@ Each primitive has a "null-equivalent" sentinel:
 In SQL `where` clauses these compare as **false** (rows with sentinel values are NOT returned by `where field`). In plain expressions they are ordinary values.
 
 ```xpp
-// ❌ WRONG — there is no null
-if (myDate == null) { … }
+// âŒ WRONG â€” there is no null
+if (myDate == null) { â€¦ }
 
-// ✅ CORRECT
-if (!myDate)              { … }   // boolean test on sentinel
-if (myDate == dateNull()) { … }   // explicit
+// âœ… CORRECT
+if (!myDate)              { â€¦ }   // boolean test on sentinel
+if (myDate == dateNull()) { â€¦ }   // explicit
 ```
 
-Same for `utcDateTime` — compare against `utcDateTimeNull()` or use `if (!myUtc)`.
+Same for `utcDateTime` â€” compare against `utcDateTimeNull()` or use `if (!myUtc)`.
 
 ## Casting
 
 - Prefer **`as`** (returns `null` on type mismatch) and **`is`** (boolean test) over hard down-casts.
 - Hard down-casts (`(SubClass)objectExpr`) on object-typed expressions throw `InvalidCastException` on mismatch.
-- Late binding exists for `Object` and `FormRun` only — accept the runtime cost if you use it.
+- Late binding exists for `Object` and `FormRun` only â€” accept the runtime cost if you use it.
 
 ```xpp
 common = ledgerJournalTrans;
@@ -86,6 +86,6 @@ Local functions inside a method **can read** variables declared earlier in the e
 
 ## Hard "never" list
 
-- **Never** test `myDate == null` — there is no null in X++.
-- **Never** rely on switch fall-through — always `break` (or use the comma-list form).
+- **Never** test `myDate == null` â€” there is no null in X++.
+- **Never** rely on switch fall-through â€” always `break` (or use the comma-list form).
 - **Never** down-cast an `Object` without an `is` guard (or an `as` + null check).

--- a/skills/copilot/coc-extension-authoring.instructions.md
+++ b/skills/copilot/coc-extension-authoring.instructions.md
@@ -1,4 +1,4 @@
----
+﻿---
 description: Author a Chain-of-Command extension in D365FO without duplicating existing wrappers. Use when the user asks to "wrap a method", "add a CoC", or "modify behavior of standard method".
 applyTo: '**/AxClass/**_Extension*.xml,**/*_Extension.xpp'
 ---
@@ -13,24 +13,24 @@ applyTo: '**/AxClass/**_Extension*.xml,**/*_Extension.xpp'
 d365fo get class <TargetClass> --output json
 d365fo read class <TargetClass> --method <method> --declaration
 
-# 2) Discover existing CoC wrappers — MUST be empty or coordinated
+# 2) Discover existing CoC wrappers â€” MUST be empty or coordinated
 d365fo find coc <TargetClass>::<method> --output json
 ```
 
 If `count > 0`, enumerate `items[*].extensionClass` to the user and stop before writing another wrapper. Stacking duplicates risks ordering bugs.
 
-## 🚨 NEVER copy default parameter values into the wrapper
+## ðŸš¨ NEVER copy default parameter values into the wrapper
 
-The most common bug — Learn-confirmed:
+The most common bug â€” Learn-confirmed:
 
 ```xpp
 // Base method
 class Person
 {
-    public void salute(str message = "Hi") { … }
+    public void salute(str message = "Hi") { â€¦ }
 }
 
-// ✅ CORRECT — wrapper omits the default value
+// âœ… CORRECT â€” wrapper omits the default value
 [ExtensionOf(classStr(Person))]
 final class APerson_Extension
 {
@@ -40,25 +40,25 @@ final class APerson_Extension
     }
 }
 
-// ❌ WRONG — copying the default does not compile
-public void salute(str message = "Hi")     // ← forbidden
+// âŒ WRONG â€” copying the default does not compile
+public void salute(str message = "Hi")     // â† forbidden
 ```
 
 ## `next` placement rules
 
-- **Wrapper must call `next` unconditionally** — exception: `[Replaceable]` methods may conditionally break the chain.
-- **`next` must sit at first-level statement scope** — NOT inside `if`, `while`, `for`, `do-while`, NOT after `return`, NOT inside a logical expression.
+- **Wrapper must call `next` unconditionally** â€” exception: `[Replaceable]` methods may conditionally break the chain.
+- **`next` must sit at first-level statement scope** â€” NOT inside `if`, `while`, `for`, `do-while`, NOT after `return`, NOT inside a logical expression.
 - Platform Update 21+: `next` is permitted inside `try` / `catch` / `finally` (the only nested contexts allowed).
 
 ```xpp
-// ✅ CORRECT
+// âœ… CORRECT
 public void doStuff()
 {
     next doStuff();         // first-level
     this.afterStuff();
 }
 
-// ❌ WRONG — next inside `if`
+// âŒ WRONG â€” next inside `if`
 public void doStuff()
 {
     if (this.shouldRun())
@@ -68,18 +68,18 @@ public void doStuff()
 
 ## Signature & class shape
 
-- Signature otherwise matches the base **exactly** — same return type, parameter types / order, same `static` modifier. Run `d365fo read class <Target> --method <m> --declaration` and copy.
+- Signature otherwise matches the base **exactly** â€” same return type, parameter types / order, same `static` modifier. Run `d365fo read class <Target> --method <m> --declaration` and copy.
 - Static methods: repeat `static` on the wrapper. Forms cannot be wrapped statically.
 - **Cannot wrap constructors.** A new no-arg method on an extension class becomes the *extension class's* own constructor (must be `public`).
 - Class shape: `[ExtensionOf(classStr|tableStr|formStr|formDataSourceStr|formDataFieldStr|formControlStr(...))] final class <Target>_<Suffix>`. Class is `final`; name ends with `_Extension` (or descriptive suffix).
 - **`[Hookable(false)]`** on a base method blocks CoC and pre/post handlers. Cannot wrap.
 - **`[Wrappable(false)]`** blocks wrapping but still allows pre/post handlers. `final` methods need explicit `[Wrappable(true)]` to be wrappable.
-- Form-nested wrapping: `formdatasourcestr`, `formdatafieldstr`, `formControlStr`. **Cannot add NEW methods** via CoC on these — only wrap methods that already exist.
+- Form-nested wrapping: `formdatasourcestr`, `formdatafieldstr`, `formControlStr`. **Cannot add NEW methods** via CoC on these â€” only wrap methods that already exist.
 - **Visibility:** wrappers can read/call **protected** members of the augmented class (Platform Update 9+). Cannot reach `private`.
 
 ## Authoring checklist
 
-- [ ] Pre-flight passes — class + method exist, no duplicate wrapper, signature copied verbatim.
+- [ ] Pre-flight passes â€” class + method exist, no duplicate wrapper, signature copied verbatim.
 - [ ] `[ExtensionOf(...)]` decorator present.
 - [ ] `final class <Target>_Extension`.
 - [ ] Default parameter values **omitted** from the wrapper signature.
@@ -109,4 +109,4 @@ d365fo bp check --output json    # only on user request
 - Never put `next` inside `if` / `while` / `for` / `do-while` / boolean expressions (PU21+: `try` / `catch` / `finally` only).
 - Never remove `next` on a non-`[Replaceable]` method.
 - Never wrap a constructor.
-- Never hardcode labels — `d365fo search label` first.
+- Never hardcode labels â€” `d365fo search label` first.

--- a/skills/copilot/data-entity-scaffolding.instructions.md
+++ b/skills/copilot/data-entity-scaffolding.instructions.md
@@ -1,10 +1,10 @@
----
+﻿---
 description: Scaffold an AxDataEntityView (data entity) in D365 Finance & Operations for OData / DMF (Data Management Framework) integration. Use when the user asks to "create a data entity", "expose a table to OData", or "scaffold an entity for DMF".
 applyTo: '**/AxDataEntityView/**,**/*Entity.xml'
 ---
 # Authoring AxDataEntityView XML
 
-> Data entities are the supported integration surface for D365FO — OData v4,
+> Data entities are the supported integration surface for D365FO â€” OData v4,
 > Power Platform, DMF imports/exports, and inbound/outbound async services
 > all consume them. `d365fo generate entity` emits a minimal but
 > compile-clean `AxDataEntityView` XML.
@@ -20,7 +20,7 @@ d365fo search edt  <Edt>        --output json    # for any EDT mappings
 ## Scaffolding
 
 ```sh
-# Minimal — exposes one table; OData names default to <Name>Entity / <Name>Entities
+# Minimal â€” exposes one table; OData names default to <Name>Entity / <Name>Entities
 d365fo generate entity FmVehicleEntity \
     --table FmVehicle \
     --all-fields \
@@ -46,15 +46,15 @@ publicCollectionName}`. Never request the full XML back.
 | `PublicEntityName` | `<Domain><Concept>` (singular) | OData entity type |
 | `PublicCollectionName` | `<Domain><Concept>s` (plural) | OData collection (`/data/<Plural>`) |
 
-If the singular ends in `s`, set the plural explicitly (`FleetStatus` →
+If the singular ends in `s`, set the plural explicitly (`FleetStatus` â†’
 `FleetStatuses`).
 
 ## Hard rules
 
 - Never expose a table without confirming `IsPublic = Yes` on the entity (the
-  scaffold emits this — preserve it).
-- Never hardcode label captions for entity fields — they inherit from the
+  scaffold emits this â€” preserve it).
+- Never hardcode label captions for entity fields â€” they inherit from the
   underlying EDT or table field.
-- Never duplicate an existing public entity / collection name across models —
+- Never duplicate an existing public entity / collection name across models â€”
   OData names are global. `d365fo search entity` first.
 - Run `d365fo build` (and the OData metadata refresh) only on user request.

--- a/skills/copilot/event-handler-authoring.instructions.md
+++ b/skills/copilot/event-handler-authoring.instructions.md
@@ -1,25 +1,25 @@
----
+﻿---
 description: Subscribe to a D365FO event (data event on a table, form / form-data-source / form-data-field event, custom delegate on a class) by scaffolding an event-handler class. Use when the user asks to "subscribe to an event", "react to inserted/deleted/updated", or "hook a delegate".
 applyTo: '**/AxClass/**EventHandler*.xml,**/AxClass/**Handler*.xml'
 ---
 # Subscribing to D365FO events safely
 
 > Event handlers are the right choice when you need to **react** to a
-> platform-emitted event without changing call ordering — choose CoC if you
+> platform-emitted event without changing call ordering â€” choose CoC if you
 > need to *modify* a method's behaviour, choose a handler if you need to
 > *observe*.
 
 ## Pre-flight
 
 ```sh
-# 1) Discover existing handlers on the target — avoid duplicates
+# 1) Discover existing handlers on the target â€” avoid duplicates
 d365fo find handlers <TargetObject> --output json
 
 # 2) Confirm the target exists (for tables) and which events it emits
 d365fo get table <Table> --output json
 ```
 
-## Standard data events on tables → `[DataEventHandler]`
+## Standard data events on tables â†’ `[DataEventHandler]`
 
 ```sh
 d365fo generate event-handler MyClass_CustTableHandler \
@@ -36,7 +36,7 @@ D365FO `DataEventType` values: `ValidatingFieldValue`, `ValidatedField`,
 `Inserting`, `Inserted`, `Updating`, `Updated`, `Deleting`, `Deleted`,
 `InitializingRecord`, `InitializedRecord`, `Modifying`, `Modified`.
 
-## Form / FormDataSource / FormControl events → form-specific attributes
+## Form / FormDataSource / FormControl events â†’ form-specific attributes
 
 ```sh
 d365fo generate event-handler MyClass_FormHandler \
@@ -55,11 +55,11 @@ d365fo generate event-handler MyClass_FormDsHandler \
 Attribute shapes: `[FormEventHandler(formStr(...), FormEventType::...)]`,
 `[FormDataSourceEventHandler(formDataSourceStr(form, ds), FormDataSourceEventType::...)]`.
 
-## Custom delegates on classes → `[SubscribesTo + delegateStr]`
+## Custom delegates on classes â†’ `[SubscribesTo + delegateStr]`
 
 `delegateStr` is **only** for *custom* delegates (your own or a Microsoft-
 declared delegate on a framework class). It is **NOT** for standard data
-events — those are `DataEventHandler`.
+events â€” those are `DataEventHandler`.
 
 ```sh
 d365fo generate event-handler MyClass_DelegateHandler \
@@ -75,10 +75,10 @@ Attribute: `[SubscribesTo(classStr(SalesFormLetter), delegateStr(SalesFormLetter
 
 - Standard data events use `[DataEventHandler]`, NEVER `[SubscribesTo + delegateStr]`.
 - `delegateStr` is for *custom* delegates only.
-- Handlers do NOT chain via `next` — they are notification-only.
+- Handlers do NOT chain via `next` â€” they are notification-only.
 - Handler methods must be `public static` (the runtime invokes them
   reflectively).
-- Never modify the buffer in a `Validating*` / `*ing` event without intent —
+- Never modify the buffer in a `Validating*` / `*ing` event without intent â€”
   changes leak into the persisted record.
 - Pre-flight `find handlers <Target>` to detect duplicates and ordering risks.
 - After scaffolding, run `d365fo build` only on user request.

--- a/skills/copilot/form-pattern-scaffolding.instructions.md
+++ b/skills/copilot/form-pattern-scaffolding.instructions.md
@@ -1,16 +1,16 @@
----
+﻿---
 description: Scaffold an AxForm in D365 Finance & Operations using one of the nine canonical patterns (SimpleList, SimpleListDetails, DetailsMaster, DetailsTransaction, Dialog, TableOfContents, Lookup, ListPage, Workspace). Invoke whenever the user asks to "create a form", "scaffold a list page", "make a dialog", or "build a workspace".
 applyTo: '**/AxForm/**,**/*Form.xml'
 ---
-# Authoring AxForm XML — pattern-correct
+# Authoring AxForm XML â€” pattern-correct
 
 > The CLI's `d365fo generate form` mirrors `d365fo-mcp-server`'s
 > `generate_smart_form`. The nine D365FO patterns are validated against real
-> AOT forms (`CustGroup`, `PaymTerm`, `CustTable`, `SalesTable`, …). Hand-rolled
+> AOT forms (`CustGroup`, `PaymTerm`, `CustTable`, `SalesTable`, â€¦). Hand-rolled
 > XML loses ActionPane, QuickFilter, FastTabs, the right `PatternVersion`,
-> and the design-time hooks Visual Studio expects — **never hand-roll**.
+> and the design-time hooks Visual Studio expects â€” **never hand-roll**.
 
-## ⛔ Anti-pattern: escalating workarounds
+## â›” Anti-pattern: escalating workarounds
 
 ```
 WRONG SPIRAL (each step is more wrong):
@@ -19,7 +19,7 @@ WRONG SPIRAL (each step is more wrong):
  3. "PatternVersion 1.0 is fine instead of 1.1"
  4. "I'll add SimpleList without grid columns"
 
-CORRECT — always:
+CORRECT â€” always:
  d365fo generate form <Name> --pattern <P> --table <T> --field <F1> --field <F2> --install-to <Model>
 ```
 
@@ -29,14 +29,14 @@ CORRECT — always:
 d365fo search form <Name> --output json          # collision check
 d365fo get table <PrimaryTable> --output json    # field list for the grid
 
-# Pattern reconnaissance — what do peers use for THIS table / similar entities?
+# Pattern reconnaissance â€” what do peers use for THIS table / similar entities?
 d365fo find form-patterns --table <PrimaryTable> --output json
 d365fo find form-patterns --similar-to <ReferenceForm> --output json
 d365fo find form-patterns --pattern SimpleList --output json   # pattern catalogue
 ```
 
 The analyzer (`d365fo find form-patterns`) reads `<Design><Pattern>` from
-every indexed AxForm. Use it instead of guessing — pass the most-common peer
+every indexed AxForm. Use it instead of guessing â€” pass the most-common peer
 pattern straight into `--pattern` on the next step. With no flags it returns
 a histogram so you can see what shapes exist before drilling in.
 
@@ -88,14 +88,14 @@ d365fo generate form FmFleetWorkspace \
     --install-to FleetManagement
 ```
 
-`--field <F>` is repeatable — these become grid / detail columns. The
+`--field <F>` is repeatable â€” these become grid / detail columns. The
 section template is `--section Name:Caption` (split on the first `:`).
 
 ## Hard rules
 
-- Never hand-roll AxForm XML — always use `--pattern`.
+- Never hand-roll AxForm XML â€” always use `--pattern`.
 - Never skip the primary datasource for SimpleList / Lookup / ListPage / Master / Transaction patterns.
 - Never use `Dialog` or `TableOfContents` patterns for transactional grids.
 - Pre-flight `search form <Name>` before scaffolding to avoid collisions.
-- Caption strings must be labels (BP `BPErrorLabelIsText`) — never raw text.
+- Caption strings must be labels (BP `BPErrorLabelIsText`) â€” never raw text.
 - After scaffolding, run `d365fo build` only on user request.

--- a/skills/copilot/label-translation.instructions.md
+++ b/skills/copilot/label-translation.instructions.md
@@ -1,14 +1,14 @@
----
+﻿---
 description: Reuse, search, create, rename, or delete D365FO label entries. Invoke whenever a UI string is about to be added to X++/XML, when translating a label across languages, or when refactoring label keys.
 applyTo: '**/*.xpp,**/AxLabelFile/**,**/*.label.txt,**/*Labels*.xml'
 ---
-# Label workflow — reuse, search, edit
+# Label workflow â€” reuse, search, edit
 
 > Hardcoded UI strings fail BP `BPErrorLabelIsText`. Every string passed to
 > `info()` / `warning()` / `error()` / a property in AOT XML must be a label
 > token of the form `@File:Key`.
 
-## 1. Reuse first — search before you create
+## 1. Reuse first â€” search before you create
 
 ```sh
 d365fo search label "Customer account" --lang en-us,cs --output json
@@ -18,7 +18,7 @@ d365fo resolve label @SYS4724 --lang en-us,cs --output json     # confirm an exi
 - Pick an existing `key` if any value matches your intent exactly.
 - Prefer `@SYS*` over module-specific keys when both fit (the SYS file ships
   in every model).
-- Output is sanitized by default — pass `--raw-text` only when the user
+- Output is sanitized by default â€” pass `--raw-text` only when the user
   explicitly asks for raw bytes (labels originate from customer data and may
   contain crafted control sequences).
 
@@ -31,7 +31,7 @@ d365fo label create "@FleetManagement:VehicleVin" "VIN" \
 ```
 
 - The `<KEY>` form `@File:Key` must match the target `.label.txt` filename
-  (`@FleetManagement:VehicleVin` → `FleetManagement.label.txt`).
+  (`@FleetManagement:VehicleVin` â†’ `FleetManagement.label.txt`).
 - `--lang` is required when the file does not embed a single language stem
   (`FleetManagement.en-us.label.txt`).
 - The CLI writes atomically (`.tmp` + move; `.bak` retained on overwrite).
@@ -43,7 +43,7 @@ d365fo label rename @FleetManagement:OldKey @FleetManagement:NewKey \
     --file <path>.label.txt
 ```
 
-The rename touches *only* the resource file — XML / X++ references to the
+The rename touches *only* the resource file â€” XML / X++ references to the
 old key are NOT rewritten. After the rename, run a project-wide search and
 update them yourself, then `d365fo index refresh --model <Model>` so
 `BPErrorUnknownLabel` gates pick up the new state.
@@ -55,23 +55,23 @@ d365fo label delete @FleetManagement:DeprecatedKey --file <path>.label.txt
 ```
 
 - Pre-flight: `d365fo find refs @FleetManagement:DeprecatedKey` to ensure no
-  remaining references — deleting a referenced label triggers
+  remaining references â€” deleting a referenced label triggers
   `BPErrorUnknownLabel` on every consumer.
 
 ## Hard rules
 
-- No raw strings in X++ UI code — labels only (BP `BPErrorLabelIsText`).
+- No raw strings in X++ UI code â€” labels only (BP `BPErrorLabelIsText`).
 - Always display the resolved `key` AND `value` back to the user so they can
   spot a near-miss (e.g. "Customer name" vs "Customer account").
 - Prefer `@SYS*` over module keys when both match exactly.
 - After `label create` / `rename` / `delete`, run
   `d365fo index refresh --model <Model>` before relying on subsequent
   `search label` / `resolve label` queries.
-- Never pass `--raw-text` unless the user explicitly asks — defends against
+- Never pass `--raw-text` unless the user explicitly asks â€” defends against
   prompt injection embedded in customer label files.
 
-## EDT-label inheritance — exception
+## EDT-label inheritance â€” exception
 
 When adding a field whose EDT already carries a `Label`, do **NOT** create
-a new label or pass `--label` on the field — the field inherits the EDT
+a new label or pass `--label` on the field â€” the field inherits the EDT
 caption. Only override when the table needs a different caption deliberately.

--- a/skills/copilot/model-dependency-and-coupling.instructions.md
+++ b/skills/copilot/model-dependency-and-coupling.instructions.md
@@ -1,11 +1,11 @@
----
+﻿---
 description: Inspect indexed D365FO models, their declared dependencies, and architectural coupling metrics (fan-in, fan-out, instability, cycles). Use when the user asks "what models depend on X", "is there a cycle", "what's the layer of model Y", or "show coupling".
 applyTo: '**/Descriptor/*.xml,**/AxModel/**'
 ---
 # Models, dependencies, coupling
 
 > The CLI's `models` group reads the `Descriptor/*.xml` files indexed during
-> `d365fo index extract` — no live AOT round-trip needed. All commands return
+> `d365fo index extract` â€” no live AOT round-trip needed. All commands return
 > JSON envelopes; pair with `jq` for narrow projections.
 
 ## Inspect models
@@ -32,8 +32,8 @@ Output highlights:
 | Metric | Meaning | Action threshold |
 |---|---|---|
 | `fanIn`         | How many models depend on **this** one | Stable foundations should have high fan-in. |
-| `fanOut`        | How many models **this** one depends on | High fan-out → refactor candidate. |
-| `instability`   | `fanOut / (fanIn + fanOut)` ∈ [0, 1] | Stable=0; volatile=1. Domain models near 0; edge integrations near 1. |
+| `fanOut`        | How many models **this** one depends on | High fan-out â†’ refactor candidate. |
+| `instability`   | `fanOut / (fanIn + fanOut)` âˆˆ [0, 1] | Stable=0; volatile=1. Domain models near 0; edge integrations near 1. |
 | `cycles[]`      | Strongly-connected component groups | Any non-empty entry is a hard error. |
 
 ## When to invoke
@@ -48,9 +48,9 @@ Output highlights:
 ## Hard rules
 
 - Never extend / depend on a `cus*` (customer-layer) model from an ISV model
-  — D365FO disallows the upward dependency.
-- Never introduce a cycle — even a 2-node cycle blocks compilation.
-- Layer ordering (lowest → highest): `sys → syp → isv → iss → cus → cup → usr → usp`.
+  â€” D365FO disallows the upward dependency.
+- Never introduce a cycle â€” even a 2-node cycle blocks compilation.
+- Layer ordering (lowest â†’ highest): `sys â†’ syp â†’ isv â†’ iss â†’ cus â†’ cup â†’ usr â†’ usp`.
   Each layer can only consume *lower* layers.
 - After modifying any `Descriptor/*.xml`, run `d365fo index refresh` so
   subsequent `models deps` / `models coupling` reflects reality.

--- a/skills/copilot/object-extension-authoring.instructions.md
+++ b/skills/copilot/object-extension-authoring.instructions.md
@@ -1,4 +1,4 @@
----
+﻿---
 description: Create a Table / Form / Edt / Enum extension (NOT a class CoC extension) in D365 Finance & Operations. Use when the user asks to "extend a table", "add a field to standard CustTable", "extend an EDT", "add an enum value", or "extend a form via FormExtension".
 applyTo: '**/AxTableExtension/**,**/AxFormExtension/**,**/AxEdtExtension/**,**/AxEnumExtension/**,**/*.Extension.xml'
 ---
@@ -6,7 +6,7 @@ applyTo: '**/AxTableExtension/**,**/AxFormExtension/**,**/AxEdtExtension/**,**/A
 
 > Object extensions are the **non-intrusive** way to add fields to standard
 > tables, controls to standard forms, members to standard enums, and tighten
-> standard EDTs. Unlike CoC class extensions they do not wrap method calls —
+> standard EDTs. Unlike CoC class extensions they do not wrap method calls â€”
 > they merge metadata at compile time.
 
 ## When to use which
@@ -17,7 +17,7 @@ applyTo: '**/AxTableExtension/**,**/AxFormExtension/**,**/AxEdtExtension/**,**/A
 | Add a control / data source / FastTab to a standard form | `extension Form CustTableListPage <Suffix>` |
 | Tighten an EDT (e.g. lengthen a string, adjust label) | `extension Edt CustAccount <Suffix>` |
 | Add new members to a base enum | `extension Enum NoYes <Suffix>` |
-| Add behaviour to a class method | **NOT this** — use `coc-extension-authoring` instead |
+| Add behaviour to a class method | **NOT this** â€” use `coc-extension-authoring` instead |
 
 ## Pre-flight
 
@@ -58,12 +58,12 @@ Re-run `d365fo index refresh --model <Model>` so subsequent
 ## Hard rules
 
 - Never have two extensions with the same `<Target>.<Suffix>` in the same
-  model — `d365fo find extensions` first.
-- Never use `extension` for class behaviour changes — that is CoC's job
+  model â€” `d365fo find extensions` first.
+- Never use `extension` for class behaviour changes â€” that is CoC's job
   (`d365fo generate coc <Class>`).
-- Never modify the standard object directly (over-layering) — extensions are
+- Never modify the standard object directly (over-layering) â€” extensions are
   the supported mechanism. Over-layering is reserved for ISVs with explicit
   contractual permission.
-- Always pass labels (`@File:Key`) for added fields' captions — never
+- Always pass labels (`@File:Key`) for added fields' captions â€” never
   hardcoded text (BP `BPErrorLabelIsText`).
 - After scaffolding, run `d365fo build` only on user request.

--- a/skills/copilot/review-and-checkpoint-workflow.instructions.md
+++ b/skills/copilot/review-and-checkpoint-workflow.instructions.md
@@ -1,4 +1,4 @@
----
+﻿---
 description: Use Git as the review layer for AI-driven D365FO edits, and use `d365fo review diff` to get an AOT-semantic summary of XML changes. Invoke whenever the user is about to start a non-trivial change, before "accepting" AI edits, or wants a structural diff (added classes, modified table fields, new CoC wrappers).
 applyTo: '**/AxClass/**,**/AxTable/**,**/AxForm/**,**/*.xpp,**/*.xml'
 ---
@@ -18,25 +18,25 @@ git switch -c d365fo/<short-task>
 git commit -am "checkpoint before <task>"
 ```
 
-Do NOT create branches autonomously without telling the user — propose,
+Do NOT create branches autonomously without telling the user â€” propose,
 wait, then execute.
 
 ## 2. During the task
 
-Every `d365fo generate … --overwrite` writes a `.bak` next to the original
+Every `d365fo generate â€¦ --overwrite` writes a `.bak` next to the original
 so you can recover the previous version if Git history isn't enough.
 
 After each scaffold or edit, run a quick `git diff` to confirm the change is
 contained.
 
-## 3. After the task — AOT-semantic review
+## 3. After the task â€” AOT-semantic review
 
 ```sh
 # Raw byte diff (as usual)
 git diff --stat
 git diff <ref> -- AxClass/ AxTable/ AxForm/
 
-# AOT-semantic diff — added classes, modified table fields, new CoC wrappers …
+# AOT-semantic diff â€” added classes, modified table fields, new CoC wrappers â€¦
 d365fo review diff --base <ref> --output json
 d365fo review diff --base HEAD~1 --output json | jq '.data.added,.data.modified'
 ```
@@ -50,18 +50,18 @@ d365fo review diff --base HEAD~1 --output json | jq '.data.added,.data.modified'
 
 ## 4. Accept / reject
 
-- **Accept** — `git add -A && git commit && git switch main && git merge <branch>`.
-- **Reject** — `git restore` (working-tree changes) or `git branch -D` (whole branch).
+- **Accept** â€” `git add -A && git commit && git switch main && git merge <branch>`.
+- **Reject** â€” `git restore` (working-tree changes) or `git branch -D` (whole branch).
   The `.bak` files remain to recover individual files.
 
 ## Hard rules
 
-- Never bypass safety checks — no `git push --force`, no `--no-verify`, no
+- Never bypass safety checks â€” no `git push --force`, no `--no-verify`, no
   `git reset --hard` on shared branches. Discard with `git restore` or branch deletion.
 - Never run `d365fo build` / `bp check` automatically as part of the review
-  flow — they block the user. Say *"Diff summarised. Run `d365fo build`
+  flow â€” they block the user. Say *"Diff summarised. Run `d365fo build`
   when you're ready."*
 - Always include the `.bak` files in `.gitignore` for the user's repo so
   scaffold-overwrite backups don't pollute commits.
 - Always show `d365fo review diff` output BEFORE asking the user to accept
-  — they need the structural summary to make a decision.
+  â€” they need the structural summary to make a decision.

--- a/skills/copilot/security-hierarchy-trace.instructions.md
+++ b/skills/copilot/security-hierarchy-trace.instructions.md
@@ -1,4 +1,4 @@
----
+﻿---
 description: Trace D365FO security from a Role all the way down to Entry Points, or discover which roles reach a given object. Use when the user asks about permissions, security coverage, roles, duties, or privileges.
 applyTo: '**/AxSecurityRole/**,**/AxSecurityDuty/**,**/AxSecurityPrivilege/**'
 ---
@@ -6,12 +6,12 @@ applyTo: '**/AxSecurityRole/**,**/AxSecurityDuty/**,**/AxSecurityPrivilege/**'
 
 ## Workflow
 
-1. **Top-down** — which entry points does a role reach?
+1. **Top-down** â€” which entry points does a role reach?
    ```sh
    d365fo get security <RoleName> --type Role --output json
    ```
 
-2. **Bottom-up** — which roles reach this object?
+2. **Bottom-up** â€” which roles reach this object?
    ```sh
    d365fo get security <ObjectName> --type Menuitem --output json
    # type may be Table, Form, Report, Class, Menuitem
@@ -19,7 +19,7 @@ applyTo: '**/AxSecurityRole/**,**/AxSecurityDuty/**,**/AxSecurityPrivilege/**'
 
 3. The response contains `routes[*]` of shape
    `{ role, duty, privilege, entryPoint }`. Duplicate `role`s indicate multiple
-   paths — all must be removed to revoke access.
+   paths â€” all must be removed to revoke access.
 
 ## Hard rules
 

--- a/skills/copilot/table-scaffolding.instructions.md
+++ b/skills/copilot/table-scaffolding.instructions.md
@@ -1,4 +1,4 @@
----
+﻿---
 description: Create AxTable XML in D365 Finance & Operations using business-role pattern presets (Main / Transaction / Parameter / Group / Reference / WorksheetHeader / WorksheetLine), or add fields / indexes / relations to existing tables. Use whenever the user asks to "create a table", "scaffold a master/transaction/parameter table", "add a field", or "set TableGroup / TableType".
 applyTo: '**/AxTable/**,**/*Table.xml'
 ---
@@ -7,7 +7,7 @@ applyTo: '**/AxTable/**,**/*Table.xml'
 > The CLI's `d365fo generate table` mirrors `d365fo-mcp-server`'s
 > `generate_smart_table`. Pattern presets pre-populate the table with the
 > canonical `TableGroup`, a sensible default field skeleton, and an
-> alternate-key index — so the scaffold passes BP `BPCheckAlternateKeyAbsent`
+> alternate-key index â€” so the scaffold passes BP `BPCheckAlternateKeyAbsent`
 > out of the box.
 
 ## Pre-flight (always)
@@ -43,19 +43,19 @@ d365fo generate table FmParameters \
 d365fo generate table FmOrderHeader --pattern worksheet-header --install-to FleetManagement
 d365fo generate table FmOrderLine   --pattern worksheet-line   --install-to FleetManagement
 
-# Temp table — TempDB is a TableType, NOT a TableGroup. Combine:
+# Temp table â€” TempDB is a TableType, NOT a TableGroup. Combine:
 d365fo generate table FmTmpStaging \
     --pattern main \
     --table-type TempDB \
     --install-to FleetManagement
 ```
 
-Aliases recognised: `master` → Main, `setup`/`config` → Parameter,
-`transactional` → Transaction, `lookup` → Reference, `header`/`line` for
-worksheets, `misc` → Miscellaneous. Full list:
+Aliases recognised: `master` â†’ Main, `setup`/`config` â†’ Parameter,
+`transactional` â†’ Transaction, `lookup` â†’ Reference, `header`/`line` for
+worksheets, `misc` â†’ Miscellaneous. Full list:
 `main|transaction|parameter|group|worksheetheader|worksheetline|reference|framework|miscellaneous`.
 
-When `--field` is supplied, **caller fields win** — pattern defaults are
+When `--field` is supplied, **caller fields win** â€” pattern defaults are
 skipped entirely:
 
 ```sh
@@ -73,22 +73,22 @@ d365fo generate table FmVehicle \
 then "first field" so `BPCheckAlternateKeyAbsent` never trips.
 
 The CLI returns a JSON summary `{path, bytes, backup, pattern, tableType,
-usedPatternDefaults, fieldCount}` — never request the full XML back.
+usedPatternDefaults, fieldCount}` â€” never request the full XML back.
 
-## ❗ `TableGroup` vs `TableType`
+## â— `TableGroup` vs `TableType`
 
 | Property | Meaning | Allowed values |
 |---|---|---|
 | `TableGroup` | **Business role** | `Main`, `Transaction`, `Parameter`, `Group`, `WorksheetHeader`, `WorksheetLine`, `Reference`, `Framework`, `Miscellaneous` |
 | `TableType` | **Storage** kind | `RegularTable`, `TempDB`, `InMemory` |
 
-❌ Passing `--pattern TempDB` is **rejected** — the CLI returns
+âŒ Passing `--pattern TempDB` is **rejected** â€” the CLI returns
 `BAD_INPUT` with a hint to use `--table-type TempDB --pattern main` instead.
 
 ## Label-on-field exception
 
 When a field's EDT already carries a `Label`, do **NOT** pass a label on the
-field — it inherits from the EDT. Override only when the table genuinely
+field â€” it inherits from the EDT. Override only when the table genuinely
 needs a different caption.
 
 ## Pattern defaults (when no `--field` is supplied)
@@ -103,15 +103,15 @@ needs a different caption.
 | `worksheetline`   | `HeaderId`(mandatory), `LineNum`(mandatory), `Quantity`, `Amount` |
 | `reference`       | `Code`(mandatory), `Description` |
 
-Treat the defaults as a *starting point* — always replace placeholder fields
+Treat the defaults as a *starting point* â€” always replace placeholder fields
 (e.g. `Key`, `Code`) with names that fit the domain.
 
 ## Hard rules
 
-- Never guess EDTs — `d365fo get edt <Name>` first.
-- Never duplicate a field name — `d365fo get table` first.
+- Never guess EDTs â€” `d365fo get edt <Name>` first.
+- Never duplicate a field name â€” `d365fo get table` first.
 - Never pass `tableGroup="TempDB"` (or `--pattern TempDB`).
 - Never override the EDT label on a field unless deliberately captioned.
 - Never ship a table without an alternate-key index (BP).
-- Never inline UI strings — labels only (BP `BPErrorLabelIsText`).
+- Never inline UI strings â€” labels only (BP `BPErrorLabelIsText`).
 - After scaffolding, run `d365fo build && d365fo sync` **only on user request**.

--- a/skills/copilot/x++-class-authoring.instructions.md
+++ b/skills/copilot/x++-class-authoring.instructions.md
@@ -1,4 +1,4 @@
----
+﻿---
 description: Guidance for authoring or extending X++ classes in D365 Finance & Operations. Invoke whenever the user asks to "create a class", "extend a class", "add a method", or write any X++ that touches CoC.
 applyTo: '**/*.xpp,**/AxClass/**,**/*Class.xml'
 ---
@@ -32,8 +32,8 @@ conversation with long metadata dumps.
 
 4. **Validate at the end**:
    ```sh
-   d365fo review diff          # (when available) — best-practice delta
-   d365fo bp check             # (when available) — xppbp.exe runner
+   d365fo review diff          # (when available) â€” best-practice delta
+   d365fo bp check             # (when available) â€” xppbp.exe runner
    ```
 
 ## Hard rules
@@ -41,6 +41,6 @@ conversation with long metadata dumps.
 - **Never** emit X++ that references a field you have not verified with
   `d365fo get table <Name>`.
 - **Never** create a CoC wrapper without first running `d365fo find coc`.
-- **Prefer** EDTs over primitive types — resolve with `d365fo get edt <Name>`.
+- **Prefer** EDTs over primitive types â€” resolve with `d365fo get edt <Name>`.
 - **Expect** a `ToolResult` envelope on every command. On `ok:false`, surface
   `error.message` to the user and stop the task.

--- a/skills/copilot/xpp-best-practice-rules.instructions.md
+++ b/skills/copilot/xpp-best-practice-rules.instructions.md
@@ -1,14 +1,14 @@
----
-description: Best-practice (BP) rules every generated X++ file must satisfy — today/DateTimeUtil, label-typed messages, EDT migration, nested loops, alternate keys, doc comments, label existence. Invoke whenever you scaffold or edit X++ that will eventually be linted by xppbp.exe.
+﻿---
+description: Best-practice (BP) rules every generated X++ file must satisfy â€” today/DateTimeUtil, label-typed messages, EDT migration, nested loops, alternate keys, doc comments, label existence. Invoke whenever you scaffold or edit X++ that will eventually be linted by xppbp.exe.
 applyTo: '**/*.xpp,**/AxClass/**,**/AxTable/**,**/AxForm/**'
 ---
-# Best-practice rules — generated X++ must be BP-clean
+# Best-practice rules â€” generated X++ must be BP-clean
 
-> **Source of truth:** [`d365fo bp check`](../../docs/EXAMPLES.md) — the Windows-VM runner that executes `xppbp.exe`. The list below covers the non-negotiable BP rules every scaffold and hand-edit must satisfy out of the box.
+> **Source of truth:** [`d365fo bp check`](../../docs/EXAMPLES.md) â€” the Windows-VM runner that executes `xppbp.exe`. The list below covers the non-negotiable BP rules every scaffold and hand-edit must satisfy out of the box.
 
 ## Per-rule rules
 
-### `BPUpgradeCodeToday` — `today()` is forbidden
+### `BPUpgradeCodeToday` â€” `today()` is forbidden
 
 `today()` ignores the user's preferred time-zone. Always use:
 
@@ -16,7 +16,7 @@ applyTo: '**/*.xpp,**/AxClass/**,**/AxTable/**,**/AxForm/**'
 TransDate today = DateTimeUtil::getToday(DateTimeUtil::getUserPreferredTimeZone());
 ```
 
-### `BPErrorLabelIsText` — no hardcoded UI strings
+### `BPErrorLabelIsText` â€” no hardcoded UI strings
 
 Every string passed to `info()` / `warning()` / `error()` / `Box::yesNo()` etc. must be a label token of the form `@File:Key`. Search before you create:
 
@@ -25,38 +25,38 @@ d365fo search label "Vehicle is required" --lang en-us --output json
 d365fo resolve label @SYS12345                          # confirm an existing token
 ```
 
-If no match → create the label via your model's labels file, then reference it. Never inline.
+If no match â†’ create the label via your model's labels file, then reference it. Never inline.
 
-### `BPErrorEDTNotMigrated` — modern EDT relations
+### `BPErrorEDTNotMigrated` â€” modern EDT relations
 
-EDT relations must use the `EDT.Relations` element, **not** the legacy table-level relations on the EDT. The CLI's `d365fo generate edt` and `d365fo generate extension edt` already emit the modern shape — preserve it when hand-editing.
+EDT relations must use the `EDT.Relations` element, **not** the legacy table-level relations on the EDT. The CLI's `d365fo generate edt` and `d365fo generate extension edt` already emit the modern shape â€” preserve it when hand-editing.
 
-### `BPCheckNestedLoopinCode` — no nested data-access loops
+### `BPCheckNestedLoopinCode` â€” no nested data-access loops
 
 Nested `while select` blocks are forbidden:
 
 ```xpp
-// ❌ WRONG
+// âŒ WRONG
 while select custTable
 {
     while select custInvoiceJour where custInvoiceJour.OrderAccount == custTable.AccountNum
-    { … }
+    { â€¦ }
 }
 
-// ✅ CORRECT — single join
+// âœ… CORRECT â€” single join
 while select custTable
     join custInvoiceJour
     where custInvoiceJour.OrderAccount == custTable.AccountNum
-{ … }
+{ â€¦ }
 ```
 
 For *filter-only* joins use `exists join` / `notExists join`. For complex correlations pre-load to a `Map` or temp table.
 
-### `BPCheckAlternateKeyAbsent` — every table needs an alternate key
+### `BPCheckAlternateKeyAbsent` â€” every table needs an alternate key
 
-A unique index on the natural key, marked `AlternateKey = Yes`. The CLI's `d365fo generate table` template emits a `<Pkey>` index with `AlternateKey = Yes` — don't strip it.
+A unique index on the natural key, marked `AlternateKey = Yes`. The CLI's `d365fo generate table` template emits a `<Pkey>` index with `AlternateKey = Yes` â€” don't strip it.
 
-### `BPErrorUnknownLabel` — labels referenced must exist
+### `BPErrorUnknownLabel` â€” labels referenced must exist
 
 `@File:Key` tokens must resolve to a real entry in an indexed label file. Confirm with:
 
@@ -64,9 +64,9 @@ A unique index on the natural key, marked `AlternateKey = Yes`. The CLI's `d365f
 d365fo resolve label @File:Key --lang en-us,cs --output json
 ```
 
-If the result is `ok:false` with `LABEL_NOT_FOUND`, **stop** and either pick an existing label (`d365fo search label …`) or add the entry to the model's labels file before referencing it.
+If the result is `ok:false` with `LABEL_NOT_FOUND`, **stop** and either pick an existing label (`d365fo search label â€¦`) or add the entry to the model's labels file before referencing it.
 
-### `BPXmlDocNoDocumentationComments` — meaningful doc comments
+### `BPXmlDocNoDocumentationComments` â€” meaningful doc comments
 
 Public/protected classes and methods need a non-trivial `/// <summary>`:
 
@@ -74,35 +74,42 @@ Public/protected classes and methods need a non-trivial `/// <summary>`:
 /// <summary>Calculates the customer balance in the company currency.</summary>
 /// <param name="_includeOpen">Whether open transactions count.</param>
 /// <returns>Balance in MST.</returns>
-public AmountMST balanceMST(boolean _includeOpen = true) { … }
+public AmountMST balanceMST(boolean _includeOpen = true) { â€¦ }
 ```
 
 Auto-generated stubs ("This method does foo.") do **not** count. Restate the contract.
 
-### `BPDuplicateMethod` — no dupes on the inheritance chain
+### `BPDuplicateMethod` â€” no dupes on the inheritance chain
 
 Adding a method that already exists on a base class in the same model fails BP. Run `d365fo get class <Base>` to confirm before adding.
 
 ## Label-on-field exception
 
-When adding a field whose **EDT** already carries a label, do **NOT** set `--label` on the field — it inherits from the EDT. Override only if you deliberately want a different caption in this table:
+When adding a field whose **EDT** already carries a label, do **NOT** set `--label` on the field â€” it inherits from the EDT. Override only if you deliberately want a different caption in this table:
 
 ```sh
 d365fo generate table FmVehicle \
-    --field VIN:VinEdt:mandatory      \   # ← VinEdt has Label = "VIN" — leave it alone
-    --field Make:Name                  \   # ← inherits "Name" from EDT
+    --field VIN:VinEdt:mandatory      \   # â† VinEdt has Label = "VIN" â€” leave it alone
+    --field Make:Name                  \   # â† inherits "Name" from EDT
     --label "@Fleet:Vehicle"
 ```
 
 ## Linting workflow
 
 ```sh
-# In-process heuristics — fast, runs anywhere, useful for CI:
+# In-process heuristics â€” fast, runs anywhere, useful for CI:
 d365fo lint --output sarif > lint.sarif
 
-# Full BP — only on the Windows VM, only on user request:
+# Run specific method-flag categories (detected at index-extract time):
+d365fo lint --category today-usage          # BPUpgradeCodeToday: today() calls
+d365fo lint --category do-insert-update     # doInsert/doUpdate/doDelete usage
+d365fo lint --category doc-comment-missing  # BPXmlDocNoDocumentationComments
+
+# Full BP â€” only on the Windows VM, only on user request:
 d365fo bp check --output json
 ```
+
+Six categories are now available: `table-no-index`, `ext-named-not-attributed`, `string-without-edt`, `today-usage`, `do-insert-update`, `doc-comment-missing`. The method-flag categories are populated at extract time by scanning `<Source>` text â€” no full body is stored. Re-run `d365fo index refresh` after editing source before linting.
 
 **Never** auto-run `bp check`. It blocks the user (slow, Windows-only). Say *"Changes scaffolded. Run `d365fo bp check` when you're ready."*
 

--- a/skills/copilot/xpp-class-and-method-rules.instructions.md
+++ b/skills/copilot/xpp-class-and-method-rules.instructions.md
@@ -1,4 +1,4 @@
----
+﻿---
 description: Rules for X++ class declarations, method modifiers, parameter passing, constructors, and extension methods (separate from CoC). Invoke when authoring new classes, overrides, factory methods, or extension methods.
 applyTo: '**/*.xpp,**/AxClass/**'
 ---
@@ -15,9 +15,9 @@ applyTo: '**/*.xpp,**/AxClass/**'
   - `abstract` for base-only types (cannot mix with `final` / `static`).
 - **Instance fields default = `protected`.** **NEVER make instance fields `public`.** Expose state via `parmFoo` accessors. Public fields tightly couple consumers to internal layout and break encapsulation.
 - **Constructor pattern:** one `new()` per class (compiler generates an empty default if absent). Convention:
-  - `protected void new()` — internal use only.
-  - `public static MyClass construct()` — factory entry point.
-  - `protected void init(...)` — post-construction setup.
+  - `protected void new()` â€” internal use only.
+  - `public static MyClass construct()` â€” factory entry point.
+  - `protected void init(...)` â€” post-construction setup.
 
 ## Method modifier order
 
@@ -26,28 +26,28 @@ applyTo: '**/*.xpp,**/AxClass/**'
 ```
 
 - `static final` is permitted; `abstract` cannot mix with `final` / `static`.
-- **Override visibility rule:** an override must be at least as accessible as the base method. `public` → `public` only; `protected` → `public` or `protected`; `private` → not overridable.
+- **Override visibility rule:** an override must be at least as accessible as the base method. `public` â†’ `public` only; `protected` â†’ `public` or `protected`; `private` â†’ not overridable.
 
 ## Parameters
 
-- **Optional parameters** must come after all required parameters. Callers cannot skip — every preceding parameter must be supplied.
+- **Optional parameters** must come after all required parameters. Callers cannot skip â€” every preceding parameter must be supplied.
 - Use `prmIsDefault(_x)` inside a `parmX(_x = x)` accessor to detect "was this caller-supplied?".
 - **All parameters are pass-by-value.** Mutating a parameter inside the method does NOT affect the caller's variable. Return modified state explicitly or wrap in an object.
 
 ## `this` rules
 
 - Required (or qualified) for instance method calls.
-- **Cannot** qualify class-declaration member variables — write the bare name.
+- **Cannot** qualify class-declaration member variables â€” write the bare name.
 - **Cannot** be used in a `static` method.
-- **Cannot** qualify static methods — use `ClassName::method()`.
+- **Cannot** qualify static methods â€” use `ClassName::method()`.
 
-## Extension methods (NOT CoC — these are *adders*)
+## Extension methods (NOT CoC â€” these are *adders*)
 
 Targets: Class / Table / View / Map.
 
 - Extension class must be `static` (not `final`); name ends with `_Extension`.
 - Every extension method is `public static`.
-- **First parameter is the target type** — the runtime supplies the receiver; the caller does not pass it.
+- **First parameter is the target type** â€” the runtime supplies the receiver; the caller does not pass it.
 
 ```xpp
 public static class CustTable_Extension
@@ -58,20 +58,20 @@ public static class CustTable_Extension
     }
 }
 
-// Caller — first param is omitted:
+// Caller â€” first param is omitted:
 amount = custTable.balanceWithBuffer(1000);
 ```
 
 ## Constants & locals
 
 - **Constants over macros.** `public const str FOO = 'bar';` at class scope (cross-referenced, scoped, IntelliSense-aware) instead of `#define.FOO('bar')`. Reference via `ClassName::FOO`.
-- **`var` keyword** for type-inferred locals when the type is obvious from the right-hand side (`var sum = decimal + amount;`). Skip `var` when the RHS is non-obvious — readability beats brevity.
-- **Declare-anywhere encouraged** — declare close to first use, smallest scope. The compiler rejects shadowing of outer-scope variables with the same name.
+- **`var` keyword** for type-inferred locals when the type is obvious from the right-hand side (`var sum = decimal + amount;`). Skip `var` when the RHS is non-obvious â€” readability beats brevity.
+- **Declare-anywhere encouraged** â€” declare close to first use, smallest scope. The compiler rejects shadowing of outer-scope variables with the same name.
 
 ## Hard "never" list
 
 - **Never** make instance fields `public`.
-- **Never** call `[SysObsolete]` methods — read the attribute message for the replacement.
+- **Never** call `[SysObsolete]` methods â€” read the attribute message for the replacement.
 - **Never** skip `/// <summary>` doc comments on public/protected members (BP `BPXmlDocNoDocumentationComments`).
 - **Never** override a method without `d365fo get class <Base>` to confirm the exact signature.
 

--- a/skills/copilot/xpp-database-queries.instructions.md
+++ b/skills/copilot/xpp-database-queries.instructions.md
@@ -1,8 +1,8 @@
----
+﻿---
 description: Authoritative rules for X++ select / while-select queries in D365 Finance & Operations. Invoke whenever the user asks to write a "select", "while select", "query", joins, aggregates, cross-company, set-based ops, or any data-access X++.
 applyTo: '**/*.xpp,**/AxClass/**,**/AxTable/**,**/AxQuery/**'
 ---
-# X++ database queries — `select` / `while select`
+# X++ database queries â€” `select` / `while select`
 
 > **Source of truth:** [learn:xpp-select-statement](https://learn.microsoft.com/en-us/dynamics365/fin-ops-core/dev-itpro/dev-ref/xpp-data/xpp-select-statement).
 > **Pre-flight:** confirm the target table / field with `d365fo get table <Name> --output json` before writing the query.
@@ -10,31 +10,31 @@ applyTo: '**/*.xpp,**/AxClass/**,**/AxTable/**,**/AxQuery/**'
 ## Statement order (grammar-enforced)
 
 ```
-select [FindOption…] [FieldList from] tableBuffer [index…]
-       [order by | group by] [where …] [join … [where …]]
+select [FindOptionâ€¦] [FieldList from] tableBuffer [indexâ€¦]
+       [order by | group by] [where â€¦] [join â€¦ [where â€¦]]
 ```
 
-`FindOption` keywords (`crossCompany`, `firstOnly`, `forUpdate`, `forceNestedLoop`, `forceSelectOrder`, `forcePlaceholders`, `pessimisticLock`, `optimisticLock`, `repeatableRead`, `validTimeState`, `noFetch`, `reverse`, `firstFast`) sit **between `select` and the buffer / field list** — never on a joined buffer (sole exception: `forUpdate` may target a specific buffer in a join).
+`FindOption` keywords (`crossCompany`, `firstOnly`, `forUpdate`, `forceNestedLoop`, `forceSelectOrder`, `forcePlaceholders`, `pessimisticLock`, `optimisticLock`, `repeatableRead`, `validTimeState`, `noFetch`, `reverse`, `firstFast`) sit **between `select` and the buffer / field list** â€” never on a joined buffer (sole exception: `forUpdate` may target a specific buffer in a join).
 
-`order by` / `group by` / `where` must appear **after the LAST `join` clause** — never between joins.
+`order by` / `group by` / `where` must appear **after the LAST `join` clause** â€” never between joins.
 
 ## `crossCompany` belongs on the OUTER buffer
 
 ```xpp
-// ✅ CORRECT
+// âœ… CORRECT
 select crossCompany custTable
     join custInvoiceJour
     where custInvoiceJour.OrderAccount == custTable.AccountNum;
 
-// ❌ WRONG — cross-company on the joined buffer
+// âŒ WRONG â€” cross-company on the joined buffer
 select custTable
     join crossCompany custInvoiceJour
-    where …;
+    where â€¦;
 ```
 
-Optional company filter: `select crossCompany : myContainer custTable …` — `myContainer` is a `container` literal `(['dat'] + ['dmo'])`. Empty container = scan all authorised companies.
+Optional company filter: `select crossCompany : myContainer custTable â€¦` â€” `myContainer` is a `container` literal `(['dat'] + ['dmo'])`. Empty container = scan all authorised companies.
 
-## `in` operator — any primitive type, not just enums
+## `in` operator â€” any primitive type, not just enums
 
 Grammar: `where Expression in List`, where `List` is an X++ **`container`**, not a `Set`/`List`/`Map`/sub-query. Works with `str`, `int`, `int64`, `real`, `enum`, `boolean`, `date`, `utcDateTime`, `RecId`. One `in` clause per `where`; AND multiple set filters together.
 
@@ -46,33 +46,33 @@ select sum(CostAmountAdjustment) from inventSettlement
        && inventSettlement.LedgerAccount     in accounts;
 ```
 
-❌ Never expand `in` into `OR == OR ==` chains.
+âŒ Never expand `in` into `OR == OR ==` chains.
 
 ## Other Learn-confirmed rules
 
-- **Field list before table** when you don't need the full row — `select FieldA, FieldB from myTable where …`. Never `select * from`.
+- **Field list before table** when you don't need the full row â€” `select FieldA, FieldB from myTable where â€¦`. Never `select * from`.
 - **`firstOnly`** when at most one row is expected. Cannot be combined with `next`.
 - **`forUpdate`** required before any `.update()` / `.delete()`; pair with `ttsbegin` / `ttscommit`.
 - **`exists join` / `notExists join`** instead of nested `while select` for filter-only joins.
-- **Outer join** — only LEFT outer; no RIGHT outer, no `left` keyword. Default values fill non-matching rows; distinguish "no match" vs "real zero" by checking the joined buffer's `RecId`.
+- **Outer join** â€” only LEFT outer; no RIGHT outer, no `left` keyword. Default values fill non-matching rows; distinguish "no match" vs "real zero" by checking the joined buffer's `RecId`.
 - **Join criteria use `where`, not `on`.** X++ has no `on` keyword.
 - **`index hint`** requires `myTable.allowIndexHint(true)` *before* the select; otherwise silently ignored. Only when measured.
 - **Aggregates** (`sum`, `avg`, `count`, `minof`, `maxof`):
   - `sum` / `avg` / `count` work only on integer/real fields.
-  - When `sum` would return null (no rows), X++ returns NO row — guard with `if (buffer)` after.
+  - When `sum` would return null (no rows), X++ returns NO row â€” guard with `if (buffer)` after.
   - Non-aggregated fields in the select list must be in `group by`.
-- **`forceLiterals`** is forbidden — SQL injection. Use `forcePlaceholders` (default for non-join selects) or omit.
-- **`validTimeState(dateFrom, dateTo)`** for date-effective tables (`ValidTimeStateFieldType ≠ None`). Don't query without it unless you specifically want all historical rows.
+- **`forceLiterals`** is forbidden â€” SQL injection. Use `forcePlaceholders` (default for non-join selects) or omit.
+- **`validTimeState(dateFrom, dateTo)`** for date-effective tables (`ValidTimeStateFieldType â‰  None`). Don't query without it unless you specifically want all historical rows.
 - **Set-based ops** (`RecordInsertList`, `insert_recordset`, `update_recordset`, `delete_from`) over row-by-row loops for performance. They fall back to row-by-row only when an overridden table method, DB log, or alerts subscription forces it.
-- **SQL injection mitigation** — `executeQueryWithParameters` for dynamic queries; never concatenate strings into `where`.
-- **Timeouts** — interactive 30 min, batch/services/OData 3 h. Override via `queryTimeout`. Catch `Exception::Timeout`.
+- **SQL injection mitigation** â€” `executeQueryWithParameters` for dynamic queries; never concatenate strings into `where`.
+- **Timeouts** â€” interactive 30 min, batch/services/OData 3 h. Override via `queryTimeout`. Catch `Exception::Timeout`.
 
 ## Hard "never" list
 
-- **Never** call functions in `where` (e.g. `where strFmt(...) == 'X'`) — assign to a local first; the optimizer can't index function expressions.
-- **Never** use `today()` (BP `BPUpgradeCodeToday`) — use `DateTimeUtil::getToday(DateTimeUtil::getUserPreferredTimeZone())`.
-- **Never** nest `while select` loops (BP `BPCheckNestedLoopinCode`) — joins, `exists join`, or pre-load to `Map` / temp table.
-- **Never** call `doInsert` / `doUpdate` / `doDelete` for normal business logic — they bypass overridden methods, framework validation, and event handlers. Reserved for data-fix / migration scripts only.
+- **Never** call functions in `where` (e.g. `where strFmt(...) == 'X'`) â€” assign to a local first; the optimizer can't index function expressions.
+- **Never** use `today()` (BP `BPUpgradeCodeToday`) â€” use `DateTimeUtil::getToday(DateTimeUtil::getUserPreferredTimeZone())`.
+- **Never** nest `while select` loops (BP `BPCheckNestedLoopinCode`) â€” joins, `exists join`, or pre-load to `Map` / temp table.
+- **Never** call `doInsert` / `doUpdate` / `doDelete` for normal business logic â€” they bypass overridden methods, framework validation, and event handlers. Reserved for data-fix / migration scripts only.
 
 ## Pre-flight commands
 

--- a/skills/copilot/xpp-statement-and-type-rules.instructions.md
+++ b/skills/copilot/xpp-statement-and-type-rules.instructions.md
@@ -1,5 +1,5 @@
----
-description: X++ statement-level and type-system rules — switch / break, ternary, no-DB-null sentinels, casting (`as` / `is`), `using` blocks, embedded function declarations. Invoke when writing any non-trivial X++ control flow or type conversion.
+﻿---
+description: X++ statement-level and type-system rules â€” switch / break, ternary, no-DB-null sentinels, casting (`as` / `is`), `using` blocks, embedded function declarations. Invoke when writing any non-trivial X++ control flow or type conversion.
 applyTo: '**/*.xpp,**/AxClass/**,**/AxTable/**'
 ---
 # X++ statement & type rules
@@ -9,10 +9,10 @@ applyTo: '**/*.xpp,**/AxClass/**,**/AxTable/**'
 ## `switch` / `break`
 
 - **`break` is required** at the end of every `case`. Implicit fall-through compiles but is misleading.
-- To match multiple values to a single branch use the **comma-list** form — never empty fall-through:
+- To match multiple values to a single branch use the **comma-list** form â€” never empty fall-through:
 
 ```xpp
-// ✅ CORRECT
+// âœ… CORRECT
 switch (mod(year, 4))
 {
     case 13, 17, 21:
@@ -26,9 +26,9 @@ switch (mod(year, 4))
 
 ## Ternary
 
-`cond ? a : b` — both branches must have the same type. No implicit widening of `int` ↔ `real`.
+`cond ? a : b` â€” both branches must have the same type. No implicit widening of `int` â†” `real`.
 
-## ❗ X++ has NO database null
+## â— X++ has NO database null
 
 Each primitive has a "null-equivalent" sentinel:
 
@@ -46,21 +46,21 @@ Each primitive has a "null-equivalent" sentinel:
 In SQL `where` clauses these compare as **false** (rows with sentinel values are NOT returned by `where field`). In plain expressions they are ordinary values.
 
 ```xpp
-// ❌ WRONG — there is no null
-if (myDate == null) { … }
+// âŒ WRONG â€” there is no null
+if (myDate == null) { â€¦ }
 
-// ✅ CORRECT
-if (!myDate)              { … }   // boolean test on sentinel
-if (myDate == dateNull()) { … }   // explicit
+// âœ… CORRECT
+if (!myDate)              { â€¦ }   // boolean test on sentinel
+if (myDate == dateNull()) { â€¦ }   // explicit
 ```
 
-Same for `utcDateTime` — compare against `utcDateTimeNull()` or use `if (!myUtc)`.
+Same for `utcDateTime` â€” compare against `utcDateTimeNull()` or use `if (!myUtc)`.
 
 ## Casting
 
 - Prefer **`as`** (returns `null` on type mismatch) and **`is`** (boolean test) over hard down-casts.
 - Hard down-casts (`(SubClass)objectExpr`) on object-typed expressions throw `InvalidCastException` on mismatch.
-- Late binding exists for `Object` and `FormRun` only — accept the runtime cost if you use it.
+- Late binding exists for `Object` and `FormRun` only â€” accept the runtime cost if you use it.
 
 ```xpp
 common = ledgerJournalTrans;
@@ -85,6 +85,6 @@ Local functions inside a method **can read** variables declared earlier in the e
 
 ## Hard "never" list
 
-- **Never** test `myDate == null` — there is no null in X++.
-- **Never** rely on switch fall-through — always `break` (or use the comma-list form).
+- **Never** test `myDate == null` â€” there is no null in X++.
+- **Never** rely on switch fall-through â€” always `break` (or use the comma-list form).
 - **Never** down-cast an `Object` without an `is` guard (or an `as` + null check).

--- a/src/D365FO.Cli/Commands/Analyze/AnalyzeCompletenessCommand.cs
+++ b/src/D365FO.Cli/Commands/Analyze/AnalyzeCompletenessCommand.cs
@@ -1,0 +1,165 @@
+using System.Text.RegularExpressions;
+using System.Xml.Linq;
+using D365FO.Core;
+using D365FO.Core.Index;
+using Spectre.Console.Cli;
+
+namespace D365FO.Cli.Commands.Analyze;
+
+/// <summary>
+/// Walks a workspace folder (or single model directory) and cross-checks
+/// every AOT XML object against the local SQLite index, reporting broken
+/// references.
+///
+/// Checks performed:
+/// <list type="bullet">
+///   <item><term>MISSING_DUTY</term> — AxSecurityRole references a duty not in the index.</item>
+///   <item><term>MISSING_PRIVILEGE</term> — AxSecurityRole / AxSecurityDuty references a privilege not in the index.</item>
+///   <item><term>MISSING_EDT</term> — AxTable field references an EDT not in the index.</item>
+///   <item><term>MISSING_LABEL</term> — An AOT XML element value holds a label token (@File:Key) whose key has no indexed translation.</item>
+/// </list>
+///
+/// Mirrors upstream MCP heuristic; ROADMAP §P4b.
+/// </summary>
+public sealed class AnalyzeCompletenessCommand : Command<AnalyzeCompletenessCommand.Settings>
+{
+    public sealed class Settings : D365OutputSettings
+    {
+        [CommandArgument(0, "<PATH>")]
+        [System.ComponentModel.Description("Path to a model folder, PackagesLocalDirectory, or single AOT XML file to analyse.")]
+        public string Path { get; init; } = "";
+
+        [CommandOption("--skip-labels")]
+        [System.ComponentModel.Description("Skip label-key existence checks (faster).")]
+        public bool SkipLabels { get; init; }
+
+        [CommandOption("--skip-edts")]
+        [System.ComponentModel.Description("Skip EDT existence checks.")]
+        public bool SkipEdts { get; init; }
+
+        [CommandOption("--skip-security")]
+        [System.ComponentModel.Description("Skip security role/duty/privilege cross-checks.")]
+        public bool SkipSecurity { get; init; }
+    }
+
+    // Matches @LabelFile:LabelKey or @LabelKey (no file prefix).
+    private static readonly Regex LabelTokenRegex =
+        new(@"@(?:[A-Za-z0-9_]+:)?[A-Za-z0-9_]+", RegexOptions.Compiled);
+
+    public override int Execute(CommandContext ctx, Settings settings)
+    {
+        var kind = OutputMode.Resolve(settings.Output);
+        var path = settings.Path.Trim();
+
+        if (string.IsNullOrWhiteSpace(path) || (!File.Exists(path) && !Directory.Exists(path)))
+            return RenderHelpers.Render(kind, ToolResult<object>.Fail(
+                D365FoErrorCodes.BadInput, $"Path not found: {path}"));
+
+        var repo   = RepoFactory.Create();
+        var issues = new List<object>();
+
+        IEnumerable<string> xmlFiles = File.Exists(path)
+            ? [path]
+            : Directory.EnumerateFiles(path, "*.xml", SearchOption.AllDirectories);
+
+        foreach (var file in xmlFiles)
+        {
+            XDocument doc;
+            try
+            {
+                doc = XDocument.Load(file);
+            }
+            catch (Exception ex)
+            {
+                issues.Add(Issue("error", "PARSE_ERROR", file, $"Could not parse XML: {ex.Message}"));
+                continue;
+            }
+
+            var rootName = doc.Root?.Name.LocalName ?? "";
+
+            // ---- Security checks ------------------------------------------------
+            if (!settings.SkipSecurity)
+            {
+                if (rootName == "AxSecurityRole")
+                {
+                    foreach (var dutyRef in doc.Descendants("AxSecurityDutyReference"))
+                    {
+                        var duty = dutyRef.Element("Name")?.Value;
+                        if (!string.IsNullOrWhiteSpace(duty) && repo.GetSecurityDuty(duty) is null)
+                            issues.Add(Issue("warning", "MISSING_DUTY", file,
+                                $"Role references duty '{duty}' which is not in the index."));
+                    }
+                    foreach (var privRef in doc.Descendants("AxSecurityPrivilegeReference"))
+                    {
+                        var priv = privRef.Element("Name")?.Value;
+                        if (!string.IsNullOrWhiteSpace(priv) && repo.GetSecurityPrivilege(priv) is null)
+                            issues.Add(Issue("warning", "MISSING_PRIVILEGE", file,
+                                $"Role references privilege '{priv}' which is not in the index."));
+                    }
+                }
+
+                if (rootName == "AxSecurityDuty")
+                {
+                    foreach (var privRef in doc.Descendants("AxSecurityPrivilegeReference"))
+                    {
+                        var priv = privRef.Element("Name")?.Value;
+                        if (!string.IsNullOrWhiteSpace(priv) && repo.GetSecurityPrivilege(priv) is null)
+                            issues.Add(Issue("warning", "MISSING_PRIVILEGE", file,
+                                $"Duty references privilege '{priv}' which is not in the index."));
+                    }
+                }
+            }
+
+            // ---- EDT checks (AxTable fields) ------------------------------------
+            if (!settings.SkipEdts && rootName == "AxTable")
+            {
+                foreach (var field in doc.Descendants("AxTableField"))
+                {
+                    var edtName = field.Element("ExtendedDataType")?.Value
+                                ?? field.Element("Edt")?.Value;
+                    if (!string.IsNullOrWhiteSpace(edtName) && repo.GetEdt(edtName) is null)
+                    {
+                        var fieldName = field.Element("Name")?.Value ?? "(unknown)";
+                        issues.Add(Issue("warning", "MISSING_EDT", file,
+                            $"Field '{fieldName}' references EDT '{edtName}' which is not in the index."));
+                    }
+                }
+            }
+
+            // ---- Label checks (any element value @File:Key) ---------------------
+            if (!settings.SkipLabels)
+            {
+                foreach (var el in doc.Descendants())
+                {
+                    if (el.HasElements) continue; // only leaf text nodes
+                    var text = el.Value;
+                    if (string.IsNullOrWhiteSpace(text) || !text.StartsWith('@')) continue;
+                    var m = LabelTokenRegex.Match(text.Trim());
+                    if (!m.Success) continue;
+                    var token = m.Value;
+                    var hits = repo.ResolveLabel(token);
+                    if (hits.Count == 0)
+                        issues.Add(Issue("warning", "MISSING_LABEL", file,
+                            $"Element <{el.Name.LocalName}> references label '{token}' which has no indexed translation."));
+                }
+            }
+        }
+
+        var summary = new
+        {
+            path,
+            issueCount = issues.Count,
+            skipLabels   = settings.SkipLabels,
+            skipEdts     = settings.SkipEdts,
+            skipSecurity = settings.SkipSecurity,
+            issues,
+        };
+
+        return RenderHelpers.Render(kind, issues.Count == 0
+            ? ToolResult<object>.Success(summary)
+            : ToolResult<object>.Success(summary, warnings: [$"{issues.Count} completeness issue(s) found."]));
+    }
+
+    private static object Issue(string severity, string code, string file, string message) =>
+        new { severity, code, file = System.IO.Path.GetFileName(file), filePath = file, message };
+}

--- a/src/D365FO.Cli/Commands/Daemon/DaemonCommands.cs
+++ b/src/D365FO.Cli/Commands/Daemon/DaemonCommands.cs
@@ -1,6 +1,7 @@
 using System.IO.Pipes;
 using System.Net;
 using System.Net.Sockets;
+using D365FO.Cli.Commands.Index;
 using D365FO.Core;
 using D365FO.Mcp;
 using Spectre.Console.Cli;
@@ -60,8 +61,20 @@ public sealed class DaemonStartCommand : AsyncCommand<DaemonStartCommand.Setting
         [CommandOption("--db <PATH>")]
         public string? DatabasePath { get; init; }
 
+        [CommandOption("--packages <PATH>")]
+        [System.ComponentModel.Description("PackagesLocalDirectory to watch for XML changes. Defaults to D365FO_PACKAGES_PATH.")]
+        public string? PackagesPath { get; init; }
+
         [CommandOption("--foreground")]
         public bool Foreground { get; init; }
+
+        [CommandOption("--no-watch")]
+        [System.ComponentModel.Description("Disable the automatic file watcher (index refresh on XML change).")]
+        public bool NoWatch { get; init; }
+
+        [CommandOption("--watch-debounce <MS>")]
+        [System.ComponentModel.Description("Debounce delay in milliseconds before triggering index refresh after a file change. Default: 3000.")]
+        public int WatchDebounceMs { get; init; } = 3000;
     }
 
     public override async Task<int> ExecuteAsync(CommandContext ctx, Settings settings)
@@ -82,16 +95,28 @@ public sealed class DaemonStartCommand : AsyncCommand<DaemonStartCommand.Setting
         using var cts = new CancellationTokenSource();
         Console.CancelKeyPress += (_, e) => { e.Cancel = true; cts.Cancel(); };
 
+        // Resolve packages path for the file watcher.
+        var packagesPath = settings.PackagesPath
+            ?? D365FoSettings.FromEnvironment(settings.DatabasePath).PackagesPath;
+
         var summary = ToolResult<object>.Success(new
         {
             endpoint = DaemonEndpoint.Describe(),
             pid = Environment.ProcessId,
             pidFile = DaemonEndpoint.PidFilePath,
             platform = OperatingSystem.IsWindows() ? "windows-named-pipe" : "unix-socket",
+            watching = !settings.NoWatch && !string.IsNullOrWhiteSpace(packagesPath),
+            watchPath = string.IsNullOrWhiteSpace(packagesPath) ? null : packagesPath,
+            watchDebounceMs = settings.WatchDebounceMs,
         });
 
         // Emit the start envelope so callers know the daemon is listening.
         RenderHelpers.Render(kind, summary);
+
+        // Start file watcher if requested.
+        using var watcher = settings.NoWatch || string.IsNullOrWhiteSpace(packagesPath)
+            ? null
+            : StartWatcher(packagesPath, settings.DatabasePath, settings.WatchDebounceMs, cts.Token);
 
         try
         {
@@ -103,6 +128,77 @@ public sealed class DaemonStartCommand : AsyncCommand<DaemonStartCommand.Setting
             TryDeleteSocket();
         }
         return 0;
+    }
+
+    /// <summary>
+    /// Creates a <see cref="FileSystemWatcher"/> over <paramref name="packagesPath"/>
+    /// that debounces XML changes and triggers an incremental <c>index refresh</c>
+    /// for the affected model. Returns the watcher so the caller can dispose it.
+    /// </summary>
+    private static FileSystemWatcher? StartWatcher(
+        string packagesPath, string? dbPath, int debounceMs, CancellationToken ct)
+    {
+        if (!Directory.Exists(packagesPath)) return null;
+
+        // model name → debounce timer
+        var pending = new Dictionary<string, Timer>(StringComparer.OrdinalIgnoreCase);
+        var @lock = new object();
+
+        void ScheduleRefresh(string modelName)
+        {
+            lock (@lock)
+            {
+                if (pending.TryGetValue(modelName, out var existing))
+                {
+                    existing.Change(debounceMs, Timeout.Infinite);
+                    return;
+                }
+                pending[modelName] = new Timer(_ =>
+                {
+                    lock (@lock) { pending.Remove(modelName); }
+                    if (ct.IsCancellationRequested) return;
+                    // Fire-and-forget incremental extract for this model only.
+                    try
+                    {
+                        IndexExtractCommand.ExtractCore(
+                            OutputMode.Kind.Json,
+                            packagesPath,
+                            dbPath,
+                            modelName,
+                            sinceIso: null);
+                        Console.Error.WriteLine(
+                            D365Json.Serialize(new { @event = "index_refreshed", model = modelName }));
+                    }
+                    catch (Exception ex)
+                    {
+                        Console.Error.WriteLine(
+                            D365Json.Serialize(new { @event = "index_refresh_failed", model = modelName, error = ex.Message }));
+                    }
+                }, null, debounceMs, Timeout.Infinite);
+            }
+        }
+
+        void OnChanged(object _, FileSystemEventArgs e)
+        {
+            // Identify model: packagesPath/<model>/<model>/Ax*/*.xml
+            var rel = Path.GetRelativePath(packagesPath, e.FullPath);
+            var parts = rel.Split(Path.DirectorySeparatorChar, StringSplitOptions.RemoveEmptyEntries);
+            if (parts.Length < 1) return;
+            ScheduleRefresh(parts[0]);
+        }
+
+        var fsw = new FileSystemWatcher(packagesPath)
+        {
+            IncludeSubdirectories = true,
+            Filter = "*.xml",
+            NotifyFilter = NotifyFilters.LastWrite | NotifyFilters.FileName,
+            EnableRaisingEvents = true,
+        };
+        fsw.Changed += OnChanged;
+        fsw.Created += OnChanged;
+        fsw.Deleted += OnChanged;
+        fsw.Renamed += (s, e) => OnChanged(s, e);
+        return fsw;
     }
 
     private static async Task AcceptLoop(StdioDispatcher dispatcher, CancellationToken ct)

--- a/src/D365FO.Cli/Commands/Generate/GenerateMoreCommands.cs
+++ b/src/D365FO.Cli/Commands/Generate/GenerateMoreCommands.cs
@@ -528,6 +528,183 @@ public sealed class GenerateRoleCommand : Command<GenerateRoleCommand.Settings>
 }
 
 /// <summary>
+/// Scaffolds an <c>AxReport</c> + matching <c>SrsReportDataProviderBase</c> AxClass.
+/// Mirrors upstream MCP <c>generate_smart_report</c>. ROADMAP §P3.
+/// </summary>
+public sealed class GenerateReportCommand : Command<GenerateReportCommand.Settings>
+{
+    public sealed class Settings : GenerateSettings
+    {
+        [CommandArgument(0, "<NAME>")]
+        [System.ComponentModel.Description("AOT report name, e.g. FleetVehicleReport.")]
+        public string Name { get; init; } = "";
+
+        [CommandOption("--dp <CLASS>")]
+        [System.ComponentModel.Description("Primary data provider class name. Defaults to <Name>DP.")]
+        public string? DpClass { get; init; }
+
+        [CommandOption("--tmp <TABLE>")]
+        [System.ComponentModel.Description("Temp table class name used by the primary DP. Defaults to <Name>Tmp.")]
+        public string? TmpTable { get; init; }
+
+        [CommandOption("--dataset <NAME>")]
+        [System.ComponentModel.Description("Primary dataset name inside the report. Defaults to <Name>DS.")]
+        public string? DatasetName { get; init; }
+
+        [CommandOption("--caption <TEXT>")]
+        public string? Caption { get; init; }
+
+        [CommandOption("--field <FIELD>")]
+        [System.ComponentModel.Description("Tablix column field name (repeatable). Generates header + data rows in the tablix.")]
+        public string[]? Fields { get; init; }
+
+        [CommandOption("--parameter <NAME[:TYPE]>")]
+        [System.ComponentModel.Description("Report parameter (repeatable). Format: Name or Name:Type. Type: String (default), Integer, DateTime, Boolean, Decimal.")]
+        public string[]? Parameters { get; init; }
+
+        [CommandOption("--extra-dataset <NAME:DPCLASS>")]
+        [System.ComponentModel.Description("Additional dataset (repeatable). Format: DatasetName:DPClassName. Each produces its own tablix in the design.")]
+        public string[]? ExtraDatasets { get; init; }
+
+        [CommandOption("--out-dp <PATH>")]
+        [System.ComponentModel.Description("Output path for the primary DP class XML. Defaults to sibling of --out named <DpClass>.xml.")]
+        public string? OutDp { get; init; }
+
+        [CommandOption("--out-contract <PATH>")]
+        [System.ComponentModel.Description("Output path for the DataContract class XML. Auto-derived when --parameter is used.")]
+        public string? OutContract { get; init; }
+    }
+
+    public override int Execute(CommandContext ctx, Settings settings)
+    {
+        var kind = OutputMode.Resolve(settings.Output);
+        if (string.IsNullOrWhiteSpace(settings.Name))
+            return RenderHelpers.Render(kind, ToolResult<object>.Fail(D365FoErrorCodes.BadInput, "Report name required."));
+
+        var hasInstall = !string.IsNullOrWhiteSpace(settings.InstallTo);
+        var hasOut     = !string.IsNullOrWhiteSpace(settings.Out);
+        if (!hasInstall && !hasOut)
+            return RenderHelpers.Render(kind, ToolResult<object>.Fail(D365FoErrorCodes.BadInput, "--out or --install-to is required."));
+
+        // --- Parse extra datasets ---
+        List<ReportDatasetSpec>? extraDatasets = null;
+        if (settings.ExtraDatasets is { Length: > 0 })
+        {
+            extraDatasets = [];
+            foreach (var raw in settings.ExtraDatasets)
+            {
+                var parts = raw.Split(':', 2);
+                if (parts.Length < 2 || string.IsNullOrWhiteSpace(parts[1]))
+                    return RenderHelpers.Render(kind, ToolResult<object>.Fail(D365FoErrorCodes.BadInput,
+                        $"--extra-dataset '{raw}' must be in Name:DPClass format."));
+                extraDatasets.Add(new ReportDatasetSpec(parts[0], parts[1]));
+            }
+        }
+
+        // --- Parse parameters ---
+        List<ReportParameterSpec>? paramSpecs = null;
+        if (settings.Parameters is { Length: > 0 })
+        {
+            paramSpecs = settings.Parameters.Select(p =>
+            {
+                var parts = p.Split(':', 2);
+                return new ReportParameterSpec(parts[0], parts.Length > 1 ? parts[1] : "String");
+            }).ToList();
+        }
+
+        var spec = new ReportSpec(
+            settings.Name,
+            settings.DpClass,
+            settings.TmpTable,
+            settings.DatasetName,
+            settings.Caption,
+            extraDatasets is { Count: > 0 }
+                ? [new ReportDatasetSpec(
+                    string.IsNullOrWhiteSpace(settings.DatasetName) ? settings.Name + "DS" : settings.DatasetName,
+                    string.IsNullOrWhiteSpace(settings.DpClass)     ? settings.Name + "DP" : settings.DpClass,
+                    settings.Fields), .. extraDatasets]
+                : null,
+            settings.Fields,
+            paramSpecs);
+
+        var hasContract = spec.Parameters is { Count: > 0 };
+
+        // --- Resolve output paths ---
+        string? reportPath, dpPath, contractPath;
+        if (hasInstall && !hasOut)
+        {
+            reportPath = GenerateInstaller.ResolveInstallPath(kind, "AxReport", settings.Name, settings.InstallTo!, out var f1);
+            if (f1.HasValue) return f1.Value;
+
+            if (!string.IsNullOrWhiteSpace(settings.OutDp))
+            {
+                dpPath = settings.OutDp;
+            }
+            else
+            {
+                dpPath = GenerateInstaller.ResolveInstallPath(kind, "AxClass", spec.EffectiveDpClass, settings.InstallTo!, out var f2);
+                if (f2.HasValue) return f2.Value;
+            }
+
+            if (hasContract)
+            {
+                if (!string.IsNullOrWhiteSpace(settings.OutContract))
+                {
+                    contractPath = settings.OutContract;
+                }
+                else
+                {
+                    contractPath = GenerateInstaller.ResolveInstallPath(kind, "AxClass", spec.ContractClass, settings.InstallTo!, out var f3);
+                    if (f3.HasValue) return f3.Value;
+                }
+            }
+            else contractPath = null;
+        }
+        else
+        {
+            var dir = System.IO.Path.GetDirectoryName(settings.Out!)!;
+            reportPath   = settings.Out!;
+            dpPath       = settings.OutDp ?? System.IO.Path.Combine(dir, spec.EffectiveDpClass + ".xml");
+            contractPath = hasContract
+                ? (settings.OutContract ?? System.IO.Path.Combine(dir, spec.ContractClass + ".xml"))
+                : null;
+        }
+
+        try
+        {
+            var reportResult   = ScaffoldFileWriter.Write(XppScaffolder.Report(spec),   reportPath!,   settings.Overwrite);
+            var dpResult       = ScaffoldFileWriter.Write(XppScaffolder.ReportDp(spec), dpPath!,       settings.Overwrite);
+
+            ScaffoldFileWriter.WriteResult? contractResult = null;
+            if (hasContract && contractPath is not null)
+            {
+                var contractDoc = XppScaffolder.ReportContract(spec);
+                if (contractDoc is not null)
+                    contractResult = ScaffoldFileWriter.Write(contractDoc, contractPath, settings.Overwrite);
+            }
+
+            return RenderHelpers.Render(kind, ToolResult<object>.Success(new
+            {
+                kind        = "AxReport",
+                name        = spec.Name,
+                dpClass     = spec.EffectiveDpClass,
+                contractClass = spec.ContractClass,
+                datasets    = spec.EffectiveDatasets.Select(ds => new { ds.Name, ds.DpClass }).ToList(),
+                parameters  = spec.Parameters?.Select(p => new { p.Name, p.DataType }).ToList(),
+                report      = new { path = reportResult.Path,   bytes = reportResult.Bytes,   backup = reportResult.BackupPath },
+                dp          = new { path = dpResult.Path,       bytes = dpResult.Bytes,       backup = dpResult.BackupPath },
+                contract    = contractResult is null ? null : new { path = contractResult.Path, bytes = contractResult.Bytes, backup = contractResult.BackupPath },
+                model       = settings.InstallTo,
+            }));
+        }
+        catch (Exception ex)
+        {
+            return RenderHelpers.Render(kind, ToolResult<object>.Fail(D365FoErrorCodes.WriteFailed, ex.Message));
+        }
+    }
+}
+
+/// <summary>
 /// Idempotent &quot;add duty / privilege reference into an existing role&quot; merge,
 /// used by <c>generate role --add-to</c> and by the <c>--into-role</c> flag on
 /// <c>generate duty</c> / <c>generate privilege</c>. Loads the role XML,

--- a/src/D365FO.Cli/Commands/Lint/LintCommand.cs
+++ b/src/D365FO.Cli/Commands/Lint/LintCommand.cs
@@ -17,7 +17,7 @@ public sealed class LintCommand : Command<LintCommand.Settings>
     public sealed class Settings : D365OutputSettings
     {
         [CommandOption("--category <NAMES>")]
-        [System.ComponentModel.Description("Comma/semicolon-separated subset of: table-no-index, ext-named-not-attributed, string-without-edt.")]
+        [System.ComponentModel.Description("Comma/semicolon-separated subset of: table-no-index, ext-named-not-attributed, string-without-edt, today-usage, do-insert-update, doc-comment-missing.")]
         public string? Category { get; init; }
 
         [CommandOption("--all-models")]
@@ -30,7 +30,8 @@ public sealed class LintCommand : Command<LintCommand.Settings>
     }
 
     private static readonly string[] All =
-        { "table-no-index", "ext-named-not-attributed", "string-without-edt" };
+        { "table-no-index", "ext-named-not-attributed", "string-without-edt",
+          "today-usage", "do-insert-update", "doc-comment-missing" };
 
     public override int Execute(CommandContext ctx, Settings settings)
     {
@@ -51,6 +52,9 @@ public sealed class LintCommand : Command<LintCommand.Settings>
                 "table-no-index" => repo.FindTablesWithoutIndex(onlyCustom),
                 "ext-named-not-attributed" => repo.FindExtensionNamedButNotAttributed(onlyCustom),
                 "string-without-edt" => repo.FindStringFieldsWithoutEdt(onlyCustom),
+                "today-usage" => repo.FindTodayCallMethods(onlyCustom),
+                "do-insert-update" => repo.FindDoInsertOrUpdateMethods(onlyCustom),
+                "doc-comment-missing" => repo.FindMissingDocCommentMethods(onlyCustom),
                 _ => Array.Empty<LintHit>(),
             };
             hitsByCat[cat] = hits;
@@ -106,6 +110,12 @@ public sealed class LintCommand : Command<LintCommand.Settings>
             "Classes named '*_Extension' must carry [ExtensionOf(...)] or CoC / event-handler attributes."),
         ["string-without-edt"] = ("warning", "StringFieldWithoutEdt",
             "String fields should use an Extended Data Type so they inherit length/label/help centrally."),
+        ["today-usage"] = ("warning", "BPUpgradeCodeToday",
+            "today() ignores the user time-zone. Use DateTimeUtil::getToday(DateTimeUtil::getUserPreferredTimeZone())."),
+        ["do-insert-update"] = ("error", "DoInsertOrUpdateBypass",
+            "doInsert()/doUpdate()/doDelete() bypass overridden table methods and framework validation. Reserved for data-fix/migration scripts."),
+        ["doc-comment-missing"] = ("note", "BPXmlDocNoDocumentationComments",
+            "Public/protected methods should carry a meaningful /// <summary> XML doc comment."),
     };
 
     private static object BuildSarif(Dictionary<string, IReadOnlyList<LintHit>> hitsByCat)

--- a/src/D365FO.Cli/Commands/Ops/BuildCommands.cs
+++ b/src/D365FO.Cli/Commands/Ops/BuildCommands.cs
@@ -150,6 +150,11 @@ public sealed class TestRunCommand : Command<TestRunCommand.Settings>
 
 public sealed class BpCheckCommand : Command<BpCheckCommand.Settings>
 {
+    // xppbp help-text fragments that indicate the tool printed usage instead of results.
+    private static readonly Regex HelpTextPattern = new(
+        @"^usage:|BPCheck Tool|^xppbp\.exe|unrecognized|missing required|X\+\+ Best Practice Options",
+        RegexOptions.IgnoreCase | RegexOptions.Multiline | RegexOptions.Compiled);
+
     public sealed class Settings : D365OutputSettings
     {
         [CommandOption("--tool <PATH>")]
@@ -157,6 +162,14 @@ public sealed class BpCheckCommand : Command<BpCheckCommand.Settings>
 
         [CommandOption("--model <NAME>")]
         public string? Model { get; init; }
+
+        [CommandOption("--packages <PATH>")]
+        [System.ComponentModel.Description("PackagesLocalDirectory (or FrameworkDirectory on UDE). Defaults to D365FO_PACKAGES_PATH.")]
+        public string? PackagesPath { get; init; }
+
+        [CommandOption("--metadata <PATH>")]
+        [System.ComponentModel.Description("Custom model metadata root (ModelStoreFolder on UDE). Defaults to --packages when not set.")]
+        public string? MetadataPath { get; init; }
     }
 
     public override int Execute(CommandContext ctx, Settings settings)
@@ -165,13 +178,63 @@ public sealed class BpCheckCommand : Command<BpCheckCommand.Settings>
         var guard = WindowsGuard.Check("d365fo bp check");
         if (guard is not null) return RenderHelpers.Render(kind, guard);
 
-        var bp = settings.BpToolPath ?? "xppbp.exe";
-        var args = new List<string>();
-        if (!string.IsNullOrEmpty(settings.Model)) args.Add($"-model={settings.Model}");
-        var (exit, stdout, stderr, elapsed) = ProcessRunner.Run(bp, args);
+        var modelName = settings.Model;
+        if (string.IsNullOrEmpty(modelName))
+            return RenderHelpers.Render(kind, ToolResult<object>.Fail(
+                "MISSING_ARGUMENT", "--model <NAME> is required for bp check.",
+                "Example: d365fo bp check --model MyCustomModel"));
+
+        // Resolve paths. In UDE environments:
+        //   packagesRoot = FrameworkDirectory (where xppbp.exe lives, under Bin/)
+        //   metadataPath = ModelStoreFolder   (where custom source XML lives)
+        // In traditional environments both roles are served by packagesRoot.
+        var packagesRoot = settings.PackagesPath
+            ?? Environment.GetEnvironmentVariable("D365FO_PACKAGES_PATH")
+            ?? @"K:\AosService\PackagesLocalDirectory";
+        var metadataPath = settings.MetadataPath ?? packagesRoot;
+
+        var bp = settings.BpToolPath
+            ?? System.IO.Path.Combine(packagesRoot, "Bin", "xppbp.exe");
+
+        if (!System.IO.File.Exists(bp))
+            return RenderHelpers.Render(kind, ToolResult<object>.Fail(
+                "XPPBP_NOT_FOUND",
+                $"xppbp.exe not found at: {bp}",
+                "Set D365FO_PACKAGES_PATH (or --packages) to the FrameworkDirectory that contains Bin\\xppbp.exe."));
+
+        // Build argument list using modern -metadata: flag.
+        // Falls back to legacy -packagesroot: when the modern flag is not recognised.
+        List<string> BuildArgs(string metadataFlag) => new()
+        {
+            $"{metadataFlag}{metadataPath}",
+            $"-module:{modelName}",
+            $"-model:{modelName}",
+            "-all",
+        };
+
+        var (exit, stdout, stderr, elapsed) = ProcessRunner.Run(bp, BuildArgs("-metadata:"));
+        var combined = string.Join("\n", stdout, stderr).Trim();
+
+        // If the modern flag is not supported, fall back to the legacy -packagesroot: flag.
+        if (HelpTextPattern.IsMatch(combined) || string.IsNullOrWhiteSpace(combined))
+        {
+            (exit, stdout, stderr, elapsed) = ProcessRunner.Run(bp, BuildArgs("-packagesroot:"));
+        }
+
+        var tail = stdout.Split('\n').TakeLast(40).ToArray();
         return RenderHelpers.Render(kind, exit == 0
-            ? ToolResult<object>.Success(new { exitCode = exit, elapsedMs = (long)elapsed.TotalMilliseconds, tail = stdout.Split('\n').TakeLast(40).ToArray() })
-            : ToolResult<object>.Fail("BP_FAILED", $"Best practice check exited with {exit}.", string.Join('\n', stderr.Split('\n').TakeLast(5))));
+            ? ToolResult<object>.Success(new
+            {
+                exitCode = exit,
+                elapsedMs = (long)elapsed.TotalMilliseconds,
+                packagesRoot,
+                metadataPath,
+                model = modelName,
+                tail,
+            })
+            : ToolResult<object>.Fail("BP_FAILED",
+                $"Best practice check exited with {exit}.",
+                string.Join('\n', stderr.Split('\n').TakeLast(5))));
     }
 }
 

--- a/src/D365FO.Cli/Commands/Suggest/SuggestCommands.cs
+++ b/src/D365FO.Cli/Commands/Suggest/SuggestCommands.cs
@@ -1,4 +1,5 @@
 using D365FO.Core;
+using D365FO.Core.Index;
 using Spectre.Console.Cli;
 
 namespace D365FO.Cli.Commands.Suggest;
@@ -45,3 +46,206 @@ public sealed class SuggestEdtCommand : Command<SuggestEdtCommand.Settings>
         }));
     }
 }
+
+/// <summary>
+/// Recommends the best extensibility strategy for a D365FO target object
+/// (Class, Table, or Form): CoC wrapper, event handler, or AOT extension.
+/// Analyses what the target exposes (delegate count, sealed methods,
+/// existing extensions) and outputs ranked options with one-line rationale.
+/// Mirrors upstream MCP <c>suggest_extension_strategy</c>. ROADMAP §P4a.
+/// </summary>
+public sealed class SuggestExtensionCommand : Command<SuggestExtensionCommand.Settings>
+{
+    public sealed class Settings : D365OutputSettings
+    {
+        [CommandArgument(0, "<TARGET>")]
+        [System.ComponentModel.Description("Name of the class, table, or form to analyse.")]
+        public string Target { get; init; } = "";
+
+        [CommandOption("--kind <KIND>")]
+        [System.ComponentModel.Description("Hint for target kind: Class, Table, or Form. Auto-detected when omitted.")]
+        public string? Kind { get; init; }
+    }
+
+    private sealed record Recommendation(
+        string Approach,
+        string Rationale,
+        string Confidence,
+        string? Command);
+
+    public override int Execute(CommandContext ctx, Settings settings)
+    {
+        var kind = OutputMode.Resolve(settings.Output);
+        if (string.IsNullOrWhiteSpace(settings.Target))
+            return RenderHelpers.Render(kind, ToolResult<object>.Fail("BAD_INPUT", "Target name required."));
+
+        var repo = RepoFactory.Create();
+        var target = settings.Target.Trim();
+
+        // --- auto-detect kind ---
+        string? detectedKind = settings.Kind?.Trim();
+        ClassDetails? classDetails = null;
+        TableDetails? tableDetails = null;
+        FormDetails?  formDetails  = null;
+
+        if (string.IsNullOrEmpty(detectedKind) || detectedKind.Equals("Class", StringComparison.OrdinalIgnoreCase))
+        {
+            classDetails = repo.GetClassDetails(target);
+            if (classDetails is not null) detectedKind = "Class";
+        }
+        if (classDetails is null && (string.IsNullOrEmpty(detectedKind) || detectedKind.Equals("Table", StringComparison.OrdinalIgnoreCase)))
+        {
+            tableDetails = repo.GetTableDetails(target);
+            if (tableDetails is not null) detectedKind = "Table";
+        }
+        if (classDetails is null && tableDetails is null && (string.IsNullOrEmpty(detectedKind) || detectedKind.Equals("Form", StringComparison.OrdinalIgnoreCase)))
+        {
+            formDetails = repo.GetForm(target);
+            if (formDetails is not null) detectedKind = "Form";
+        }
+
+        if (classDetails is null && tableDetails is null && formDetails is null)
+            return RenderHelpers.Render(kind, ToolResult<object>.Fail("NOT_FOUND",
+                $"'{target}' not found in the index as Class, Table, or Form. Run `d365fo index refresh` if recently added."));
+
+        // --- gather signals ---
+        var cocCount      = classDetails is not null ? repo.FindCocExtensions(target).Count : 0;
+        var handlerCount  = repo.FindEventSubscribers(target).Count;
+        var extensionCount= repo.FindExtensions(target).Count;
+        var delegates     = classDetails?.Methods.Count(m => m.Name.StartsWith("delegate", StringComparison.OrdinalIgnoreCase)) ?? 0;
+
+        // Detect [Hookable(false)] / [Wrappable(false)] by checking if NO CoC wrappers exist
+        // despite the class being non-final. This is a heuristic — the index does not store
+        // attribute declarations, so we cannot detect them directly.
+        var isFinal    = classDetails?.Class.IsFinal ?? false;
+        var isAbstract = classDetails?.Class.IsAbstract ?? false;
+        var methodCount= classDetails?.Methods.Count ?? 0;
+
+        var recs = new List<Recommendation>();
+
+        switch (detectedKind)
+        {
+            case "Class":
+                // CoC: strongly preferred when class is not final; even final
+                // classes can be wrapped with [Wrappable(true)].
+                if (!isFinal)
+                {
+                    var cocConf = cocCount > 5 ? "medium" : "high";
+                    var cocNote = cocCount > 0
+                        ? $"{cocCount} existing CoC wrapper(s) already present."
+                        : "No existing CoC wrappers — clean slate.";
+                    recs.Add(new Recommendation(
+                        "CoC (Chain of Command)",
+                        $"Class is non-final and wrappable. {cocNote} Wrap individual methods to extend behaviour without replacing them.",
+                        cocConf,
+                        $"d365fo generate coc {target} --method <method> --out <PATH>"));
+                }
+                else
+                {
+                    recs.Add(new Recommendation(
+                        "CoC (Chain of Command)",
+                        "Class is marked final. CoC wrapping may still work if the method carries [Wrappable(true)]. Verify before scaffolding.",
+                        "low",
+                        $"d365fo generate coc {target} --method <method> --out <PATH>"));
+                }
+
+                // Event handler: good when delegates exist, or as a lightweight hook.
+                if (delegates > 0)
+                {
+                    recs.Add(new Recommendation(
+                        "Event handler (delegate subscribe)",
+                        $"{delegates} delegate(s) found on {target}. Subscribe with [SubscribesTo] for zero-coupling extension.",
+                        "high",
+                        $"d365fo generate event-handler --source-kind Class --source {target} --event <delegateName> --out <PATH>"));
+                }
+                else
+                {
+                    recs.Add(new Recommendation(
+                        "Event handler (pre/post)",
+                        $"No custom delegates found. Pre/post handlers via [DataEventHandler] attach before/after standard events.",
+                        "medium",
+                        $"d365fo generate event-handler --source-kind Class --source {target} --event <EventName> --out <PATH>"));
+                }
+
+                // Class extension (add new methods / members without CoC).
+                recs.Add(new Recommendation(
+                    "Class extension",
+                    $"Add new public methods or parm accessors to {target} via an extension class without touching the base object.",
+                    "medium",
+                    $"d365fo generate extension Class {target} <Suffix> --out <PATH>"));
+                break;
+
+            case "Table":
+                recs.Add(new Recommendation(
+                    "Table extension",
+                    $"Add new fields, field groups, indexes, or relations to {target} without modifying the base table XML.",
+                    "high",
+                    $"d365fo generate extension Table {target} <Suffix> --out <PATH>"));
+                if (delegates > 0)
+                {
+                    recs.Add(new Recommendation(
+                        "Event handler (data event)",
+                        $"{delegates} delegate(s) found on {target}.",
+                        "high",
+                        $"d365fo generate event-handler --source-kind Table --source {target} --event <Inserted|Updated|Deleted> --out <PATH>"));
+                }
+                else
+                {
+                    recs.Add(new Recommendation(
+                        "Event handler (data event)",
+                        $"Subscribe to standard DataEventType (Inserted, Updated, Deleted, etc.) on {target}.",
+                        "high",
+                        $"d365fo generate event-handler --source-kind Table --source {target} --event Inserted --out <PATH>"));
+                }
+                recs.Add(new Recommendation(
+                    "CoC (table method wrapping)",
+                    $"Wrap insert(), update(), delete(), or any other method on {target}'s table class.",
+                    "medium",
+                    $"d365fo generate coc {target} --method insert --out <PATH>"));
+                break;
+
+            case "Form":
+                recs.Add(new Recommendation(
+                    "Form extension",
+                    $"Add controls, datasources, or menu items to {target} without replacing the base form.",
+                    "high",
+                    $"d365fo generate extension Form {target} <Suffix> --out <PATH>"));
+                recs.Add(new Recommendation(
+                    "Event handler (form event)",
+                    $"Subscribe to FormEventType (Initialized, Closed, etc.) or FormDataSourceEventType on {target}.",
+                    "high",
+                    $"d365fo generate event-handler --source-kind Form --source {target} --event Initialized --out <PATH>"));
+                recs.Add(new Recommendation(
+                    "CoC (form method wrapping)",
+                    $"Wrap init(), run(), or closeCanExecute() on {target}'s form class.",
+                    "medium",
+                    $"d365fo generate coc {target} --method init --out <PATH>"));
+                break;
+        }
+
+        return RenderHelpers.Render(kind, ToolResult<object>.Success(new
+        {
+            target,
+            targetKind = detectedKind,
+            signals = new
+            {
+                isFinal,
+                isAbstract,
+                methodCount,
+                delegateCount    = delegates,
+                existingCoc      = cocCount,
+                existingHandlers = handlerCount,
+                existingExtensions = extensionCount,
+            },
+            recommendations = recs.Select((r, i) => new
+            {
+                rank       = i + 1,
+                approach   = r.Approach,
+                rationale  = r.Rationale,
+                confidence = r.Confidence,
+                command    = r.Command,
+            }).ToList(),
+        }));
+    }
+}
+

--- a/src/D365FO.Cli/Program.cs
+++ b/src/D365FO.Cli/Program.cs
@@ -1,4 +1,5 @@
 ﻿using D365FO.Cli.Commands.Agent;
+using D365FO.Cli.Commands.Analyze;
 using D365FO.Cli.Commands.Daemon;
 using D365FO.Cli.Commands.Find;
 using D365FO.Cli.Commands.Generate;
@@ -85,6 +86,7 @@ app.Configure(cfg =>
     {
         b.SetDescription("Heuristic suggestions over the index (no scaffolding).");
         b.AddCommand<SuggestEdtCommand>("edt").WithDescription("Suggest EDTs matching a field name.");
+        b.AddCommand<SuggestExtensionCommand>("extension").WithDescription("Recommend CoC / event-handler / AOT-extension strategy for a Class, Table, or Form.");
     });
 
     cfg.AddBranch("validate", b =>
@@ -141,6 +143,13 @@ app.Configure(cfg =>
         b.AddCommand<GeneratePrivilegeCommand>("privilege").WithDescription("Create a security privilege over an entry point.");
         b.AddCommand<GenerateDutyCommand>("duty").WithDescription("Create a security duty grouping privileges.");
         b.AddCommand<GenerateRoleCommand>("role").WithDescription("Create an AxSecurityRole or merge duties/privileges into an existing role.");
+        b.AddCommand<GenerateReportCommand>("report").WithDescription("Create an AxReport + SrsReportDataProviderBase skeleton (DP class).");
+    });
+
+    cfg.AddBranch("analyze", b =>
+    {
+        b.SetDescription("Cross-check workspace AOT XML against the index.");
+        b.AddCommand<AnalyzeCompletenessCommand>("completeness").WithDescription("Report broken EDT, label, security-role references in a project folder.");
     });
 
     cfg.AddBranch("test", b =>

--- a/src/D365FO.Core/Extract/MetadataExtractor.cs
+++ b/src/D365FO.Core/Extract/MetadataExtractor.cs
@@ -420,7 +420,13 @@ public sealed class MetadataExtractor
             var signature = ExtractSignatureLine(source);
             var returnType = InferReturnType(signature);
             var isStatic = signature.Contains(" static ", StringComparison.Ordinal);
-            methods.Add(new ExtractedMethod(mname!, signature, returnType, isStatic));
+            var hasDocComment     = source.Contains("/// <summary>", StringComparison.OrdinalIgnoreCase);
+            var hasTodayCall      = source.Contains("today()", StringComparison.OrdinalIgnoreCase);
+            var hasDoInsertUpdate = source.Contains("doInsert(", StringComparison.OrdinalIgnoreCase)
+                                 || source.Contains("doUpdate(", StringComparison.OrdinalIgnoreCase)
+                                 || source.Contains("doDelete(", StringComparison.OrdinalIgnoreCase);
+            methods.Add(new ExtractedMethod(mname!, signature, returnType, isStatic,
+                hasDocComment, hasTodayCall, hasDoInsertUpdate));
             sources.Add((mname!, source));
         }
         return (methods, sources);
@@ -486,7 +492,10 @@ public sealed class MetadataExtractor
         var dotIdx = nameNoExt.LastIndexOf('.');
         if (dotIdx < 0) yield break;
         var labelFile = nameNoExt.Substring(0, dotIdx);
-        var language = nameNoExt.Substring(dotIdx + 1);
+        // Normalize to BCP-47 canonical form: 'en-us' → 'en-US', 'es-mx' → 'es-MX'.
+        // Microsoft packages on Linux store locale dirs as lowercase; custom packages
+        // use mixed-case. Normalize on ingest so DB comparisons are consistent.
+        var language = NormalizeLocale(nameNoExt.Substring(dotIdx + 1));
         if (!LangPasses(langs, language)) yield break;
 
         foreach (var entry in ReadLabelTxt(txt, labelFile, language))
@@ -511,7 +520,7 @@ public sealed class MetadataExtractor
 
         foreach (var loc in Children(doc.Root, "Labels"))
         {
-            var language = Local(loc, "Language") ?? "en-us";
+            var language = NormalizeLocale(Local(loc, "Language") ?? "en-us");
             if (!LangPasses(langs, language)) continue;
             foreach (var entry in loc.Descendants().Where(x => x.Name.LocalName == "AxLabel"))
             {
@@ -547,7 +556,7 @@ public sealed class MetadataExtractor
         {
             foreach (var loc in Children(inlineRoot, "Labels"))
             {
-                var language = Local(loc, "Language") ?? "en-us";
+                var language = NormalizeLocale(Local(loc, "Language") ?? "en-us");
                 if (!LangPasses(langs, language)) continue;
                 var entries = loc.Descendants().Where(x => x.Name.LocalName == "AxLabel");
                 foreach (var entry in entries)
@@ -570,7 +579,7 @@ public sealed class MetadataExtractor
             var dotIdx = nameNoExt.LastIndexOf('.');
             if (dotIdx < 0) continue;
             var labelFile = nameNoExt.Substring(0, dotIdx);
-            var language = nameNoExt.Substring(dotIdx + 1);
+            var language = NormalizeLocale(nameNoExt.Substring(dotIdx + 1));
             if (!LangPasses(langs, language)) continue;
 
             // Only index labels that belong to the manifest we're reading.
@@ -582,6 +591,20 @@ public sealed class MetadataExtractor
             foreach (var entry in ReadLabelTxt(txt, labelFile, language))
                 yield return entry;
         }
+    }
+
+    /// <summary>
+    /// Normalize a locale string to BCP-47 canonical form.
+    /// 'en-us' → 'en-US', 'es-mx' → 'es-MX', 'zh-hans' → 'zh-Hans'.
+    /// Only the last subtag is uppercased; single-subtag locales are lowercased.
+    /// </summary>
+    private static string NormalizeLocale(string locale)
+    {
+        if (string.IsNullOrEmpty(locale)) return locale;
+        var parts = locale.Split('-');
+        for (int i = 0; i < parts.Length; i++)
+            parts[i] = i == 0 ? parts[i].ToLowerInvariant() : parts[i].ToUpperInvariant();
+        return string.Join('-', parts);
     }
 
     private static bool LangPasses(IReadOnlyCollection<string>? langs, string language) =>

--- a/src/D365FO.Core/Index/ExtractModels.cs
+++ b/src/D365FO.Core/Index/ExtractModels.cs
@@ -60,7 +60,8 @@ public sealed record ExtractedClass(string Name, string? Extends, bool IsAbstrac
 {
     public IReadOnlyList<ExtractedClassAttribute> Attributes { get; init; } = Array.Empty<ExtractedClassAttribute>();
 }
-public sealed record ExtractedMethod(string Name, string? Signature, string? ReturnType, bool IsStatic);
+public sealed record ExtractedMethod(string Name, string? Signature, string? ReturnType, bool IsStatic,
+    bool HasDocComment = false, bool HasTodayCall = false, bool HasDoInsertOrUpdate = false);
 public sealed record ExtractedClassAttribute(string? MethodName, string AttributeName, string RawArgs);
 public sealed record ExtractedEventSubscriber(
     string SubscriberClass,

--- a/src/D365FO.Core/Index/MetadataRepository.cs
+++ b/src/D365FO.Core/Index/MetadataRepository.cs
@@ -14,7 +14,7 @@ namespace D365FO.Core.Index;
 public sealed class MetadataRepository
 {
     /// <summary>Current schema version tracked in PRAGMA user_version.</summary>
-    public const int CurrentSchemaVersion = 8;
+    public const int CurrentSchemaVersion = 9;
 
     private static readonly Lazy<string> SchemaSql = new(LoadEmbeddedSchema);
 
@@ -86,6 +86,22 @@ public sealed class MetadataRepository
                 .ToHashSet(StringComparer.OrdinalIgnoreCase);
             if (!dsCols.Contains("OrderIndex")) conn.Execute("ALTER TABLE FormDataSources ADD COLUMN OrderIndex INTEGER NOT NULL DEFAULT 0");
             if (!dsCols.Contains("JoinSource")) conn.Execute("ALTER TABLE FormDataSources ADD COLUMN JoinSource TEXT");
+        }
+        if (current < 9)
+        {
+            // v9: Lint-flag columns on Methods / TableMethods. Populated during
+            // extract by scanning <Source> text — no full body storage.
+            var methodCols = conn.Query<string>("SELECT name FROM pragma_table_info('Methods')")
+                .ToHashSet(StringComparer.OrdinalIgnoreCase);
+            if (!methodCols.Contains("HasDocComment"))    conn.Execute("ALTER TABLE Methods ADD COLUMN HasDocComment    INTEGER NOT NULL DEFAULT 0");
+            if (!methodCols.Contains("HasTodayCall"))     conn.Execute("ALTER TABLE Methods ADD COLUMN HasTodayCall     INTEGER NOT NULL DEFAULT 0");
+            if (!methodCols.Contains("HasDoInsertOrUpdate")) conn.Execute("ALTER TABLE Methods ADD COLUMN HasDoInsertOrUpdate INTEGER NOT NULL DEFAULT 0");
+
+            var tmCols = conn.Query<string>("SELECT name FROM pragma_table_info('TableMethods')")
+                .ToHashSet(StringComparer.OrdinalIgnoreCase);
+            if (!tmCols.Contains("HasDocComment"))    conn.Execute("ALTER TABLE TableMethods ADD COLUMN HasDocComment    INTEGER NOT NULL DEFAULT 0");
+            if (!tmCols.Contains("HasTodayCall"))     conn.Execute("ALTER TABLE TableMethods ADD COLUMN HasTodayCall     INTEGER NOT NULL DEFAULT 0");
+            if (!tmCols.Contains("HasDoInsertOrUpdate")) conn.Execute("ALTER TABLE TableMethods ADD COLUMN HasDoInsertOrUpdate INTEGER NOT NULL DEFAULT 0");
         }
         conn.Execute($"PRAGMA user_version = {CurrentSchemaVersion}");
         conn.Execute(
@@ -502,6 +518,85 @@ public sealed class MetadataRepository
             .Select(r => new LintHit((string)r.TargetName, (string)r.Model, (string?)r.Detail)).ToList();
     }
 
+    /// <summary>
+    /// Returns methods (class or table) that call <c>today()</c>
+    /// — should use <c>DateTimeUtil::getToday(...)</c> instead (BP: BPUpgradeCodeToday).
+    /// </summary>
+    public IReadOnlyList<LintHit> FindTodayCallMethods(bool onlyCustomModels = true)
+    {
+        using var conn = Open();
+        // Union class methods and table methods.
+        var sql = @"
+            SELECT (c.Name || '::' || mt.Name) AS TargetName, m.Name AS Model, 'today()' AS Detail
+            FROM Methods mt
+            JOIN Classes c ON c.ClassId = mt.ClassId
+            JOIN Models m ON m.ModelId = c.ModelId
+            WHERE mt.HasTodayCall = 1
+              AND (@custom = 0 OR m.IsCustom = 1)
+            UNION ALL
+            SELECT (t.Name || '::' || mt.Name) AS TargetName, m.Name AS Model, 'today()' AS Detail
+            FROM TableMethods mt
+            JOIN Tables t ON t.TableId = mt.TableId
+            JOIN Models m ON m.ModelId = t.ModelId
+            WHERE mt.HasTodayCall = 1
+              AND (@custom = 0 OR m.IsCustom = 1)
+            ORDER BY TargetName";
+        return conn.Query(sql, new { custom = onlyCustomModels ? 1 : 0 })
+            .Select(r => new LintHit((string)r.TargetName, (string)r.Model, (string?)r.Detail)).ToList();
+    }
+
+    /// <summary>
+    /// Returns methods that call <c>doInsert()</c>, <c>doUpdate()</c>, or <c>doDelete()</c>
+    /// (bypasses table overrides — reserved for migration scripts).
+    /// </summary>
+    public IReadOnlyList<LintHit> FindDoInsertOrUpdateMethods(bool onlyCustomModels = true)
+    {
+        using var conn = Open();
+        var sql = @"
+            SELECT (c.Name || '::' || mt.Name) AS TargetName, m.Name AS Model, 'doInsert/doUpdate/doDelete' AS Detail
+            FROM Methods mt
+            JOIN Classes c ON c.ClassId = mt.ClassId
+            JOIN Models m ON m.ModelId = c.ModelId
+            WHERE mt.HasDoInsertOrUpdate = 1
+              AND (@custom = 0 OR m.IsCustom = 1)
+            UNION ALL
+            SELECT (t.Name || '::' || mt.Name) AS TargetName, m.Name AS Model, 'doInsert/doUpdate/doDelete' AS Detail
+            FROM TableMethods mt
+            JOIN Tables t ON t.TableId = mt.TableId
+            JOIN Models m ON m.ModelId = t.ModelId
+            WHERE mt.HasDoInsertOrUpdate = 1
+              AND (@custom = 0 OR m.IsCustom = 1)
+            ORDER BY TargetName";
+        return conn.Query(sql, new { custom = onlyCustomModels ? 1 : 0 })
+            .Select(r => new LintHit((string)r.TargetName, (string)r.Model, (string?)r.Detail)).ToList();
+    }
+
+    /// <summary>
+    /// Returns public/protected methods that lack a <c>/// &lt;summary&gt;</c> doc comment
+    /// (BP: BPXmlDocNoDocumentationComments).
+    /// </summary>
+    public IReadOnlyList<LintHit> FindMissingDocCommentMethods(bool onlyCustomModels = true)
+    {
+        using var conn = Open();
+        var sql = @"
+            SELECT (c.Name || '::' || mt.Name) AS TargetName, m.Name AS Model, 'missing doc-comment' AS Detail
+            FROM Methods mt
+            JOIN Classes c ON c.ClassId = mt.ClassId
+            JOIN Models m ON m.ModelId = c.ModelId
+            WHERE mt.HasDocComment = 0
+              AND (@custom = 0 OR m.IsCustom = 1)
+            UNION ALL
+            SELECT (t.Name || '::' || mt.Name) AS TargetName, m.Name AS Model, 'missing doc-comment' AS Detail
+            FROM TableMethods mt
+            JOIN Tables t ON t.TableId = mt.TableId
+            JOIN Models m ON m.ModelId = t.ModelId
+            WHERE mt.HasDocComment = 0
+              AND (@custom = 0 OR m.IsCustom = 1)
+            ORDER BY TargetName";
+        return conn.Query(sql, new { custom = onlyCustomModels ? 1 : 0 })
+            .Select(r => new LintHit((string)r.TargetName, (string)r.Model, (string?)r.Detail)).ToList();
+    }
+
     // ---- v4: queries / views / data entities / reports / services / workflow ----
 
     public IReadOnlyList<QueryInfo> SearchQueries(string query, int limit = 50)
@@ -800,6 +895,9 @@ public sealed class MetadataRepository
         var prefix = splitIdx > 0 ? raw.Substring(0, splitIdx) : raw;
         var suffix = splitIdx < raw.Length ? raw.Substring(splitIdx) : string.Empty;
 
+        // Normalize to lowercase so both 'en-US' (Windows filesystem) and 'en-us'
+        // (Linux filesystem, Microsoft packages) match the caller's request.
+        var langsLower = languages?.Select(l => l.ToLowerInvariant()).ToList();
         using var conn = Open();
         // Try two shapes: Key == raw (e.g. "SYS12345") in file=prefix,
         // or Key == suffix (e.g. "12345") in file=prefix. Fall back to
@@ -807,13 +905,13 @@ public sealed class MetadataRepository
         var sql = @"
             SELECT LabelFile AS File, Language, Key, Value
             FROM Labels
-            WHERE (@langs IS NULL OR Language IN @langs)
+            WHERE (@langs IS NULL OR LOWER(Language) IN @langs)
               AND (
                     (LabelFile = @prefix AND Key IN (@raw, @suffix))
                  OR Key = @raw
               )
             ORDER BY LabelFile, Language";
-        return conn.Query<LabelMatch>(sql, new { langs = languages, prefix, raw, suffix }).ToList();
+        return conn.Query<LabelMatch>(sql, new { langs = langsLower, prefix, raw, suffix }).ToList();
     }
 
     /// <summary>
@@ -1069,9 +1167,10 @@ public sealed class MetadataRepository
             }
             foreach (var mtd in t.Methods)
             {
-                conn.Execute(@"INSERT INTO TableMethods(TableId, Name, Signature, IsStatic, ReturnType)
-                               VALUES(@t, @n, @s, @st, @rt)",
-                             new { t = tableId, n = mtd.Name, s = mtd.Signature, st = mtd.IsStatic ? 1 : 0, rt = mtd.ReturnType }, tx);
+                conn.Execute(@"INSERT INTO TableMethods(TableId, Name, Signature, IsStatic, ReturnType, HasDocComment, HasTodayCall, HasDoInsertOrUpdate)
+                               VALUES(@t, @n, @s, @st, @rt, @hd, @ht, @hi)",
+                             new { t = tableId, n = mtd.Name, s = mtd.Signature, st = mtd.IsStatic ? 1 : 0, rt = mtd.ReturnType,
+                                   hd = mtd.HasDocComment ? 1 : 0, ht = mtd.HasTodayCall ? 1 : 0, hi = mtd.HasDoInsertOrUpdate ? 1 : 0 }, tx);
             }
             foreach (var ix in t.Indexes)
             {
@@ -1101,9 +1200,10 @@ public sealed class MetadataRepository
             var classId = conn.ExecuteScalar<long>("SELECT last_insert_rowid()", transaction: tx);
             foreach (var mtd in c.Methods)
             {
-                conn.Execute(@"INSERT INTO Methods(ClassId, Name, Signature, IsStatic, ReturnType)
-                               VALUES(@c, @n, @s, @st, @rt)",
-                             new { c = classId, n = mtd.Name, s = mtd.Signature, st = mtd.IsStatic ? 1 : 0, rt = mtd.ReturnType }, tx);
+                conn.Execute(@"INSERT INTO Methods(ClassId, Name, Signature, IsStatic, ReturnType, HasDocComment, HasTodayCall, HasDoInsertOrUpdate)
+                               VALUES(@c, @n, @s, @st, @rt, @hd, @ht, @hi)",
+                             new { c = classId, n = mtd.Name, s = mtd.Signature, st = mtd.IsStatic ? 1 : 0, rt = mtd.ReturnType,
+                                   hd = mtd.HasDocComment ? 1 : 0, ht = mtd.HasTodayCall ? 1 : 0, hi = mtd.HasDoInsertOrUpdate ? 1 : 0 }, tx);
             }
             foreach (var a in c.Attributes)
             {

--- a/src/D365FO.Core/Index/Schema.sql
+++ b/src/D365FO.Core/Index/Schema.sql
@@ -63,6 +63,9 @@ CREATE TABLE IF NOT EXISTS Methods (
     Signature       TEXT,
     IsStatic        INTEGER NOT NULL DEFAULT 0,
     ReturnType      TEXT,
+    HasDocComment   INTEGER NOT NULL DEFAULT 0,
+    HasTodayCall    INTEGER NOT NULL DEFAULT 0,
+    HasDoInsertOrUpdate INTEGER NOT NULL DEFAULT 0,
     FOREIGN KEY (ClassId) REFERENCES Classes(ClassId) ON DELETE CASCADE
 );
 CREATE INDEX IF NOT EXISTS IX_Methods_ClassId_Name ON Methods(ClassId, Name);
@@ -167,6 +170,9 @@ CREATE TABLE IF NOT EXISTS TableMethods (
     Signature       TEXT,
     IsStatic        INTEGER NOT NULL DEFAULT 0,
     ReturnType      TEXT,
+    HasDocComment   INTEGER NOT NULL DEFAULT 0,
+    HasTodayCall    INTEGER NOT NULL DEFAULT 0,
+    HasDoInsertOrUpdate INTEGER NOT NULL DEFAULT 0,
     FOREIGN KEY (TableId) REFERENCES Tables(TableId) ON DELETE CASCADE
 );
 CREATE INDEX IF NOT EXISTS IX_TableMethods_TableId ON TableMethods(TableId, Name);

--- a/src/D365FO.Core/Scaffolding/XppScaffolder.cs
+++ b/src/D365FO.Core/Scaffolding/XppScaffolder.cs
@@ -343,6 +343,276 @@ public static class XppScaffolder
         return changed;
     }
 
+    /// <summary>
+    /// Scaffolds an <c>AxReport</c> XML with full dataset / tablix / parameter structure.
+    /// Supports multiple datasets (each bound to a DP class), tablix column definitions
+    /// derived from <paramref name="spec"/>.<c>Fields</c> / <c>Datasets[i].Fields</c>,
+    /// and <c>AxReportParameter</c> elements for report-dialog filters.
+    /// Mirrors upstream MCP <c>generate_smart_report</c>. Pair with
+    /// <see cref="ReportDp"/> and (when parameters exist) <see cref="ReportContract"/>.
+    /// </summary>
+    public static XDocument Report(ReportSpec spec)
+    {
+        ArgumentNullException.ThrowIfNull(spec);
+
+        var datasets = spec.EffectiveDatasets;
+
+        // --- <ReportParameters> (optional) ---
+        XElement? parametersEl = null;
+        if (spec.Parameters is { Count: > 0 })
+        {
+            parametersEl = new XElement("ReportParameters",
+                spec.Parameters.Select(p => new XElement("AxReportParameter",
+                    new XElement("Name",       p.Name),
+                    new XElement("AllowBlank", p.AllowBlank ? "Yes" : "No"),
+                    new XElement("DataType",   p.DataType),
+                    new XElement("Prompt",     p.Prompt     ? "Yes" : "No"))));
+        }
+
+        // --- <Datasets> ---
+        var datasetsEl = new XElement("Datasets",
+            datasets.Select(ds => new XElement("AxReportDataset",
+                new XElement("Name",           ds.Name),
+                new XElement("DataProvider",   ds.DpClass),
+                new XElement("QueryType",      "DataProvider"),
+                new XElement("DynamicFilters", "Yes"))));
+
+        // --- <Designs> with AutoDesignSpecs + one tablix per dataset ---
+        var autoNodes = datasets.Select((ds, i) => new XElement("AxReportAutoDesignNode",
+            new XElement("Name",    i == 0 ? "AutoDesign" : $"AutoDesign{i + 1}"),
+            new XElement("DataSet", ds.Name),
+            new XElement("ReportAutoDesignItems",
+                new XElement("AxReportAutoDesignDataSet",
+                    new XElement("Name",       $"AutoDesignDataSet{i + 1}"),
+                    new XElement("DataSet",    ds.Name),
+                    new XElement("AutoFields", "Yes")))));
+
+        var tablixItems = datasets.Select((ds, i) => BuildTablix(ds.Name, ds.Fields, i + 1));
+
+        var designEl = new XElement("Designs",
+            new XElement("AxReportDesign",
+                new XElement("Name", "Report"),
+                string.IsNullOrEmpty(spec.Caption) ? null : new XElement("Caption", spec.Caption),
+                new XElement("AutoDesignSpecs", autoNodes),
+                new XElement("ReportDesignItems", tablixItems)));
+
+        return new XDocument(
+            new XElement("AxReport",
+                new XElement("Name", spec.Name),
+                parametersEl,
+                datasetsEl,
+                designEl));
+    }
+
+    /// <summary>
+    /// Builds one <c>AxReportTablix</c> element. When <paramref name="fields"/> is
+    /// provided, emits a column hierarchy, a bold header row, and a detail data row.
+    /// When empty, produces a minimal tablix shell for manual completion.
+    /// </summary>
+    private static XElement BuildTablix(string datasetName, IReadOnlyList<string>? fields, int index)
+    {
+        var name = $"Tablix{index}";
+
+        if (fields is not { Count: > 0 })
+        {
+            // Minimal shell — developer fills in columns manually.
+            return new XElement("AxReportTablix",
+                new XElement("Name",        name),
+                new XElement("DataSetName", datasetName),
+                new XElement("TablixBody",
+                    new XElement("TablixColumns"),
+                    new XElement("TablixRows")),
+                new XElement("TablixColumnHierarchy",
+                    new XElement("TablixMembers")),
+                new XElement("TablixRowHierarchy",
+                    new XElement("TablixMembers",
+                        new XElement("TablixMember",
+                            new XElement("Group", new XAttribute("Name", "Detail"))))));
+        }
+
+        // Column width definitions (2 in per column).
+        var columnEls = fields.Select(_ =>
+            new XElement("TablixColumn", new XElement("Width", "2in")));
+
+        // Header row — one bold textbox per field.
+        var headerCells = fields.Select(f =>
+            new XElement("TablixCell",
+                new XElement("CellContents",
+                    new XElement("Textbox", new XAttribute("Name", $"{name}_{f}_Header"),
+                        new XElement("Value", f),
+                        new XElement("Style",
+                            new XElement("FontWeight", "Bold"),
+                            new XElement("BackgroundColor", "#e0e0e0"))))));
+
+        // Detail row — one =Fields!<Field>.Value textbox per field.
+        var dataCells = fields.Select(f =>
+            new XElement("TablixCell",
+                new XElement("CellContents",
+                    new XElement("Textbox", new XAttribute("Name", $"{name}_{f}"),
+                        new XElement("Value", $"=Fields!{f}.Value")))));
+
+        // Column hierarchy: one static member per column.
+        var colMembers = fields.Select(_ => new XElement("TablixMember"));
+
+        return new XElement("AxReportTablix",
+            new XElement("Name",        name),
+            new XElement("DataSetName", datasetName),
+            new XElement("TablixBody",
+                new XElement("TablixColumns", columnEls),
+                new XElement("TablixRows",
+                    new XElement("TablixRow",
+                        new XElement("Height", "0.25in"),
+                        new XElement("TablixCells", headerCells)),
+                    new XElement("TablixRow",
+                        new XElement("Height", "0.25in"),
+                        new XElement("TablixCells", dataCells)))),
+            new XElement("TablixColumnHierarchy",
+                new XElement("TablixMembers", colMembers)),
+            new XElement("TablixRowHierarchy",
+                new XElement("TablixMembers",
+                    new XElement("TablixMember"), // static header row
+                    new XElement("TablixMember",  // detail data row
+                        new XElement("Group", new XAttribute("Name", "Detail"))))));
+    }
+
+    /// <summary>
+    /// Scaffolds an <c>AxClass</c> implementing <c>SrsReportDataProviderBase</c>
+    /// with a <c>[SRSReportDataSet]</c> getter per dataset and a
+    /// <c>processReport()</c> override with a <c>QueryRun</c> skeleton.
+    /// When <see cref="ReportSpec.Parameters"/> is non-empty, the declaration
+    /// includes a typed cast to the companion contract. Companion: <see cref="ReportContract"/>.
+    /// </summary>
+    public static XDocument ReportDp(ReportSpec spec)
+    {
+        ArgumentNullException.ThrowIfNull(spec);
+        var dp       = spec.EffectiveDpClass;
+        var tmp      = spec.EffectiveTmpTable;
+        var datasets = spec.EffectiveDatasets;
+
+        // Member fields for every dataset's temp table.
+        var memberDecls = string.Join("\n", datasets.Select(ds =>
+            $"    {ds.DpClass + "Tmp"} {char.ToLower(ds.DpClass[0]) + ds.DpClass[1..]}Tmp;"));
+
+        var declaration =
+            $"[SRSReportDataContract(\"{spec.ContractClass}\")]\n" +
+            $"class {dp} extends SrsReportDataProviderBase\n" +
+            "{\n" +
+            memberDecls + "\n" +
+            "}\n";
+
+        // Build one getter method per dataset.
+        var getterMethods = datasets.Select((ds, i) =>
+        {
+            var dsTmp    = ds.DpClass + "Tmp";
+            var dsField  = char.ToLower(ds.DpClass[0]) + ds.DpClass[1..] + "Tmp";
+            var dsGetter = "get" + dsTmp;
+            var src =
+                $"[SRSReportDataSet(\"{ds.Name}\")]\n" +
+                $"public {dsTmp} {dsGetter}()\n" +
+                "{\n" +
+                $"    select {dsField};\n" +
+                $"    return {dsField};\n" +
+                "}\n";
+            return new XElement("Method",
+                new XElement("Name",   dsGetter),
+                new XElement("Source", src));
+        }).ToList();
+
+        // processReport — contract cast only when parameters are defined.
+        var contractLine = spec.Parameters is { Count: > 0 }
+            ? $"\n    {spec.ContractClass} contract = this.parmDataContract() as {spec.ContractClass};\n"
+            : "\n";
+
+        var processReportSrc =
+            "public void processReport()\n" +
+            "{\n" +
+            contractLine +
+            "    QueryRun qr = new QueryRun(this.parmQuery());\n" +
+            "\n" +
+            "    ttsbegin;\n" +
+            "    while (qr.next())\n" +
+            "    {\n" +
+            "        // Retrieve the primary source buffer:\n" +
+            "        // MyTable src = qr.get(tableNum(MyTable));\n" +
+            "\n" +
+            "        // Populate the staging table and insert:\n" +
+            "        // " + (datasets[0].DpClass[0] | 0x20) + datasets[0].DpClass[1..] + "Tmp.Field1 = src.Field1;\n" +
+            "        // " + (datasets[0].DpClass[0] | 0x20) + datasets[0].DpClass[1..] + "Tmp.insert();\n" +
+            "    }\n" +
+            "    ttscommit;\n" +
+            "}\n";
+
+        getterMethods.Add(new XElement("Method",
+            new XElement("Name",   "processReport"),
+            new XElement("Source", processReportSrc)));
+
+        return new XDocument(
+            new XElement("AxClass",
+                new XElement("Name",    dp),
+                new XElement("Extends", "SrsReportDataProviderBase"),
+                new XElement("SourceCode",
+                    new XElement("Declaration", declaration),
+                    new XElement("Methods", getterMethods))));
+    }
+
+    /// <summary>
+    /// Scaffolds the companion <c>SrsReportDataContractBase</c> class for
+    /// <see cref="ReportDp"/>. Emits one <c>parm*()</c> accessor per entry in
+    /// <see cref="ReportSpec.Parameters"/>. Returns <see langword="null"/> when the
+    /// spec has no parameters (no contract class needed).
+    /// </summary>
+    public static XDocument? ReportContract(ReportSpec spec)
+    {
+        ArgumentNullException.ThrowIfNull(spec);
+        if (spec.Parameters is not { Count: > 0 }) return null;
+
+        var contractName = spec.ContractClass;
+
+        // Map SSRS DataType to X++ primitive.
+        static string XppType(string dt) => dt switch
+        {
+            "Integer"              => "int",
+            "DateTime"             => "utcDateTime",
+            "Boolean"              => "boolean",
+            "Decimal" or "Float"   => "real",
+            _                      => "str",
+        };
+
+        var memberDecls = string.Join("\n",
+            spec.Parameters.Select(p => $"    {XppType(p.DataType)} {char.ToLower(p.Name[0])}{p.Name[1..]};"));
+
+        var declaration =
+            "[DataContractAttribute]\n" +
+            $"class {contractName} extends SrsReportDataContractBase\n" +
+            "{\n" +
+            memberDecls + "\n" +
+            "}\n";
+
+        var parmMethods = spec.Parameters.Select(p =>
+        {
+            var member  = char.ToLower(p.Name[0]) + p.Name[1..];
+            var xppType = XppType(p.DataType);
+            var src =
+                $"[DataMemberAttribute('{p.Name}')]\n" +
+                $"public {xppType} parm{p.Name}({xppType} _{member} = {member})\n" +
+                "{\n" +
+                $"    {member} = _{member};\n" +
+                $"    return {member};\n" +
+                "}\n";
+            return new XElement("Method",
+                new XElement("Name",   $"parm{p.Name}"),
+                new XElement("Source", src));
+        }).ToList();
+
+        return new XDocument(
+            new XElement("AxClass",
+                new XElement("Name",    contractName),
+                new XElement("Extends", "SrsReportDataContractBase"),
+                new XElement("SourceCode",
+                    new XElement("Declaration", declaration),
+                    new XElement("Methods", parmMethods))));
+    }
+
     private static bool AppendRefs(XElement root, string containerName, string itemName, IEnumerable<string>? values)
     {
         var items = (values ?? Enumerable.Empty<string>())
@@ -376,6 +646,52 @@ public static class XppScaffolder
 }
 
 public sealed record EntityFieldSpec(string Name, string? DataField, bool IsMandatory);
+
+/// <summary>One dataset within an <c>AxReport</c>, bound to a DP class.</summary>
+public sealed record ReportDatasetSpec(
+    string Name,
+    string DpClass,
+    IReadOnlyList<string>? Fields = null);
+
+/// <summary>One SSRS report parameter exposed on the report dialog.</summary>
+public sealed record ReportParameterSpec(
+    string Name,
+    string DataType = "String",
+    bool AllowBlank = true,
+    bool Prompt = true);
+
+/// <summary>
+/// Parameters for <see cref="XppScaffolder.Report"/>, <see cref="XppScaffolder.ReportDp"/>,
+/// and <see cref="XppScaffolder.ReportContract"/>.
+/// Derived effective names are computed by the <c>Effective*</c> properties when the caller
+/// does not supply an explicit override.
+/// </summary>
+public sealed record ReportSpec(
+    string Name,
+    string? DpClass = null,
+    string? TmpTable = null,
+    string? DatasetName = null,
+    string? Caption = null,
+    IReadOnlyList<ReportDatasetSpec>? Datasets = null,
+    IReadOnlyList<string>? Fields = null,
+    IReadOnlyList<ReportParameterSpec>? Parameters = null)
+{
+    public string EffectiveDpClass  => string.IsNullOrWhiteSpace(DpClass)     ? Name + "DP"  : DpClass!;
+    public string EffectiveTmpTable => string.IsNullOrWhiteSpace(TmpTable)    ? Name + "Tmp" : TmpTable!;
+    public string EffectiveDataset  => string.IsNullOrWhiteSpace(DatasetName) ? Name + "DS"  : DatasetName!;
+
+    /// <summary>
+    /// Effective dataset list: either caller-supplied multi-dataset list, or the single
+    /// primary dataset derived from <see cref="EffectiveDataset"/> / <see cref="EffectiveDpClass"/>.
+    /// </summary>
+    public IReadOnlyList<ReportDatasetSpec> EffectiveDatasets =>
+        (Datasets is { Count: > 0 })
+            ? Datasets
+            : [new ReportDatasetSpec(EffectiveDataset, EffectiveDpClass, Fields)];
+
+    /// <summary>Name of the companion DataContract class.</summary>
+    public string ContractClass => EffectiveDpClass + "Contract";
+}
 
 public sealed record TableFieldSpec(string Name, string? Edt, string? Label, bool Mandatory);
 

--- a/tests/D365FO.Core.Tests/D365FO.Core.Tests.csproj
+++ b/tests/D365FO.Core.Tests/D365FO.Core.Tests.csproj
@@ -23,4 +23,11 @@
     <ProjectReference Include="..\..\src\D365FO.Mcp\D365FO.Mcp.csproj" />
   </ItemGroup>
 
+  <ItemGroup>
+    <Content Include="..\Samples\**">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+      <Link>Samples\%(RecursiveDir)%(Filename)%(Extension)</Link>
+    </Content>
+  </ItemGroup>
+
 </Project>

--- a/tests/D365FO.Core.Tests/LabelTxtExtractorTests.cs
+++ b/tests/D365FO.Core.Tests/LabelTxtExtractorTests.cs
@@ -41,7 +41,8 @@ public class LabelTxtExtractorTests : IDisposable
         var batches = ex.ExtractAll(_root).ToList();
         var batch = Assert.Single(batches);
         Assert.Equal(4, batch.Labels.Count);
-        var title = batch.Labels.First(l => l.Key == "Title" && l.Language == "en-us");
+        // Language is normalized to BCP-47 canonical form on ingest: en-us → en-US.
+        var title = batch.Labels.First(l => l.Key == "Title" && l.Language == "en-US");
         Assert.Equal("Fleet Manager", title.Value);
         var multi = batch.Labels.First(l => l.Key == "MultiEq");
         Assert.Equal("a=b=c", multi.Value); // split on first '=' only

--- a/tests/D365FO.Core.Tests/MiniAotEndToEndTests.cs
+++ b/tests/D365FO.Core.Tests/MiniAotEndToEndTests.cs
@@ -1,0 +1,202 @@
+using D365FO.Core.Extract;
+using D365FO.Core.Index;
+using System.Text.Json;
+using Xunit;
+
+namespace D365FO.Core.Tests;
+
+/// <summary>
+/// End-to-end pipeline tests driven by a checked-in "mini AOT" fixture.
+/// Covers: XML parse → SQLite ingest → repository queries.
+/// </summary>
+public class MiniAotEndToEndTests : IDisposable
+{
+    private static readonly string SamplesDir =
+        Path.GetFullPath(Path.Combine(AppContext.BaseDirectory, "Samples", "MiniAot"));
+
+    private readonly string _dbPath = Path.Combine(
+        Path.GetTempPath(), $"d365fo-miniaot-{Guid.NewGuid():N}.sqlite");
+
+    private readonly MetadataRepository _repo;
+
+    public MiniAotEndToEndTests()
+    {
+        _repo = new MetadataRepository(_dbPath);
+        _repo.EnsureSchema();
+
+        var ex = new MetadataExtractor();
+        foreach (var batch in ex.ExtractAll(SamplesDir))
+            _repo.ApplyExtract(batch);
+    }
+
+    public void Dispose()
+    {
+        Microsoft.Data.Sqlite.SqliteConnection.ClearAllPools();
+        foreach (var ext in new[] { "", "-wal", "-shm" })
+        {
+            var p = _dbPath + ext;
+            if (File.Exists(p)) File.Delete(p);
+        }
+    }
+
+    // ─── Fixture sanity ────────────────────────────────────────────────────
+
+    [Fact]
+    public void Samples_fixture_exists()
+    {
+        Assert.True(Directory.Exists(SamplesDir),
+            $"Fixture directory missing: {SamplesDir}");
+    }
+
+    // ─── Extract: model-level assertions ───────────────────────────────────
+
+    [Fact]
+    public void ExtractAll_finds_one_model_with_correct_publisher()
+    {
+        var ex = new MetadataExtractor();
+        var batches = ex.ExtractAll(SamplesDir).ToList();
+
+        var batch = Assert.Single(batches);
+        Assert.Equal("TestModel", batch.Model);
+        Assert.Equal("Contoso", batch.Publisher);
+        Assert.Equal("usr", batch.Layer);
+    }
+
+    [Fact]
+    public void ExtractAll_has_ApplicationSuite_dependency()
+    {
+        var ex = new MetadataExtractor();
+        var batch = ex.ExtractAll(SamplesDir).Single();
+
+        Assert.Contains("ApplicationSuite", batch.Dependencies);
+    }
+
+    // ─── Extract: table assertions ─────────────────────────────────────────
+
+    [Fact]
+    public void ExtractAll_parses_FmVehicle_fields()
+    {
+        var ex = new MetadataExtractor();
+        var batch = ex.ExtractAll(SamplesDir).Single();
+
+        var table = Assert.Single(batch.Tables);
+        Assert.Equal("FmVehicle", table.Name);
+        Assert.Equal(3, table.Fields.Count);
+
+        var vin = table.Fields.Single(f => f.Name == "VIN");
+        Assert.True(vin.Mandatory);
+        Assert.Equal("VinEdt", vin.EdtName);
+
+        Assert.Contains(table.Fields, f => f.Name == "Make");
+        Assert.Contains(table.Fields, f => f.Name == "Year");
+    }
+
+    // ─── Extract: class assertions ─────────────────────────────────────────
+
+    [Fact]
+    public void ExtractAll_parses_FmVehicleService_methods()
+    {
+        var ex = new MetadataExtractor();
+        var batch = ex.ExtractAll(SamplesDir).Single();
+
+        var cls = Assert.Single(batch.Classes);
+        Assert.Equal("FmVehicleService", cls.Name);
+        Assert.Equal(3, cls.Methods.Count);
+
+        Assert.Contains(cls.Methods, m => m.Name == "new");
+        Assert.Contains(cls.Methods, m => m.Name == "run");
+        Assert.Contains(cls.Methods, m => m.Name == "construct");
+    }
+
+    // ─── Repository: count assertions ──────────────────────────────────────
+
+    [Fact]
+    public void Repository_counts_match_fixture()
+    {
+        var counts = _repo.CountAll();
+        Assert.Equal(1, counts.Tables);
+        Assert.Equal(3, counts.Fields);
+        Assert.Equal(1, counts.Classes);
+    }
+
+    // ─── Repository: GetTableDetails snapshot ──────────────────────────────
+
+    [Fact]
+    public void GetTableDetails_FmVehicle_returns_correct_shape()
+    {
+        var details = _repo.GetTableDetails("FmVehicle");
+        Assert.NotNull(details);
+        Assert.Equal("FmVehicle", details!.Table.Name);
+        Assert.Equal("TestModel", details.Table.Model);
+        Assert.Equal("@Fleet:Vehicle", details.Table.Label);
+        Assert.Equal(3, details.Fields.Count);
+
+        var vin = details.Fields.Single(f => f.Name == "VIN");
+        Assert.True(vin.Mandatory);
+        Assert.Equal("VinEdt", vin.EdtName);
+    }
+
+    [Fact]
+    public void GetTableDetails_FmVehicle_has_alternateKey_index()
+    {
+        var indexes = _repo.GetTableIndexes("FmVehicle");
+        Assert.NotEmpty(indexes);
+        var vinIdx = indexes.Single(i => i.Name == "VINIdx");
+        Assert.True(vinIdx.AlternateKey);
+    }
+
+    // ─── Repository: GetClassDetails snapshot ──────────────────────────────
+
+    [Fact]
+    public void GetClassDetails_FmVehicleService_returns_correct_shape()
+    {
+        var details = _repo.GetClassDetails("FmVehicleService");
+        Assert.NotNull(details);
+        Assert.Equal("FmVehicleService", details!.Class.Name);
+        Assert.Equal("TestModel", details.Class.Model);
+        Assert.Equal(3, details.Methods.Count);
+
+        Assert.Contains(details.Methods, m => m.Name == "construct");
+    }
+
+    // ─── Repository: serialization round-trip ──────────────────────────────
+
+    [Fact]
+    public void GetTableDetails_serializes_to_valid_json()
+    {
+        var details = _repo.GetTableDetails("FmVehicle");
+        Assert.NotNull(details);
+        var json = JsonSerializer.Serialize(details, new JsonSerializerOptions { WriteIndented = false });
+        Assert.StartsWith("{", json);
+        Assert.Contains("FmVehicle", json);
+        Assert.Contains("VIN", json);
+    }
+
+    [Fact]
+    public void GetClassDetails_serializes_to_valid_json()
+    {
+        var details = _repo.GetClassDetails("FmVehicleService");
+        Assert.NotNull(details);
+        var json = JsonSerializer.Serialize(details, new JsonSerializerOptions { WriteIndented = false });
+        Assert.StartsWith("{", json);
+        Assert.Contains("FmVehicleService", json);
+        Assert.Contains("run", json);
+    }
+
+    // ─── Repository: idempotency ────────────────────────────────────────────
+
+    [Fact]
+    public void ApplyExtract_twice_is_idempotent()
+    {
+        var ex = new MetadataExtractor();
+        var batches = ex.ExtractAll(SamplesDir).ToList();
+
+        foreach (var b in batches)
+            _repo.ApplyExtract(b);
+
+        var counts = _repo.CountAll();
+        Assert.Equal(1, counts.Tables);
+        Assert.Equal(3, counts.Fields);
+        Assert.Equal(1, counts.Classes);
+    }
+}

--- a/tests/Samples/MiniAot/TestModel/Descriptor/TestModel.xml
+++ b/tests/Samples/MiniAot/TestModel/Descriptor/TestModel.xml
@@ -1,0 +1,8 @@
+<AxModelInfo>
+  <Name>TestModel</Name>
+  <Publisher>Contoso</Publisher>
+  <Layer>usr</Layer>
+  <ModuleReferences>
+    <string>ApplicationSuite</string>
+  </ModuleReferences>
+</AxModelInfo>

--- a/tests/Samples/MiniAot/TestModel/TestModel/AxClass/FmVehicleService.xml
+++ b/tests/Samples/MiniAot/TestModel/TestModel/AxClass/FmVehicleService.xml
@@ -1,0 +1,46 @@
+<AxClass>
+  <Name>FmVehicleService</Name>
+  <SourceCode>
+    <Declaration><![CDATA[
+/// <summary>
+/// Service class for fleet vehicle operations.
+/// </summary>
+public class FmVehicleService
+{
+    FmVehicle vehicle;
+}
+]]></Declaration>
+    <Methods>
+      <Method>
+        <Name>new</Name>
+        <Source><![CDATA[
+    public void new()
+    {
+        super();
+    }
+]]></Source>
+      </Method>
+      <Method>
+        <Name>run</Name>
+        <Source><![CDATA[
+    public void run()
+    {
+        FmVehicle v;
+        select firstOnly v
+            where v.VIN != '';
+        Info(strFmt("@Fleet:Found", v.RecId));
+    }
+]]></Source>
+      </Method>
+      <Method>
+        <Name>construct</Name>
+        <Source><![CDATA[
+    public static FmVehicleService construct()
+    {
+        return new FmVehicleService();
+    }
+]]></Source>
+      </Method>
+    </Methods>
+  </SourceCode>
+</AxClass>

--- a/tests/Samples/MiniAot/TestModel/TestModel/AxTable/FmVehicle.xml
+++ b/tests/Samples/MiniAot/TestModel/TestModel/AxTable/FmVehicle.xml
@@ -1,0 +1,33 @@
+<AxTable>
+  <Name>FmVehicle</Name>
+  <Label>@Fleet:Vehicle</Label>
+  <Fields>
+    <AxTableField xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:type="AxTableFieldString">
+      <Name>VIN</Name>
+      <ExtendedDataType>VinEdt</ExtendedDataType>
+      <Mandatory>Yes</Mandatory>
+      <StringSize>17</StringSize>
+    </AxTableField>
+    <AxTableField xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:type="AxTableFieldString">
+      <Name>Make</Name>
+      <ExtendedDataType>Name</ExtendedDataType>
+    </AxTableField>
+    <AxTableField xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:type="AxTableFieldInt">
+      <Name>Year</Name>
+    </AxTableField>
+  </Fields>
+  <FullTextIndexes />
+  <Indexes>
+    <AxTableIndex>
+      <Name>VINIdx</Name>
+      <AlternateKey>Yes</AlternateKey>
+      <Fields>
+        <AxTableIndexField>
+          <DataField>VIN</DataField>
+        </AxTableIndexField>
+      </Fields>
+    </AxTableIndex>
+  </Indexes>
+  <Relations />
+  <StateMachines />
+</AxTable>


### PR DESCRIPTION
… tests

- daemon start: --packages, --no-watch, --watch-debounce flags; FileSystemWatcher auto-triggers incremental index refresh on *.xml changes (debounce 3s default)

- schema v9: HasDocComment / HasTodayCall / HasDoInsertOrUpdate boolean flags on Methods + TableMethods; populated at extract time by scanning <Source> CDATA

- lint: 3 new categories -- today-usage (BPUpgradeCodeToday), do-insert-update, doc-comment-missing (BPXmlDocNoDocumentationComments); SARIF metadata included

- tests/Samples/MiniAot: FmVehicle (table) + FmVehicleService (class) fixture; MiniAotEndToEndTests.cs -- 12 E2E tests (extract -> ingest -> query -> serialize)

- docs: ARCHITECTURE.md (schema v9 description, Daemon section), EXAMPLES.md (lint table 6 categories, daemon --packages/--no-watch examples), ROADMAP.md (shipped items removed)

- skills: xpp-best-practice-rules updated with 3 new lint categories; all 15 skills regenerated via emit-skills.ps1