### PR TITLE
fix(index refresh): include .label.txt in fingerprint + LabelLanguage…

### DIFF
--- a/src/D365FO.Cli/Commands/Index/IndexCommands.cs
+++ b/src/D365FO.Cli/Commands/Index/IndexCommands.cs
@@ -175,7 +175,7 @@ public sealed class IndexExtractCommand : Command<IndexExtractCommand.Settings>
             foreach (var modelDir in modelDirs)
             {
                 var model = Path.GetFileName(modelDir)!;
-                var fp = ComputeFingerprint(modelDir);
+                var fp = ComputeFingerprint(modelDir, cfg.LabelLanguages);
                 if (since.HasValue && NewestMtime(modelDir) is { } newest && newest < since.Value)
                 {
                     skippedCount++;
@@ -290,18 +290,28 @@ public sealed class IndexExtractCommand : Command<IndexExtractCommand.Settings>
 
     /// <summary>
     /// Cheap per-model content fingerprint used by <c>d365fo index refresh</c>.
-    /// Format: <c>"{fileCount}:{newestMtimeTicks}"</c>. Sensitive enough to
-    /// catch touches (re-export, rebase, partial sync) without paying the cost
-    /// of hashing every byte. The trade-off is documented in ROADMAP §1.1.
+    /// Format: <c>"{fileCount}:{newestMtimeTicks}:{langs}"</c>. Sensitive enough
+    /// to catch touches (re-export, rebase, partial sync) without paying the
+    /// cost of hashing every byte. The trade-off is documented in ROADMAP §1.1.
+    /// <para>
+    /// Both <c>*.xml</c> and <c>*.label.txt</c> files are included so that
+    /// label-only changes (new translations, deletions) are not silently skipped.
+    /// The sorted <paramref name="labelLanguages"/> suffix ensures that adding
+    /// a language to <c>D365FO_LABEL_LANGUAGES</c> forces re-extraction even
+    /// when the underlying files have not changed.
+    /// </para>
     /// </summary>
-    internal static string ComputeFingerprint(string dir)
+    internal static string ComputeFingerprint(string dir, IReadOnlyList<string>? labelLanguages = null)
     {
         long newestTicks = 0;
         int count = 0;
         try
         {
-            foreach (var f in Directory.EnumerateFiles(dir, "*.xml", SearchOption.AllDirectories))
+            foreach (var f in Directory.EnumerateFiles(dir, "*", SearchOption.AllDirectories))
             {
+                if (!f.EndsWith(".xml", StringComparison.OrdinalIgnoreCase)
+                    && !f.EndsWith(".label.txt", StringComparison.OrdinalIgnoreCase))
+                    continue;
                 count++;
                 try
                 {
@@ -312,7 +322,10 @@ public sealed class IndexExtractCommand : Command<IndexExtractCommand.Settings>
             }
         }
         catch { }
-        return $"{count}:{newestTicks}";
+        var langs = labelLanguages is { Count: > 0 }
+            ? string.Join(",", labelLanguages.Select(l => l.ToLowerInvariant()).OrderBy(l => l))
+            : "";
+        return $"{count}:{newestTicks}:{langs}";
     }
 
     private static IEnumerable<string> EnumerateModelDirs(string packagesRoot, string? onlyModel)

--- a/src/D365FO.Cli/D365FO.Cli.csproj
+++ b/src/D365FO.Cli/D365FO.Cli.csproj
@@ -12,6 +12,12 @@
     <PackageReference Include="Spectre.Console.Json" Version="0.49.1" />
   </ItemGroup>
 
+  <ItemGroup>
+    <AssemblyAttribute Include="System.Runtime.CompilerServices.InternalsVisibleTo">
+      <_Parameter1>D365FO.Cli.Tests</_Parameter1>
+    </AssemblyAttribute>
+  </ItemGroup>
+
   <PropertyGroup>
     <OutputType>Exe</OutputType>
     <TargetFramework>net10.0</TargetFramework>

--- a/tests/D365FO.Cli.Tests/ComputeFingerprintTests.cs
+++ b/tests/D365FO.Cli.Tests/ComputeFingerprintTests.cs
@@ -1,0 +1,75 @@
+using D365FO.Cli.Commands.Index;
+
+namespace D365FO.Cli.Tests;
+
+/// <summary>
+/// Verifies that <see cref="IndexExtractCommand.ComputeFingerprint"/> is
+/// sensitive to both label-file changes and LabelLanguages config changes.
+/// </summary>
+public class ComputeFingerprintTests : IDisposable
+{
+    private readonly string _dir = Path.Combine(Path.GetTempPath(), $"d365fo-fp-{Guid.NewGuid():N}");
+
+    public ComputeFingerprintTests() => Directory.CreateDirectory(_dir);
+
+    public void Dispose()
+    {
+        try { Directory.Delete(_dir, recursive: true); } catch { }
+    }
+
+    [Fact]
+    public void Fingerprint_changes_when_label_txt_added()
+    {
+        var fp1 = IndexExtractCommand.ComputeFingerprint(_dir);
+        File.WriteAllText(Path.Combine(_dir, "SysLabel.en-US.label.txt"), "Title=Hello");
+        var fp2 = IndexExtractCommand.ComputeFingerprint(_dir);
+
+        Assert.NotEqual(fp1, fp2);
+    }
+
+    [Fact]
+    public void Fingerprint_changes_when_label_txt_modified()
+    {
+        var txt = Path.Combine(_dir, "SysLabel.en-US.label.txt");
+        File.WriteAllText(txt, "Title=Hello");
+        var fp1 = IndexExtractCommand.ComputeFingerprint(_dir);
+
+        // Force mtime change (some FS have 1-s resolution)
+        File.SetLastWriteTimeUtc(txt, File.GetLastWriteTimeUtc(txt).AddSeconds(2));
+        var fp2 = IndexExtractCommand.ComputeFingerprint(_dir);
+
+        Assert.NotEqual(fp1, fp2);
+    }
+
+    [Fact]
+    public void Fingerprint_changes_when_LabelLanguages_extended()
+    {
+        File.WriteAllText(Path.Combine(_dir, "SysLabel.en-US.label.txt"), "Title=Hello");
+
+        var fp1 = IndexExtractCommand.ComputeFingerprint(_dir, new[] { "en-us" });
+        var fp2 = IndexExtractCommand.ComputeFingerprint(_dir, new[] { "en-us", "cs" });
+
+        Assert.NotEqual(fp1, fp2);
+    }
+
+    [Fact]
+    public void Fingerprint_stable_when_nothing_changes()
+    {
+        File.WriteAllText(Path.Combine(_dir, "SysLabel.en-US.label.txt"), "Title=Hello");
+        var langs = new[] { "en-us", "cs" };
+
+        var fp1 = IndexExtractCommand.ComputeFingerprint(_dir, langs);
+        var fp2 = IndexExtractCommand.ComputeFingerprint(_dir, langs);
+
+        Assert.Equal(fp1, fp2);
+    }
+
+    [Fact]
+    public void Fingerprint_langs_order_insensitive()
+    {
+        var fp1 = IndexExtractCommand.ComputeFingerprint(_dir, new[] { "en-us", "cs" });
+        var fp2 = IndexExtractCommand.ComputeFingerprint(_dir, new[] { "cs", "en-us" });
+
+        Assert.Equal(fp1, fp2);
+    }
+}


### PR DESCRIPTION
…s suffix

Previously ComputeFingerprint only scanned *.xml files, so two cases silently skipped re-extraction when they should not have:

1. A *.label.txt file was added / modified / deleted — the fingerprint didn't change → model skipped → stale labels in the index.

2. D365FO_LABEL_LANGUAGES was extended (e.g. 'en-us' → 'en-us,cs') — the env-var change was invisible to the fingerprint → model skipped → newly requested language never indexed (root cause of issue #19).

Changes:
- ComputeFingerprint now iterates *.xml AND *.label.txt files
- Sorted, normalised LabelLanguages appended as a third colon-segment so any change to the language config invalidates stored fingerprints
- D365FO.Cli exposes internals to D365FO.Cli.Tests via InternalsVisibleTo
- 5 new tests in ComputeFingerprintTests cover all fixed scenarios