### PR TITLE
Improve CLI-first agent workflows and command discovery

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -84,6 +84,11 @@ When the user just wants to *understand* code, never edit:
 | Find inbound/outbound table relations | `d365fo find relations <Table> --output json` |
 | Resolve a label token | `d365fo resolve label @SYS12345 --lang en-us,cs` |
 | Trace security coverage | `d365fo get security <Object> --type <Kind>` |
+| Discover CLI surface (compact agent manifest) | `d365fo schema --output json` |
+| Discover CLI surface (full parity catalog) | `d365fo schema --full --output json` |
+| Search multiple names at once | `d365fo search batch <q1> <q2> … --output json` |
+| Generic object fetch (agent shortcut) | `d365fo get object <kind> <name> --output json` |
+| Generic relation lookup (agent shortcut) | `d365fo find related <relation> <name> --output json` |
 
 > **`--output json` is mandatory** in agent contexts. Without it the CLI may render rich console output that wastes tokens.
 

--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,4 @@ coverage/
 *.trx
 .DS_Store
 *.log
+*.lscache

--- a/README.md
+++ b/README.md
@@ -40,6 +40,7 @@ The CLI sits between your AI agent and the D365FO metadata layer. It exposes a s
 - **Scaffold X++ objects** — pattern-validated XML for tables, classes, CoC extensions, and AxForms (all 9 D365FO patterns: `SimpleList`, `SimpleListDetails`, `DetailsMaster`, `DetailsTransaction`, `Dialog`, `TableOfContents`, `Lookup`, `ListPage`, `Workspace`)
 - **Understand the code** — trace CoC targets, inbound/outbound relations, event handlers, label translations, and cross-references across your workspace
 - **AI-ready JSON** — every command returns a stable `{ ok, data, warnings }` envelope; agents parse once, never re-adapt
+- **Agent-first command shortcuts** — `search batch`, `get object`, and `find related` collapse common MCP multi-tool workflows into one CLI process
 - **15 lazy-loaded Skills** — full X++/CoC/BP rule canon (database queries, class rules, statement types, best practices) loaded only when relevant; ~90% fewer tokens per workflow than MCP
 - **Daemon mode** — warm-cache named-pipe server with file-system watcher; auto-refreshes index on AOT XML changes (debounce configurable)
 - **CI / pipeline ready** — runs in PowerShell, bash/zsh, GitHub Actions, Azure DevOps; no GUI required
@@ -223,9 +224,9 @@ See [`docs/TOKEN_ECONOMICS.md`](docs/TOKEN_ECONOMICS.md) for the full analysis a
 | Group | Commands |
 |---|---|
 | **Index** | `index build`, `index extract`, `index refresh`, `index status` |
-| **Discover** | `search class\|table\|edt\|enum\|form\|query\|view\|entity\|report\|service\|workflow\|label` |
-| **Get** | `get table\|class\|edt\|enum\|form\|menu-item\|security\|label\|role\|duty\|privilege\|query\|view\|entity\|report\|service` |
-| **Find** | `find coc`, `find relations`, `find usages`, `find extensions`, `find handlers`, `find refs`, `find form-patterns` |
+| **Discover** | `search any`, `search batch`, `search class\|table\|edt\|enum\|form\|query\|view\|entity\|report\|service\|workflow\|label` |
+| **Get** | `get object`, `get table\|class\|edt\|enum\|form\|menu-item\|security\|label\|role\|duty\|privilege\|query\|view\|entity\|report\|service` |
+| **Find** | `find related`, `find coc`, `find relations`, `find usages`, `find extensions`, `find handlers`, `find refs`, `find form-patterns` |
 | **Read** | `read class`, `read table`, `read form` |
 | **Resolve** | `resolve label` |
 | **Generate** | `generate table\|class\|coc\|form\|entity\|extension\|event-handler\|privilege\|duty\|role` |

--- a/docs/EXAMPLES.md
+++ b/docs/EXAMPLES.md
@@ -526,6 +526,26 @@ Drop `skills/anthropic/` into the project or `~/.claude/skills/`. Each `SKILL.md
 
 Paste the output of `d365fo agent-prompt` into the session system prompt, or reference it from `AGENTS.md`.
 
+Use the compact manifest when the agent needs to discover the CLI surface:
+
+```sh
+d365fo schema
+```
+
+Use the complete manifest only when needed:
+
+```sh
+d365fo schema --full
+```
+
+CLI-first shortcuts replace common MCP multi-call workflows:
+
+```sh
+d365fo search batch CustTable SalesTable CustAccount --output json
+d365fo get object table CustTable --output json
+d365fo find related coc CustTable --method validateWrite --output json
+```
+
 ### MCP server (`d365fo-mcp`)
 
 Standalone JSON-RPC 2.0 server (protocol `2024-11-05`) that shares the CLI's index. Config sample for Claude Desktop:

--- a/docs/MIGRATION_FROM_MCP.md
+++ b/docs/MIGRATION_FROM_MCP.md
@@ -103,6 +103,10 @@ If upstream `d365fo-mcp-server` updates its rule canon, sync this repo's [`.gith
 
 | MCP tool | CLI command |
 |---|---|
+| `search` / `search_any` | `d365fo search any <q>` |
+| `batch_search` | `d365fo search batch <q1> <q2> ...` |
+| `get_*` family | `d365fo get object <kind> <name>` or the dedicated `d365fo get <kind> <name>` |
+| `find_*` relation family | `d365fo find related <relation> <name>` or the dedicated `d365fo find ...` command |
 | `search_classes` | `d365fo search class <q>` |
 | `get_table_details` | `d365fo get table <name>` *(now also includes indexes, methods, delete actions)* |
 | `get_edt_details` | `d365fo get edt <name>` |
@@ -117,6 +121,10 @@ If upstream `d365fo-mcp-server` updates its rule canon, sync this repo's [`.gith
 
 | Command | Purpose |
 |---|---|
+| `d365fo schema` / `d365fo schema --full` | Compact agent-first manifest or complete CLI parity catalog. |
+| `d365fo search batch <q1> <q2> ...` | Batch scope-agnostic discovery in one process, replacing repeated MCP calls. |
+| `d365fo get object <kind> <name>` | Generic object fetch for agents; dedicated `get` commands remain available. |
+| `d365fo find related <relation> <name>` | Generic relation lookup for agents; dedicated `find` commands remain available. |
 | `d365fo search query\|view\|entity\|report\|service\|workflow` | Index queries, views, data entities (by name or OData `PublicEntityName`/`PublicCollectionName`), SSRS/RDL reports, SOAP services, workflow types. |
 | `d365fo get form\|role\|duty\|privilege\|query\|view\|entity\|report\|service\|service-group` | Full details for each object type. |
 | `d365fo find extensions <Target>` | Enumerate Table / Form / Edt / Enum extensions targeting an object. |

