### PR TITLE
Fix Spectre command option templates

### DIFF
--- a/src/D365FO.Cli/Commands/Generate/GenerateMoreCommands.cs
+++ b/src/D365FO.Cli/Commands/Generate/GenerateMoreCommands.cs
@@ -558,11 +558,11 @@ public sealed class GenerateReportCommand : Command<GenerateReportCommand.Settin
         [System.ComponentModel.Description("Tablix column field name (repeatable). Generates header + data rows in the tablix.")]
         public string[]? Fields { get; init; }
 
-        [CommandOption("--parameter <NAME[:TYPE]>")]
+        [CommandOption("--parameter <SPEC>")]
         [System.ComponentModel.Description("Report parameter (repeatable). Format: Name or Name:Type. Type: String (default), Integer, DateTime, Boolean, Decimal.")]
         public string[]? Parameters { get; init; }
 
-        [CommandOption("--extra-dataset <NAME:DPCLASS>")]
+        [CommandOption("--extra-dataset <SPEC>")]
         [System.ComponentModel.Description("Additional dataset (repeatable). Format: DatasetName:DPClassName. Each produces its own tablix in the design.")]
         public string[]? ExtraDatasets { get; init; }
 


### PR DESCRIPTION
Fixes d365fo index build error (Issue #16): Spectre.Console.Cli startup failures caused by invalid value placeholders in command option templates.

Changes:
- Replaces `--parameter <NAME[:TYPE]>` with `--parameter <SPEC>`
- Replaces `--extra-dataset <NAME:DPCLASS>` with `--extra-dataset <SPEC>`

The accepted CLI values are unchanged; descriptions still document the expected formats.

Verified:
- `dotnet build src/D365FO.Cli/D365FO.Cli.csproj`
- `dotnet run --project src/D365FO.Cli --no-build -- index build --db /tmp/d365fo-cli-index-build-smoke.sqlite -o json`
- `dotnet test d365fo-cli.slnx`