### PR TITLE
Phase 1 on the Roadmap

### DIFF
--- a/docs/AUDIT_PLAN.md
+++ b/docs/AUDIT_PLAN.md
@@ -6,38 +6,38 @@ Full audit of the d365fo-cli solution identifying incomplete functionality, miss
 
 ---
 
-## Phase 1: Index & Performance Optimizations
+## Phase 1: Index & Performance Optimizations ✅
 
 Extraction and index operations are the heaviest workloads. These improvements reduce wall-clock time and resource consumption.
 
-### 1.1 Parallel model extraction
+### 1.1 Parallel model extraction ✅
 
 Currently models are extracted sequentially (per-file parallelism exists inside each model). Add `Parallel.ForEach` over models with configurable `--parallelism N` (default: `Environment.ProcessorCount / 2`). Guard the SQLite write path with a per-model commit lock.
 
 - File: `src/D365FO.Core/Extract/MetadataExtractor.cs`
 - File: `src/D365FO.Cli/Commands/Index/IndexCommands.cs` (ExtractCore method)
 
-### 1.2 Index VACUUM / ANALYZE command
+### 1.2 Index VACUUM / ANALYZE command ✅
 
 After large extractions, SQLite benefits from `VACUUM` (reclaims space) and `ANALYZE` (updates query planner stats). Add `d365fo index optimize` command.
 
 - File: `src/D365FO.Core/Index/MetadataRepository.cs` — new `Optimize()` method
 - File: `src/D365FO.Cli/Commands/Index/IndexCommands.cs` — new `IndexOptimizeCommand`
 
-### 1.3 Incremental FTS5 updates
+### 1.3 Incremental FTS5 updates ✅
 
 Current FTS5 rebuild is full (`INSERT INTO LabelFts(LabelFts) VALUES('rebuild')`). Switch to incremental content-sync triggers or per-model FTS row delete + re-insert during `ApplyExtract`.
 
 - File: `src/D365FO.Core/Index/Schema.sql`
 - File: `src/D365FO.Core/Index/MetadataRepository.cs` (ApplyExtract label section)
 
-### 1.4 Index export/import for team sharing
+### 1.4 Index export/import for team sharing ✅
 
 Add `d365fo index export --out index.tar.gz` and `d365fo index import --from index.tar.gz` to share pre-built indexes across team (CI artifact).
 
 - New command files under `src/D365FO.Cli/Commands/Index/`
 
-### 1.5 Daemon warm-up command
+### 1.5 Daemon warm-up command ✅
 
 `d365fo daemon warmup` pre-loads frequently-queried tables/classes into SQLite page cache (single `SELECT count(*) FROM ...` per major table).
 

--- a/src/D365FO.Cli/Commands/Daemon/DaemonCommands.cs
+++ b/src/D365FO.Cli/Commands/Daemon/DaemonCommands.cs
@@ -348,3 +348,45 @@ public sealed class DaemonStatusCommand : Command<DaemonStatusCommand.Settings>
         }));
     }
 }
+
+/// <summary>
+/// Pre-warms the SQLite page cache by issuing lightweight count queries on
+/// the major index tables. Speeds up the first real query after a cold start
+/// (e.g., after booting the daemon) by loading frequently-accessed B-tree
+/// pages into the OS page cache before any user request arrives.
+/// </summary>
+public sealed class DaemonWarmupCommand : Command<DaemonWarmupCommand.Settings>
+{
+    public sealed class Settings : D365OutputSettings
+    {
+        [CommandOption("--db <PATH>")]
+        public string? DatabasePath { get; init; }
+    }
+
+    public override int Execute(CommandContext ctx, Settings settings)
+    {
+        var kind = OutputMode.Resolve(settings.Output);
+        var repo = RepoFactory.Create(settings.DatabasePath);
+        var sw = System.Diagnostics.Stopwatch.StartNew();
+        var counts = repo.Warmup();
+        sw.Stop();
+        return RenderHelpers.Render(kind, ToolResult<object>.Success(new
+        {
+            elapsedMs = sw.ElapsedMilliseconds,
+            counts = new
+            {
+                tables       = counts.Tables,
+                classes      = counts.Classes,
+                methods      = counts.Methods,
+                edts         = counts.Edts,
+                enums        = counts.Enums,
+                labels       = counts.Labels,
+                forms        = counts.Forms,
+                cocExtensions = counts.CocExtensions,
+                dataEntities = counts.DataEntities,
+            },
+        }), _ => Spectre.Console.AnsiConsole.MarkupLine(
+            $"[green]OK[/] warm-up complete in {sw.ElapsedMilliseconds}ms " +
+            $"(tables={counts.Tables} classes={counts.Classes} labels={counts.Labels})"));
+    }
+}