--- a/docs/TOKEN_ECONOMICS.md
+++ b/docs/TOKEN_ECONOMICS.md
@@ -29,7 +29,11 @@ There's also a hidden cost: MCP encourages multi-step discovery (`find_type` →
 - The agent sees **one** tool: the shell / `bash` tool (~100 tokens).
 - At session start the harness enumerates available skills and loads **only** their YAML frontmatter (`name`, `description`, `applies_when`). Each skill costs ~30–60 tokens until it is actually triggered.
 - When a skill fires, its body (Markdown instructions + CLI invocations) is loaded on demand.
-- Agent discovery happens through `d365fo --help` and `d365fo schema --full` — again, on demand.
+- Agent discovery happens through `d365fo schema` (compact, agent-first) and
+  `d365fo schema --full` (complete parity catalog) — again, on demand.
+- Common MCP multi-tool flows collapse into one CLI process:
+  `d365fo search batch ...`, `d365fo get object <kind> <name>`, and
+  `d365fo find related <relation> <name>`.
 
 ## Expected savings
 
@@ -42,7 +46,9 @@ Using the same per-turn accounting:
 | 15 | ~44,000 | ~4,000 | ~91% |
 | 20 | ~58,000 | ~4,500 | ~92% |
 
-Real workflows save more, because MCP also pays for extra discovery round-trips (often 5–15 kT per workflow) that the CLI eliminates via `d365fo get table <Name>` in a single call.
+Real workflows save more, because MCP also pays for extra discovery round-trips
+(often 5–15 kT per workflow) that the CLI eliminates via single calls such as
+`d365fo get object table <Name>` or `d365fo search batch <A> <B> <C>`.
 
 ## When the saving does *not* apply
 

--- a/src/D365FO.Cli/Commands/Agent/SchemaCommand.cs
+++ b/src/D365FO.Cli/Commands/Agent/SchemaCommand.cs
@@ -8,90 +8,198 @@ public sealed class SchemaCommand : Command<SchemaCommand.Settings>
     public sealed class Settings : CommandSettings
     {
         [CommandOption("--full")]
+        [System.ComponentModel.Description("Emit every CLI command. Default emits the compact agent-first surface.")]
         public bool Full { get; init; }
     }
 
+    private sealed record CommandSpec(
+        string Command,
+        string Description,
+        string[] Args,
+        string[] Options,
+        string[] ReplacesMcp,
+        bool Preferred = false);
+
     public override int Execute(CommandContext ctx, Settings settings)
     {
-        // Static catalog — deliberately handwritten so the schema ships even
-        // when the CLI binary is AOT-trimmed. Keep in sync with Program.cs.
-        var commands = new object[]
-        {
-            new { group = "search",  name = "class",       description = "Find X++ classes by substring.",
-                  args = new[] { "<QUERY>" }, options = new[] { "--model", "--limit" } },
-            new { group = "search",  name = "table",       description = "Find tables by substring.",
-                  args = new[] { "<QUERY>" }, options = new[] { "--model", "--limit" } },
-            new { group = "search",  name = "edt",         description = "Find Extended Data Types.",
-                  args = new[] { "<QUERY>" }, options = new[] { "--limit" } },
-            new { group = "search",  name = "enum",        description = "Find base enums.",
-                  args = new[] { "<QUERY>" }, options = new[] { "--limit" } },
-            new { group = "search",  name = "label",       description = "Search label file keys/values.",
-                  args = new[] { "<QUERY>" }, options = new[] { "--lang", "--limit" } },
-            new { group = "get",     name = "table",       description = "Return full table shape (fields, relations).",
-                  args = new[] { "<NAME>" }, options = new[] { "--include" } },
-            new { group = "get",     name = "edt",         description = "Return EDT definition.",
-                  args = new[] { "<NAME>" }, options = Array.Empty<string>() },
-            new { group = "get",     name = "class",       description = "Return class methods and signatures.",
-                  args = new[] { "<NAME>" }, options = Array.Empty<string>() },
-            new { group = "get",     name = "enum",        description = "Return base enum values.",
-                  args = new[] { "<NAME>" }, options = Array.Empty<string>() },
-            new { group = "get",     name = "menu-item",   description = "Resolve a menu item to its object.",
-                  args = new[] { "<NAME>" }, options = Array.Empty<string>() },
-            new { group = "get",     name = "security",    description = "Security hierarchy coverage for an object.",
-                  args = new[] { "<OBJECT>" }, options = new[] { "--type" } },
-            new { group = "get",     name = "label",       description = "Resolve single label entry.",
-                  args = new[] { "<FILE>", "<KEY>" }, options = new[] { "--lang" } },
-            new { group = "find",    name = "coc",         description = "Chain-of-Command extensions targeting Class::method.",
-                  args = new[] { "<TARGET>" }, options = Array.Empty<string>() },
-            new { group = "find",    name = "relations",   description = "Inbound/outbound table relations.",
-                  args = new[] { "<TABLE>" }, options = Array.Empty<string>() },
-            new { group = "find",    name = "usages",      description = "Find index entities whose name contains a substring.",
-                  args = new[] { "<SYMBOL>" }, options = new[] { "--limit" } },
-            new { group = "index",   name = "build",       description = "Ensure / create metadata index database.",
-                  args = Array.Empty<string>(), options = new[] { "--db" } },
-            new { group = "index",   name = "status",      description = "Report index size and config.",
-                  args = Array.Empty<string>(), options = Array.Empty<string>() },
-            new { group = "index",   name = "extract",     description = "Walk PACKAGES_PATH and ingest AOT metadata.",
-                  args = Array.Empty<string>(), options = new[] { "--packages", "--db", "--model" } },
-            new { group = "generate",name = "table",       description = "Scaffold a new AxTable XML.",
-                  args = new[] { "<NAME>" }, options = new[] { "--out", "--label", "--field", "--overwrite" } },
-            new { group = "generate",name = "class",       description = "Scaffold a new AxClass XML.",
-                  args = new[] { "<NAME>" }, options = new[] { "--out", "--extends", "--non-final", "--overwrite" } },
-            new { group = "generate",name = "coc",         description = "Scaffold a Chain-of-Command extension.",
-                  args = new[] { "<TARGET>" }, options = new[] { "--out", "--method", "--overwrite" } },
-            new { group = "generate",name = "simple-list", description = "Scaffold a SimpleList AxForm.",
-                  args = new[] { "<FORM_NAME>" }, options = new[] { "--out", "--table", "--overwrite" } },
-            new { group = "review",  name = "diff",        description = "Inspect AOT changes vs. a git revision.",
-                  args = Array.Empty<string>(), options = new[] { "--base", "--head", "--repo" } },
-            new { group = "test",    name = "run",         description = "Run D365FO tests via SysTestRunner (Windows VM).",
-                  args = Array.Empty<string>(), options = new[] { "--runner", "--suite" } },
-            new { group = "bp",      name = "check",       description = "Run best-practice checks via xppbp (Windows VM).",
-                  args = Array.Empty<string>(), options = new[] { "--tool", "--model" } },
-            new { group = "(root)",  name = "build",       description = "Invoke MSBuild (Windows VM).",
-                  args = Array.Empty<string>(), options = new[] { "--msbuild", "--project", "--config" } },
-            new { group = "(root)",  name = "sync",        description = "Run DB sync (Windows VM).",
-                  args = Array.Empty<string>(), options = new[] { "--tool", "--full" } },
-            new { group = "(root)",  name = "doctor",      description = "Diagnose configuration.",
-                  args = Array.Empty<string>(), options = Array.Empty<string>() },
-            new { group = "(root)",  name = "version",     description = "Print version info.",
-                  args = Array.Empty<string>(), options = Array.Empty<string>() },
-            new { group = "(root)",  name = "agent-prompt",description = "Emit LLM system prompt for this CLI.",
-                  args = Array.Empty<string>(), options = new[] { "--out" } },
-            new { group = "(root)",  name = "schema",      description = "Emit JSON manifest of commands.",
-                  args = Array.Empty<string>(), options = new[] { "--full" } },
-        };
+        var commands = Commands();
+        var selected = settings.Full ? commands : commands.Where(c => c.Preferred).ToArray();
 
         var payload = new
         {
             name = "d365fo",
             version = typeof(SchemaCommand).Assembly.GetName().Version?.ToString() ?? "0.1.0-dev",
-            envelope = new { ok = "bool", data = "T", error = new { code = "string", message = "string", hint = "string?" } },
-            commands = settings.Full
-                ? commands
-                : commands.Select(c => new { ((dynamic)c).group, ((dynamic)c).name, ((dynamic)c).description }).Cast<object>().ToArray(),
+            defaultOutput = "json when stdout/stderr are redirected; table in an interactive TTY",
+            envelope = new
+            {
+                ok = "bool",
+                data = "T",
+                error = new { code = "string", message = "string", hint = "string?" },
+            },
+            guidance = new[]
+            {
+                "Prefer CLI commands over MCP when a shell is available; command text is cheaper than MCP tool schemas over multi-turn work.",
+                "Use compact commands first: search any, search batch, get object, find related, read class/table/form.",
+                "Use dedicated commands when you need a narrower command or a bridge-backed live read.",
+                "Generated AOT XML is written to files; stdout returns a JSON summary to avoid loading large XML into the prompt.",
+            },
+            workflows = Workflows(),
+            commands = selected,
+            fullManifestHint = settings.Full ? null : "Run `d365fo schema --full` only when you need the complete command catalog.",
         };
 
         Console.Out.WriteLine(D365Json.Serialize(ToolResult<object>.Success(payload), indented: true));
         return 0;
     }
