### PR TITLE
fix: resolve row value misused error by restructuring SQL queries for…

### DIFF
--- a/src/D365FO.Core/Index/MetadataRepository.cs
+++ b/src/D365FO.Core/Index/MetadataRepository.cs
@@ -282,14 +282,28 @@ public sealed class MetadataRepository
         using var conn = OpenReadOnly();
         var like = $"%{query}%";
         var langsLower = languages?.Select(l => l.ToLowerInvariant()).ToList();
-        var sql = @"
+        string sql;
+        if (langsLower is null || langsLower.Count == 0)
+        {
+            sql = @"
             SELECT LabelFile AS File, Language, Key, Value
             FROM Labels
             WHERE (Value LIKE @like OR Key LIKE @like)
-              AND (@langs IS NULL OR LOWER(Language) IN @langs)
             ORDER BY LabelFile, Key
             LIMIT @limit";
-        return conn.Query<LabelMatch>(sql, new { like, langs = langsLower, limit }).ToList();
+            return conn.Query<LabelMatch>(sql, new { like, limit }).ToList();
+        }
+        else
+        {
+            sql = @"
+            SELECT LabelFile AS File, Language, Key, Value
+            FROM Labels
+            WHERE (Value LIKE @like OR Key LIKE @like)
+              AND LOWER(Language) IN @langs
+            ORDER BY LabelFile, Key
+            LIMIT @limit";
+            return conn.Query<LabelMatch>(sql, new { like, langs = langsLower, limit }).ToList();
+        }
     }
 
     /// <summary>
@@ -304,14 +318,28 @@ public sealed class MetadataRepository
         var langsLower = languages?.Select(l => l.ToLowerInvariant()).ToList();
         try
         {
-            var sql = @"
+            string sql;
+            if (langsLower is null || langsLower.Count == 0)
+            {
+                sql = @"
                 SELECT LabelFile AS File, Language, Key, Value
                 FROM LabelFts
                 WHERE LabelFts MATCH @q
-                  AND (@langs IS NULL OR LOWER(Language) IN @langs)
                 ORDER BY rank
                 LIMIT @limit";
-            return conn.Query<LabelMatch>(sql, new { q = query, langs = langsLower, limit }).ToList();
+                return conn.Query<LabelMatch>(sql, new { q = query, limit }).ToList();
+            }
+            else
+            {
+                sql = @"
+                SELECT LabelFile AS File, Language, Key, Value
+                FROM LabelFts
+                WHERE LabelFts MATCH @q
+                  AND LOWER(Language) IN @langs
+                ORDER BY rank
+                LIMIT @limit";
+                return conn.Query<LabelMatch>(sql, new { q = query, langs = langsLower, limit }).ToList();
+            }
         }
         catch (Microsoft.Data.Sqlite.SqliteException)
         {
@@ -1015,16 +1043,34 @@ public sealed class MetadataRepository
         // Try two shapes: Key == raw (e.g. "SYS12345") in file=prefix,
         // or Key == suffix (e.g. "12345") in file=prefix. Fall back to
         // exact key match across all files for odd prefixes.
-        var sql = @"
+        //
+        // NOTE: Dapper's list expansion rewrites "IN @langs" to "IN (@langs0, @langs1, ...)"
+        // which breaks a combined "@langs IS NULL" check (SQLite: "row value misused").
+        // We branch the SQL in C# instead.
+        string sql;
+        if (langsLower is null || langsLower.Count == 0)
+        {
+            sql = @"
             SELECT LabelFile AS File, Language, Key, Value
             FROM Labels
-            WHERE (@langs IS NULL OR LOWER(Language) IN @langs)
+            WHERE (LabelFile = @prefix AND Key IN (@raw, @suffix))
+               OR Key = @raw
+            ORDER BY LabelFile, Language";
+            return conn.Query<LabelMatch>(sql, new { prefix, raw, suffix }).ToList();
+        }
+        else
+        {
+            sql = @"
+            SELECT LabelFile AS File, Language, Key, Value
+            FROM Labels
+            WHERE LOWER(Language) IN @langs
               AND (
                     (LabelFile = @prefix AND Key IN (@raw, @suffix))
                  OR Key = @raw
               )
             ORDER BY LabelFile, Language";
-        return conn.Query<LabelMatch>(sql, new { langs = langsLower, prefix, raw, suffix }).ToList();
+            return conn.Query<LabelMatch>(sql, new { langs = langsLower, prefix, raw, suffix }).ToList();
+        }
     }
 
     /// <summary>


### PR DESCRIPTION
… language filtering

This pull request refactors the label search and resolution queries in `MetadataRepository.cs` to improve correctness and reliability when filtering by language. The main change is to branch the SQL logic in C# based on whether a language filter is provided, instead of relying on SQL checks that do not behave correctly with Dapper's list expansion and SQLite.

**Label search and filtering improvements:**

* The SQL logic in `SearchLabels`, `SearchLabelsFts`, and `ResolveLabel` is now branched in C# to handle cases where the language filter is empty or null, avoiding the use of `(@langs IS NULL OR ...)` in SQL, which is not compatible with Dapper's list expansion for SQLite. [[1]](diffhunk://#diff-daf80b3446ddf99297e4849c8b972197e2d8599afc51d760414f421097ef588bL285-R307) [[2]](diffhunk://#diff-daf80b3446ddf99297e4849c8b972197e2d8599afc51d760414f421097ef588bL307-R343) [[3]](diffhunk://#diff-daf80b3446ddf99297e4849c8b972197e2d8599afc51d760414f421097ef588bL1018-R1074)
* For all three methods, if no languages are specified, the SQL omits the language filter entirely; if languages are specified, the filter uses `LOWER(Language) IN @langs`. [[1]](diffhunk://#diff-daf80b3446ddf99297e4849c8b972197e2d8599afc51d760414f421097ef588bL285-R307) [[2]](diffhunk://#diff-daf80b3446ddf99297e4849c8b972197e2d8599afc51d760414f421097ef588bL307-R343) [[3]](diffhunk://#diff-daf80b3446ddf99297e4849c8b972197e2d8599afc51d760414f421097ef588bL1018-R1074)
* The comments in the code have been updated to explain the reasoning behind the change, specifically regarding Dapper's behavior and SQLite limitations.

#19 