--- a/src/D365FO.Cli/Commands/Index/IndexCommands.cs
+++ b/src/D365FO.Cli/Commands/Index/IndexCommands.cs
@@ -104,6 +104,10 @@ public sealed class IndexExtractCommand : Command<IndexExtractCommand.Settings>
         [CommandOption("--since <ISO8601>")]
         [System.ComponentModel.Description("Skip models whose newest XML mtime is older than this timestamp. Enables mtime-based incremental refresh.")]
         public string? Since { get; init; }
+
+        [CommandOption("--parallelism <N>")]
+        [System.ComponentModel.Description("Number of models to parse in parallel. Defaults to half the CPU core count. SQLite writes are always serialized.")]
+        public int? Parallelism { get; init; }
     }
 
     public override int Execute(CommandContext ctx, Settings settings)
@@ -112,7 +116,8 @@ public sealed class IndexExtractCommand : Command<IndexExtractCommand.Settings>
             settings.PackagesPath,
             settings.DatabasePath,
             settings.OnlyModel,
-            settings.Since);
+            settings.Since,
+            parallelism: settings.Parallelism);
 
     internal static int ExtractCore(
         OutputMode.Kind kind,
@@ -120,7 +125,8 @@ public sealed class IndexExtractCommand : Command<IndexExtractCommand.Settings>
         string? databaseOverride,
         string? onlyModel,
         string? sinceIso,
-        IReadOnlyDictionary<string, string?>? fingerprintsByModel = null)
+        IReadOnlyDictionary<string, string?>? fingerprintsByModel = null,
+        int? parallelism = null)
     {
         var cfg = D365FoSettings.FromEnvironment(databaseOverride);
         var root = packagesOverride ?? cfg.PackagesPath;
@@ -158,6 +164,13 @@ public sealed class IndexExtractCommand : Command<IndexExtractCommand.Settings>
         var per = new List<object>();
         var runSw = System.Diagnostics.Stopwatch.StartNew();
 
+        // Effective model-level parallelism: default = half the CPU core count.
+        // SQLite writes (ApplyExtract) are always serialized by the consumer
+        // thread — only XML parsing runs in parallel.
+        int effectiveParallelism = parallelism is > 0
+            ? parallelism.Value
+            : Math.Max(1, Environment.ProcessorCount / 2);
+
         // Pre-enumerate candidate model folders so we can report progress
         // *before* each model is parsed (useful when a single model like
         // ApplicationSuite takes many minutes).
@@ -172,48 +185,63 @@ public sealed class IndexExtractCommand : Command<IndexExtractCommand.Settings>
 
         void ProcessAll(Action<string>? onStart, Action<string, ExtractBatch, long>? onDone)
         {
-            // Producer-consumer pipeline: producer thread parses models while the
-            // consumer (this thread) writes to SQLite. This overlaps the CPU-intensive
-            // XML parse of model N+1 with the I/O-intensive ApplyExtract of model N —
-            // hiding parse latency behind write latency for large models.
-            // Bounded capacity = 2 limits peak RAM to ~2 parsed batches at a time.
+            // Producer-consumer pipeline: one or more producer threads parse model XML
+            // while the single consumer (this thread) writes to SQLite. This overlaps
+            // CPU-intensive XML parsing with I/O-intensive ApplyExtract calls.
+            // Bounded capacity = effectiveParallelism + 1 limits peak RAM to roughly
+            // (parallelism + 1) parsed batches at a time, capping memory usage while
+            // keeping the consumer fed.
             var queue = new System.Collections.Concurrent.BlockingCollection<(
-                ExtractBatch Batch, string Fp, DateTime StartedUtc, long ParseMs)>(boundedCapacity: 2);
+                ExtractBatch Batch, string Fp, DateTime StartedUtc, long ParseMs)>(
+                boundedCapacity: effectiveParallelism + 1);
             var cts = new System.Threading.CancellationTokenSource();
 
             var producer = System.Threading.Tasks.Task.Run(() =>
             {
                 try
                 {
-                    foreach (var modelDir in modelDirs)
-                    {
-                        var model = Path.GetFileName(modelDir)!;
-                        var fp = ComputeFingerprint(modelDir, cfg.LabelLanguages);
-                        if (since.HasValue && NewestMtime(modelDir) is { } newest && newest < since.Value)
+                    // Parallel.ForEach over model directories: each iteration parses one
+                    // model's XML fully before handing the ExtractBatch to the write queue.
+                    // ExtractModel is itself parallel-internally (Parallel.Invoke over
+                    // artifact kinds), so we avoid unbounded thread proliferation by using
+                    // a degree capped to effectiveParallelism at the model level.
+                    System.Threading.Tasks.Parallel.ForEach(
+                        modelDirs,
+                        new System.Threading.Tasks.ParallelOptions
                         {
-                            skippedCount++;
-                            continue;
-                        }
-                        if (dbFingerprints.TryGetValue(model, out var stored)
-                            && !string.IsNullOrEmpty(stored)
-                            && string.Equals(stored, fp, StringComparison.Ordinal))
+                            MaxDegreeOfParallelism = effectiveParallelism,
+                            CancellationToken = cts.Token,
+                        },
+                        modelDir =>
                         {
-                            skippedCount++;
-                            continue;
-                        }
-                        var startedUtc = DateTime.UtcNow;
-                        var parseSw = System.Diagnostics.Stopwatch.StartNew();
-                        ExtractBatch batch;
-                        try
-                        {
-                            batch = extractor.ExtractModel(modelDir, model, cfg.LabelLanguages, matcher.IsMatch(model));
-                        }
-                        catch { continue; }
-                        parseSw.Stop();
-                        try { queue.Add((batch, fp, startedUtc, parseSw.ElapsedMilliseconds), cts.Token); }
-                        catch (OperationCanceledException) { break; }
-                    }
+                            var model = Path.GetFileName(modelDir)!;
+                            var fp = ComputeFingerprint(modelDir, cfg.LabelLanguages);
+                            if (since.HasValue && NewestMtime(modelDir) is { } newest && newest < since.Value)
+                            {
+                                System.Threading.Interlocked.Increment(ref skippedCount);
+                                return;
+                            }
+                            if (dbFingerprints.TryGetValue(model, out var stored)
+                                && !string.IsNullOrEmpty(stored)
+                                && string.Equals(stored, fp, StringComparison.Ordinal))
+                            {
+                                System.Threading.Interlocked.Increment(ref skippedCount);
+                                return;
+                            }
+                            var startedUtc = DateTime.UtcNow;
+                            var parseSw = System.Diagnostics.Stopwatch.StartNew();
+                            ExtractBatch batch;
+                            try
+                            {
+                                batch = extractor.ExtractModel(modelDir, model, cfg.LabelLanguages, matcher.IsMatch(model));
+                            }
+                            catch { return; }
+                            parseSw.Stop();
+                            try { queue.Add((batch, fp, startedUtc, parseSw.ElapsedMilliseconds), cts.Token); }
+                            catch (OperationCanceledException) { /* consumer cancelled; stop */ }
+                        });
                 }
+                catch (OperationCanceledException) { /* consumer cancelled; normal exit */ }
                 finally { queue.CompleteAdding(); }
             });
 