+
+    private static object[] Workflows() =>
+    [
+        new
+        {
+            name = "discover object",
+            commands = new[]
+            {
+                "d365fo search any <name> --output json",
+                "d365fo get object <kind> <name> --output json",
+                "d365fo find related usages <name> --output json",
+            },
+        },
+        new
+        {
+            name = "author extension",
+            commands = new[]
+            {
+                "d365fo suggest extension <target> --output json",
+                "d365fo find related extensions <target> --output json",
+                "d365fo generate extension <kind> <target> --suffix <suffix> --out <path> --output json",
+            },
+        },
+        new
+        {
+            name = "safe table/form scaffolding",
+            commands = new[]
+            {
+                "d365fo search batch <new-name> <primary-table> --output json",
+                "d365fo get object table <primary-table> --output json",
+                "d365fo find form-patterns --table <primary-table> --output json",
+                "d365fo generate form <name> --pattern <pattern> --table <primary-table> --out <path> --output json",
+            },
+        },
+        new
+        {
+            name = "security trace",
+            commands = new[]
+            {
+                "d365fo get security <menu-item> --type Menuitem --output json",
+                "d365fo get object role <role> --output json",
+                "d365fo get object duty <duty> --output json",
+                "d365fo get object privilege <privilege> --output json",
+            },
+        },
+    ];
+
+    private static CommandSpec[] Commands() =>
+    [
+        C("search any", "Scope-agnostic search across every indexed kind.", ["<QUERY>"], ["--limit", "--output"], ["search", "search_any"], true),
+        C("search batch", "Run several scope-agnostic searches in one process.", ["<QUERY>..."], ["--limit", "--output"], ["batch_search"], true),
+        C("get object", "Generic get by kind/name across object types.", ["<KIND>", "<NAME>"], ["--output", "--resolve-labels"], ["get_*", "get_object"], true),
+        C("find related", "Generic relation lookup by relation/name.", ["<RELATION>", "<NAME>"], ["--kind", "--method", "--limit", "--output"], ["find_*", "find_related"], true),
+        C("read class", "Read X++ source embedded in an AxClass.", ["<NAME>"], ["--method", "--declaration", "--lines", "--around", "--output"], [], true),
+        C("read table", "Read X++ source embedded in an AxTable.", ["<NAME>"], ["--method", "--declaration", "--lines", "--around", "--output"], [], true),
+        C("read form", "Read X++ source embedded in an AxForm.", ["<NAME>"], ["--method", "--declaration", "--lines", "--around", "--output"], [], true),
+        C("suggest edt", "Suggest EDTs for a field name.", ["<FIELDNAME>"], ["--limit", "--output"], ["suggest_edt"], true),
+        C("suggest extension", "Recommend CoC/event-handler/AOT-extension strategy.", ["<TARGET>"], ["--kind", "--output"], ["suggest_extension_strategy"], true),
+        C("validate name", "Check object name against naming conventions.", ["<KIND>", "<NAME>"], ["--prefix", "--output"], ["validate_object_naming"], true),
+        C("stats", "Aggregate counters over the index.", [], ["--top", "--output"], ["stats"], true),
+        C("lint", "In-process best-practice gate over the index.", [], ["--category", "--all-models", "--format", "--output"], ["lint"], true),
+        C("schema", "Emit this JSON command manifest.", [], ["--full"], [], true),
+        C("agent-prompt", "Emit the CLI-first LLM system prompt.", [], ["--out"], [], true),
+
+        C("search class", "Find X++ classes by substring.", ["<QUERY>"], ["--model", "--limit", "--output"], ["search_classes"]),
+        C("search table", "Find tables by substring.", ["<QUERY>"], ["--model", "--limit", "--output"], ["search_tables"]),
+        C("search edt", "Find Extended Data Types by substring.", ["<QUERY>"], ["--limit", "--output"], ["search_edts"]),
+        C("search enum", "Find base enums by substring.", ["<QUERY>"], ["--limit", "--output"], ["search_enums"]),
+        C("search label", "Search label keys/values; FTS5 is preferred automatically.", ["<QUERY>"], ["--lang", "--limit", "--fts", "--raw-text", "--output"], ["search_labels", "search_labels_fts"]),
+        C("search query", "Find AOT queries.", ["<QUERY>"], ["--limit", "--output"], ["search_queries"]),
+        C("search view", "Find AOT views.", ["<QUERY>"], ["--limit", "--output"], ["search_views"]),
+        C("search entity", "Find data entities by AOT/OData name.", ["<QUERY>"], ["--limit", "--output"], ["search_data_entities"]),
+        C("search report", "Find SSRS/RDL reports.", ["<QUERY>"], ["--limit", "--output"], ["search_reports"]),
+        C("search service", "Find SOAP services.", ["<QUERY>"], ["--limit", "--output"], ["search_services"]),
+        C("search workflow", "Find workflow types.", ["<QUERY>"], ["--limit", "--output"], ["search_workflow_types"]),
+
+        C("get table", "Get table fields, relations, indexes, methods, and delete actions.", ["<NAME>"], ["--include", "--output", "--resolve-labels"], ["get_table_details", "get_table_methods", "get_table_indexes", "get_table_delete_actions"]),
+        C("get edt", "Get an EDT definition.", ["<NAME>"], ["--output"], ["get_edt_details"]),
+        C("get class", "Get class metadata and method signatures.", ["<NAME>"], ["--output"], ["get_class_details"]),
+        C("get enum", "Get enum values.", ["<NAME>"], ["--output"], ["get_enum_details"]),
+        C("get menu-item", "Resolve menu item to launched object.", ["<NAME>"], ["--output"], ["get_menu_item"]),
+        C("get security", "Get role/duty/privilege coverage for an object.", ["<OBJECT>"], ["--type", "--output"], ["get_security_coverage_for_object"]),
+        C("get label", "Resolve a label entry or token.", ["<FILE_OR_KEY>", "[KEY]"], ["--lang", "--raw-text", "--output"], ["get_label", "resolve_label"]),
+        C("get form", "Get form data sources and metadata.", ["<NAME>"], ["--output"], ["get_form"]),
+        C("get role", "Get security role duties/privileges.", ["<NAME>"], ["--output"], ["get_security_role"]),
+        C("get duty", "Get security duty privileges.", ["<NAME>"], ["--output"], ["get_security_duty"]),
+        C("get privilege", "Get security privilege entry points.", ["<NAME>"], ["--output"], ["get_security_privilege"]),
+        C("get query", "Get query metadata and joins.", ["<NAME>"], ["--output"], ["get_query"]),
+        C("get view", "Get view fields and source query.", ["<NAME>"], ["--output"], ["get_view"]),
+        C("get entity", "Get data entity metadata and OData names.", ["<NAME>"], ["--output"], ["get_data_entity"]),
+        C("get report", "Get report datasets.", ["<NAME>"], ["--output"], ["get_report"]),
+        C("get service", "Get service operations.", ["<NAME>"], ["--output"], ["get_service"]),
+        C("get service-group", "Get service group members.", ["<NAME>"], ["--output"], ["get_service_group"]),
+
+        C("find coc", "Find Chain-of-Command extensions.", ["<TARGET>"], ["--output"], ["find_coc_extensions"]),
+        C("find relations", "Find table relations.", ["<TABLE>"], ["--output"], ["get_table_relations"]),
+        C("find usages", "Find indexed entities whose names contain a substring.", ["<SYMBOL>"], ["--limit", "--output"], ["find_usages"]),
+        C("find extensions", "Find Table/Form/Edt/Enum extensions targeting an object.", ["<TARGET>"], ["--kind", "--output"], ["find_extensions", "get_table_extension_info"]),
+        C("find handlers", "Find event subscribers.", ["<OBJECT>"], ["--kind", "--output"], ["find_event_subscribers"]),
+        C("find refs", "Scan indexed X++ source for reverse references.", ["<NAME>"], ["--kind", "--model", "--limit", "--xref", "--output"], []),
+        C("find form-patterns", "Find forms by Microsoft form pattern, table, or peer form.", [], ["--pattern", "--table", "--similar-to", "--output"], []),
+
+        C("resolve label", "Resolve @SYS12345-style label token across languages.", ["<TOKEN>"], ["--lang", "--raw-text", "--output"], ["resolve_label"]),
+        C("label create", "Create or update a label entry.", ["<KEY>", "<VALUE>"], ["--file", "--overwrite", "--output"], ["create_label"]),
+        C("label rename", "Rename a label key.", ["<OLD>", "<NEW>"], ["--file", "--overwrite", "--output"], ["rename_label"]),
+        C("label delete", "Delete a label key.", ["<KEY>"], ["--file", "--output"], ["delete_label"]),
+
+        C("index build", "Create or ensure the metadata index schema.", [], ["--db", "--output"], ["index_status"]),
+        C("index status", "Report index table counts and config.", [], ["--output"], ["index_status"]),
+        C("index extract", "Walk PackagesLocalDirectory and ingest AOT metadata.", [], ["--packages", "--db", "--model", "--since", "--output"], []),
+        C("index refresh", "Incremental extract using model fingerprints.", [], ["--packages", "--db", "--model", "--since", "--force", "--output"], []),
+        C("index history", "Show recent extraction telemetry.", [], ["--db", "--model", "--limit", "--output"], ["index_history"]),
+        C("models list", "List indexed models.", [], ["--output"], ["list_models"]),
+        C("models deps", "Show dependencies for a model.", ["<NAME>"], ["--output"], ["get_model_dependencies"]),
+        C("models coupling", "Show fan-in/fan-out/instability/cycles.", [], ["--top", "--only-cycles", "--output"], ["models_coupling"]),
+
+        C("generate table", "Scaffold AxTable XML.", ["<NAME>"], ["--out", "--overwrite", "--install-to", "--label", "--field", "--pattern", "--table-type", "--primary-key", "--output"], ["generate_smart_table"]),
+        C("generate class", "Scaffold AxClass XML.", ["<NAME>"], ["--out", "--overwrite", "--install-to", "--extends", "--non-final", "--output"], []),
+        C("generate coc", "Scaffold a Chain-of-Command class.", ["<TARGET>"], ["--out", "--overwrite", "--install-to", "--method", "--output"], []),
+        C("generate form", "Scaffold AxForm XML for the supported form patterns.", ["<FORM_NAME>"], ["--out", "--overwrite", "--install-to", "--pattern", "--table", "--caption", "--field", "--section", "--lines-table", "--output"], ["generate_smart_form"]),
+        C("generate simple-list", "Deprecated alias for generate form --pattern SimpleList.", ["<FORM_NAME>"], ["--out", "--table", "--overwrite", "--output"], ["generate_smart_form"]),
+        C("generate entity", "Scaffold AxDataEntityView XML.", ["<ENTITY>"], ["--out", "--overwrite", "--install-to", "--table", "--public-entity", "--public-collection", "--field", "--all-fields", "--output"], []),
+        C("generate extension", "Scaffold Table/Form/Edt/Enum extension XML.", ["<KIND>", "<TARGET>"], ["--suffix", "--out", "--overwrite", "--install-to", "--output"], []),
+        C("generate event-handler", "Scaffold an event subscriber class.", ["<CLASS_NAME>"], ["--source-kind", "--source-object", "--event", "--method", "--out", "--overwrite", "--install-to", "--output"], []),
+        C("generate privilege", "Scaffold a security privilege.", ["<NAME>"], ["--entry-point", "--entry-kind", "--entry-object", "--access", "--label", "--into-role", "--out", "--overwrite", "--install-to", "--output"], []),
+        C("generate duty", "Scaffold a security duty.", ["<NAME>"], ["--privilege", "--label", "--into-role", "--out", "--overwrite", "--install-to", "--output"], []),
+        C("generate role", "Scaffold or merge a security role.", ["<NAME>"], ["--duty", "--privilege", "--label", "--description", "--add-to", "--out", "--overwrite", "--install-to", "--output"], []),
+        C("generate report", "Scaffold AxReport and RDP skeleton.", ["<NAME>"], ["--dp", "--tmp", "--dataset", "--caption", "--field", "--parameter", "--extra-dataset", "--out-dp", "--out-contract", "--out", "--overwrite", "--install-to", "--output"], []),
+
+        C("analyze completeness", "Cross-check workspace AOT XML against the index.", [], ["--workspace", "--output"], []),
+        C("review diff", "Inspect AOT changes vs. a git revision.", [], ["--base", "--head", "--repo", "--output"], []),
+        C("build", "Invoke MSBuild on a D365FO project.", [], ["--msbuild", "--project", "--config", "--output"], []),
+        C("sync", "Run DB sync.", [], ["--tool", "--full", "--output"], []),
+        C("test run", "Invoke SysTestRunner.", [], ["--runner", "--suite", "--output"], []),
+        C("bp check", "Invoke xppbp best-practice checks.", [], ["--tool", "--model", "--packages", "--metadata", "--output"], []),
+        C("daemon start", "Start warm JSON-RPC daemon.", [], ["--db", "--packages", "--foreground", "--no-watch", "--watch-debounce"], []),
+        C("daemon stop", "Stop daemon.", [], [], []),
+        C("daemon status", "Report daemon status.", [], [], []),
+        C("doctor", "Diagnose environment.", [], ["--output"], []),
+        C("init", "Quickstart index/profile setup.", [], ["--packages", "--db", "--run-extract", "--dry-run", "--persist-profile"], []),
+        C("version", "Print version information.", [], ["--output"], []),
+    ];
+
+    private static CommandSpec C(
+        string command,
+        string description,
+        string[] args,
+        string[] options,
+        string[] replacesMcp,
+        bool preferred = false)
+        => new(command, description, args, options, replacesMcp, preferred);
 }

