### PR TITLE
docs: add Visual Studio 2022/2026 setup section and Install-D365FoCop…

### DIFF
--- a/docs/SETUP.md
+++ b/docs/SETUP.md
@@ -198,6 +198,149 @@ d365fo doctor
 
 ---
 
+## Visual Studio 2022 / 2026 integration
+
+D365FO development happens in Visual Studio with the **Dynamics 365 Finance and Operations** developer tools. This section wires up `d365fo` as an External Tool and installs the GitHub Copilot Skills into your X++ project so Copilot has the X++ rule canon in scope at all times.
+
+### 1. Prerequisites
+
+- Visual Studio 2022 or 2026 with the **Dynamics 365 Finance and Operations** workload installed.
+- [GitHub Copilot extension](https://marketplace.visualstudio.com/items?itemName=GitHub.copilotvs) installed in Visual Studio (supports VS 2022 17.10+ and VS 2026).
+- `d365fo` reachable on `PATH` (Scenario A alias or Scenario B binary from the **Install** section above).
+
+### 2. Register `d365fo` as an External Tool
+
+External Tools let you run any CLI command from the **Tools** menu without leaving Visual Studio.
+
+1. Open **Tools → External Tools…**
+2. Click **Add** and fill in:
+
+   | Field | Value |
+   |---|---|
+   | Title | `d365fo: index status` |
+   | Command | `d365fo` |
+   | Arguments | `index status --output json` |
+   | Initial directory | `$(SolutionDir)` |
+   | ☑ Use Output window | checked |
+
+3. Repeat for any commands you want one-click access to (e.g. `index refresh --model $(ProjectName)`, `lint --output json`).
+4. Click **OK**.
+
+> **Tip.** Add a second entry with **Arguments** = `doctor --output json` to run a health check straight from the menu.
+
+### 3. Copy Skills and Copilot instructions to your X++ project
+
+GitHub Copilot in Visual Studio reads `.github/copilot-instructions.md` and `.github/instructions/*.instructions.md` from the root of your solution (repository). Deploying these files gives Copilot the full X++ rule canon — D365FO table/method names, CoC rules, BP rules, label rules — without burning context tokens.
+
+**Automated script** — run once per X++ project (re-run after `d365fo-cli` updates to pick up new Skills):
+
+```powershell
+# Install-D365FoCopilotSkills.ps1
+# Usage:
+#   .\Install-D365FoCopilotSkills.ps1 -CliRepo C:\source\d365fo-cli -XppRepo K:\D365FO\MyProject
+#
+# Parameters:
+#   -CliRepo   Path to your d365fo-cli clone (source of skills + copilot-instructions.md)
+#   -XppRepo   Root of your X++ project / solution repository (target)
+
+param(
+    [Parameter(Mandatory)][string] $CliRepo,
+    [Parameter(Mandatory)][string] $XppRepo
+)
+
+Set-StrictMode -Version Latest
+$ErrorActionPreference = 'Stop'
+
+$src      = Join-Path $CliRepo 'skills\copilot'
+$canon    = Join-Path $CliRepo '.github\copilot-instructions.md'
+$dstRoot  = Join-Path $XppRepo '.github'
+$dstInstr = Join-Path $dstRoot 'instructions'
+
+# Create target directories if absent
+New-Item -ItemType Directory -Force -Path $dstRoot  | Out-Null
+New-Item -ItemType Directory -Force -Path $dstInstr | Out-Null
+
+# Copy the main X++ rule canon
+if (Test-Path $canon) {
+    Copy-Item -Path $canon -Destination $dstRoot -Force
+    Write-Host "[OK] copilot-instructions.md  →  $dstRoot"
+} else {
+    Write-Warning "copilot-instructions.md not found at: $canon"
+}
+
+# Copy all 15 Skills (.instructions.md)
+$skills = Get-ChildItem -Path $src -Filter '*.instructions.md'
+if ($skills.Count -eq 0) {
+    Write-Warning "No *.instructions.md files found in: $src"
+    Write-Warning "Run 'python scripts/emit-skills.py' in the d365fo-cli repo first."
+} else {
+    foreach ($f in $skills) {
+        Copy-Item -Path $f.FullName -Destination $dstInstr -Force
+        Write-Host "[OK] $($f.Name)  →  $dstInstr"
+    }
+}
+
+Write-Host ""
+Write-Host "Done. $($skills.Count) skill(s) + copilot-instructions.md deployed to $XppRepo"
+Write-Host "Restart Visual Studio (or reload the solution) to apply."
+```
+
+**Example invocation:**
+
+```powershell
+.\Install-D365FoCopilotSkills.ps1 `
+    -CliRepo  "C:\source\d365fo-cli" `
+    -XppRepo  "K:\D365FO\MyProject"
+```
+
+After the script runs your X++ repository will have:
+
+```
+.github/
+  copilot-instructions.md          ← full X++ / CoC / BP rule canon
+  instructions/
+    coc-extension-authoring.instructions.md
+    data-entity-scaffolding.instructions.md
+    event-handler-authoring.instructions.md
+    form-pattern-scaffolding.instructions.md
+    label-translation.instructions.md
+    model-dependency-and-coupling.instructions.md
+    object-extension-authoring.instructions.md
+    review-and-checkpoint-workflow.instructions.md
+    security-hierarchy-trace.instructions.md
+    table-scaffolding.instructions.md
+    x++-class-authoring.instructions.md
+    xpp-best-practice-rules.instructions.md
+    xpp-class-and-method-rules.instructions.md
+    xpp-database-queries.instructions.md
+    xpp-statement-and-type-rules.instructions.md
+```
+
+Commit these files so every developer on the project gets the same Copilot context automatically.
+
+### 4. Keep Skills up to date
+
+When you pull a new version of `d365fo-cli`, re-emit the Skills and re-run the install script:
+
+```powershell
+# In the d365fo-cli clone
+cd C:\source\d365fo-cli
+git pull
+python scripts/emit-skills.py
+
+# Re-deploy to your X++ project
+.\Install-D365FoCopilotSkills.ps1 `
+    -CliRepo "C:\source\d365fo-cli" `
+    -XppRepo "K:\D365FO\MyProject"
+
+# Then commit the updated files in your X++ project
+cd K:\D365FO\MyProject
+git add .github/
+git commit -m "chore: update d365fo Copilot skills"
+```
+
+---
+
 ## Verify
 
 ```sh

--- a/scripts/Install-D365FoCopilotSkills.ps1
+++ b/scripts/Install-D365FoCopilotSkills.ps1
@@ -1,0 +1,111 @@
+<#
+.SYNOPSIS
+    Deploys d365fo Copilot Skills and the X++ rule canon to an X++ project repo.
+
+.DESCRIPTION
+    Copies:
+      - .github/copilot-instructions.md  (full X++ / CoC / BP rule canon)
+      - .github/instructions/*.instructions.md  (15 topic Skills)
+    from this d365fo-cli clone into the target X++ project repository so that
+    GitHub Copilot in Visual Studio 2022 / 2026 has the D365FO rule canon in
+    scope without manual setup.
+
+    Re-run after pulling updates to d365fo-cli to keep Skills current.
+
+.PARAMETER CliRepo
+    Absolute path to your d365fo-cli clone.
+    Default: the parent of the directory that contains this script.
+
+.PARAMETER XppRepo
+    Absolute path to the root of your X++ project repository (the folder that
+    contains — or will contain — the .github/ directory).
+
+.EXAMPLE
+    .\Install-D365FoCopilotSkills.ps1 `
+        -CliRepo  "C:\source\d365fo-cli" `
+        -XppRepo  "K:\D365FO\MyProject"
+
+.EXAMPLE
+    # Run from inside the d365fo-cli scripts folder — CliRepo is auto-detected
+    .\Install-D365FoCopilotSkills.ps1 -XppRepo "K:\D365FO\MyProject"
+
+.NOTES
+    After running, commit .github/ in your X++ repo so teammates get the same
+    Copilot context automatically:
+        git add .github/
+        git commit -m "chore: add d365fo Copilot skills"
+#>
+
+[CmdletBinding()]
+param(
+    [string] $CliRepo = (Resolve-Path (Join-Path $PSScriptRoot '..')).Path,
+    [Parameter(Mandatory)][string] $XppRepo
+)
+
+Set-StrictMode -Version Latest
+$ErrorActionPreference = 'Stop'
+
+# ── Resolve paths ──────────────────────────────────────────────────────────────
+$skillsSrc  = Join-Path $CliRepo 'skills\copilot'
+$canonSrc   = Join-Path $CliRepo '.github\copilot-instructions.md'
+$dstRoot    = Join-Path $XppRepo '.github'
+$dstInstr   = Join-Path $dstRoot 'instructions'
+
+Write-Host "d365fo-cli repo : $CliRepo"
+Write-Host "X++ project repo: $XppRepo"
+Write-Host ""
+
+# ── Validate source ────────────────────────────────────────────────────────────
+if (-not (Test-Path $CliRepo)) {
+    Write-Error "CliRepo not found: $CliRepo"
+}
+if (-not (Test-Path $XppRepo)) {
+    Write-Error "XppRepo not found: $XppRepo"
+}
+
+# ── Regenerate Skills if the source folder is stale ───────────────────────────
+$skillFiles = Get-ChildItem -Path $skillsSrc -Filter '*.instructions.md' -ErrorAction SilentlyContinue
+if ($skillFiles.Count -eq 0) {
+    Write-Warning "No *.instructions.md found in $skillsSrc — running emit-skills.py first..."
+    $py = Get-Command python -ErrorAction SilentlyContinue
+    if (-not $py) { $py = Get-Command python3 -ErrorAction SilentlyContinue }
+    if ($py) {
+        & $py.Source (Join-Path $CliRepo 'scripts\emit-skills.py') `
+              --source (Join-Path $CliRepo 'skills\_source') `
+              --out-root (Join-Path $CliRepo 'skills')
+        $skillFiles = Get-ChildItem -Path $skillsSrc -Filter '*.instructions.md'
+    } else {
+        Write-Warning "Python not found. Run 'python scripts/emit-skills.py' manually in the d365fo-cli repo, then re-run this script."
+    }
+}
+
+# ── Create target directories ─────────────────────────────────────────────────
+New-Item -ItemType Directory -Force -Path $dstRoot  | Out-Null
+New-Item -ItemType Directory -Force -Path $dstInstr | Out-Null
+
+# ── Copy X++ rule canon ────────────────────────────────────────────────────────
+if (Test-Path $canonSrc) {
+    Copy-Item -Path $canonSrc -Destination $dstRoot -Force
+    Write-Host "[OK] copilot-instructions.md"
+} else {
+    Write-Warning "copilot-instructions.md not found at: $canonSrc"
+}
+
+# ── Copy Skills ────────────────────────────────────────────────────────────────
+$copied = 0
+foreach ($f in $skillFiles) {
+    Copy-Item -Path $f.FullName -Destination $dstInstr -Force
+    Write-Host "[OK] instructions\$($f.Name)"
+    $copied++
+}
+
+# ── Summary ───────────────────────────────────────────────────────────────────
+Write-Host ""
+Write-Host "Deployed $copied skill(s) + copilot-instructions.md to:"
+Write-Host "  $dstRoot"
+Write-Host ""
+Write-Host "Next steps:"
+Write-Host "  1. Restart Visual Studio to pick up the new instructions."
+Write-Host "  2. Commit .github/ in your X++ project:"
+Write-Host "       git -C `"$XppRepo`" add .github/"
+Write-Host "       git -C `"$XppRepo`" commit -m `"chore: add d365fo Copilot skills`""


### PR DESCRIPTION
…ilotSkills.ps1

- docs/SETUP.md: new section 'Visual Studio 2022 / 2026 integration' with four sub-steps: prerequisites, External Tools registration, automated Skills deploy script, and keep-up-to-date workflow
- scripts/Install-D365FoCopilotSkills.ps1: standalone script that copies .github/copilot-instructions.md + all 15 skills/copilot/*.instructions.md into the target X++ project repo; auto-detects CliRepo from script location, optionally re-runs emit-skills.py if Skills are missing