@@ -422,6 +450,10 @@ public sealed class IndexRefreshCommand : Command<IndexRefreshCommand.Settings>
         [CommandOption("--force")]
         [System.ComponentModel.Description("Ignore any computed threshold and re-extract every model.")]
         public bool Force { get; init; }
+
+        [CommandOption("--parallelism <N>")]
+        [System.ComponentModel.Description("Number of models to parse in parallel. Defaults to half the CPU core count.")]
+        public int? Parallelism { get; init; }
     }
 
     public override int Execute(CommandContext ctx, Settings settings)
@@ -458,7 +490,8 @@ public sealed class IndexRefreshCommand : Command<IndexRefreshCommand.Settings>
             settings.DatabasePath,
             settings.OnlyModel,
             since,
-            fingerprints);
+            fingerprints,
+            parallelism: settings.Parallelism);
     }
 }
 
@@ -506,5 +539,194 @@ public sealed class IndexHistoryCommand : Command<IndexHistoryCommand.Settings>
                 isCustom = r.IsCustom,
             }),
         }));
+    }
+}
+
+/// <summary>
+/// Runs VACUUM + ANALYZE on the SQLite index to reclaim space and refresh
+/// query-planner statistics. Useful after large-scale re-extractions that
+/// delete and re-insert many rows.
+/// </summary>
+public sealed class IndexOptimizeCommand : Command<IndexOptimizeCommand.Settings>
+{
+    public sealed class Settings : D365OutputSettings
+    {
+        [CommandOption("--db <PATH>")]
+        public string? DatabasePath { get; init; }
+    }
+
+    public override int Execute(CommandContext ctx, Settings settings)
+    {
+        var kind = OutputMode.Resolve(settings.Output);
+        var repo = RepoFactory.Create(settings.DatabasePath);
+        var r = repo.Optimize();
+        return RenderHelpers.Render(kind, ToolResult<object>.Success(new
+        {
+            sizeBeforeBytes = r.SizeBeforeBytes,
+            sizeAfterBytes  = r.SizeAfterBytes,
+            savedBytes      = r.SizeBeforeBytes - r.SizeAfterBytes,
+            elapsedMs       = r.ElapsedMs,
+        }), _ =>
+        {
+            long saved = r.SizeBeforeBytes - r.SizeAfterBytes;
+            AnsiConsole.MarkupLine(
+                $"[green]OK[/] VACUUM+ANALYZE complete in {r.ElapsedMs}ms " +
+                $"(saved {saved / 1024.0:F1} KB)");
+        });
+    }
+}
+
+/// <summary>
+/// Exports the index database as a GZip-compressed SQLite snapshot for
+/// team sharing or CI artifact caching.
+/// Usage: <c>d365fo index export --out index.gz</c>
+/// </summary>
+public sealed class IndexExportCommand : Command<IndexExportCommand.Settings>
+{
+    public sealed class Settings : D365OutputSettings
+    {
+        [CommandOption("--db <PATH>")]
+        public string? DatabasePath { get; init; }
+
+        [CommandOption("--out <PATH>")]
+        [System.ComponentModel.Description("Destination .gz file path.")]
+        public string? OutPath { get; init; }
+    }
+
+    public override int Execute(CommandContext ctx, Settings settings)
+    {
+        var kind = OutputMode.Resolve(settings.Output);
+        var cfg = D365FoSettings.FromEnvironment(settings.DatabasePath);
+        if (!File.Exists(cfg.DatabasePath))
+        {
+            return RenderHelpers.Render(kind, ToolResult<object>.Fail(
+                "INDEX_NOT_FOUND",
+                $"Index not found at: {cfg.DatabasePath}",
+                "Run 'd365fo index extract' first."));
+        }
+
+        var outPath = settings.OutPath
+            ?? Path.ChangeExtension(cfg.DatabasePath, ".gz");
+        outPath = Path.GetFullPath(outPath);
+        var outDir = Path.GetDirectoryName(outPath);
+        if (!string.IsNullOrEmpty(outDir)) Directory.CreateDirectory(outDir);
+
+        var sw = System.Diagnostics.Stopwatch.StartNew();
+        // VACUUM INTO writes a clean, wal-checkpointed copy to a temp file so
+        // the source DB stays open and consistent during the export.
+        var tmpPath = outPath + ".tmp.sqlite";
+        try
+        {
+            // Checkpoint + clean copy via VACUUM INTO (SQLite 3.27+), via Core.
+            var repo = new D365FO.Core.Index.MetadataRepository(cfg.DatabasePath);
+            repo.VacuumInto(tmpPath);
+
+            // GZip compress the clean copy.
+            using (var inStream  = File.OpenRead(tmpPath))
+            using (var outStream = File.Create(outPath))
+            using (var gz = new System.IO.Compression.GZipStream(
+                outStream, System.IO.Compression.CompressionLevel.Optimal))
+            {
+                inStream.CopyTo(gz);
+            }
+        }
+        finally
+        {
+            if (File.Exists(tmpPath)) try { File.Delete(tmpPath); } catch { }
+        }
+
+        sw.Stop();
+        var sizeBytes = new FileInfo(outPath).Length;
+        return RenderHelpers.Render(kind, ToolResult<object>.Success(new
+        {
+            source      = cfg.DatabasePath,
+            output      = outPath,
+            sizeBytes,
+            elapsedMs   = sw.ElapsedMilliseconds,
+        }), _ => AnsiConsole.MarkupLine(
+            $"[green]OK[/] exported {sizeBytes / 1024.0:F1} KB → {Markup.Escape(outPath)} ({sw.ElapsedMilliseconds}ms)"));
+    }
+}
+
+/// <summary>
+/// Imports a previously exported GZip-compressed index snapshot.
+/// Usage: <c>d365fo index import --from index.gz</c>
+/// </summary>
+public sealed class IndexImportCommand : Command<IndexImportCommand.Settings>
+{
+    public sealed class Settings : D365OutputSettings
+    {
+        [CommandOption("--db <PATH>")]
+        public string? DatabasePath { get; init; }
+
+        [CommandOption("--from <PATH>")]
+        [System.ComponentModel.Description("Source .gz file exported by 'd365fo index export'.")]
+        public string? FromPath { get; init; }
+    }
+
+    // SQLite magic header: "SQLite format 3\0" (16 bytes).
+    private static readonly byte[] SqliteMagic =
+        System.Text.Encoding.ASCII.GetBytes("SQLite format 3\0");
+
+    public override int Execute(CommandContext ctx, Settings settings)
+    {
+        var kind = OutputMode.Resolve(settings.Output);
+        if (string.IsNullOrEmpty(settings.FromPath))
+        {
+            return RenderHelpers.Render(kind, ToolResult<object>.Fail(
+                "MISSING_ARGUMENT",
+                "Required option --from <PATH> was not provided."));
+        }
+        if (!File.Exists(settings.FromPath))
+        {
+            return RenderHelpers.Render(kind, ToolResult<object>.Fail(
+                "FILE_NOT_FOUND",
+                $"Import file not found: {settings.FromPath}"));
+        }
+
+        var cfg = D365FoSettings.FromEnvironment(settings.DatabasePath);
+        var dir = Path.GetDirectoryName(Path.GetFullPath(cfg.DatabasePath));
+        if (!string.IsNullOrEmpty(dir)) Directory.CreateDirectory(dir);
+
+        var sw = System.Diagnostics.Stopwatch.StartNew();
+        var tmpPath = cfg.DatabasePath + ".import.tmp";
+        try
+        {
+            using (var inStream  = File.OpenRead(settings.FromPath!))
+            using (var gz        = new System.IO.Compression.GZipStream(inStream, System.IO.Compression.CompressionMode.Decompress))
+            using (var outStream = File.Create(tmpPath))
+            {
+                gz.CopyTo(outStream);
+            }
+
+            // Validate the decompressed file is a real SQLite DB via magic bytes.
+            var header = new byte[16];
+            using (var fs = File.OpenRead(tmpPath))
+            {
+                if (fs.Read(header, 0, 16) < 16 || !header.SequenceEqual(SqliteMagic))
+                    throw new InvalidDataException("Imported file does not appear to be a valid SQLite database.");
+            }
+
+            // Atomic replace: move existing to .bak, move import to final path.
+            if (File.Exists(cfg.DatabasePath))
+                File.Move(cfg.DatabasePath, cfg.DatabasePath + ".bak", overwrite: true);
+            File.Move(tmpPath, cfg.DatabasePath, overwrite: false);
+        }
+        catch
+        {
+            if (File.Exists(tmpPath)) try { File.Delete(tmpPath); } catch { }
+            throw;
+        }
+
+        sw.Stop();
+        var sizeBytes = new FileInfo(cfg.DatabasePath).Length;
+        return RenderHelpers.Render(kind, ToolResult<object>.Success(new
+        {
+            source    = settings.FromPath,
+            target    = cfg.DatabasePath,
+            sizeBytes,
+            elapsedMs = sw.ElapsedMilliseconds,
+        }), _ => AnsiConsole.MarkupLine(
+            $"[green]OK[/] imported {sizeBytes / 1024.0:F1} KB → {Markup.Escape(cfg.DatabasePath)} ({sw.ElapsedMilliseconds}ms)"));
     }
 }