--- a/src/D365FO.Cli/Commands/Agent/SchemaCommand.cs
+++ b/src/D365FO.Cli/Commands/Agent/SchemaCommand.cs
@@ -61,7 +61,7 @@ public sealed class SchemaCommand : Command<SchemaCommand.Settings>
             {
                 "d365fo search any <name> --output json",
                 "d365fo get object <kind> <name> --output json",
-                "d365fo find related usages <name> --output json",
+                "d365fo find related name-search <name> --output json",
             },
         },
         new

--- a/src/D365FO.Cli/Commands/Find/FindCommands.cs
+++ b/src/D365FO.Cli/Commands/Find/FindCommands.cs
@@ -335,3 +335,111 @@ public sealed class FindFormPatternsCommand : Command<FindFormPatternsCommand.Se
         }));
     }
 }
+
+public sealed class FindRelatedCommand : Command<FindRelatedCommand.Settings>
+{
+    public sealed class Settings : D365OutputSettings
+    {
+        [CommandArgument(0, "<RELATION>")]
+        [System.ComponentModel.Description("usages|refs|table-relations|coc|security|extensions|handlers|table-methods|table-indexes|table-delete-actions")]
+        public string Relation { get; init; } = "";
+
+        [CommandArgument(1, "<NAME>")]
+        public string Name { get; init; } = "";
+
+        [CommandOption("--kind <KIND>")]
+        [System.ComponentModel.Description("Optional kind filter or security object type.")]
+        public string? Kind { get; init; }
+
+        [CommandOption("--method <NAME>")]
+        [System.ComponentModel.Description("Method filter for relation=coc.")]
+        public string? Method { get; init; }
+
+        [CommandOption("-l|--limit <N>")]
+        public int Limit { get; init; } = 100;
+    }
+
+    public override int Execute(CommandContext ctx, Settings settings)
+    {
+        var output = OutputMode.Resolve(settings.Output);
+        if (string.IsNullOrWhiteSpace(settings.Relation) || string.IsNullOrWhiteSpace(settings.Name))
+            return RenderHelpers.Render(output, ToolResult<object>.Fail("BAD_INPUT", "Relation and name are required."));
+
+        var repo = RepoFactory.Create();
+        return Normalize(settings.Relation) switch
+        {
+            "usages" => RenderUsages(output, repo, settings.Name, settings.Limit),
+            "refs" or "references" => RenderRefs(output, repo, settings.Name, settings.Kind, settings.Limit),
+            "tablerelations" or "relations" => RenderItems(output, repo.GetTableRelations(settings.Name)),
+            "coc" => RenderItems(output, repo.FindCocExtensions(settings.Name, settings.Method)),
+            "security" => RenderHelpers.Render(output, ToolResult<object>.Success(repo.GetSecurityCoverage(
+                settings.Name,
+                string.IsNullOrWhiteSpace(settings.Kind) ? "Menuitem" : settings.Kind))),
+            "extensions" => RenderItems(output, repo.FindExtensions(settings.Name, settings.Kind)),
+            "handlers" or "eventhandlers" => RenderItems(output, repo.FindEventSubscribers(settings.Name, settings.Kind)),
+            "tablemethods" => RenderItems(output, repo.GetTableMethods(settings.Name)),
+            "tableindexes" => RenderItems(output, repo.GetTableIndexes(settings.Name)),
+            "tabledeleteactions" => RenderItems(output, repo.GetTableDeleteActions(settings.Name)),
+            _ => RenderHelpers.Render(output, ToolResult<object>.Fail(
+                "BAD_INPUT",
+                $"Unsupported relation '{settings.Relation}'.",
+                "Use usages, refs, table-relations, coc, security, extensions, handlers, table-methods, table-indexes, or table-delete-actions.")),
+        };
+    }
+
+    private static int RenderUsages(OutputMode.Kind output, D365FO.Core.Index.MetadataRepository repo, string name, int limit)
+    {
+        var items = repo.FindUsages(name, limit)
+            .Select(t => new { kind = t.Kind, name = t.Name, model = t.Model })
+            .ToList();
+        return RenderHelpers.Render(output, ToolResult<object>.Success(new { count = items.Count, items }));
+    }
+
+    private static int RenderRefs(OutputMode.Kind output, D365FO.Core.Index.MetadataRepository repo, string name, string? kind, int limit)
+    {
+        var sources = repo.EnumerateSourcePaths();
+        if (!string.IsNullOrWhiteSpace(kind))
+            sources = sources.Where(s => string.Equals(s.Kind, kind, StringComparison.OrdinalIgnoreCase)).ToList();
+
+        var rx = new System.Text.RegularExpressions.Regex(
+            $@"\b{System.Text.RegularExpressions.Regex.Escape(name)}\b",
+            System.Text.RegularExpressions.RegexOptions.IgnoreCase);
+        var hits = new List<object>();
+        var scanned = 0;
+
+        foreach (var row in sources)
+        {
+            if (hits.Count >= limit) break;
+            scanned++;
+            var src = XppSourceReader.Read(row.SourcePath);
+            if (src is null) continue;
+            foreach (var method in src.Methods)
+            {
+                if (!rx.IsMatch(method.Body)) continue;
+                hits.Add(new
+                {
+                    kind = row.Kind,
+                    name = row.Name,
+                    model = row.Model,
+                    method = method.Name,
+                    path = row.SourcePath,
+                });
+                if (hits.Count >= limit) break;
+            }
+        }
+
+        return RenderHelpers.Render(output, ToolResult<object>.Success(new
+        {
+            needle = name,
+            filesScanned = scanned,
+            count = hits.Count,
+            items = hits,
+        }));
+    }
+
+    private static int RenderItems<T>(OutputMode.Kind output, IReadOnlyList<T> items)
+        => RenderHelpers.Render(output, ToolResult<object>.Success(new { count = items.Count, items }));
+
+    private static string Normalize(string value)
+        => new(value.Where(char.IsLetterOrDigit).Select(char.ToLowerInvariant).ToArray());
+}

