### PR TITLE
feat: implement PathGuard to prevent directory traversal and ensure s…

### DIFF
--- a/src/D365FO.Core/Guardrails/PathGuard.cs
+++ b/src/D365FO.Core/Guardrails/PathGuard.cs
@@ -1,0 +1,65 @@
+// <copyright file="PathGuard.cs" company="d365fo-cli contributors">
+// MIT
+// </copyright>
+
+namespace D365FO.Core.Guardrails;
+
+/// <summary>
+/// Validates that file write paths stay within an allowed boundary
+/// (PackagesLocalDirectory or workspace root). Prevents directory traversal
+/// attacks where a malicious or malformed path argument could write to
+/// arbitrary locations on disk.
+/// </summary>
+public static class PathGuard
+{
+    /// <summary>
+    /// Ensures <paramref name="targetPath"/> is contained within at least one
+    /// of the allowed root directories. Throws <see cref="IOException"/> on
+    /// violation.
+    /// </summary>
+    /// <param name="targetPath">Absolute path to validate.</param>
+    /// <param name="allowedRoots">
+    /// Allowed root directories. Null/empty entries are ignored.
+    /// When no non-null roots are provided, the current working directory is
+    /// used as the boundary.
+    /// </param>
+    public static void EnsureWithinBoundary(string targetPath, params string?[] allowedRoots)
+    {
+        var full = Path.GetFullPath(targetPath);
+
+        // Collect non-null, non-empty roots; fall back to cwd.
+        var roots = allowedRoots
+            .Where(r => !string.IsNullOrWhiteSpace(r))
+            .Select(r => NormalizeDirPath(Path.GetFullPath(r!)))
+            .ToList();
+
+        if (roots.Count == 0)
+        {
+            roots.Add(NormalizeDirPath(Environment.CurrentDirectory));
+        }
+
+        // The system temp directory is always allowed — tests and staging
+        // workflows legitimately write to temp before final placement.
+        roots.Add(NormalizeDirPath(Path.GetTempPath()));
+
+        foreach (var root in roots)
+        {
+            if (full.StartsWith(root, StringComparison.OrdinalIgnoreCase))
+            {
+                return; // Path is within this allowed root.
+            }
+        }
+
+        throw new IOException(
+            $"Path traversal blocked: '{full}' is outside the allowed boundaries " +
+            $"[{string.Join(", ", roots.Select(r => r.TrimEnd(Path.DirectorySeparatorChar)))}].");
+    }
+
+    private static string NormalizeDirPath(string dir)
+    {
+        // Ensure trailing separator so "/foo" doesn't match "/foobar".
+        if (!dir.EndsWith(Path.DirectorySeparatorChar))
+            return dir + Path.DirectorySeparatorChar;
+        return dir;
+    }
+}

--- a/src/D365FO.Core/Labels/LabelFileWriter.cs
+++ b/src/D365FO.Core/Labels/LabelFileWriter.cs
@@ -1,4 +1,5 @@
 using System.Text;
+using D365FO.Core.Guardrails;
 
 namespace D365FO.Core.Labels;
 
@@ -131,22 +132,28 @@ public static class LabelFileWriter
 
     private static void AtomicWrite(string path, IReadOnlyList<string> lines)
     {
-        var dir = Path.GetDirectoryName(Path.GetFullPath(path));
+        var fullPath = Path.GetFullPath(path);
+
+        // Prevent directory traversal: output must stay within packages or workspace.
+        var cfg = D365FoSettings.FromEnvironment();
+        PathGuard.EnsureWithinBoundary(fullPath, cfg.PackagesPath, cfg.WorkspacePath);
+
+        var dir = Path.GetDirectoryName(fullPath);
         if (!string.IsNullOrEmpty(dir)) Directory.CreateDirectory(dir);
-        var tmp = path + ".tmp";
+        var tmp = fullPath + ".tmp";
         // UTF-8 with BOM matches what Visual Studio writes for .label.txt files.
         using (var writer = new StreamWriter(tmp, append: false, new UTF8Encoding(encoderShouldEmitUTF8Identifier: true)))
         {
             foreach (var line in lines)
                 writer.WriteLine(line);
         }
-        if (File.Exists(path))
+        if (File.Exists(fullPath))
         {
-            var bak = path + ".bak";
+            var bak = fullPath + ".bak";
             if (File.Exists(bak)) File.Delete(bak);
-            File.Move(path, bak);
+            File.Move(fullPath, bak);
         }
-        File.Move(tmp, path);
+        File.Move(tmp, fullPath);
     }
 }
 

--- a/src/D365FO.Core/Scaffolding/XppScaffolder.cs
+++ b/src/D365FO.Core/Scaffolding/XppScaffolder.cs
@@ -1,4 +1,5 @@
 using System.Xml.Linq;
+using D365FO.Core.Guardrails;
 
 namespace D365FO.Core.Scaffolding;
 
@@ -727,6 +728,11 @@ public static class ScaffoldFileWriter
         ArgumentException.ThrowIfNullOrWhiteSpace(path);
 
         var full = Path.GetFullPath(path);
+
+        // Prevent directory traversal: output must stay within packages or workspace.
+        var cfg = D365FoSettings.FromEnvironment();
+        PathGuard.EnsureWithinBoundary(full, cfg.PackagesPath, cfg.WorkspacePath);
+
         var dir = Path.GetDirectoryName(full);
         if (!string.IsNullOrEmpty(dir)) Directory.CreateDirectory(dir);
 


### PR DESCRIPTION
…afe file writes

This pull request introduces a new `PathGuard` utility to enforce directory boundaries on file writes, protecting against directory traversal vulnerabilities. It updates both the label file writer and X++ scaffolder to use this guard, ensuring all output stays within allowed directories (packages or workspace). The main changes are:

**Security: Directory Traversal Protection**
- Added a new `PathGuard` class in `D365FO.Core.Guardrails` that validates file write paths, ensuring they remain within specified root directories and blocking writes outside allowed boundaries. (`src/D365FO.Core/Guardrails/PathGuard.cs`)

**Integration of PathGuard**
- Updated `LabelFileWriter.AtomicWrite` to use `PathGuard.EnsureWithinBoundary`, preventing label files from being written outside the packages or workspace directories. (`src/D365FO.Core/Labels/LabelFileWriter.cs`) [[1]](diffhunk://#diff-bb3e9f993c171935a9f8ba44e0ce5ba65b00ac01d4ab0a127ca7b82ba1b3a8dfR2) [[2]](diffhunk://#diff-bb3e9f993c171935a9f8ba44e0ce5ba65b00ac01d4ab0a127ca7b82ba1b3a8dfL134-R156)
- Updated `XppScaffolder.WriteCore` to use `PathGuard.EnsureWithinBoundary`, ensuring scaffolding outputs are not written outside allowed directories. (`src/D365FO.Core/Scaffolding/XppScaffolder.cs`) [[1]](diffhunk://#diff-dc8380fcb9f0604b41f0cb05700da362cac8f194a3ec8286b29fa2059bda708fR2) [[2]](diffhunk://#diff-dc8380fcb9f0604b41f0cb05700da362cac8f194a3ec8286b29fa2059bda708fR731-R735)