### PR TITLE
fix(resolve label): PowerShell quoting hint, sanitization, table rend…

### DIFF
--- a/src/D365FO.Cli/Commands/Resolve/ResolveCommands.cs
+++ b/src/D365FO.Cli/Commands/Resolve/ResolveCommands.cs
@@ -1,5 +1,6 @@
 using D365FO.Core;
 using D365FO.Core.Extract;
+using Spectre.Console;
 using Spectre.Console.Cli;
 
 namespace D365FO.Cli.Commands.Resolve;
@@ -22,7 +23,7 @@ public sealed class ResolveLabelCommand : Command<ResolveLabelCommand.Settings>
         var kind = OutputMode.Resolve(settings.Output);
         var langs = string.IsNullOrWhiteSpace(settings.Languages)
             ? null
-            : settings.Languages.Split(',', System.StringSplitOptions.RemoveEmptyEntries | System.StringSplitOptions.TrimEntries);
+            : settings.Languages.Split([',', ';'], System.StringSplitOptions.RemoveEmptyEntries | System.StringSplitOptions.TrimEntries);
 
         var repo = RepoFactory.Create();
         var hits = repo.ResolveLabel(settings.Token, langs);
@@ -30,8 +31,20 @@ public sealed class ResolveLabelCommand : Command<ResolveLabelCommand.Settings>
         {
             return RenderHelpers.Render(kind,
                 ToolResult<object>.Fail("LABEL_NOT_FOUND", $"Label '{settings.Token}' not resolved.",
-                    "Verify @FilePrefix+Key spelling and that the language is indexed."));
+                    "Verify @FilePrefix+Key spelling and that the language is indexed. " +
+                    "In PowerShell, wrap the token in single quotes to prevent @ from being treated as the splat operator: '@SYS12345'. " +
+                    "Also quote comma-separated --lang values: --lang 'en-us,cs'."));
         }
-        return RenderHelpers.Render(kind, ToolResult<object>.Success(new { count = hits.Count, items = hits }));
+
+        if (!settings.RawText)
+            hits = hits.Select(h => h with { Value = StringSanitizer.Sanitize(h.Value) }).ToList();
+
+        return RenderHelpers.Render(kind, ToolResult<object>.Success(new { count = hits.Count, items = hits }), _ =>
+        {
+            var table = new Table().AddColumn("File").AddColumn("Lang").AddColumn("Key").AddColumn("Value");
+            foreach (var h in hits)
+                table.AddRow(h.File, h.Language, h.Key, RenderHelpers.Escape(h.Value) ?? "-");
+            AnsiConsole.Write(table);
+        });
     }
 }


### PR DESCRIPTION
…erer, semicolon separator

Fixes #19

Two bugs reported:
1. `@SYS12345` in PowerShell is silently splatted to nothing → TOKEN missing
2. `en-us,cs` without quotes becomes a two-element array → `cs` lands in the TOKEN positional slot instead of --lang

Changes:
- LABEL_NOT_FOUND error now explicitly hints at PowerShell single-quote quoting for both `@TOKEN` and comma-separated `--lang` values
- Apply StringSanitizer.Sanitize unless --raw-text (parity with search/get label)
- Add table renderer for TTY output mode
- Accept `;` as additional --lang separator (parity with search label)