--- a/src/D365FO.Cli/Commands/Find/FindCommands.cs
+++ b/src/D365FO.Cli/Commands/Find/FindCommands.cs
@@ -341,7 +341,7 @@ public sealed class FindRelatedCommand : Command<FindRelatedCommand.Settings>
     public sealed class Settings : D365OutputSettings
     {
         [CommandArgument(0, "<RELATION>")]
-        [System.ComponentModel.Description("usages|refs|table-relations|coc|security|extensions|handlers|table-methods|table-indexes|table-delete-actions")]
+        [System.ComponentModel.Description("name-search|refs|table-relations|coc|security|extensions|handlers|table-methods|table-indexes|table-delete-actions")]
         public string Relation { get; init; } = "";
 
         [CommandArgument(1, "<NAME>")]
@@ -366,9 +366,9 @@ public sealed class FindRelatedCommand : Command<FindRelatedCommand.Settings>
             return RenderHelpers.Render(output, ToolResult<object>.Fail("BAD_INPUT", "Relation and name are required."));
 
         var repo = RepoFactory.Create();
-        return Normalize(settings.Relation) switch
+        return RenderHelpers.NormalizeKind(settings.Relation) switch
         {
-            "usages" => RenderUsages(output, repo, settings.Name, settings.Limit),
+            "namesearch" or "name-search" => RenderUsages(output, repo, settings.Name, settings.Limit),
             "refs" or "references" => RenderRefs(output, repo, settings.Name, settings.Kind, settings.Limit),
             "tablerelations" or "relations" => RenderItems(output, repo.GetTableRelations(settings.Name)),
             "coc" => RenderItems(output, repo.FindCocExtensions(settings.Name, settings.Method)),
@@ -383,7 +383,7 @@ public sealed class FindRelatedCommand : Command<FindRelatedCommand.Settings>
             _ => RenderHelpers.Render(output, ToolResult<object>.Fail(
                 "BAD_INPUT",
                 $"Unsupported relation '{settings.Relation}'.",
-                "Use usages, refs, table-relations, coc, security, extensions, handlers, table-methods, table-indexes, or table-delete-actions.")),
+                "Use name-search, refs, table-relations, coc, security, extensions, handlers, table-methods, table-indexes, or table-delete-actions.")),
         };
     }
 
