### PR TITLE
fix: table field extraction picks FieldGroup nested Fields element (#24)

### DIFF
--- a/src/D365FO.Core/Extract/MetadataExtractor.cs
+++ b/src/D365FO.Core/Extract/MetadataExtractor.cs
@@ -304,7 +304,7 @@ public sealed class MetadataExtractor
         var name = Local(root, "Name") ?? Path.GetFileNameWithoutExtension(file);
         var label = Local(root, "Label");
         var fields = new List<ExtractedTableField>();
-        var fieldsContainer = root.Descendants().FirstOrDefault(x => x.Name.LocalName == "Fields");
+        var fieldsContainer = root.Elements().FirstOrDefault(x => x.Name.LocalName == "Fields");
         if (fieldsContainer is not null)
         {
             foreach (var fe in fieldsContainer.Elements().Where(x => x.Name.LocalName.StartsWith("AxTableField", StringComparison.Ordinal)))

--- a/tests/D365FO.Core.Tests/ExtractPipelineTests.cs
+++ b/tests/D365FO.Core.Tests/ExtractPipelineTests.cs
@@ -196,6 +196,45 @@ public class ExtractPipelineTests : IDisposable
     }
 
     [Fact]
+    public void MetadataExtractor_reads_table_fields_when_FieldGroups_precede_Fields()
+    {
+        // Regression: FieldGroups contain their own <Fields> children.
+        // The extractor must pick the root-level <Fields>, not a nested one.
+        var model = Path.Combine(_workRoot, "PkgFG", "PkgFG");
+        Directory.CreateDirectory(Path.Combine(model, "AxTable"));
+        File.WriteAllText(Path.Combine(model, "AxTable", "TWithFG.xml"), """
+            <AxTable>
+              <Name>TWithFG</Name>
+              <FieldGroups>
+                <AxTableFieldGroup>
+                  <Name>AutoReport</Name>
+                  <Fields>
+                    <AxTableFieldGroupField><DataField>AccountNum</DataField></AxTableFieldGroupField>
+                  </Fields>
+                </AxTableFieldGroup>
+              </FieldGroups>
+              <Fields>
+                <AxTableFieldString>
+                  <Name>AccountNum</Name>
+                  <ExtendedDataType>CustAccount</ExtendedDataType>
+                  <Mandatory>Yes</Mandatory>
+                </AxTableFieldString>
+                <AxTableFieldString>
+                  <Name>Name</Name>
+                  <ExtendedDataType>Name</ExtendedDataType>
+                </AxTableFieldString>
+              </Fields>
+            </AxTable>
+            """);
+        var batches = new MetadataExtractor().ExtractAll(_workRoot).ToList();
+        var batch = batches.Single(b => b.Model == "PkgFG");
+        var table = Assert.Single(batch.Tables);
+        Assert.Equal(2, table.Fields.Count);
+        Assert.Equal("AccountNum", table.Fields[0].Name);
+        Assert.Equal("Name", table.Fields[1].Name);
+    }
+
+    [Fact]
     public void MetadataExtractor_detects_abstract_with_newline_in_declaration()
     {
         var model = Path.Combine(_workRoot, "PkgFix4", "PkgFix4");


### PR DESCRIPTION
root.Descendants() found the first <Fields> in document order, which in real AxTable XML is inside <FieldGroups>/<AxTableFieldGroup> — not the table-level field definitions. Changed to root.Elements() (direct children only), consistent with Relations/Indexes lookup in the same method.

Added regression test with FieldGroups preceding Fields.