--- a/src/D365FO.Cli/Program.cs
+++ b/src/D365FO.Cli/Program.cs
@@ -122,6 +122,9 @@ app.Configure(cfg =>
         b.AddCommand<IndexExtractCommand>("extract").WithDescription("Walk PACKAGES_PATH and ingest AOT metadata.");
         b.AddCommand<IndexRefreshCommand>("refresh").WithDescription("Incremental extract — skip models whose XMLs haven't changed since last extract.");
         b.AddCommand<IndexHistoryCommand>("history").WithDescription("Show recent ExtractionRuns (per-model timings persisted across runs).");
+        b.AddCommand<IndexOptimizeCommand>("optimize").WithDescription("VACUUM + ANALYZE the index (reclaim space, refresh query-planner stats).");
+        b.AddCommand<IndexExportCommand>("export").WithDescription("Export index as a GZip-compressed snapshot for sharing or CI caching.");
+        b.AddCommand<IndexImportCommand>("import").WithDescription("Import a GZip-compressed index snapshot.");
     });
 
     cfg.AddBranch("models", b =>
@@ -179,6 +182,7 @@ app.Configure(cfg =>
         b.AddCommand<DaemonStartCommand>("start").WithDescription("Start the daemon (foreground).");
         b.AddCommand<DaemonStopCommand>("stop").WithDescription("Stop the running daemon.");
         b.AddCommand<DaemonStatusCommand>("status").WithDescription("Report daemon status.");
+        b.AddCommand<DaemonWarmupCommand>("warmup").WithDescription("Pre-warm the SQLite page cache for faster first queries.");
     });
 
     cfg.AddCommand<BuildCommand>("build").WithDescription("Invoke MSBuild (Windows VM).");