@@ -439,7 +439,4 @@ public sealed class FindRelatedCommand : Command<FindRelatedCommand.Settings>
 
     private static int RenderItems<T>(OutputMode.Kind output, IReadOnlyList<T> items)
         => RenderHelpers.Render(output, ToolResult<object>.Success(new { count = items.Count, items }));
-
-    private static string Normalize(string value)
-        => new(value.Where(char.IsLetterOrDigit).Select(char.ToLowerInvariant).ToArray());
 }

--- a/src/D365FO.Cli/Commands/Get/GetCommands.cs
+++ b/src/D365FO.Cli/Commands/Get/GetCommands.cs
@@ -484,3 +484,69 @@ public sealed class GetServiceGroupCommand : Command<GetServiceGroupCommand.Sett
             : ToolResult<object>.Success(g));
     }
 }
+
+public sealed class GetObjectCommand : Command<GetObjectCommand.Settings>
+{
+    public sealed class Settings : D365OutputSettings
+    {
+        [CommandArgument(0, "<KIND>")]
+        [System.ComponentModel.Description("class|table|edt|enum|form|menu-item|query|view|entity|report|service|service-group|role|duty|privilege")]
+        public string Kind { get; init; } = "";
+
+        [CommandArgument(1, "<NAME>")]
+        public string Name { get; init; } = "";
+    }
+
+    public override int Execute(CommandContext ctx, Settings settings)
+    {
+        var output = OutputMode.Resolve(settings.Output);
+        if (string.IsNullOrWhiteSpace(settings.Kind) || string.IsNullOrWhiteSpace(settings.Name))
+            return RenderHelpers.Render(output, ToolResult<object>.Fail("BAD_INPUT", "Kind and name are required."));
+
+        var repo = RepoFactory.Create();
+        return Normalize(settings.Kind) switch
+        {
+            "class" => Render(output, repo.GetClassDetails(settings.Name), "CLASS_NOT_FOUND", $"Class '{settings.Name}' not found."),
+            "table" => RenderTable(output, repo.GetTableDetails(settings.Name), settings.Name),
+            "edt" => Render(output, repo.GetEdt(settings.Name), "EDT_NOT_FOUND", $"EDT '{settings.Name}' not found."),
+            "enum" => Render(output, repo.GetEnum(settings.Name), "ENUM_NOT_FOUND", $"Enum '{settings.Name}' not found."),
+            "form" => Render(output, repo.GetForm(settings.Name), "FORM_NOT_FOUND", $"Form '{settings.Name}' not found."),
+            "menuitem" => Render(output, repo.GetMenuItem(settings.Name), "MENU_ITEM_NOT_FOUND", $"Menu item '{settings.Name}' not found."),
+            "query" => Render(output, repo.GetQuery(settings.Name), "QUERY_NOT_FOUND", $"Query '{settings.Name}' not found."),
+            "view" => Render(output, repo.GetView(settings.Name), "VIEW_NOT_FOUND", $"View '{settings.Name}' not found."),
+            "entity" or "dataentity" => Render(output, repo.GetDataEntity(settings.Name), "ENTITY_NOT_FOUND", $"Data entity '{settings.Name}' not found."),
+            "report" => Render(output, repo.GetReport(settings.Name), "REPORT_NOT_FOUND", $"Report '{settings.Name}' not found."),
+            "service" => Render(output, repo.GetService(settings.Name), "SERVICE_NOT_FOUND", $"Service '{settings.Name}' not found."),
+            "servicegroup" => Render(output, repo.GetServiceGroup(settings.Name), "SERVICE_GROUP_NOT_FOUND", $"Service group '{settings.Name}' not found."),
+            "role" => Render(output, repo.GetSecurityRole(settings.Name), "ROLE_NOT_FOUND", $"Role '{settings.Name}' not found."),
+            "duty" => Render(output, repo.GetSecurityDuty(settings.Name), "DUTY_NOT_FOUND", $"Duty '{settings.Name}' not found."),
+            "privilege" => Render(output, repo.GetSecurityPrivilege(settings.Name), "PRIVILEGE_NOT_FOUND", $"Privilege '{settings.Name}' not found."),
+            _ => RenderHelpers.Render(output, ToolResult<object>.Fail(
+                "BAD_INPUT",
+                $"Unsupported object kind '{settings.Kind}'.",
+                "Use class, table, edt, enum, form, menu-item, query, view, entity, report, service, service-group, role, duty, or privilege.")),
+        };
+    }
+
+    private static int Render<T>(OutputMode.Kind output, T? data, string code, string message)
+        where T : class
+        => RenderHelpers.Render(output, data is null
+            ? ToolResult<object>.Fail(code, message)
+            : ToolResult<object>.Success(data));
+
+    private static int RenderTable(OutputMode.Kind output, TableDetails? details, string name)
+        => RenderHelpers.Render(output, details is null
+            ? ToolResult<object>.Fail("TABLE_NOT_FOUND", $"Table '{name}' not found in index.")
+            : ToolResult<object>.Success(new
+            {
+                table = details.Table,
+                fields = details.Fields,
+                relations = details.Relations,
+                methods = details.Methods,
+                indexes = details.Indexes,
+                deleteActions = details.DeleteActions,
+            }));
+
+    private static string Normalize(string value)
+        => new(value.Where(char.IsLetterOrDigit).Select(char.ToLowerInvariant).ToArray());
+}

