### PR TITLE
feat: enforce d365fo CLI over built-in tools

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -10,7 +10,7 @@
 
 This workspace is the **`d365fo` CLI** — a metadata-aware command-line tool for D365 Finance & Operations. It exposes the same knowledge as `d365fo-mcp-server` but as deterministic shell commands instead of MCP tool calls. Use it whenever you need to reason about a D365FO codebase without burning conversation tokens on long XML or AOT dumps.
 
-> **Audience.** This file gives an AI assistant (GitHub Copilot, Claude Code, Codex CLI, …) the rules for using the `d365fo` CLI to author X++ correctly. Human-facing docs live in [README.md](../README.md) and [docs/](../docs/).
+> **Audience.** This file gives an AI assistant (GitHub Copilot, Claude Code, Codex CLI, …) the rules for using the `d365fo` CLI to author X++ correctly. Human-facing docs live in the [d365fo-cli repository](https://github.com/dynamics365ninja/d365fo-cli).
 
 ---
 
@@ -115,6 +115,60 @@ When the user just wants to *understand* code, never edit:
 - **NEVER auto-run `d365fo build`, `sync`, `bp check`, or `test run`.** They block the user (Windows VM, slow). After scaffolding, say *"Changes scaffolded. Run `d365fo build` when you're ready to validate."* Only build on explicit request ("build", "compile", "check errors").
 - **NEVER use `replace_string_in_file` on `.xml` AOT files when an `index refresh` has not been run since the last edit.** You'll get pre-edit data back from `d365fo get`.
 - **NEVER infer the target model from search results.** Models are policy boundaries (ISV vs customer). Ask, or read from the project's `.rnrproj`.
+
+---
+
+## ⛔ Forbidden agent actions — D365FO XML files
+
+### 5. Forbidden built-in tools for AOT objects
+
+For any D365FO object (`.xml` AOT files, `.xpp` source):
+
+| Tool / action | Why forbidden | Use instead |
+|---|---|---|
+| `create_file` | Wrong location, spaces in path, causes "not valid metadata elements" | `d365fo generate … --out <PATH>` or `--install-to <Model>` |
+| `edit_file` / `apply_patch` / `replace_string_in_file` on raw AOT XML | Corrupts `<SourceCode>` escaping, breaks `<Methods>` nesting | `d365fo generate … --overwrite` for full replace; hand-edit only after `index refresh` |
+| `read_file` on AOT XML to understand object shape | Objects live in SQL index, not as readable source | `d365fo get class/table/form <Name> --output json` |
+| `file_search` / `grep_search` across AOT XML | Can't parse the schema; returns misleading snippets | `d365fo search <type> <query> --output json` |
+| Any shell command to **write** AOT XML (`Set-Content`, `Out-File`, `[IO.File]::WriteAllText`, `New-Item`) | VS 2022 MCP does not support interactive terminal sessions — spawned PowerShell/Python processes hang forever waiting for stdin, causing an infinite spinner with no output | `d365fo generate …` |
+
+### 6. NEVER use scripts as a fallback — and NEVER read-then-write
+
+When `d365fo` is unavailable or returns an error, **NEVER**:
+
+- ❌ Write or run PowerShell scripts (`.ps1`) to modify D365FO XML files
+- ❌ Write or run Python scripts to patch XML
+- ❌ Use any shell execution (`run_in_terminal`, terminal tools) to write AOT files
+- ❌ Generate `Set-Content`, `Out-File`, `[System.IO.File]::WriteAllText` or similar file-write commands targeting `.xml` AOT files
+
+**Critical anti-pattern — NEVER do this:**
+
+```
+// ❌ WRONG — looks reasonable, always fails in VS 2022
+read_file(path)                      // reads XML for "context" — succeeds
+→ manually construct XML edit        // LLM guesses the schema — wrong
+→ generate PowerShell Set-Content    // process spawns, hangs forever, no output
+```
+
+`read_file` exists in VS 2022 but `write_file`/`edit_file` do not. The only correct path to produce AOT XML is `d365fo generate …`.
+
+**Second critical anti-pattern — "CLI failed but I have metadata from open files":**
+
+```
+// ❌ WRONG — a common escalation that must NEVER happen
+d365fo get class Foo --output json   // returns ok:false, internal error
+→ "I verified the metadata from open XML files"   // agent reads raw XML instead
+→ "I have everything I need, proceeding with refactoring"  // agent writes XML directly
+```
+
+**This is forbidden regardless of where the metadata came from.** Even when you can read the correct field names, method signatures, or enum values from open files — the *write path* is still broken without `d365fo generate`. Metadata from open files does **not** substitute for the CLI. Stop and report the `d365fo` error to the user.
+
+**Instead, when a `d365fo` command cannot complete the operation:**
+
+1. Report the exact error to the user (`ok: false` + `error.message`).
+2. Suggest the correct `d365fo` command to use next.
+3. **Skip the step entirely** — never attempt a workaround via scripts or shell.
+4. If no `d365fo` command exists for the operation, tell the user to perform it manually in Visual Studio AOT.
 
 ---
 
@@ -390,7 +444,7 @@ d365fo generate form <Name> --pattern <P> --table <T> \
        --field <F1> --field <F2> --install-to <Model>   # 3. pattern-correct scaffold
 ```
 
-Pattern catalogue: `SimpleList`, `SimpleListDetails`, `DetailsMaster`, `DetailsTransaction`, `Dialog`, `TableOfContents`, `Lookup`, `ListPage`, `Workspace`. See [docs/EXAMPLES.md](../docs/EXAMPLES.md#form-any-of-nine-d365fo-patterns).
+Pattern catalogue: `SimpleList`, `SimpleListDetails`, `DetailsMaster`, `DetailsTransaction`, `Dialog`, `TableOfContents`, `Lookup`, `ListPage`, `Workspace`. See [docs/EXAMPLES.md](https://github.com/dynamics365ninja/d365fo-cli/blob/main/docs/EXAMPLES.md#form-any-of-nine-d365fo-patterns).
 
 ### Tracing security
 
@@ -423,9 +477,9 @@ Combine Learn (syntax authority) with `d365fo` (real metadata: table/field/metho
 
 ## 📦 See also
 
-- [README.md](../README.md) — features, install, agent integration.
-- [docs/SETUP.md](../docs/SETUP.md) — install + configure the CLI and bridge.
-- [docs/EXAMPLES.md](../docs/EXAMPLES.md) — one worked example per command.
-- [docs/MIGRATION_FROM_MCP.md](../docs/MIGRATION_FROM_MCP.md) — moving from `d365fo-mcp-server`.
-- [docs/ROADMAP.md](../docs/ROADMAP.md) — what's still planned.
-- [skills/](../skills/) — focused workflow skills (Copilot + Anthropic flavours) for `Claude Code`, GitHub Copilot, and other agent harnesses.
+- [README.md](https://github.com/dynamics365ninja/d365fo-cli/blob/main/README.md) — features, install, agent integration.
+- [docs/SETUP.md](https://github.com/dynamics365ninja/d365fo-cli/blob/main/docs/SETUP.md) — install + configure the CLI and bridge.
+- [docs/EXAMPLES.md](https://github.com/dynamics365ninja/d365fo-cli/blob/main/docs/EXAMPLES.md) — one worked example per command.
+- [docs/MIGRATION_FROM_MCP.md](https://github.com/dynamics365ninja/d365fo-cli/blob/main/docs/MIGRATION_FROM_MCP.md) — moving from `d365fo-mcp-server`.
+- [docs/ROADMAP.md](https://github.com/dynamics365ninja/d365fo-cli/blob/main/docs/ROADMAP.md) — what's still planned.
+- `.github/instructions/*.instructions.md` — focused workflow skills installed by `Install-D365FoCopilotSkills.ps1` into this repo (Copilot reads them automatically from `.github/instructions/`).

--- a/README.md
+++ b/README.md
@@ -169,6 +169,39 @@ Reference the `SKILL.md` files from `skills/anthropic/` in your session prompt o
 
 ---
 
+## When to use built-in tools vs. `d365fo`
+
+> Quick reference for developers and AI agents working in VS 2022 / VS Code.
+
+| Scenario | Built-in editor / terminal tools | `d365fo` CLI |
+|---|---|---|
+| Read class structure (methods, signatures) | ❌ `get_file` on XML — unreliable schema | ✅ `d365fo get class <Name> --output json` |
+| Read a method body (X++ source) | ❌ | ✅ `d365fo read class <Name> --method <M>` |
+| Inspect table fields / indexes / relations | ❌ `get_file` on AxTable XML — unreliable | ✅ `d365fo get table <Name> --output json` |
+| Search for a class / table / method | ❌ `code_search` / `file_search` — can't parse AOT XML schema, returns misleading snippets | ✅ `d365fo search class <query> --output json` |
+| Check for existing CoC wrappers | ❌ | ✅ `d365fo find coc <Class>::<method> --output json` |
+| Create a new AOT object (class, table, form…) | ❌ `create_file` — wrong location, wrong XML schema | ✅ `d365fo generate class/table/form … --install-to <Model>` |
+| Modify existing AOT XML — targeted method body edit (inside CDATA) | ⚠️ `replace_string_in_file` / `multi_replace_string_in_file` — allowed for method bodies only; run `d365fo index refresh` after | ✅ `d365fo generate … --overwrite` for full-file replace |
+| Modify existing AOT XML — structural change (add field, index, relation…) | ❌ `replace_string_in_file` — corrupts XML structure | ✅ `d365fo generate extension … --overwrite` or VS AOT |
+| Search for a label | ❌ | ✅ `d365fo search label "<text>" --output json` |
+| Resolve a label key | ❌ | ✅ `d365fo resolve label @SYS12345 --lang en-us,cs` |
+| Trace security (Role → Duty → Privilege) | ❌ | ✅ `d365fo get security <Role> --type Role --output json` |
+| Run best-practice check | ❌ | ✅ `d365fo bp check --output json` (Windows VM only, on user request) |
+| Inspect model dependencies | ❌ | ✅ `d365fo get model <Name> --output json` |
+| Build / compile — check errors across workspace | ⚠️ `run_build` — on explicit user request only | ✅ `d365fo build` — **on explicit user request only** |
+| Get compilation errors for a specific file (fast) | ✅ `get_errors` — per-file, no full build needed | ➖ not available |
+| Navigate workspace structure (projects, file lists) | ✅ `get_projects_in_solution`, `get_files_in_project` | ➖ not needed |
+| Read / edit non-AOT files (PS scripts, docs, JSON config) | ✅ `get_file`, `replace_string_in_file`, `multi_replace_string_in_file` | ➖ not needed |
+| Git operations (commit, diff, branch) | ✅ `run_command_in_terminal` — `git …` | ➖ not needed |
+| Refresh index after editing XML | ❌ | ✅ `d365fo index refresh --model <Model>` |
+| Verify index health | ❌ | ✅ `d365fo doctor --output json` + `d365fo index status --output json` |
+
+**One-line rule:** if the file ends in `.xml` and is an AOT object → always `d365fo`. Everything else (config, scripts, docs) → standard editor tools.
+
+> ⛔ **When `d365fo` returns `ok: false`** — report the error to the user and stop. Metadata read from open XML files does **not** substitute for the CLI. Never fall back to PowerShell / Python scripts to write AOT XML: spawned processes hang forever in VS 2022 (no interactive terminal).
+
+---
+
 ## Why CLI instead of MCP?
 
 MCP servers inject every tool definition into the model's context on every single turn. For this project that used to be **54 tools ≈ 2,900 tokens every turn**.

--- a/scripts/Install-D365FoCopilotSkills.ps1
+++ b/scripts/Install-D365FoCopilotSkills.ps1
@@ -66,7 +66,7 @@ if (-not (Test-Path $XppRepo)) {
 # ── Regenerate Skills if the source folder is stale ───────────────────────────
 $skillFiles = Get-ChildItem -Path $skillsSrc -Filter '*.instructions.md' -ErrorAction SilentlyContinue
 if ($skillFiles.Count -eq 0) {
-    Write-Warning "No *.instructions.md found in $skillsSrc — running emit-skills.py first..."
+    Write-Warning "No *.instructions.md found in $skillsSrc - running emit-skills.py first..."
     $py = Get-Command python -ErrorAction SilentlyContinue
     if (-not $py) { $py = Get-Command python3 -ErrorAction SilentlyContinue }
     if ($py) {

--- a/skills/_source/coc-extension-authoring.md
+++ b/skills/_source/coc-extension-authoring.md
@@ -7,6 +7,8 @@ applyTo:
 appliesWhen: User intent mentions Chain-of-Command, CoC, method wrapping, next() pattern, or non-intrusive extension.
 ---
 
+> ⛔ **NEVER write X++ AOT XML files directly** via PowerShell, terminal file commands (`Set-Content`, `Out-File`, `New-Item`), editor write tools, or any raw text approach. The XML schema (`<AxClass>`, `<AxTable>`, `<AxForm>`, `<Methods>`, `<SourceCode>`) is proprietary — LLMs have not been trained on it reliably. **ALWAYS use `d365fo generate …` commands** to produce correct AOT XML. If `d365fo` is unavailable in PATH, stop and ask the user to install it.
+
 # Writing a Chain-of-Command extension safely
 
 > **Source of truth:** [learn:method-wrapping-coc](https://learn.microsoft.com/en-us/dynamics365/fin-ops-core/dev-itpro/extensibility/method-wrapping-coc).

--- a/skills/_source/data-entity-scaffolding.md
+++ b/skills/_source/data-entity-scaffolding.md
@@ -7,6 +7,8 @@ applyTo:
 appliesWhen: User intent mentions data entity, AxDataEntityView, OData, DMF, public entity name, public collection name, or exposing tables to integrations.
 ---
 
+> ⛔ **NEVER write X++ AOT XML files directly** via PowerShell, terminal file commands (`Set-Content`, `Out-File`, `New-Item`), editor write tools, or any raw text approach. The XML schema (`<AxClass>`, `<AxTable>`, `<AxForm>`, `<Methods>`, `<SourceCode>`) is proprietary — LLMs have not been trained on it reliably. **ALWAYS use `d365fo generate …` commands** to produce correct AOT XML. If `d365fo` is unavailable in PATH, stop and ask the user to install it.
+
 # Authoring AxDataEntityView XML
 
 > Data entities are the supported integration surface for D365FO — OData v4,

--- a/skills/_source/event-handler-authoring.md
+++ b/skills/_source/event-handler-authoring.md
@@ -7,6 +7,8 @@ applyTo:
 appliesWhen: User intent mentions event handler, SubscribesTo, DataEventHandler, FormEventHandler, FormDataSourceEventHandler, or reacting to a D365FO platform event.
 ---
 
+> ⛔ **NEVER write X++ AOT XML files directly** via PowerShell, terminal file commands (`Set-Content`, `Out-File`, `New-Item`), editor write tools, or any raw text approach. The XML schema (`<AxClass>`, `<AxTable>`, `<AxForm>`, `<Methods>`, `<SourceCode>`) is proprietary — LLMs have not been trained on it reliably. **ALWAYS use `d365fo generate …` commands** to produce correct AOT XML. If `d365fo` is unavailable in PATH, stop and ask the user to install it.
+
 # Subscribing to D365FO events safely
 
 > Event handlers are the right choice when you need to **react** to a

--- a/skills/_source/form-pattern-scaffolding.md
+++ b/skills/_source/form-pattern-scaffolding.md
@@ -7,6 +7,8 @@ applyTo:
 appliesWhen: User intent mentions creating an AxForm, choosing a form pattern, list pages, master records, dialogs, lookups, workspaces, or details/transaction (header+lines) forms.
 ---
 
+> ⛔ **NEVER write X++ AOT XML files directly** via PowerShell, terminal file commands (`Set-Content`, `Out-File`, `New-Item`), editor write tools, or any raw text approach. The XML schema (`<AxClass>`, `<AxTable>`, `<AxForm>`, `<Methods>`, `<SourceCode>`) is proprietary — LLMs have not been trained on it reliably. **ALWAYS use `d365fo generate …` commands** to produce correct AOT XML. If `d365fo` is unavailable in PATH, stop and ask the user to install it.
+
 # Authoring AxForm XML — pattern-correct
 
 > The CLI's `d365fo generate form` mirrors `d365fo-mcp-server`'s

--- a/skills/_source/label-translation.md
+++ b/skills/_source/label-translation.md
@@ -9,6 +9,8 @@ applyTo:
 appliesWhen: User intent mentions labels, translations, `@SYS`, `@MODULE`, display strings, or any of the `d365fo label create / rename / delete` operations.
 ---
 
+> ⛔ **NEVER write X++ AOT XML files directly** via PowerShell, terminal file commands (`Set-Content`, `Out-File`, `New-Item`), editor write tools, or any raw text approach. The XML schema (`<AxClass>`, `<AxTable>`, `<AxForm>`, `<Methods>`, `<SourceCode>`) is proprietary — LLMs have not been trained on it reliably. **ALWAYS use `d365fo generate …` commands** to produce correct AOT XML. If `d365fo` is unavailable in PATH, stop and ask the user to install it.
+
 # Label workflow — reuse, search, edit
 
 > Hardcoded UI strings fail BP `BPErrorLabelIsText`. Every string passed to

--- a/skills/_source/model-dependency-and-coupling.md
+++ b/skills/_source/model-dependency-and-coupling.md
@@ -7,6 +7,8 @@ applyTo:
 appliesWhen: User intent mentions model dependencies, layer (sys/syp/isv/iss/cus/cup/usr/usp), coupling, fan-in / fan-out / instability metrics, or "which model contains object X".
 ---
 
+> ⛔ **NEVER write X++ AOT XML files directly** via PowerShell, terminal file commands (`Set-Content`, `Out-File`, `New-Item`), editor write tools, or any raw text approach. The XML schema (`<AxClass>`, `<AxTable>`, `<AxForm>`, `<Methods>`, `<SourceCode>`) is proprietary — LLMs have not been trained on it reliably. **ALWAYS use `d365fo generate …` commands** to produce correct AOT XML. If `d365fo` is unavailable in PATH, stop and ask the user to install it.
+
 # Models, dependencies, coupling
 
 > The CLI's `models` group reads the `Descriptor/*.xml` files indexed during

--- a/skills/_source/object-extension-authoring.md
+++ b/skills/_source/object-extension-authoring.md
@@ -10,6 +10,8 @@ applyTo:
 appliesWhen: User intent mentions extending a Table / Form / Edt / Enum (not a class) — adding fields to a standard table, adding controls to a standard form, extending an enum or EDT.
 ---
 
+> ⛔ **NEVER write X++ AOT XML files directly** via PowerShell, terminal file commands (`Set-Content`, `Out-File`, `New-Item`), editor write tools, or any raw text approach. The XML schema (`<AxClass>`, `<AxTable>`, `<AxForm>`, `<Methods>`, `<SourceCode>`) is proprietary — LLMs have not been trained on it reliably. **ALWAYS use `d365fo generate …` commands** to produce correct AOT XML. If `d365fo` is unavailable in PATH, stop and ask the user to install it.
+
 # Authoring object extensions (Table / Form / Edt / Enum)
 
 > Object extensions are the **non-intrusive** way to add fields to standard

--- a/skills/_source/review-and-checkpoint-workflow.md
+++ b/skills/_source/review-and-checkpoint-workflow.md
@@ -10,6 +10,8 @@ applyTo:
 appliesWhen: User intent mentions reviewing changes, accepting / rejecting AI edits, "what changed", AOT diff, structural diff, or VS 2022's missing accept/undo UI.
 ---
 
+> ⛔ **NEVER write X++ AOT XML files directly** via PowerShell, terminal file commands (`Set-Content`, `Out-File`, `New-Item`), editor write tools, or any raw text approach. The XML schema (`<AxClass>`, `<AxTable>`, `<AxForm>`, `<Methods>`, `<SourceCode>`) is proprietary — LLMs have not been trained on it reliably. **ALWAYS use `d365fo generate …` commands** to produce correct AOT XML. If `d365fo` is unavailable in PATH, stop and ask the user to install it.
+
 # Git-checkpoint review workflow
 
 > Visual Studio 2022 has no inline accept/reject UI for AI edits. Use Git as

--- a/skills/_source/security-hierarchy-trace.md
+++ b/skills/_source/security-hierarchy-trace.md
@@ -8,6 +8,8 @@ applyTo:
 appliesWhen: User intent mentions security, roles, duties, privileges, entry points, or access control analysis.
 ---
 
+> ⛔ **NEVER write X++ AOT XML files directly** via PowerShell, terminal file commands (`Set-Content`, `Out-File`, `New-Item`), editor write tools, or any raw text approach. The XML schema (`<AxClass>`, `<AxTable>`, `<AxForm>`, `<Methods>`, `<SourceCode>`) is proprietary — LLMs have not been trained on it reliably. **ALWAYS use `d365fo generate …` commands** to produce correct AOT XML. If `d365fo` is unavailable in PATH, stop and ask the user to install it.
+
 # Tracing D365FO security hierarchies
 
 ## Workflow

--- a/skills/_source/table-scaffolding.md
+++ b/skills/_source/table-scaffolding.md
@@ -7,6 +7,8 @@ applyTo:
 appliesWhen: User intent mentions creating a table, choosing TableGroup / TableType, adding fields / indexes / relations, or temporary (TempDB / InMemory) tables.
 ---
 
+> ⛔ **NEVER write X++ AOT XML files directly** via PowerShell, terminal file commands (`Set-Content`, `Out-File`, `New-Item`), editor write tools, or any raw text approach. The XML schema (`<AxClass>`, `<AxTable>`, `<AxForm>`, `<Methods>`, `<SourceCode>`) is proprietary — LLMs have not been trained on it reliably. **ALWAYS use `d365fo generate …` commands** to produce correct AOT XML. If `d365fo` is unavailable in PATH, stop and ask the user to install it.
+
 # Creating & modifying AxTable definitions
 
 > The CLI's `d365fo generate table` mirrors `d365fo-mcp-server`'s

--- a/skills/_source/x++-class-authoring.md
+++ b/skills/_source/x++-class-authoring.md
@@ -8,6 +8,8 @@ applyTo:
 appliesWhen: User intent mentions X++ classes, Chain-of-Command, SysOperation, controller/service patterns, or method overrides.
 ---
 
+> ⛔ **NEVER write X++ AOT XML files directly** via PowerShell, terminal file commands (`Set-Content`, `Out-File`, `New-Item`), editor write tools, or any raw text approach. The XML schema (`<AxClass>`, `<AxTable>`, `<AxForm>`, `<Methods>`, `<SourceCode>`) is proprietary — LLMs have not been trained on it reliably. **ALWAYS use `d365fo generate …` commands** to produce correct AOT XML. If `d365fo` is unavailable in PATH, stop and ask the user to install it.
+
 # Authoring X++ classes with the d365fo index
 
 Before you write or modify any X++ class, **ground yourself in the index**. The

--- a/skills/_source/xpp-best-practice-rules.md
+++ b/skills/_source/xpp-best-practice-rules.md
@@ -9,6 +9,8 @@ applyTo:
 appliesWhen: User intent involves authoring X++ that must pass `d365fo bp check` / xppbp.exe — i.e. virtually all D365FO code.
 ---
 
+> ⛔ **NEVER write X++ AOT XML files directly** via PowerShell, terminal file commands (`Set-Content`, `Out-File`, `New-Item`), editor write tools, or any raw text approach. The XML schema (`<AxClass>`, `<AxTable>`, `<AxForm>`, `<Methods>`, `<SourceCode>`) is proprietary — LLMs have not been trained on it reliably. **ALWAYS use `d365fo generate …` commands** to produce correct AOT XML. If `d365fo` is unavailable in PATH, stop and ask the user to install it.
+
 # Best-practice rules — generated X++ must be BP-clean
 
 > **Source of truth:** [`d365fo bp check`](../../docs/EXAMPLES.md) — the Windows-VM runner that executes `xppbp.exe`. The list below covers the non-negotiable BP rules every scaffold and hand-edit must satisfy out of the box.

--- a/skills/_source/xpp-class-and-method-rules.md
+++ b/skills/_source/xpp-class-and-method-rules.md
@@ -7,6 +7,8 @@ applyTo:
 appliesWhen: User intent involves declaring an X++ class, choosing access modifiers, designing a constructor, overriding a method, or creating extension methods.
 ---
 
+> ⛔ **NEVER write X++ AOT XML files directly** via PowerShell, terminal file commands (`Set-Content`, `Out-File`, `New-Item`), editor write tools, or any raw text approach. The XML schema (`<AxClass>`, `<AxTable>`, `<AxForm>`, `<Methods>`, `<SourceCode>`) is proprietary — LLMs have not been trained on it reliably. **ALWAYS use `d365fo generate …` commands** to produce correct AOT XML. If `d365fo` is unavailable in PATH, stop and ask the user to install it.
+
 # X++ class & method authoring rules
 
 > **Source of truth:** [learn:xpp-classes-methods](https://learn.microsoft.com/en-us/dynamics365/fin-ops-core/dev-itpro/dev-ref/xpp-classes-methods).

--- a/skills/_source/xpp-database-queries.md
+++ b/skills/_source/xpp-database-queries.md
@@ -9,6 +9,8 @@ applyTo:
 appliesWhen: User intent involves X++ data access — select / while select / joins / aggregates / cross-company / validTimeState / set-based operations.
 ---
 
+> ⛔ **NEVER write X++ AOT XML files directly** via PowerShell, terminal file commands (`Set-Content`, `Out-File`, `New-Item`), editor write tools, or any raw text approach. The XML schema (`<AxClass>`, `<AxTable>`, `<AxForm>`, `<Methods>`, `<SourceCode>`) is proprietary — LLMs have not been trained on it reliably. **ALWAYS use `d365fo generate …` commands** to produce correct AOT XML. If `d365fo` is unavailable in PATH, stop and ask the user to install it.
+
 # X++ database queries — `select` / `while select`
 
 > **Source of truth:** [learn:xpp-select-statement](https://learn.microsoft.com/en-us/dynamics365/fin-ops-core/dev-itpro/dev-ref/xpp-data/xpp-select-statement).

--- a/skills/_source/xpp-statement-and-type-rules.md
+++ b/skills/_source/xpp-statement-and-type-rules.md
@@ -8,6 +8,8 @@ applyTo:
 appliesWhen: User intent involves X++ control flow, switch statements, casting, null/empty checks on date/utcDateTime, or IDisposable resource handling.
 ---
 
+> ⛔ **NEVER write X++ AOT XML files directly** via PowerShell, terminal file commands (`Set-Content`, `Out-File`, `New-Item`), editor write tools, or any raw text approach. The XML schema (`<AxClass>`, `<AxTable>`, `<AxForm>`, `<Methods>`, `<SourceCode>`) is proprietary — LLMs have not been trained on it reliably. **ALWAYS use `d365fo generate …` commands** to produce correct AOT XML. If `d365fo` is unavailable in PATH, stop and ask the user to install it.
+
 # X++ statement & type rules
 
 > **Sources of truth:** [learn:xpp-conditional](https://learn.microsoft.com/en-us/dynamics365/fin-ops-core/dev-itpro/dev-ref/xpp-conditional) and [learn:xpp-variables-data-types](https://learn.microsoft.com/en-us/dynamics365/fin-ops-core/dev-itpro/dev-ref/xpp-variables-data-types).

--- a/skills/copilot/coc-extension-authoring.instructions.md
+++ b/skills/copilot/coc-extension-authoring.instructions.md
@@ -2,6 +2,9 @@
 description: Author a Chain-of-Command extension in D365FO without duplicating existing wrappers. Use when the user asks to "wrap a method", "add a CoC", or "modify behavior of standard method".
 applyTo: '**/AxClass/**_Extension*.xml,**/*_Extension.xpp'
 ---
+
+> ⛔ **NEVER write X++ AOT XML files directly** via PowerShell, terminal file commands (`Set-Content`, `Out-File`, `New-Item`), editor write tools, or any raw text approach. The XML schema (`<AxClass>`, `<AxTable>`, `<AxForm>`, `<Methods>`, `<SourceCode>`) is proprietary — LLMs have not been trained on it reliably. **ALWAYS use `d365fo generate …` commands** to produce correct AOT XML. If `d365fo` is unavailable in PATH, stop and ask the user to install it.
+
 # Writing a Chain-of-Command extension safely
 
 > **Source of truth:** [learn:method-wrapping-coc](https://learn.microsoft.com/en-us/dynamics365/fin-ops-core/dev-itpro/extensibility/method-wrapping-coc).

--- a/skills/copilot/data-entity-scaffolding.instructions.md
+++ b/skills/copilot/data-entity-scaffolding.instructions.md
@@ -2,6 +2,9 @@
 description: Scaffold an AxDataEntityView (data entity) in D365 Finance & Operations for OData / DMF (Data Management Framework) integration. Use when the user asks to "create a data entity", "expose a table to OData", or "scaffold an entity for DMF".
 applyTo: '**/AxDataEntityView/**,**/*Entity.xml'
 ---
+
+> ⛔ **NEVER write X++ AOT XML files directly** via PowerShell, terminal file commands (`Set-Content`, `Out-File`, `New-Item`), editor write tools, or any raw text approach. The XML schema (`<AxClass>`, `<AxTable>`, `<AxForm>`, `<Methods>`, `<SourceCode>`) is proprietary — LLMs have not been trained on it reliably. **ALWAYS use `d365fo generate …` commands** to produce correct AOT XML. If `d365fo` is unavailable in PATH, stop and ask the user to install it.
+
 # Authoring AxDataEntityView XML
 
 > Data entities are the supported integration surface for D365FO — OData v4,

--- a/skills/copilot/event-handler-authoring.instructions.md
+++ b/skills/copilot/event-handler-authoring.instructions.md
@@ -2,6 +2,9 @@
 description: Subscribe to a D365FO event (data event on a table, form / form-data-source / form-data-field event, custom delegate on a class) by scaffolding an event-handler class. Use when the user asks to "subscribe to an event", "react to inserted/deleted/updated", or "hook a delegate".
 applyTo: '**/AxClass/**EventHandler*.xml,**/AxClass/**Handler*.xml'
 ---
+
+> ⛔ **NEVER write X++ AOT XML files directly** via PowerShell, terminal file commands (`Set-Content`, `Out-File`, `New-Item`), editor write tools, or any raw text approach. The XML schema (`<AxClass>`, `<AxTable>`, `<AxForm>`, `<Methods>`, `<SourceCode>`) is proprietary — LLMs have not been trained on it reliably. **ALWAYS use `d365fo generate …` commands** to produce correct AOT XML. If `d365fo` is unavailable in PATH, stop and ask the user to install it.
+
 # Subscribing to D365FO events safely
 
 > Event handlers are the right choice when you need to **react** to a

--- a/skills/copilot/form-pattern-scaffolding.instructions.md
+++ b/skills/copilot/form-pattern-scaffolding.instructions.md
@@ -2,6 +2,9 @@
 description: Scaffold an AxForm in D365 Finance & Operations using one of the nine canonical patterns (SimpleList, SimpleListDetails, DetailsMaster, DetailsTransaction, Dialog, TableOfContents, Lookup, ListPage, Workspace). Invoke whenever the user asks to "create a form", "scaffold a list page", "make a dialog", or "build a workspace".
 applyTo: '**/AxForm/**,**/*Form.xml'
 ---
+
+> ⛔ **NEVER write X++ AOT XML files directly** via PowerShell, terminal file commands (`Set-Content`, `Out-File`, `New-Item`), editor write tools, or any raw text approach. The XML schema (`<AxClass>`, `<AxTable>`, `<AxForm>`, `<Methods>`, `<SourceCode>`) is proprietary — LLMs have not been trained on it reliably. **ALWAYS use `d365fo generate …` commands** to produce correct AOT XML. If `d365fo` is unavailable in PATH, stop and ask the user to install it.
+
 # Authoring AxForm XML — pattern-correct
 
 > The CLI's `d365fo generate form` mirrors `d365fo-mcp-server`'s

--- a/skills/copilot/label-translation.instructions.md
+++ b/skills/copilot/label-translation.instructions.md
@@ -2,6 +2,9 @@
 description: Reuse, search, create, rename, or delete D365FO label entries. Invoke whenever a UI string is about to be added to X++/XML, when translating a label across languages, or when refactoring label keys.
 applyTo: '**/*.xpp,**/AxLabelFile/**,**/*.label.txt,**/*Labels*.xml'
 ---
+
+> ⛔ **NEVER write X++ AOT XML files directly** via PowerShell, terminal file commands (`Set-Content`, `Out-File`, `New-Item`), editor write tools, or any raw text approach. The XML schema (`<AxClass>`, `<AxTable>`, `<AxForm>`, `<Methods>`, `<SourceCode>`) is proprietary — LLMs have not been trained on it reliably. **ALWAYS use `d365fo generate …` commands** to produce correct AOT XML. If `d365fo` is unavailable in PATH, stop and ask the user to install it.
+
 # Label workflow — reuse, search, edit
 
 > Hardcoded UI strings fail BP `BPErrorLabelIsText`. Every string passed to

--- a/skills/copilot/model-dependency-and-coupling.instructions.md
+++ b/skills/copilot/model-dependency-and-coupling.instructions.md
@@ -2,6 +2,9 @@
 description: Inspect indexed D365FO models, their declared dependencies, and architectural coupling metrics (fan-in, fan-out, instability, cycles). Use when the user asks "what models depend on X", "is there a cycle", "what's the layer of model Y", or "show coupling".
 applyTo: '**/Descriptor/*.xml,**/AxModel/**'
 ---
+
+> ⛔ **NEVER write X++ AOT XML files directly** via PowerShell, terminal file commands (`Set-Content`, `Out-File`, `New-Item`), editor write tools, or any raw text approach. The XML schema (`<AxClass>`, `<AxTable>`, `<AxForm>`, `<Methods>`, `<SourceCode>`) is proprietary — LLMs have not been trained on it reliably. **ALWAYS use `d365fo generate …` commands** to produce correct AOT XML. If `d365fo` is unavailable in PATH, stop and ask the user to install it.
+
 # Models, dependencies, coupling
 
 > The CLI's `models` group reads the `Descriptor/*.xml` files indexed during

--- a/skills/copilot/object-extension-authoring.instructions.md
+++ b/skills/copilot/object-extension-authoring.instructions.md
@@ -2,6 +2,9 @@
 description: Create a Table / Form / Edt / Enum extension (NOT a class CoC extension) in D365 Finance & Operations. Use when the user asks to "extend a table", "add a field to standard CustTable", "extend an EDT", "add an enum value", or "extend a form via FormExtension".
 applyTo: '**/AxTableExtension/**,**/AxFormExtension/**,**/AxEdtExtension/**,**/AxEnumExtension/**,**/*.Extension.xml'
 ---
+
+> ⛔ **NEVER write X++ AOT XML files directly** via PowerShell, terminal file commands (`Set-Content`, `Out-File`, `New-Item`), editor write tools, or any raw text approach. The XML schema (`<AxClass>`, `<AxTable>`, `<AxForm>`, `<Methods>`, `<SourceCode>`) is proprietary — LLMs have not been trained on it reliably. **ALWAYS use `d365fo generate …` commands** to produce correct AOT XML. If `d365fo` is unavailable in PATH, stop and ask the user to install it.
+
 # Authoring object extensions (Table / Form / Edt / Enum)
 
 > Object extensions are the **non-intrusive** way to add fields to standard

--- a/skills/copilot/review-and-checkpoint-workflow.instructions.md
+++ b/skills/copilot/review-and-checkpoint-workflow.instructions.md
@@ -2,6 +2,9 @@
 description: Use Git as the review layer for AI-driven D365FO edits, and use `d365fo review diff` to get an AOT-semantic summary of XML changes. Invoke whenever the user is about to start a non-trivial change, before "accepting" AI edits, or wants a structural diff (added classes, modified table fields, new CoC wrappers).
 applyTo: '**/AxClass/**,**/AxTable/**,**/AxForm/**,**/*.xpp,**/*.xml'
 ---
+
+> ⛔ **NEVER write X++ AOT XML files directly** via PowerShell, terminal file commands (`Set-Content`, `Out-File`, `New-Item`), editor write tools, or any raw text approach. The XML schema (`<AxClass>`, `<AxTable>`, `<AxForm>`, `<Methods>`, `<SourceCode>`) is proprietary — LLMs have not been trained on it reliably. **ALWAYS use `d365fo generate …` commands** to produce correct AOT XML. If `d365fo` is unavailable in PATH, stop and ask the user to install it.
+
 # Git-checkpoint review workflow
 
 > Visual Studio 2022 has no inline accept/reject UI for AI edits. Use Git as

--- a/skills/copilot/security-hierarchy-trace.instructions.md
+++ b/skills/copilot/security-hierarchy-trace.instructions.md
@@ -2,6 +2,9 @@
 description: Trace D365FO security from a Role all the way down to Entry Points, or discover which roles reach a given object. Use when the user asks about permissions, security coverage, roles, duties, or privileges.
 applyTo: '**/AxSecurityRole/**,**/AxSecurityDuty/**,**/AxSecurityPrivilege/**'
 ---
+
+> ⛔ **NEVER write X++ AOT XML files directly** via PowerShell, terminal file commands (`Set-Content`, `Out-File`, `New-Item`), editor write tools, or any raw text approach. The XML schema (`<AxClass>`, `<AxTable>`, `<AxForm>`, `<Methods>`, `<SourceCode>`) is proprietary — LLMs have not been trained on it reliably. **ALWAYS use `d365fo generate …` commands** to produce correct AOT XML. If `d365fo` is unavailable in PATH, stop and ask the user to install it.
+
 # Tracing D365FO security hierarchies
 
 ## Workflow

--- a/skills/copilot/table-scaffolding.instructions.md
+++ b/skills/copilot/table-scaffolding.instructions.md
@@ -2,6 +2,9 @@
 description: Create AxTable XML in D365 Finance & Operations using business-role pattern presets (Main / Transaction / Parameter / Group / Reference / WorksheetHeader / WorksheetLine), or add fields / indexes / relations to existing tables. Use whenever the user asks to "create a table", "scaffold a master/transaction/parameter table", "add a field", or "set TableGroup / TableType".
 applyTo: '**/AxTable/**,**/*Table.xml'
 ---
+
+> ⛔ **NEVER write X++ AOT XML files directly** via PowerShell, terminal file commands (`Set-Content`, `Out-File`, `New-Item`), editor write tools, or any raw text approach. The XML schema (`<AxClass>`, `<AxTable>`, `<AxForm>`, `<Methods>`, `<SourceCode>`) is proprietary — LLMs have not been trained on it reliably. **ALWAYS use `d365fo generate …` commands** to produce correct AOT XML. If `d365fo` is unavailable in PATH, stop and ask the user to install it.
+
 # Creating & modifying AxTable definitions
 
 > The CLI's `d365fo generate table` mirrors `d365fo-mcp-server`'s

--- a/skills/copilot/x++-class-authoring.instructions.md
+++ b/skills/copilot/x++-class-authoring.instructions.md
@@ -2,6 +2,9 @@
 description: Guidance for authoring or extending X++ classes in D365 Finance & Operations. Invoke whenever the user asks to "create a class", "extend a class", "add a method", or write any X++ that touches CoC.
 applyTo: '**/*.xpp,**/AxClass/**,**/*Class.xml'
 ---
+
+> ⛔ **NEVER write X++ AOT XML files directly** via PowerShell, terminal file commands (`Set-Content`, `Out-File`, `New-Item`), editor write tools, or any raw text approach. The XML schema (`<AxClass>`, `<AxTable>`, `<AxForm>`, `<Methods>`, `<SourceCode>`) is proprietary — LLMs have not been trained on it reliably. **ALWAYS use `d365fo generate …` commands** to produce correct AOT XML. If `d365fo` is unavailable in PATH, stop and ask the user to install it.
+
 # Authoring X++ classes with the d365fo index
 
 Before you write or modify any X++ class, **ground yourself in the index**. The

--- a/skills/copilot/xpp-best-practice-rules.instructions.md
+++ b/skills/copilot/xpp-best-practice-rules.instructions.md
@@ -2,6 +2,9 @@
 description: Best-practice (BP) rules every generated X++ file must satisfy — today/DateTimeUtil, label-typed messages, EDT migration, nested loops, alternate keys, doc comments, label existence. Invoke whenever you scaffold or edit X++ that will eventually be linted by xppbp.exe.
 applyTo: '**/*.xpp,**/AxClass/**,**/AxTable/**,**/AxForm/**'
 ---
+
+> ⛔ **NEVER write X++ AOT XML files directly** via PowerShell, terminal file commands (`Set-Content`, `Out-File`, `New-Item`), editor write tools, or any raw text approach. The XML schema (`<AxClass>`, `<AxTable>`, `<AxForm>`, `<Methods>`, `<SourceCode>`) is proprietary — LLMs have not been trained on it reliably. **ALWAYS use `d365fo generate …` commands** to produce correct AOT XML. If `d365fo` is unavailable in PATH, stop and ask the user to install it.
+
 # Best-practice rules — generated X++ must be BP-clean
 
 > **Source of truth:** [`d365fo bp check`](../../docs/EXAMPLES.md) — the Windows-VM runner that executes `xppbp.exe`. The list below covers the non-negotiable BP rules every scaffold and hand-edit must satisfy out of the box.

--- a/skills/copilot/xpp-class-and-method-rules.instructions.md
+++ b/skills/copilot/xpp-class-and-method-rules.instructions.md
@@ -2,6 +2,9 @@
 description: Rules for X++ class declarations, method modifiers, parameter passing, constructors, and extension methods (separate from CoC). Invoke when authoring new classes, overrides, factory methods, or extension methods.
 applyTo: '**/*.xpp,**/AxClass/**'
 ---
+
+> ⛔ **NEVER write X++ AOT XML files directly** via PowerShell, terminal file commands (`Set-Content`, `Out-File`, `New-Item`), editor write tools, or any raw text approach. The XML schema (`<AxClass>`, `<AxTable>`, `<AxForm>`, `<Methods>`, `<SourceCode>`) is proprietary — LLMs have not been trained on it reliably. **ALWAYS use `d365fo generate …` commands** to produce correct AOT XML. If `d365fo` is unavailable in PATH, stop and ask the user to install it.
+
 # X++ class & method authoring rules
 
 > **Source of truth:** [learn:xpp-classes-methods](https://learn.microsoft.com/en-us/dynamics365/fin-ops-core/dev-itpro/dev-ref/xpp-classes-methods).

--- a/skills/copilot/xpp-database-queries.instructions.md
+++ b/skills/copilot/xpp-database-queries.instructions.md
@@ -2,6 +2,9 @@
 description: Authoritative rules for X++ select / while-select queries in D365 Finance & Operations. Invoke whenever the user asks to write a "select", "while select", "query", joins, aggregates, cross-company, set-based ops, or any data-access X++.
 applyTo: '**/*.xpp,**/AxClass/**,**/AxTable/**,**/AxQuery/**'
 ---
+
+> ⛔ **NEVER write X++ AOT XML files directly** via PowerShell, terminal file commands (`Set-Content`, `Out-File`, `New-Item`), editor write tools, or any raw text approach. The XML schema (`<AxClass>`, `<AxTable>`, `<AxForm>`, `<Methods>`, `<SourceCode>`) is proprietary — LLMs have not been trained on it reliably. **ALWAYS use `d365fo generate …` commands** to produce correct AOT XML. If `d365fo` is unavailable in PATH, stop and ask the user to install it.
+
 # X++ database queries — `select` / `while select`
 
 > **Source of truth:** [learn:xpp-select-statement](https://learn.microsoft.com/en-us/dynamics365/fin-ops-core/dev-itpro/dev-ref/xpp-data/xpp-select-statement).

--- a/skills/copilot/xpp-statement-and-type-rules.instructions.md
+++ b/skills/copilot/xpp-statement-and-type-rules.instructions.md
@@ -2,6 +2,9 @@
 description: X++ statement-level and type-system rules — switch / break, ternary, no-DB-null sentinels, casting (`as` / `is`), `using` blocks, embedded function declarations. Invoke when writing any non-trivial X++ control flow or type conversion.
 applyTo: '**/*.xpp,**/AxClass/**,**/AxTable/**'
 ---
+
+> ⛔ **NEVER write X++ AOT XML files directly** via PowerShell, terminal file commands (`Set-Content`, `Out-File`, `New-Item`), editor write tools, or any raw text approach. The XML schema (`<AxClass>`, `<AxTable>`, `<AxForm>`, `<Methods>`, `<SourceCode>`) is proprietary — LLMs have not been trained on it reliably. **ALWAYS use `d365fo generate …` commands** to produce correct AOT XML. If `d365fo` is unavailable in PATH, stop and ask the user to install it.
+
 # X++ statement & type rules
 
 > **Sources of truth:** [learn:xpp-conditional](https://learn.microsoft.com/en-us/dynamics365/fin-ops-core/dev-itpro/dev-ref/xpp-conditional) and [learn:xpp-variables-data-types](https://learn.microsoft.com/en-us/dynamics365/fin-ops-core/dev-itpro/dev-ref/xpp-variables-data-types).


### PR DESCRIPTION
- Add explicit prohibition block (NEVER write AOT XML directly) to all 15 _source/*.md skill files and all 15 copilot/*.instructions.md files
- Add Section 5 (forbidden built-in tools) and Section 6 (NEVER use scripts as fallback, incl. 'metadata from open files' anti-pattern) to .github/copilot-instructions.md — mirrors d365fo-mcp-server systemInstructions.ts sections 5 & 6
- Replace all relative ../  links in copilot-instructions.md with absolute GitHub URLs so the file works after Install-D365FoCopilotSkills.ps1 copies it to an X++ project repo
- Fix PowerShell parse error in Install-D365FoCopilotSkills.ps1 caused by UTF-8 em dash read as cp1252 curly-quote inside a string literal
- Add 'When to use built-in tools vs. d365fo' quick-reference table to README.md