--- a/src/D365FO.Core/Index/MetadataRepository.cs
+++ b/src/D365FO.Core/Index/MetadataRepository.cs
@@ -18,6 +18,7 @@ public sealed class MetadataRepository
 
     private static readonly Lazy<string> SchemaSql = new(LoadEmbeddedSchema);
 
+    private readonly string _databasePath;
     private readonly string _connectionString;
     /// <summary>
     /// Read-only connection string used by all query-only methods. Using
@@ -38,6 +39,8 @@ public sealed class MetadataRepository
     {
         if (string.IsNullOrWhiteSpace(databasePath))
             throw new ArgumentException("Database path must be provided.", nameof(databasePath));
+
+        _databasePath = Path.GetFullPath(databasePath);
 
         _connectionString = new SqliteConnectionStringBuilder
         {
@@ -61,6 +64,9 @@ public sealed class MetadataRepository
     }
 
     public string ConnectionString => _connectionString;
+
+    /// <summary>Absolute path to the SQLite database file.</summary>
+    public string DatabasePath => _databasePath;
 
     /// <summary>
     /// Ensure schema is applied. Skips the CREATE script when PRAGMA
@@ -183,14 +189,23 @@ public sealed class MetadataRepository
         // virtual table inside a transaction can cause subtle lock contention on
         // some SQLite builds. A crash here leaves the FTS5 shadow tables in an
         // out-of-sync state that the next EnsureSchema() run will fix via rebuild.
-        try
+        //
+        // v6 added the FTS5 table + INSERT/DELETE/UPDATE triggers that keep it
+        // in lock-step with Labels incrementally. Databases at v6+ never need a
+        // full rebuild on schema upgrade — the triggers have kept the index current.
+        // Only pre-v6 databases require a one-time backfill because they have
+        // existing Labels rows that predate the triggers.
+        if (current < 6)
         {
-            conn.Execute("INSERT INTO LabelFts(LabelFts) VALUES('rebuild')");
-        }
-        catch (Microsoft.Data.Sqlite.SqliteException)
-        {
-            // Host SQLite build lacks FTS5 — degrade gracefully; SearchLabels()
-            // stays on the LIKE fallback path.
+            try
+            {
+                conn.Execute("INSERT INTO LabelFts(LabelFts) VALUES('rebuild')");
+            }
+            catch (Microsoft.Data.Sqlite.SqliteException)
+            {
+                // Host SQLite build lacks FTS5 — degrade gracefully; SearchLabels()
+                // stays on the LIKE fallback path.
+            }
         }
         return true;
     }