--- a/src/D365FO.Cli/Commands/Get/GetCommands.cs
+++ b/src/D365FO.Cli/Commands/Get/GetCommands.cs
@@ -504,7 +504,7 @@ public sealed class GetObjectCommand : Command<GetObjectCommand.Settings>
             return RenderHelpers.Render(output, ToolResult<object>.Fail("BAD_INPUT", "Kind and name are required."));
 
         var repo = RepoFactory.Create();
-        return Normalize(settings.Kind) switch
+        return RenderHelpers.NormalizeKind(settings.Kind) switch
         {
             "class" => Render(output, repo.GetClassDetails(settings.Name), "CLASS_NOT_FOUND", $"Class '{settings.Name}' not found."),
             "table" => RenderTable(output, repo.GetTableDetails(settings.Name), settings.Name),
@@ -546,7 +546,4 @@ public sealed class GetObjectCommand : Command<GetObjectCommand.Settings>
                 indexes = details.Indexes,
                 deleteActions = details.DeleteActions,
             }));
-
-    private static string Normalize(string value)
-        => new(value.Where(char.IsLetterOrDigit).Select(char.ToLowerInvariant).ToArray());
 }

--- a/src/D365FO.Cli/Commands/Search/SearchCommands.cs
+++ b/src/D365FO.Cli/Commands/Search/SearchCommands.cs
@@ -289,4 +289,47 @@ public sealed class SearchAnyCommand : Command<SearchAnyCommand.Settings>
     }
 }
 
+public sealed class SearchBatchCommand : Command<SearchBatchCommand.Settings>
+{
+    public sealed class Settings : D365OutputSettings
+    {
+        [CommandArgument(0, "<QUERY>")]
+        [System.ComponentModel.Description("One or more substrings to look up across every indexed kind.")]
+        public string[] Queries { get; init; } = Array.Empty<string>();
+
+        [CommandOption("-l|--limit <N>")]
+        [System.ComponentModel.Description("Maximum hits per query.")]
+        public int Limit { get; init; } = 50;
+    }
+
+    public override int Execute(CommandContext ctx, Settings settings)
+    {
+        var kind = OutputMode.Resolve(settings.Output);
+        var queries = settings.Queries
+            .Where(q => !string.IsNullOrWhiteSpace(q))
+            .Select(q => q.Trim())
+            .Distinct(StringComparer.OrdinalIgnoreCase)
+            .ToArray();
+
+        if (queries.Length == 0)
+            return RenderHelpers.Render(kind, ToolResult<object>.Fail("BAD_INPUT", "At least one query is required."));
+
+        var repo = RepoFactory.Create();
+        var results = queries.Select(q =>
+        {
+            var hits = repo.FindUsages(q, settings.Limit)
+                .Select(t => new { kind = t.Kind, name = t.Name, model = t.Model })
+                .ToList();
+            var byKind = hits.GroupBy(h => h.kind).ToDictionary(g => g.Key, g => g.Count());
+            return new { query = q, count = hits.Count, byKind, items = hits };
+        }).ToList();
+
+        return RenderHelpers.Render(kind, ToolResult<object>.Success(new
+        {
+            count = results.Count,
+            limit = settings.Limit,
+            results,
+        }));
+    }
+}
 

--- a/src/D365FO.Cli/Commands/Search/SearchCommands.cs
+++ b/src/D365FO.Cli/Commands/Search/SearchCommands.cs
@@ -304,7 +304,7 @@ public sealed class SearchBatchCommand : Command<SearchBatchCommand.Settings>
 
     public override int Execute(CommandContext ctx, Settings settings)
     {
-        var kind = OutputMode.Resolve(settings.Output);
+        var output = OutputMode.Resolve(settings.Output);
         var queries = settings.Queries
             .Where(q => !string.IsNullOrWhiteSpace(q))
             .Select(q => q.Trim())
@@ -312,7 +312,7 @@ public sealed class SearchBatchCommand : Command<SearchBatchCommand.Settings>
             .ToArray();
 
         if (queries.Length == 0)
-            return RenderHelpers.Render(kind, ToolResult<object>.Fail("BAD_INPUT", "At least one query is required."));
+            return RenderHelpers.Render(output, ToolResult<object>.Fail("BAD_INPUT", "At least one query is required."));
 
         var repo = RepoFactory.Create();
         var results = queries.Select(q =>
@@ -324,7 +324,7 @@ public sealed class SearchBatchCommand : Command<SearchBatchCommand.Settings>
             return new { query = q, count = hits.Count, byKind, items = hits };
         }).ToList();
 
-        return RenderHelpers.Render(kind, ToolResult<object>.Success(new
+        return RenderHelpers.Render(output, ToolResult<object>.Success(new
         {
             count = results.Count,
             limit = settings.Limit,

--- a/src/D365FO.Cli/Program.cs
+++ b/src/D365FO.Cli/Program.cs
@@ -40,6 +40,7 @@ app.Configure(cfg =>
         b.AddCommand<SearchServiceCommand>("service").WithDescription("Find SOAP services.");
         b.AddCommand<SearchWorkflowCommand>("workflow").WithDescription("Find workflow types.");
         b.AddCommand<SearchAnyCommand>("any").WithDescription("Scope-agnostic search across every indexed kind.");
+        b.AddCommand<SearchBatchCommand>("batch").WithDescription("Run several scope-agnostic searches in one CLI call.");
     });
 
     cfg.AddBranch("get", b =>
@@ -62,6 +63,7 @@ app.Configure(cfg =>
         b.AddCommand<GetReportCommand>("report").WithDescription("Report: datasets + queries/RDP.");
         b.AddCommand<GetServiceCommand>("service").WithDescription("SOAP service: operations.");
         b.AddCommand<GetServiceGroupCommand>("service-group").WithDescription("Service group: members.");
+        b.AddCommand<GetObjectCommand>("object").WithDescription("Generic get by kind/name for agent workflows.");
     });
 
     cfg.AddBranch("find", b =>
@@ -74,6 +76,7 @@ app.Configure(cfg =>
         b.AddCommand<FindHandlersCommand>("handlers").WithDescription("Find event handlers subscribed to a form/table/delegate.");
         b.AddCommand<FindRefsCommand>("refs").WithDescription("Regex scan of indexed X++ source for reverse references to a symbol.");
         b.AddCommand<FindFormPatternsCommand>("form-patterns").WithDescription("Analyse indexed forms by Microsoft pattern / primary table / similarity to a reference form.");
+        b.AddCommand<FindRelatedCommand>("related").WithDescription("Generic relation lookup by relation/name for agent workflows.");
     });
 
     cfg.AddBranch("resolve", b =>
@@ -199,4 +202,3 @@ catch (Exception ex)
         D365FO.Core.ToolResult<object>.Fail("UNHANDLED", ex.Message, ex.GetType().FullName)));
     return 2;
 }
-

--- a/src/D365FO.Cli/RenderHelpers.cs
+++ b/src/D365FO.Cli/RenderHelpers.cs
@@ -8,6 +8,14 @@ namespace D365FO.Cli;
 
 public static class RenderHelpers
 {
+    /// <summary>
+    /// Strips non-alphanumeric characters and lower-cases the result so that
+    /// CLI argument values like "table-relations", "tableRelations", and
+    /// "tablerelations" all compare equal in command switch expressions.
+    /// </summary>
+    public static string NormalizeKind(string value)
+        => new(value.Where(char.IsLetterOrDigit).Select(char.ToLowerInvariant).ToArray());
+
     private static readonly System.Threading.AsyncLocal<bool> _resolveLabels = new();
 
     /// <summary>

--- a/src/D365FO.Core/Index/MetadataRepository.cs
+++ b/src/D365FO.Core/Index/MetadataRepository.cs
@@ -972,7 +972,12 @@ public sealed class MetadataRepository
     }
 
     private sealed record EnumHeaderRow(long EnumId, string Name, string Model, string? Label);
-    private sealed record UsageRow(string Kind, string Name, string Model);
+    private sealed class UsageRow
+    {
+        public string Kind { get; set; } = "";
+        public string Name { get; set; } = "";
+        public string Model { get; set; } = "";
+    }
 
     public LabelMatch? GetLabel(string file, string language, string key)
     {
@@ -1696,4 +1701,3 @@ public sealed class MetadataRepository
         return r.ReadToEnd();
     }
 }
-


### PR DESCRIPTION
## Summary

This PR strengthens the CLI as the primary, token-efficient agent interface while preserving MCP feature parity.

## Changes

- Adds `d365fo search batch <q1> <q2> ...` for multi-query discovery in one CLI process.
- Adds `d365fo get object <kind> <name>` for generic agent-friendly metadata lookup.
- Adds `d365fo find related <relation> <name>` for generic relation discovery.
- Reworks `d365fo schema` into a compact agent-first manifest, with `--full` for the complete CLI catalog.
- Adds MCP replacement mappings and workflow guidance to the schema output.
- Fixes `MetadataRepository.FindUsages` Dapper materialization.
- Updates docs to steer agents toward CLI-first usage.

## Validation

```sh
dotnet test d365fo-cli.slnx