@@ -1869,5 +1884,62 @@ public sealed class MetadataRepository
         using var s = asm.GetManifestResourceStream(resName)!;
         using var r = new StreamReader(s);
         return r.ReadToEnd();
+    }
+
+    // ---- Index maintenance ----
+
+    /// <summary>
+    /// Runs <c>PRAGMA wal_checkpoint(TRUNCATE)</c>, <c>VACUUM</c>, and
+    /// <c>ANALYZE</c> on the index database. VACUUM reclaims space freed by
+    /// DELETE-heavy ApplyExtract cycles; ANALYZE refreshes query-planner
+    /// statistics so FTS5 and multi-table JOINs stay fast.
+    /// Returns the file sizes before and after VACUUM and elapsed time.
+    /// </summary>
+    public OptimizeResult Optimize()
+    {
+        var sw = System.Diagnostics.Stopwatch.StartNew();
+        long sizeBefore = File.Exists(_databasePath) ? new FileInfo(_databasePath).Length : 0;
+        using var conn = Open();
+        conn.Execute("PRAGMA wal_checkpoint(TRUNCATE)");
+        conn.Execute("VACUUM");
+        conn.Execute("ANALYZE");
+        sw.Stop();
+        long sizeAfter = File.Exists(_databasePath) ? new FileInfo(_databasePath).Length : 0;
+        return new OptimizeResult(sizeBefore, sizeAfter, sw.ElapsedMilliseconds);
+    }
+
+    /// <summary>
+    /// Checkpoints the WAL and writes a clean defragmented copy of the index
+    /// to <paramref name="destinationPath"/> using SQLite's
+    /// <c>VACUUM INTO</c> command (requires SQLite 3.27+; bundled version is
+    /// sufficient). The source DB is not modified or locked beyond the normal
+    /// checkpoint.
+    /// </summary>
+    public void VacuumInto(string destinationPath)
+    {
+        using var conn = Open();
+        conn.Execute("PRAGMA wal_checkpoint(TRUNCATE)");
+        conn.Execute($"VACUUM INTO '{destinationPath.Replace("'", "''")}'");
+    }
+
+    /// <summary>
+    /// Pre-warms the SQLite page cache by issuing a <c>SELECT count(*)</c> on
+    /// each major table. Counts are cheap (B-tree root page only) but force
+    /// the OS page cache to load the most-accessed index pages so subsequent
+    /// queries complete without cold-start I/O latency.
+    /// </summary>
+    public WarmupResult Warmup()
+    {
+        using var conn = OpenReadOnly();
+        return new WarmupResult(
+            Tables:    conn.ExecuteScalar<long>("SELECT count(*) FROM Tables"),
+            Classes:   conn.ExecuteScalar<long>("SELECT count(*) FROM Classes"),
+            Methods:   conn.ExecuteScalar<long>("SELECT count(*) FROM Methods"),
+            Edts:      conn.ExecuteScalar<long>("SELECT count(*) FROM Edts"),
+            Enums:     conn.ExecuteScalar<long>("SELECT count(*) FROM Enums"),
+            Labels:    conn.ExecuteScalar<long>("SELECT count(*) FROM Labels"),
+            Forms:     conn.ExecuteScalar<long>("SELECT count(*) FROM Forms"),
+            CocExtensions: conn.ExecuteScalar<long>("SELECT count(*) FROM CocExtensions"),
+            DataEntities: conn.ExecuteScalar<long>("SELECT count(*) FROM DataEntities"));
     }
 }

--- a/src/D365FO.Core/Index/Models.cs
+++ b/src/D365FO.Core/Index/Models.cs
@@ -229,3 +229,20 @@ public sealed record MapFieldInfo(string Name, string? Type, string? EdtName, st
 
 /// <summary>Full detail of an AxMap including fields and mapped tables.</summary>
 public sealed record MapDetails(MapInfo Map, IReadOnlyList<MapFieldInfo> Fields, IReadOnlyList<string> MappedTables);
+
+// ---- Index maintenance DTOs ----------------------------------------------
+
+/// <summary>Result of <c>d365fo index optimize</c> (VACUUM + ANALYZE).</summary>
+public sealed record OptimizeResult(long SizeBeforeBytes, long SizeAfterBytes, long ElapsedMs);
+
+/// <summary>Row counts returned by <c>d365fo daemon warmup</c>.</summary>
+public sealed record WarmupResult(
+    long Tables,
+    long Classes,
+    long Methods,
+    long Edts,
+    long Enums,
+    long Labels,
+    long Forms,
+    long CocExtensions,
+    long DataEntities);


### PR DESCRIPTION
This pull request implements and documents a set of major index and performance optimizations for the `d365fo-cli` project, focusing on extraction parallelism, index maintenance, and improved team workflows. It introduces new CLI commands for index optimization, export/import, and cache warm-up, and updates the extraction logic to support configurable parallelism for faster processing. These changes are reflected both in the codebase and in the project audit documentation.

**Indexing and Extraction Improvements**
- Added a `--parallelism` option to extraction and refresh commands, enabling configurable parallel processing of models (defaults to half the CPU cores). The extraction pipeline now uses `Parallel.ForEach` at the model level, with bounded memory usage and serialized SQLite writes for safety. [[1]](diffhunk://#diff-561ba1924a195ef53258569d1ca58321dda26c81274928095cd81cdb30ae506fR107-R110) [[2]](diffhunk://#diff-561ba1924a195ef53258569d1ca58321dda26c81274928095cd81cdb30ae506fL115-R129) [[3]](diffhunk://#diff-561ba1924a195ef53258569d1ca58321dda26c81274928095cd81cdb30ae506fR167-R173) [[4]](diffhunk://#diff-561ba1924a195ef53258569d1ca58321dda26c81274928095cd81cdb30ae506fL175-R229) [[5]](diffhunk://#diff-561ba1924a195ef53258569d1ca58321dda26c81274928095cd81cdb30ae506fL211-R244) [[6]](diffhunk://#diff-561ba1924a195ef53258569d1ca58321dda26c81274928095cd81cdb30ae506fR453-R456) [[7]](diffhunk://#diff-561ba1924a195ef53258569d1ca58321dda26c81274928095cd81cdb30ae506fL461-R494)
- Updated the audit plan in `AUDIT_PLAN.md` to mark Phase 1 (index and performance optimizations) as complete, reflecting the implemented features.

**New Index Maintenance and Sharing Commands**
- Added `d365fo index optimize` command to run SQLite `VACUUM` and `ANALYZE`, reclaiming space and refreshing query planner stats after large extractions. [[1]](diffhunk://#diff-561ba1924a195ef53258569d1ca58321dda26c81274928095cd81cdb30ae506fR544-R732) [[2]](diffhunk://#diff-18a03fd7268c7695cbccf21407fa7235d1caec86d7e78294cb9f314eb3d92478R125-R127)
- Added `d365fo index export` and `d365fo index import` commands to enable exporting the index as a GZip-compressed snapshot and importing it elsewhere, supporting CI artifact caching and team sharing. [[1]](diffhunk://#diff-561ba1924a195ef53258569d1ca58321dda26c81274928095cd81cdb30ae506fR544-R732) [[2]](diffhunk://#diff-18a03fd7268c7695cbccf21407fa7235d1caec86d7e78294cb9f314eb3d92478R125-R127)

**Daemon and Query Performance**
- Introduced `d365fo daemon warmup` command to pre-load frequently accessed tables into the SQLite page cache, reducing latency for the first queries after a cold start. [[1]](diffhunk://#diff-86274e2d15215dc93a6504ab2f610baeef884f767b2917c0b7626c610c1178b4R351-R392) [[2]](diffhunk://#diff-18a03fd7268c7695cbccf21407fa7235d1caec86d7e78294cb9f314eb3d92478R185)

**Internal Codebase Enhancements**
- Refactored `MetadataRepository` to store the absolute database path for improved reliability and future extensibility. [[1]](diffhunk://#diff-daf80b3446ddf99297e4849c8b972197e2d8599afc51d760414f421097ef588bR21) [[2]](diffhunk://#diff-daf80b3446ddf99297e4849c8b972197e2d8599afc51d760414f421097ef588bR43-R44)

These changes collectively deliver significant improvements in extraction speed, resource usage, and developer workflows, while laying the groundwork for scalable, team-friendly index management.