### PR TITLE
feat(scaffolding): implement Phase 2 — 7 new generate commands

### DIFF
--- a/docs/AUDIT_PLAN.md
+++ b/docs/AUDIT_PLAN.md
@@ -45,67 +45,73 @@ Add `d365fo index export --out index.tar.gz` and `d365fo index import --from ind
 
 ---
 
-## Phase 2: Missing Scaffolding Commands
+## Phase 2: Missing Scaffolding Commands ✅
 
 The `generate` branch covers 12 artifact types. Key D365FO patterns are missing.
 
-### 2.1 `generate sysoperation`
+### 2.1 `generate sysoperation` ✅
 
 Scaffold the DataContract + Service + Controller triplet (the standard pattern for batch jobs).
 
-**Options:** `--contract-name`, `--service-name`, `--controller-name`, `--param <name>:<type>`, `--execution-mode Batch|Sync`.
+**Options:** `--contract-name`, `--service-name`, `--controller-name`, `--param <name>:<type>`, `--execution-mode Batch|Sync|Async`, `--service-method`, `--out-contract`, `--out-service`.
 
 - New: `src/D365FO.Core/Scaffolding/SysOperationScaffolder.cs`
 - New: `src/D365FO.Cli/Commands/Generate/GenerateSysOperationCommand.cs`
 - Reference: `skills/_source/x++-class-authoring.md` (SysOperation section)
 
-### 2.2 `generate number-sequence`
+### 2.2 `generate number-sequence` ✅
 
 Scaffold NumberSeqApplicationModule CoC extension + EDT + form handler wiring.
 
-**Options:** `--module-name`, `--edt <name>`, `--scope Company|Shared`.
+**Options:** `--edt <name>`, `--edt-label`, `--scope Company|Shared`, `--table`, `--out-edt`, `--out-handler`.
 
 - New: `src/D365FO.Core/Scaffolding/NumberSequenceScaffolder.cs`
+- New: `src/D365FO.Cli/Commands/Generate/GenerateNumberSequenceCommand.cs`
 
-### 2.3 `generate workflow`
+### 2.3 `generate workflow` ✅
 
 Scaffold WorkflowDocument subclass + WorkflowType XML + `canSubmitToWorkflow()` table method stub.
 
-**Options:** `--table`, `--approval-name`, `--task-name`.
+**Options:** `--table`, `--approval-name`, `--task-name`, `--document-class`, `--query`, `--out-document`, `--out-submit`, `--no-submit-stub`.
 
 - New: `src/D365FO.Core/Scaffolding/WorkflowScaffolder.cs`
+- New: `src/D365FO.Cli/Commands/Generate/GenerateWorkflowCommand.cs`
 
-### 2.4 `generate menu-item`
+### 2.4 `generate menu-item` ✅
 
 Scaffold AxMenuItemDisplay/Action/Output.
 
-**Options:** `--kind Display|Action|Output`, `--object <name>`, `--object-type Form|Class|Report`, `--label`.
+**Options:** `--kind Display|Action|Output`, `--object <name>`, `--object-type Form|Class|Report|Query`, `--label`.
 
 - New: `src/D365FO.Core/Scaffolding/MenuItemScaffolder.cs`
+- New: `src/D365FO.Cli/Commands/Generate/GenerateMenuItemCommand.cs`
 
-### 2.5 `generate edt`
+### 2.5 `generate edt` ✅
 
 Scaffold AxEdt with proper `extends`, `stringSize`, `label`.
 
 **Options:** `--extends <base>`, `--base-type String|Int|Real|Date|...`, `--size N`, `--label`.
 
-- Extend: `src/D365FO.Core/Scaffolding/XppScaffolder.cs`
+- Extended: `src/D365FO.Core/Scaffolding/XppScaffolder.cs` (new `Edt()` method + `EnumValueSpec` record)
+- New: `src/D365FO.Cli/Commands/Generate/GenerateEdtCommand.cs`
 
-### 2.6 `generate enum`
+### 2.6 `generate enum` ✅
 
 Scaffold AxEnum with values.
 
-**Options:** `--value <name>:<intValue>[:label]`, `--is-extensible Yes|No`.
+**Options:** `--value <name>:<intValue>[:<label>]`, `--non-extensible`, `--label`.
 
-- Extend: `src/D365FO.Core/Scaffolding/XppScaffolder.cs`
+- Extended: `src/D365FO.Core/Scaffolding/XppScaffolder.cs` (new `Enum()` method)
+- New: `src/D365FO.Cli/Commands/Generate/GenerateEnumCommand.cs`
 
-### 2.7 `generate query`
+### 2.7 `generate query` ✅
 
 Scaffold AxQuery with datasources and joins.
 
 **Options:** `--ds <table>`, `--join <table>:<joinKind>:<parentDs>`.
 
 - New: `src/D365FO.Core/Scaffolding/QueryScaffolder.cs`
+- New: `src/D365FO.Cli/Commands/Generate/GenerateQueryCommand.cs`
 
 ---
 

--- a/src/D365FO.Cli/Commands/Generate/GenerateEdtCommand.cs
+++ b/src/D365FO.Cli/Commands/Generate/GenerateEdtCommand.cs
@@ -1,0 +1,75 @@
+using D365FO.Core;
+using D365FO.Core.Scaffolding;
+using Spectre.Console.Cli;
+
+namespace D365FO.Cli.Commands.Generate;
+
+/// <summary>Scaffolds an <c>AxEdt</c> Extended Data Type.</summary>
+public sealed class GenerateEdtCommand : Command<GenerateEdtCommand.Settings>
+{
+    public sealed class Settings : GenerateSettings
+    {
+        [CommandArgument(0, "<NAME>")]
+        [System.ComponentModel.Description("EDT name.")]
+        public string Name { get; init; } = "";
+
+        [CommandOption("--extends <BASE>")]
+        [System.ComponentModel.Description("Parent EDT to extend (e.g. Name, AccountNum). Takes precedence over --base-type.")]
+        public string? Extends { get; init; }
+
+        [CommandOption("--base-type <TYPE>")]
+        [System.ComponentModel.Description("Primitive type when no --extends is given. String (default) | Int | Int64 | Real | Date | UtcDateTime | Boolean. Infers a sensible standard parent EDT.")]
+        public string? BaseType { get; init; }
+
+        [CommandOption("--size <N>")]
+        [System.ComponentModel.Description("StringSize override for string-based EDTs.")]
+        public int? Size { get; init; }
+
+        [CommandOption("--label <TEXT>")]
+        [System.ComponentModel.Description("Label text or @File:Key label reference.")]
+        public string? Label { get; init; }
+    }
+
+    public override int Execute(CommandContext ctx, Settings settings)
+    {
+        var kind = OutputMode.Resolve(settings.Output);
+
+        if (string.IsNullOrWhiteSpace(settings.Name))
+            return RenderHelpers.Render(kind, ToolResult<object>.Fail(D365FoErrorCodes.BadInput, "EDT name required."));
+
+        var hasInstall = !string.IsNullOrWhiteSpace(settings.InstallTo);
+        var hasOut     = !string.IsNullOrWhiteSpace(settings.Out);
+        if (!hasInstall && !hasOut)
+            return RenderHelpers.Render(kind, ToolResult<object>.Fail(D365FoErrorCodes.BadInput, "--out or --install-to is required."));
+
+        var outPath = settings.Out;
+        if (hasInstall && !hasOut)
+        {
+            outPath = GenerateInstaller.ResolveInstallPath(kind, "AxEdt", settings.Name, settings.InstallTo!, out var fail);
+            if (fail.HasValue) return fail.Value;
+        }
+
+        var doc = XppScaffolder.Edt(settings.Name, settings.Extends, settings.BaseType, settings.Size, settings.Label);
+        try
+        {
+            var res = ScaffoldFileWriter.Write(doc, outPath!, settings.Overwrite);
+            return RenderHelpers.Render(kind, ToolResult<object>.Success(new
+            {
+                kind       = "AxEdt",
+                name       = settings.Name,
+                extends    = settings.Extends,
+                baseType   = settings.BaseType,
+                stringSize = settings.Size,
+                label      = settings.Label,
+                path       = res.Path,
+                bytes      = res.Bytes,
+                backup     = res.BackupPath,
+                model      = settings.InstallTo,
+            }));
+        }
+        catch (Exception ex)
+        {
+            return RenderHelpers.Render(kind, ToolResult<object>.Fail(D365FoErrorCodes.WriteFailed, ex.Message));
+        }
+    }
+}

--- a/src/D365FO.Cli/Commands/Generate/GenerateEnumCommand.cs
+++ b/src/D365FO.Cli/Commands/Generate/GenerateEnumCommand.cs
@@ -1,0 +1,83 @@
+using D365FO.Core;
+using D365FO.Core.Scaffolding;
+using Spectre.Console.Cli;
+
+namespace D365FO.Cli.Commands.Generate;
+
+/// <summary>Scaffolds an <c>AxEnum</c> base enumeration.</summary>
+public sealed class GenerateEnumCommand : Command<GenerateEnumCommand.Settings>
+{
+    public sealed class Settings : GenerateSettings
+    {
+        [CommandArgument(0, "<NAME>")]
+        [System.ComponentModel.Description("Enum name.")]
+        public string Name { get; init; } = "";
+
+        [CommandOption("--value <SPEC>")]
+        [System.ComponentModel.Description("Repeatable: <name>:<intValue>[:<label>]. Example: --value None:0 --value Active:1:'Active record'")]
+        public string[] Values { get; init; } = Array.Empty<string>();
+
+        [CommandOption("--non-extensible")]
+        [System.ComponentModel.Description("Emit IsExtensible=No (default is Yes, the recommended D365FO setting).")]
+        public bool NonExtensible { get; init; }
+
+        [CommandOption("--label <TEXT>")]
+        [System.ComponentModel.Description("Enum-level label.")]
+        public string? Label { get; init; }
+    }
+
+    public override int Execute(CommandContext ctx, Settings settings)
+    {
+        var kind = OutputMode.Resolve(settings.Output);
+
+        if (string.IsNullOrWhiteSpace(settings.Name))
+            return RenderHelpers.Render(kind, ToolResult<object>.Fail(D365FoErrorCodes.BadInput, "Enum name required."));
+
+        var hasInstall = !string.IsNullOrWhiteSpace(settings.InstallTo);
+        var hasOut     = !string.IsNullOrWhiteSpace(settings.Out);
+        if (!hasInstall && !hasOut)
+            return RenderHelpers.Render(kind, ToolResult<object>.Fail(D365FoErrorCodes.BadInput, "--out or --install-to is required."));
+
+        var outPath = settings.Out;
+        if (hasInstall && !hasOut)
+        {
+            outPath = GenerateInstaller.ResolveInstallPath(kind, "AxEnum", settings.Name, settings.InstallTo!, out var fail);
+            if (fail.HasValue) return fail.Value;
+        }
+
+        var values = settings.Values.Select(ParseValue).ToList();
+        var doc = XppScaffolder.Enum(settings.Name, values, !settings.NonExtensible, settings.Label);
+
+        try
+        {
+            var res = ScaffoldFileWriter.Write(doc, outPath!, settings.Overwrite);
+            return RenderHelpers.Render(kind, ToolResult<object>.Success(new
+            {
+                kind         = "AxEnum",
+                name         = settings.Name,
+                isExtensible = !settings.NonExtensible,
+                label        = settings.Label,
+                valueCount   = values.Count,
+                values       = values.Select(v => new { v.Name, v.IntValue, v.Label }).ToList(),
+                path         = res.Path,
+                bytes        = res.Bytes,
+                backup       = res.BackupPath,
+                model        = settings.InstallTo,
+            }));
+        }
+        catch (Exception ex)
+        {
+            return RenderHelpers.Render(kind, ToolResult<object>.Fail(D365FoErrorCodes.WriteFailed, ex.Message));
+        }
+    }
+
+    private static EnumValueSpec ParseValue(string raw)
+    {
+        // Format: <name>:<intValue>[:<label>]
+        var parts = raw.Split(':', 3, StringSplitOptions.TrimEntries);
+        var name  = parts.Length > 0 ? parts[0] : raw;
+        var intVal = parts.Length > 1 && int.TryParse(parts[1], out var n) ? n : 0;
+        var label  = parts.Length > 2 ? parts[2].Trim('\'', '"') : null;
+        return new EnumValueSpec(name, intVal, string.IsNullOrEmpty(label) ? null : label);
+    }
+}

--- a/src/D365FO.Cli/Commands/Generate/GenerateMenuItemCommand.cs
+++ b/src/D365FO.Cli/Commands/Generate/GenerateMenuItemCommand.cs
@@ -1,0 +1,114 @@
+using D365FO.Core;
+using D365FO.Core.Scaffolding;
+using Spectre.Console.Cli;
+
+namespace D365FO.Cli.Commands.Generate;
+
+/// <summary>
+/// Scaffolds an <c>AxMenuItemDisplay</c>, <c>AxMenuItemAction</c>, or
+/// <c>AxMenuItemOutput</c> AOT object.
+/// </summary>
+public sealed class GenerateMenuItemCommand : Command<GenerateMenuItemCommand.Settings>
+{
+    public sealed class Settings : GenerateSettings
+    {
+        [CommandArgument(0, "<NAME>")]
+        [System.ComponentModel.Description("Menu item name.")]
+        public string Name { get; init; } = "";
+
+        [CommandOption("--kind <KIND>")]
+        [System.ComponentModel.Description("Display (default) | Action | Output.")]
+        public string Kind { get; init; } = "Display";
+
+        [CommandOption("--object <NAME>")]
+        [System.ComponentModel.Description("Target object name (form, class, or report).")]
+        public string? ObjectName { get; init; }
+
+        [CommandOption("--object-type <TYPE>")]
+        [System.ComponentModel.Description("Form (default) | Class | Report | Query.")]
+        public string ObjectType { get; init; } = "Form";
+
+        [CommandOption("--label <TEXT>")]
+        [System.ComponentModel.Description("Label text or @File:Key label reference.")]
+        public string? Label { get; init; }
+    }
+
+    public override int Execute(CommandContext ctx, Settings settings)
+    {
+        var kind = OutputMode.Resolve(settings.Output);
+
+        if (string.IsNullOrWhiteSpace(settings.Name))
+            return RenderHelpers.Render(kind, ToolResult<object>.Fail(D365FoErrorCodes.BadInput, "Menu item name required."));
+        if (string.IsNullOrWhiteSpace(settings.ObjectName))
+            return RenderHelpers.Render(kind, ToolResult<object>.Fail(D365FoErrorCodes.BadInput, "--object <NAME> required."));
+
+        if (!TryParseKind(settings.Kind, out var menuKind))
+            return RenderHelpers.Render(kind, ToolResult<object>.Fail(D365FoErrorCodes.BadInput,
+                $"Unknown --kind '{settings.Kind}'. Expected Display | Action | Output."));
+
+        if (!TryParseObjectType(settings.ObjectType, out var objType))
+            return RenderHelpers.Render(kind, ToolResult<object>.Fail(D365FoErrorCodes.BadInput,
+                $"Unknown --object-type '{settings.ObjectType}'. Expected Form | Class | Report | Query."));
+
+        var hasInstall = !string.IsNullOrWhiteSpace(settings.InstallTo);
+        var hasOut     = !string.IsNullOrWhiteSpace(settings.Out);
+        if (!hasInstall && !hasOut)
+            return RenderHelpers.Render(kind, ToolResult<object>.Fail(D365FoErrorCodes.BadInput, "--out or --install-to is required."));
+
+        var axSubfolder = MenuItemScaffolder.AxSubfolder(menuKind);
+        var outPath = settings.Out;
+        if (hasInstall && !hasOut)
+        {
+            outPath = GenerateInstaller.ResolveInstallPath(kind, axSubfolder, settings.Name, settings.InstallTo!, out var fail);
+            if (fail.HasValue) return fail.Value;
+        }
+
+        var doc = MenuItemScaffolder.MenuItem(menuKind, settings.Name, settings.ObjectName!, objType, settings.Label);
+        try
+        {
+            var res = ScaffoldFileWriter.Write(doc, outPath!, settings.Overwrite);
+            return RenderHelpers.Render(kind, ToolResult<object>.Success(new
+            {
+                kind        = axSubfolder,
+                name        = settings.Name,
+                menuKind    = menuKind.ToString(),
+                objectName  = settings.ObjectName,
+                objectType  = objType.ToString(),
+                label       = settings.Label,
+                path        = res.Path,
+                bytes       = res.Bytes,
+                backup      = res.BackupPath,
+                model       = settings.InstallTo,
+            }));
+        }
+        catch (Exception ex)
+        {
+            return RenderHelpers.Render(kind, ToolResult<object>.Fail(D365FoErrorCodes.WriteFailed, ex.Message));
+        }
+    }
+
+    private static bool TryParseKind(string raw, out MenuItemKind menuKind)
+    {
+        menuKind = raw.ToLowerInvariant() switch
+        {
+            "action"  => MenuItemKind.Action,
+            "output"  => MenuItemKind.Output,
+            "display" or "" => MenuItemKind.Display,
+            _ => (MenuItemKind)(-1),
+        };
+        return (int)menuKind >= 0;
+    }
+
+    private static bool TryParseObjectType(string raw, out MenuItemObjectType objType)
+    {
+        objType = raw.ToLowerInvariant() switch
+        {
+            "class"          => MenuItemObjectType.Class,
+            "report" or "ssrsreport" => MenuItemObjectType.Report,
+            "query"          => MenuItemObjectType.Query,
+            "form" or ""     => MenuItemObjectType.Form,
+            _ => (MenuItemObjectType)(-1),
+        };
+        return (int)objType >= 0;
+    }
+}

--- a/src/D365FO.Cli/Commands/Generate/GenerateNumberSequenceCommand.cs
+++ b/src/D365FO.Cli/Commands/Generate/GenerateNumberSequenceCommand.cs
@@ -1,0 +1,139 @@
+using D365FO.Core;
+using D365FO.Core.Scaffolding;
+using Spectre.Console.Cli;
+
+namespace D365FO.Cli.Commands.Generate;
+
+/// <summary>
+/// Scaffolds the D365FO number-sequence integration pattern:
+/// a CoC extension on the module's NumberSeqApplicationModule class, an EDT,
+/// and a form event-handler that wires up auto-generation in the UI.
+/// </summary>
+public sealed class GenerateNumberSequenceCommand : Command<GenerateNumberSequenceCommand.Settings>
+{
+    public sealed class Settings : GenerateSettings
+    {
+        [CommandArgument(0, "<MODULE_NAME>")]
+        [System.ComponentModel.Description("Module name suffix, e.g. 'Cust'. The CoC target will be NumberSeqApplicationModule_<MODULE_NAME>.")]
+        public string ModuleName { get; init; } = "";
+
+        [CommandOption("--edt <NAME>")]
+        [System.ComponentModel.Description("EDT name for the sequence field. Defaults to <MODULE_NAME>Num.")]
+        public string? EdtName { get; init; }
+
+        [CommandOption("--edt-label <TEXT>")]
+        [System.ComponentModel.Description("Label for the EDT.")]
+        public string? EdtLabel { get; init; }
+
+        [CommandOption("--scope <SCOPE>")]
+        [System.ComponentModel.Description("Company (default) | Shared.")]
+        public string Scope { get; init; } = "Company";
+
+        [CommandOption("--table <NAME>")]
+        [System.ComponentModel.Description("Table name for the form event-handler. When omitted, the form handler file is not generated.")]
+        public string? TableName { get; init; }
+
+        [CommandOption("--out-edt <PATH>")]
+        [System.ComponentModel.Description("Output path for the EDT XML. Defaults to sibling of --out.")]
+        public string? OutEdt { get; init; }
+
+        [CommandOption("--out-handler <PATH>")]
+        [System.ComponentModel.Description("Output path for the form event-handler class. Defaults to sibling of --out when --table is supplied.")]
+        public string? OutHandler { get; init; }
+    }
+
+    public override int Execute(CommandContext ctx, Settings settings)
+    {
+        var kind = OutputMode.Resolve(settings.Output);
+
+        if (string.IsNullOrWhiteSpace(settings.ModuleName))
+            return RenderHelpers.Render(kind, ToolResult<object>.Fail(D365FoErrorCodes.BadInput, "Module name required."));
+
+        var edtName = string.IsNullOrWhiteSpace(settings.EdtName)
+            ? settings.ModuleName + "Num"
+            : settings.EdtName!;
+
+        if (!TryParseScope(settings.Scope, out var scope))
+            return RenderHelpers.Render(kind, ToolResult<object>.Fail(D365FoErrorCodes.BadInput,
+                $"Unknown --scope '{settings.Scope}'. Expected Company | Shared."));
+
+        var hasInstall = !string.IsNullOrWhiteSpace(settings.InstallTo);
+        var hasOut     = !string.IsNullOrWhiteSpace(settings.Out);
+        if (!hasInstall && !hasOut)
+            return RenderHelpers.Render(kind, ToolResult<object>.Fail(D365FoErrorCodes.BadInput, "--out or --install-to is required."));
+
+        var extensionName = $"NumberSeqApplicationModule_{settings.ModuleName}_Extension";
+        var handlerClass  = string.IsNullOrWhiteSpace(settings.TableName)
+            ? null
+            : settings.TableName + "_NumberSeqHandler";
+
+        // Resolve output paths.
+        string? modulePath, edtPath, handlerPath;
+        if (hasInstall && !hasOut)
+        {
+            modulePath = GenerateInstaller.ResolveInstallPath(kind, "AxClass", extensionName, settings.InstallTo!, out var f1);
+            if (f1.HasValue) return f1.Value;
+            edtPath = string.IsNullOrWhiteSpace(settings.OutEdt)
+                ? GenerateInstaller.ResolveInstallPath(kind, "AxEdt", edtName, settings.InstallTo!, out _)
+                : settings.OutEdt;
+            handlerPath = handlerClass is null ? null
+                : string.IsNullOrWhiteSpace(settings.OutHandler)
+                    ? GenerateInstaller.ResolveInstallPath(kind, "AxClass", handlerClass, settings.InstallTo!, out _)
+                    : settings.OutHandler;
+        }
+        else
+        {
+            var dir = System.IO.Path.GetDirectoryName(settings.Out!)!;
+            modulePath  = settings.Out!;
+            edtPath     = settings.OutEdt     ?? System.IO.Path.Combine(dir, edtName + ".xml");
+            handlerPath = handlerClass is null ? null
+                : settings.OutHandler ?? System.IO.Path.Combine(dir, handlerClass + ".xml");
+        }
+
+        try
+        {
+            var moduleResult = ScaffoldFileWriter.Write(
+                NumberSequenceScaffolder.ModuleExtension(settings.ModuleName, edtName, scope),
+                modulePath!, settings.Overwrite);
+
+            var edtResult = ScaffoldFileWriter.Write(
+                NumberSequenceScaffolder.Edt(edtName, settings.ModuleName, scope, settings.EdtLabel),
+                edtPath!, settings.Overwrite);
+
+            ScaffoldFileWriter.WriteResult? handlerResult = null;
+            if (handlerClass is not null && handlerPath is not null)
+            {
+                handlerResult = ScaffoldFileWriter.Write(
+                    NumberSequenceScaffolder.FormHandler(settings.TableName!, edtName, handlerClass),
+                    handlerPath, settings.Overwrite);
+            }
+
+            return RenderHelpers.Render(kind, ToolResult<object>.Success(new
+            {
+                kind         = "NumberSequence",
+                moduleName   = settings.ModuleName,
+                edtName,
+                scope        = scope.ToString(),
+                module       = new { path = moduleResult.Path,  bytes = moduleResult.Bytes,  backup = moduleResult.BackupPath },
+                edt          = new { path = edtResult.Path,     bytes = edtResult.Bytes,     backup = edtResult.BackupPath },
+                handler      = handlerResult is null ? null : new { path = handlerResult.Path, bytes = handlerResult.Bytes, backup = handlerResult.BackupPath },
+                model        = settings.InstallTo,
+            }));
+        }
+        catch (Exception ex)
+        {
+            return RenderHelpers.Render(kind, ToolResult<object>.Fail(D365FoErrorCodes.WriteFailed, ex.Message));
+        }
+    }
+
+    private static bool TryParseScope(string raw, out NumberSequenceScope scope)
+    {
+        scope = raw.ToLowerInvariant() switch
+        {
+            "shared" => NumberSequenceScope.Shared,
+            "company" or "" => NumberSequenceScope.Company,
+            _ => (NumberSequenceScope)(-1),
+        };
+        return (int)scope >= 0;
+    }
+}

--- a/src/D365FO.Cli/Commands/Generate/GenerateQueryCommand.cs
+++ b/src/D365FO.Cli/Commands/Generate/GenerateQueryCommand.cs
@@ -1,0 +1,119 @@
+using System.Xml.Linq;
+using D365FO.Core;
+using D365FO.Core.Scaffolding;
+using Spectre.Console.Cli;
+
+namespace D365FO.Cli.Commands.Generate;
+
+/// <summary>Scaffolds an <c>AxQuery</c> with data sources and optional joins.</summary>
+public sealed class GenerateQueryCommand : Command<GenerateQueryCommand.Settings>
+{
+    public sealed class Settings : GenerateSettings
+    {
+        [CommandArgument(0, "<NAME>")]
+        [System.ComponentModel.Description("Query name.")]
+        public string Name { get; init; } = "";
+
+        [CommandOption("--ds <TABLE>")]
+        [System.ComponentModel.Description("Root data source table (repeatable). First entry becomes the root; additional entries with no --join flag are treated as InnerJoin children of the first root.")]
+        public string[] DataSources { get; init; } = Array.Empty<string>();
+
+        [CommandOption("--join <SPEC>")]
+        [System.ComponentModel.Description("Repeatable: <table>:<joinKind>:<parentDs>. JoinKind: InnerJoin (default) | OuterJoin | ExistsJoin | NotExistsJoin. Example: --join SalesLine:InnerJoin:SalesTable")]
+        public string[] Joins { get; init; } = Array.Empty<string>();
+    }
+
+    public override int Execute(CommandContext ctx, Settings settings)
+    {
+        var kind = OutputMode.Resolve(settings.Output);
+
+        if (string.IsNullOrWhiteSpace(settings.Name))
+            return RenderHelpers.Render(kind, ToolResult<object>.Fail(D365FoErrorCodes.BadInput, "Query name required."));
+        if (settings.DataSources.Length == 0)
+            return RenderHelpers.Render(kind, ToolResult<object>.Fail(D365FoErrorCodes.BadInput, "At least one --ds <TABLE> required."));
+
+        var hasInstall = !string.IsNullOrWhiteSpace(settings.InstallTo);
+        var hasOut     = !string.IsNullOrWhiteSpace(settings.Out);
+        if (!hasInstall && !hasOut)
+            return RenderHelpers.Render(kind, ToolResult<object>.Fail(D365FoErrorCodes.BadInput, "--out or --install-to is required."));
+
+        var outPath = settings.Out;
+        if (hasInstall && !hasOut)
+        {
+            outPath = GenerateInstaller.ResolveInstallPath(kind, "AxQuery", settings.Name, settings.InstallTo!, out var fail);
+            if (fail.HasValue) return fail.Value;
+        }
+
+        // Build the data-source list: roots first (no ParentDs), then joins.
+        var dsList = new List<QueryDataSourceSpec>();
+
+        // First --ds is the root; subsequent --ds entries without a matching --join
+        // are treated as additional roots.
+        foreach (var ds in settings.DataSources)
+            dsList.Add(new QueryDataSourceSpec(ds));
+
+        // --join specs override: they nominate a parent and are nested.
+        foreach (var j in settings.Joins)
+        {
+            if (!TryParseJoin(j, out var spec))
+                return RenderHelpers.Render(kind, ToolResult<object>.Fail(D365FoErrorCodes.BadInput,
+                    $"Invalid --join '{j}'. Expected <table>:<joinKind>:<parentDs>."));
+            // Remove any duplicate root entry for the same table added by --ds.
+            dsList.RemoveAll(d => string.Equals(d.Table, spec!.Table, StringComparison.OrdinalIgnoreCase) && string.IsNullOrEmpty(d.ParentDs));
+            dsList.Add(spec!);
+        }
+
+        XDocument doc;
+        try
+        {
+            doc = QueryScaffolder.Query(settings.Name, dsList);
+        }
+        catch (ArgumentException ex)
+        {
+            return RenderHelpers.Render(kind, ToolResult<object>.Fail(D365FoErrorCodes.BadInput, ex.Message));
+        }
+
+        try
+        {
+            var res = ScaffoldFileWriter.Write(doc, outPath!, settings.Overwrite);
+            var roots = dsList.Where(d => string.IsNullOrEmpty(d.ParentDs)).Select(d => d.Table).ToList();
+            var joins  = dsList.Where(d => !string.IsNullOrEmpty(d.ParentDs))
+                               .Select(d => new { d.Table, d.JoinMode, parentDs = d.ParentDs }).ToList();
+
+            return RenderHelpers.Render(kind, ToolResult<object>.Success(new
+            {
+                kind        = "AxQuery",
+                name        = settings.Name,
+                rootSources = roots,
+                joins,
+                path        = res.Path,
+                bytes       = res.Bytes,
+                backup      = res.BackupPath,
+                model       = settings.InstallTo,
+            }));
+        }
+        catch (Exception ex)
+        {
+            return RenderHelpers.Render(kind, ToolResult<object>.Fail(D365FoErrorCodes.WriteFailed, ex.Message));
+        }
+    }
+
+    private static bool TryParseJoin(string raw, out QueryDataSourceSpec? spec)
+    {
+        spec = null;
+        // Format: <table>[:<joinKind>[:<parentDs>]]
+        var parts    = raw.Split(':', 3, StringSplitOptions.TrimEntries);
+        var table    = parts.Length > 0 ? parts[0] : "";
+        if (string.IsNullOrEmpty(table)) return false;
+
+        var joinMode = parts.Length > 1 && !string.IsNullOrEmpty(parts[1]) ? parts[1] : "InnerJoin";
+        var parent   = parts.Length > 2 ? parts[2] : null;
+
+        var validModes = new HashSet<string>(StringComparer.OrdinalIgnoreCase)
+            { "InnerJoin", "OuterJoin", "ExistsJoin", "NotExistsJoin" };
+        if (!validModes.Contains(joinMode)) return false;
+
+        spec = new QueryDataSourceSpec(table, null, parent, joinMode);
+        return true;
+    }
+}

--- a/src/D365FO.Cli/Commands/Generate/GenerateSysOperationCommand.cs
+++ b/src/D365FO.Cli/Commands/Generate/GenerateSysOperationCommand.cs
@@ -1,0 +1,149 @@
+using D365FO.Core;
+using D365FO.Core.Scaffolding;
+using Spectre.Console.Cli;
+
+namespace D365FO.Cli.Commands.Generate;
+
+/// <summary>
+/// Scaffolds the DataContract + Service + Controller triplet for a SysOperation
+/// batch / service operation. Produces three separate AxClass XML files.
+/// </summary>
+public sealed class GenerateSysOperationCommand : Command<GenerateSysOperationCommand.Settings>
+{
+    public sealed class Settings : GenerateSettings
+    {
+        [CommandArgument(0, "<NAME>")]
+        [System.ComponentModel.Description("Base name used to derive default class names (e.g. MyBatch → MyBatchContract, MyBatchService, MyBatchController).")]
+        public string Name { get; init; } = "";
+
+        [CommandOption("--contract-name <NAME>")]
+        [System.ComponentModel.Description("DataContract class name. Defaults to <NAME>Contract.")]
+        public string? ContractName { get; init; }
+
+        [CommandOption("--service-name <NAME>")]
+        [System.ComponentModel.Description("Service class name. Defaults to <NAME>Service.")]
+        public string? ServiceName { get; init; }
+
+        [CommandOption("--controller-name <NAME>")]
+        [System.ComponentModel.Description("Controller class name. Defaults to <NAME>Controller.")]
+        public string? ControllerName { get; init; }
+
+        [CommandOption("--param <SPEC>")]
+        [System.ComponentModel.Description("Repeatable: <name>:<type>. Adds a parmXxx() accessor on the DataContract. Example: --param AccountNum:AccountNum")]
+        public string[] Params { get; init; } = Array.Empty<string>();
+
+        [CommandOption("--execution-mode <MODE>")]
+        [System.ComponentModel.Description("Synchronous (default) | Asynchronous | ScheduledBatch.")]
+        public string ExecutionMode { get; init; } = "Synchronous";
+
+        [CommandOption("--service-method <NAME>")]
+        [System.ComponentModel.Description("Name of the service entry-point method. Defaults to 'process'.")]
+        public string ServiceMethod { get; init; } = "process";
+
+        [CommandOption("--out-contract <PATH>")]
+        [System.ComponentModel.Description("Output path for the DataContract class. Defaults to sibling of --out.")]
+        public string? OutContract { get; init; }
+
+        [CommandOption("--out-service <PATH>")]
+        [System.ComponentModel.Description("Output path for the Service class. Defaults to sibling of --out.")]
+        public string? OutService { get; init; }
+    }
+
+    public override int Execute(CommandContext ctx, Settings settings)
+    {
+        var kind = OutputMode.Resolve(settings.Output);
+
+        if (string.IsNullOrWhiteSpace(settings.Name))
+            return RenderHelpers.Render(kind, ToolResult<object>.Fail(D365FoErrorCodes.BadInput, "Base name required."));
+
+        var contractName   = string.IsNullOrWhiteSpace(settings.ContractName)   ? settings.Name + "Contract"   : settings.ContractName!;
+        var serviceName    = string.IsNullOrWhiteSpace(settings.ServiceName)     ? settings.Name + "Service"    : settings.ServiceName!;
+        var controllerName = string.IsNullOrWhiteSpace(settings.ControllerName) ? settings.Name + "Controller" : settings.ControllerName!;
+
+        if (!TryParseExecutionMode(settings.ExecutionMode, out var mode))
+            return RenderHelpers.Render(kind, ToolResult<object>.Fail(D365FoErrorCodes.BadInput,
+                $"Unknown --execution-mode '{settings.ExecutionMode}'. Expected Synchronous | Asynchronous | ScheduledBatch."));
+
+        var hasInstall = !string.IsNullOrWhiteSpace(settings.InstallTo);
+        var hasOut     = !string.IsNullOrWhiteSpace(settings.Out);
+        if (!hasInstall && !hasOut)
+            return RenderHelpers.Render(kind, ToolResult<object>.Fail(D365FoErrorCodes.BadInput, "--out or --install-to is required."));
+
+        // Resolve all three output paths.
+        string? controllerPath, contractPath, servicePath;
+        if (hasInstall && !hasOut)
+        {
+            controllerPath = GenerateInstaller.ResolveInstallPath(kind, "AxClass", controllerName, settings.InstallTo!, out var f1);
+            if (f1.HasValue) return f1.Value;
+            contractPath = string.IsNullOrWhiteSpace(settings.OutContract)
+                ? GenerateInstaller.ResolveInstallPath(kind, "AxClass", contractName, settings.InstallTo!, out var f2)
+                : settings.OutContract;
+            if (hasInstall && string.IsNullOrWhiteSpace(settings.OutContract) && contractPath is null)
+                return RenderHelpers.Render(kind, ToolResult<object>.Fail(D365FoErrorCodes.BadInput, "Could not resolve contract path."));
+            servicePath = string.IsNullOrWhiteSpace(settings.OutService)
+                ? GenerateInstaller.ResolveInstallPath(kind, "AxClass", serviceName, settings.InstallTo!, out var f3)
+                : settings.OutService;
+            if (hasInstall && string.IsNullOrWhiteSpace(settings.OutService) && servicePath is null)
+                return RenderHelpers.Render(kind, ToolResult<object>.Fail(D365FoErrorCodes.BadInput, "Could not resolve service path."));
+        }
+        else
+        {
+            var dir = System.IO.Path.GetDirectoryName(settings.Out!)!;
+            controllerPath = settings.Out!;
+            contractPath   = settings.OutContract  ?? System.IO.Path.Combine(dir, contractName  + ".xml");
+            servicePath    = settings.OutService    ?? System.IO.Path.Combine(dir, serviceName   + ".xml");
+        }
+
+        var parms = settings.Params.Select(ParseParam).ToList();
+
+        try
+        {
+            var contractResult    = ScaffoldFileWriter.Write(
+                SysOperationScaffolder.Contract(contractName, parms), contractPath!, settings.Overwrite);
+            var serviceResult     = ScaffoldFileWriter.Write(
+                SysOperationScaffolder.Service(serviceName, contractName, settings.ServiceMethod, parms), servicePath!, settings.Overwrite);
+            var controllerResult  = ScaffoldFileWriter.Write(
+                SysOperationScaffolder.Controller(controllerName, serviceName, settings.ServiceMethod, mode), controllerPath!, settings.Overwrite);
+
+            return RenderHelpers.Render(kind, ToolResult<object>.Success(new
+            {
+                kind           = "SysOperation",
+                name           = settings.Name,
+                contractName,
+                serviceName,
+                controllerName,
+                serviceMethod  = settings.ServiceMethod,
+                executionMode  = mode.ToString(),
+                paramCount     = parms.Count,
+                contract       = new { path = contractResult.Path,   bytes = contractResult.Bytes,   backup = contractResult.BackupPath },
+                service        = new { path = serviceResult.Path,    bytes = serviceResult.Bytes,    backup = serviceResult.BackupPath },
+                controller     = new { path = controllerResult.Path, bytes = controllerResult.Bytes, backup = controllerResult.BackupPath },
+                model          = settings.InstallTo,
+            }));
+        }
+        catch (Exception ex)
+        {
+            return RenderHelpers.Render(kind, ToolResult<object>.Fail(D365FoErrorCodes.WriteFailed, ex.Message));
+        }
+    }
+
+    private static SysOperationParamSpec ParseParam(string raw)
+    {
+        var parts = raw.Split(':', 2, StringSplitOptions.TrimEntries);
+        var name  = parts.Length > 0 ? parts[0] : raw;
+        var type  = parts.Length > 1 ? parts[1] : "str";
+        return new SysOperationParamSpec(name, type);
+    }
+
+    private static bool TryParseExecutionMode(string raw, out SysOperationExecutionMode mode)
+    {
+        mode = raw.ToLowerInvariant() switch
+        {
+            "asynchronous" or "async"  => SysOperationExecutionMode.Asynchronous,
+            "scheduledbatch" or "batch" => SysOperationExecutionMode.ScheduledBatch,
+            "synchronous" or "sync" or "" => SysOperationExecutionMode.Synchronous,
+            _ => (SysOperationExecutionMode)(-1),
+        };
+        return (int)mode >= 0;
+    }
+}

--- a/src/D365FO.Cli/Commands/Generate/GenerateWorkflowCommand.cs
+++ b/src/D365FO.Cli/Commands/Generate/GenerateWorkflowCommand.cs
@@ -1,0 +1,138 @@
+using D365FO.Core;
+using D365FO.Core.Scaffolding;
+using Spectre.Console.Cli;
+
+namespace D365FO.Cli.Commands.Generate;
+
+/// <summary>
+/// Scaffolds the D365FO workflow pattern: an <c>AxWorkflow</c> type definition,
+/// a <c>WorkflowDocument</c> subclass, and optionally a CoC extension that adds
+/// <c>canSubmitToWorkflow()</c> to the driving table.
+/// </summary>
+public sealed class GenerateWorkflowCommand : Command<GenerateWorkflowCommand.Settings>
+{
+    public sealed class Settings : GenerateSettings
+    {
+        [CommandArgument(0, "<NAME>")]
+        [System.ComponentModel.Description("Workflow type name (e.g. PurchOrderWorkflow).")]
+        public string Name { get; init; } = "";
+
+        [CommandOption("--table <TABLE>")]
+        [System.ComponentModel.Description("Table that drives the workflow (e.g. PurchTable).")]
+        public string? TableName { get; init; }
+
+        [CommandOption("--approval-name <NAME>")]
+        [System.ComponentModel.Description("Name of the approval element to include.")]
+        public string? ApprovalName { get; init; }
+
+        [CommandOption("--task-name <NAME>")]
+        [System.ComponentModel.Description("Name of the task element to include.")]
+        public string? TaskName { get; init; }
+
+        [CommandOption("--document-class <NAME>")]
+        [System.ComponentModel.Description("WorkflowDocument class name. Defaults to <NAME>Document.")]
+        public string? DocumentClassName { get; init; }
+
+        [CommandOption("--query <NAME>")]
+        [System.ComponentModel.Description("Query name used by the WorkflowDocument. Defaults to <DocumentClass>Query.")]
+        public string? QueryName { get; init; }
+
+        [CommandOption("--out-document <PATH>")]
+        [System.ComponentModel.Description("Output path for the WorkflowDocument class. Defaults to sibling of --out.")]
+        public string? OutDocument { get; init; }
+
+        [CommandOption("--out-submit <PATH>")]
+        [System.ComponentModel.Description("Output path for the canSubmitToWorkflow CoC extension. Defaults to sibling of --out when --table is supplied.")]
+        public string? OutSubmit { get; init; }
+
+        [CommandOption("--no-submit-stub")]
+        [System.ComponentModel.Description("Skip generating the canSubmitToWorkflow CoC extension.")]
+        public bool NoSubmitStub { get; init; }
+    }
+
+    public override int Execute(CommandContext ctx, Settings settings)
+    {
+        var kind = OutputMode.Resolve(settings.Output);
+
+        if (string.IsNullOrWhiteSpace(settings.Name))
+            return RenderHelpers.Render(kind, ToolResult<object>.Fail(D365FoErrorCodes.BadInput, "Workflow name required."));
+        if (string.IsNullOrWhiteSpace(settings.TableName))
+            return RenderHelpers.Render(kind, ToolResult<object>.Fail(D365FoErrorCodes.BadInput, "--table <TABLE> required."));
+
+        var hasInstall = !string.IsNullOrWhiteSpace(settings.InstallTo);
+        var hasOut     = !string.IsNullOrWhiteSpace(settings.Out);
+        if (!hasInstall && !hasOut)
+            return RenderHelpers.Render(kind, ToolResult<object>.Fail(D365FoErrorCodes.BadInput, "--out or --install-to is required."));
+
+        var docClassName    = string.IsNullOrWhiteSpace(settings.DocumentClassName)
+            ? settings.Name + "Document"
+            : settings.DocumentClassName!;
+        var submitExtName   = settings.TableName + "_WorkflowExtension";
+        var generateSubmit  = !settings.NoSubmitStub;
+
+        // Resolve output paths.
+        string? workflowPath, documentPath, submitPath;
+        if (hasInstall && !hasOut)
+        {
+            workflowPath  = GenerateInstaller.ResolveInstallPath(kind, "AxWorkflow", settings.Name, settings.InstallTo!, out var f1);
+            if (f1.HasValue) return f1.Value;
+            documentPath  = string.IsNullOrWhiteSpace(settings.OutDocument)
+                ? GenerateInstaller.ResolveInstallPath(kind, "AxClass", docClassName, settings.InstallTo!, out _)
+                : settings.OutDocument;
+            submitPath    = !generateSubmit ? null
+                : string.IsNullOrWhiteSpace(settings.OutSubmit)
+                    ? GenerateInstaller.ResolveInstallPath(kind, "AxClass", submitExtName, settings.InstallTo!, out _)
+                    : settings.OutSubmit;
+        }
+        else
+        {
+            var dir = System.IO.Path.GetDirectoryName(settings.Out!)!;
+            workflowPath  = settings.Out!;
+            documentPath  = settings.OutDocument ?? System.IO.Path.Combine(dir, docClassName + ".xml");
+            submitPath    = !generateSubmit ? null
+                : settings.OutSubmit ?? System.IO.Path.Combine(dir, submitExtName + ".xml");
+        }
+
+        try
+        {
+            var workflowResult = ScaffoldFileWriter.Write(
+                WorkflowScaffolder.WorkflowType(
+                    settings.Name,
+                    settings.TableName!,
+                    settings.ApprovalName,
+                    settings.TaskName,
+                    docClassName),
+                workflowPath!, settings.Overwrite);
+
+            var documentResult = ScaffoldFileWriter.Write(
+                WorkflowScaffolder.WorkflowDocument(docClassName, settings.QueryName),
+                documentPath!, settings.Overwrite);
+
+            ScaffoldFileWriter.WriteResult? submitResult = null;
+            if (generateSubmit && submitPath is not null)
+            {
+                submitResult = ScaffoldFileWriter.Write(
+                    WorkflowScaffolder.CanSubmitExtension(settings.TableName!),
+                    submitPath, settings.Overwrite);
+            }
+
+            return RenderHelpers.Render(kind, ToolResult<object>.Success(new
+            {
+                kind            = "Workflow",
+                name            = settings.Name,
+                tableName       = settings.TableName,
+                documentClassName = docClassName,
+                approvalName    = settings.ApprovalName,
+                taskName        = settings.TaskName,
+                workflow        = new { path = workflowResult.Path,  bytes = workflowResult.Bytes,  backup = workflowResult.BackupPath },
+                document        = new { path = documentResult.Path,  bytes = documentResult.Bytes,  backup = documentResult.BackupPath },
+                submitStub      = submitResult is null ? null : new { path = submitResult.Path, bytes = submitResult.Bytes, backup = submitResult.BackupPath },
+                model           = settings.InstallTo,
+            }));
+        }
+        catch (Exception ex)
+        {
+            return RenderHelpers.Render(kind, ToolResult<object>.Fail(D365FoErrorCodes.WriteFailed, ex.Message));
+        }
+    }
+}

--- a/src/D365FO.Cli/Program.cs
+++ b/src/D365FO.Cli/Program.cs
@@ -150,6 +150,13 @@ app.Configure(cfg =>
         b.AddCommand<GenerateDutyCommand>("duty").WithDescription("Create a security duty grouping privileges.");
         b.AddCommand<GenerateRoleCommand>("role").WithDescription("Create an AxSecurityRole or merge duties/privileges into an existing role.");
         b.AddCommand<GenerateReportCommand>("report").WithDescription("Create an AxReport + SrsReportDataProviderBase skeleton (DP class).");
+        b.AddCommand<GenerateSysOperationCommand>("sysoperation").WithDescription("Create a SysOperation DataContract + Service + Controller triplet.");
+        b.AddCommand<GenerateNumberSequenceCommand>("number-sequence").WithDescription("Create a NumberSeq module extension, EDT, and form handler.");
+        b.AddCommand<GenerateWorkflowCommand>("workflow").WithDescription("Create an AxWorkflow type, WorkflowDocument class, and canSubmitToWorkflow stub.");
+        b.AddCommand<GenerateMenuItemCommand>("menu-item").WithDescription("Create an AxMenuItemDisplay, AxMenuItemAction, or AxMenuItemOutput.");
+        b.AddCommand<GenerateEdtCommand>("edt").WithDescription("Create an AxEdt Extended Data Type.");
+        b.AddCommand<GenerateEnumCommand>("enum").WithDescription("Create an AxEnum base enumeration.");
+        b.AddCommand<GenerateQueryCommand>("query").WithDescription("Create an AxQuery with data sources and joins.");
     });
 
     cfg.AddBranch("analyze", b =>

--- a/src/D365FO.Core/Scaffolding/MenuItemScaffolder.cs
+++ b/src/D365FO.Core/Scaffolding/MenuItemScaffolder.cs
@@ -1,0 +1,52 @@
+using System.Xml.Linq;
+
+namespace D365FO.Core.Scaffolding;
+
+public enum MenuItemKind { Display, Action, Output }
+public enum MenuItemObjectType { Form, Class, Report, Query }
+
+/// <summary>
+/// Scaffolds <c>AxMenuItemDisplay</c>, <c>AxMenuItemAction</c>, and
+/// <c>AxMenuItemOutput</c> AOT objects. Each maps a menu item name to a
+/// target object (Form, Class, SSRSReport, or Query).
+/// </summary>
+public static class MenuItemScaffolder
+{
+    public static XDocument MenuItem(
+        MenuItemKind kind,
+        string name,
+        string objectName,
+        MenuItemObjectType objectType = MenuItemObjectType.Form,
+        string? label = null)
+    {
+        var rootElement = kind switch
+        {
+            MenuItemKind.Action => "AxMenuItemAction",
+            MenuItemKind.Output => "AxMenuItemOutput",
+            _                   => "AxMenuItemDisplay",
+        };
+
+        var objTypeStr = objectType switch
+        {
+            MenuItemObjectType.Class  => "Class",
+            MenuItemObjectType.Report => "SSRSReport",
+            MenuItemObjectType.Query  => "Query",
+            _                         => "Form",
+        };
+
+        return new XDocument(
+            new XElement(rootElement,
+                new XElement("Name", name),
+                string.IsNullOrEmpty(label) ? null : new XElement("Label", label),
+                new XElement("Object", objectName),
+                new XElement("ObjectType", objTypeStr)));
+    }
+
+    /// <summary>Returns the canonical AOT subfolder for a given menu-item kind.</summary>
+    public static string AxSubfolder(MenuItemKind kind) => kind switch
+    {
+        MenuItemKind.Action => "AxMenuItemAction",
+        MenuItemKind.Output => "AxMenuItemOutput",
+        _                   => "AxMenuItemDisplay",
+    };
+}

--- a/src/D365FO.Core/Scaffolding/NumberSequenceScaffolder.cs
+++ b/src/D365FO.Core/Scaffolding/NumberSequenceScaffolder.cs
@@ -1,0 +1,114 @@
+using System.Xml.Linq;
+
+namespace D365FO.Core.Scaffolding;
+
+public enum NumberSequenceScope { Company, Shared }
+
+/// <summary>
+/// Scaffolds the three-part NumberSeq integration pattern:
+/// a CoC extension on the module class, the EDT, and a form event-handler.
+/// </summary>
+public static class NumberSequenceScaffolder
+{
+    /// <summary>
+    /// Scaffolds a CoC extension of the per-module <c>NumberSeqApplicationModule_&lt;ModuleName&gt;</c>
+    /// class that registers a new number sequence reference in <c>loadModule()</c>.
+    /// </summary>
+    public static XDocument ModuleExtension(
+        string moduleName,
+        string edtName,
+        NumberSequenceScope scope = NumberSequenceScope.Company)
+    {
+        var targetClass   = $"NumberSeqApplicationModule_{moduleName}";
+        var extensionName = targetClass + "_Extension";
+
+        var declaration =
+            $"[ExtensionOf(classStr({targetClass}))]\n" +
+            $"final class {extensionName}\n" +
+            "{\n" +
+            "}\n";
+
+        var scopeLine = scope == NumberSequenceScope.Shared
+            ? "    datatype.addParameterType(NumberSeqParameterType::DataArea, false, false);"
+            : "    datatype.addParameterType(NumberSeqParameterType::DataArea, true, false);";
+
+        var loadModuleSrc =
+            "public void loadModule()\n" +
+            "{\n" +
+            "    next loadModule();\n" +
+            "\n" +
+            "    NumberSeqDatatype datatype = NumberSeqDatatype::construct();\n" +
+            $"    datatype.parmDatatypeId(extendedTypeNum({edtName}));\n" +
+            $"    datatype.parmReferenceHelp(literalStr(\"{edtName}\"));\n" +
+            "    datatype.parmWizardIsContinuous(false);\n" +
+            "    datatype.parmWizardIsManual(false);\n" +
+            "    datatype.parmWizardIsChangeDownAllowed(false);\n" +
+            "    datatype.parmWizardIsChangeUpAllowed(false);\n" +
+            "    datatype.parmWizardHighest(999999);\n" +
+            scopeLine + "\n" +
+            "    this.create(datatype);\n" +
+            "}\n";
+
+        return new XDocument(
+            new XElement("AxClass",
+                new XElement("Name", extensionName),
+                new XElement("SourceCode",
+                    new XElement("Declaration", declaration),
+                    new XElement("Methods",
+                        new XElement("Method",
+                            new XElement("Name", "loadModule"),
+                            new XElement("Source", loadModuleSrc))))));
+    }
+
+    /// <summary>Scaffolds an EDT that is backed by a number sequence.</summary>
+    public static XDocument Edt(
+        string edtName,
+        string moduleName,
+        NumberSequenceScope scope = NumberSequenceScope.Company,
+        string? label = null)
+    {
+        return new XDocument(
+            new XElement("AxEdt",
+                new XElement("Name", edtName),
+                new XElement("Extends", "Num"),
+                string.IsNullOrEmpty(label) ? null : new XElement("Label", label),
+                new XElement("NumberSequenceModule", moduleName)));
+    }
+
+    /// <summary>
+    /// Scaffolds a form event-handler class that wires <c>NumberSeqFormHandler</c>
+    /// into the form's <c>Initialized</c> event so the field auto-generates its value.
+    /// </summary>
+    public static XDocument FormHandler(string tableName, string edtName, string className)
+    {
+        var declaration =
+            $"public static class {className}\n" +
+            "{\n" +
+            "}\n";
+
+        var handlerMethod = $"{tableName}Form_OnInitialized";
+
+        var initSrc =
+            $"[FormEventHandler(formStr({tableName}Form), FormEventType::Initialized)]\n" +
+            $"public static void {handlerMethod}(xFormRun _sender, FormEventArgs _e)\n" +
+            "{\n" +
+            "    FormRun formRun = _sender;\n" +
+            $"    formRun.numberSeqFormHandler(\n" +
+            $"        NumberSeqFormHandler::newForm(\n" +
+            $"            CompanyInfo::numRef{edtName}().NumberSequenceId,\n" +
+            "            new FormNumberSeqScope(),\n" +
+            $"            formRun.dataSource(tableStr({tableName})),\n" +
+            $"            fieldStr({tableName}, {edtName})));\n" +
+            "}\n";
+
+        return new XDocument(
+            new XElement("AxClass",
+                new XElement("Name", className),
+                new XElement("SourceCode",
+                    new XElement("Declaration", declaration),
+                    new XElement("Methods",
+                        new XElement("Method",
+                            new XElement("Name", handlerMethod),
+                            new XElement("Source", initSrc))))));
+    }
+}

--- a/src/D365FO.Core/Scaffolding/QueryScaffolder.cs
+++ b/src/D365FO.Core/Scaffolding/QueryScaffolder.cs
@@ -1,0 +1,84 @@
+using System.Xml.Linq;
+
+namespace D365FO.Core.Scaffolding;
+
+/// <summary>
+/// A data source specification for <see cref="QueryScaffolder.Query"/>.
+/// <para>
+/// Root data sources have no <see cref="ParentDs"/>. Joined data sources specify
+/// the <see cref="ParentDs"/> by name (defaults to the parent's <see cref="Table"/>
+/// when only one root exists). <see cref="JoinMode"/> follows D365FO values:
+/// <c>InnerJoin</c>, <c>OuterJoin</c>, <c>ExistsJoin</c>, <c>NotExistsJoin</c>.
+/// </para>
+/// </summary>
+public sealed record QueryDataSourceSpec(
+    string Table,
+    string? Name = null,
+    string? ParentDs = null,
+    string JoinMode = "InnerJoin");
+
+/// <summary>Scaffolds <c>AxQuery</c> objects with nested data-source joins.</summary>
+public static class QueryScaffolder
+{
+    public static XDocument Query(string name, IEnumerable<QueryDataSourceSpec> dataSources)
+    {
+        var dsList = (dataSources ?? throw new ArgumentNullException(nameof(dataSources))).ToList();
+        if (dsList.Count == 0)
+            throw new ArgumentException("At least one data source is required.", nameof(dataSources));
+
+        var roots = dsList.Where(ds => string.IsNullOrEmpty(ds.ParentDs)).ToList();
+        var joins  = dsList.Where(ds => !string.IsNullOrEmpty(ds.ParentDs)).ToList();
+
+        // When the caller does not tag any ParentDs we treat everything except the
+        // first entry as joined children of the first (the most common quick-use case).
+        if (roots.Count == 0)
+        {
+            roots = [dsList[0]];
+            joins  = dsList.Skip(1).Select(ds => ds with { ParentDs = dsList[0].Name ?? dsList[0].Table }).ToList();
+        }
+
+        return new XDocument(
+            new XElement("AxQuery",
+                new XElement("Name", name),
+                new XElement("DataSources",
+                    roots.Select(r => BuildRoot(r, joins)))));
+    }
+
+    private static XElement BuildRoot(QueryDataSourceSpec ds, List<QueryDataSourceSpec> allJoins)
+    {
+        var dsName   = ds.Name ?? ds.Table;
+        var children = allJoins
+            .Where(j => string.Equals(j.ParentDs, dsName, StringComparison.OrdinalIgnoreCase) ||
+                        string.Equals(j.ParentDs, ds.Table, StringComparison.OrdinalIgnoreCase))
+            .ToList();
+
+        var el = new XElement("AxQuerySimpleRootDataSource",
+            new XElement("Name", dsName),
+            new XElement("Table", ds.Table));
+
+        if (children.Count > 0)
+            el.Add(new XElement("DataSources", children.Select(c => BuildJoin(c, allJoins))));
+
+        return el;
+    }
+
+    private static XElement BuildJoin(QueryDataSourceSpec ds, List<QueryDataSourceSpec> allJoins)
+    {
+        var dsName   = ds.Name ?? ds.Table;
+        var children = allJoins
+            .Where(j => string.Equals(j.ParentDs, dsName, StringComparison.OrdinalIgnoreCase) ||
+                        string.Equals(j.ParentDs, ds.Table, StringComparison.OrdinalIgnoreCase))
+            .ToList();
+
+        var el = new XElement("AxQuerySimpleEmbeddedDataSource",
+            new XElement("Name", dsName),
+            new XElement("Table", ds.Table),
+            new XElement("JoinMode", ds.JoinMode),
+            new XElement("Relations", "Yes"));
+
+        if (children.Count > 0)
+            el.Add(new XElement("DataSources", children.Select(c => BuildJoin(c, allJoins))));
+
+        return el;
+    }
+}

--- a/src/D365FO.Core/Scaffolding/SysOperationScaffolder.cs
+++ b/src/D365FO.Core/Scaffolding/SysOperationScaffolder.cs
@@ -1,0 +1,141 @@
+using System.Xml.Linq;
+
+namespace D365FO.Core.Scaffolding;
+
+public sealed record SysOperationParamSpec(string Name, string Type);
+
+public enum SysOperationExecutionMode { Synchronous, Asynchronous, ScheduledBatch }
+
+/// <summary>
+/// Scaffolds the DataContract + Service + Controller triplet that forms the
+/// standard SysOperation pattern for batch jobs and service operations.
+/// </summary>
+public static class SysOperationScaffolder
+{
+    public static XDocument Contract(string contractName, IEnumerable<SysOperationParamSpec>? parameters = null)
+    {
+        var parms = (parameters ?? Enumerable.Empty<SysOperationParamSpec>()).ToList();
+
+        var memberDecls = parms.Count > 0
+            ? string.Join("\n", parms.Select(p => $"    {p.Type} {LowerFirst(p.Name)};")) + "\n"
+            : "";
+
+        var declaration =
+            "[DataContractAttribute]\n" +
+            $"class {contractName}\n" +
+            "{\n" +
+            memberDecls +
+            "}\n";
+
+        var methods = parms.Select(p =>
+        {
+            var member = LowerFirst(p.Name);
+            var src =
+                $"[DataMemberAttribute('{p.Name}')]\n" +
+                $"public {p.Type} parm{p.Name}({p.Type} _{member} = {member})\n" +
+                "{\n" +
+                $"    {member} = _{member};\n" +
+                $"    return {member};\n" +
+                "}\n";
+            return new XElement("Method",
+                new XElement("Name", $"parm{p.Name}"),
+                new XElement("Source", src));
+        }).ToList();
+
+        var sourceEl = new XElement("SourceCode",
+            new XElement("Declaration", declaration));
+        if (methods.Count > 0)
+            sourceEl.Add(new XElement("Methods", methods));
+
+        return new XDocument(
+            new XElement("AxClass",
+                new XElement("Name", contractName),
+                sourceEl));
+    }
+
+    public static XDocument Service(
+        string serviceName,
+        string contractName,
+        string serviceMethod,
+        IEnumerable<SysOperationParamSpec>? parameters = null)
+    {
+        var parms = (parameters ?? Enumerable.Empty<SysOperationParamSpec>()).ToList();
+
+        var declaration =
+            $"class {serviceName} extends SysOperationServiceBase\n" +
+            "{\n" +
+            "}\n";
+
+        var contractUnpack = parms.Count > 0
+            ? string.Join("\n", parms.Select(p =>
+                $"    {p.Type} {LowerFirst(p.Name)} = _contract.parm{p.Name}();")) + "\n\n"
+            : "";
+
+        var methodSrc =
+            $"[SysEntryPointAttribute(true)]\n" +
+            $"public void {serviceMethod}({contractName} _contract)\n" +
+            "{\n" +
+            contractUnpack +
+            "    // service logic here\n" +
+            "}\n";
+
+        return new XDocument(
+            new XElement("AxClass",
+                new XElement("Name", serviceName),
+                new XElement("Extends", "SysOperationServiceBase"),
+                new XElement("SourceCode",
+                    new XElement("Declaration", declaration),
+                    new XElement("Methods",
+                        new XElement("Method",
+                            new XElement("Name", serviceMethod),
+                            new XElement("Source", methodSrc))))));
+    }
+
+    public static XDocument Controller(
+        string controllerName,
+        string serviceName,
+        string serviceMethod,
+        SysOperationExecutionMode mode = SysOperationExecutionMode.Synchronous)
+    {
+        var modeStr = mode switch
+        {
+            SysOperationExecutionMode.Asynchronous    => "SysOperationExecutionMode::Asynchronous",
+            SysOperationExecutionMode.ScheduledBatch  => "SysOperationExecutionMode::ScheduledBatch",
+            _                                         => "SysOperationExecutionMode::Synchronous",
+        };
+
+        var declaration =
+            $"class {controllerName} extends SysOperationServiceController\n" +
+            "{\n" +
+            "}\n";
+
+        var newSrc =
+            "public void new()\n" +
+            "{\n" +
+            $"    super(classStr({serviceName}), methodStr({serviceName}, {serviceMethod}), {modeStr});\n" +
+            "}\n";
+
+        var mainSrc =
+            "public static void main(Args _args)\n" +
+            "{\n" +
+            $"    {controllerName} controller = new {controllerName}();\n" +
+            "    controller.startOperation();\n" +
+            "}\n";
+
+        return new XDocument(
+            new XElement("AxClass",
+                new XElement("Name", controllerName),
+                new XElement("Extends", "SysOperationServiceController"),
+                new XElement("SourceCode",
+                    new XElement("Declaration", declaration),
+                    new XElement("Methods",
+                        new XElement("Method",
+                            new XElement("Name", "new"),
+                            new XElement("Source", newSrc)),
+                        new XElement("Method",
+                            new XElement("Name", "main"),
+                            new XElement("Source", mainSrc))))));
+    }
+
+    private static string LowerFirst(string s) => s.Length == 0 ? s : char.ToLower(s[0]) + s[1..];
+}

--- a/src/D365FO.Core/Scaffolding/WorkflowScaffolder.cs
+++ b/src/D365FO.Core/Scaffolding/WorkflowScaffolder.cs
@@ -1,0 +1,124 @@
+using System.Xml.Linq;
+
+namespace D365FO.Core.Scaffolding;
+
+/// <summary>
+/// Scaffolds the standard D365FO workflow pattern:
+/// <c>WorkflowDocument</c> subclass, <c>AxWorkflow</c> type XML, and a CoC
+/// <c>canSubmitToWorkflow()</c> stub on the driving table.
+/// </summary>
+public static class WorkflowScaffolder
+{
+    /// <summary>
+    /// Scaffolds an <c>AxClass</c> extending <c>WorkflowDocument</c>.
+    /// The generated <c>getQueryName()</c> returns the companion query name.
+    /// </summary>
+    public static XDocument WorkflowDocument(string documentClassName, string? queryName = null)
+    {
+        var effectiveQuery = queryName ?? documentClassName.Replace("Document", "") + "Query";
+
+        var declaration =
+            $"class {documentClassName} extends WorkflowDocument\n" +
+            "{\n" +
+            "}\n";
+
+        var getQuerySrc =
+            "public QueryName getQueryName()\n" +
+            "{\n" +
+            $"    return queryStr({effectiveQuery});\n" +
+            "}\n";
+
+        return new XDocument(
+            new XElement("AxClass",
+                new XElement("Name", documentClassName),
+                new XElement("Extends", "WorkflowDocument"),
+                new XElement("SourceCode",
+                    new XElement("Declaration", declaration),
+                    new XElement("Methods",
+                        new XElement("Method",
+                            new XElement("Name", "getQueryName"),
+                            new XElement("Source", getQuerySrc))))));
+    }
+
+    /// <summary>
+    /// Scaffolds an <c>AxWorkflow</c> type definition that ties the workflow
+    /// to a table. Optionally includes approval and/or task sub-type elements.
+    /// </summary>
+    public static XDocument WorkflowType(
+        string workflowTypeName,
+        string tableName,
+        string? approvalName = null,
+        string? taskName = null,
+        string? documentClassName = null)
+    {
+        var docClass      = documentClassName ?? workflowTypeName + "Document";
+        var submitMenuItem = workflowTypeName + "Submit";
+        var docMenuItem    = workflowTypeName + "MenuItem";
+
+        var root = new XElement("AxWorkflow",
+            new XElement("Name", workflowTypeName),
+            new XElement("DocumentTableName", tableName),
+            new XElement("DocumentMenuItemName", docMenuItem),
+            new XElement("DocumentMenuItemType", "Display"),
+            new XElement("SubmitToWorkflowMenuItem", submitMenuItem),
+            new XElement("SubmitToWorkflowMenuItemType", "Action"),
+            new XElement("WorkflowDocumentClass", docClass));
+
+        var elements = new List<XElement>();
+        if (!string.IsNullOrWhiteSpace(approvalName))
+        {
+            elements.Add(new XElement("AxWorkflowElement",
+                new XElement("Name", approvalName),
+                new XElement("WorkflowElementType", "Approval"),
+                new XElement("OutcomeType", "TwoOutcome")));
+        }
+        if (!string.IsNullOrWhiteSpace(taskName))
+        {
+            elements.Add(new XElement("AxWorkflowElement",
+                new XElement("Name", taskName),
+                new XElement("WorkflowElementType", "Task"),
+                new XElement("OutcomeType", "SingleOutcome")));
+        }
+        if (elements.Count > 0)
+            root.Add(new XElement("WorkflowElements", elements));
+
+        return new XDocument(root);
+    }
+
+    /// <summary>
+    /// Scaffolds a CoC extension on <paramref name="tableName"/> that adds a
+    /// <c>canSubmitToWorkflow()</c> override — the entry point that controls
+    /// whether the Submit button on the form is enabled.
+    /// </summary>
+    public static XDocument CanSubmitExtension(string tableName)
+    {
+        var extensionName = tableName + "_WorkflowExtension";
+
+        var declaration =
+            $"[ExtensionOf(tableStr({tableName}))]\n" +
+            $"final class {extensionName}\n" +
+            "{\n" +
+            "}\n";
+
+        var canSubmitSrc =
+            "public boolean canSubmitToWorkflow(str _workflowType = '')\n" +
+            "{\n" +
+            "    boolean canSubmit = next canSubmitToWorkflow(_workflowType);\n" +
+            "\n" +
+            "    // Add conditions under which this record can be submitted:\n" +
+            "    // canSubmit = canSubmit && this.Status == MyStatus::Draft;\n" +
+            "\n" +
+            "    return canSubmit;\n" +
+            "}\n";
+
+        return new XDocument(
+            new XElement("AxClass",
+                new XElement("Name", extensionName),
+                new XElement("SourceCode",
+                    new XElement("Declaration", declaration),
+                    new XElement("Methods",
+                        new XElement("Method",
+                            new XElement("Name", "canSubmitToWorkflow"),
+                            new XElement("Source", canSubmitSrc))))));
+    }
+}

--- a/src/D365FO.Core/Scaffolding/XppScaffolder.cs
+++ b/src/D365FO.Core/Scaffolding/XppScaffolder.cs
@@ -614,6 +614,70 @@ public static class XppScaffolder
                     new XElement("Methods", parmMethods))));
     }
 
+    /// <summary>
+    /// Scaffolds an <c>AxEdt</c>. When neither <paramref name="extends"/> nor
+    /// <paramref name="baseType"/> is supplied the EDT is created without an extends
+    /// clause, which is valid for root EDTs. When <paramref name="baseType"/> is
+    /// supplied without <paramref name="extends"/>, a sensible standard parent is
+    /// inferred (e.g. <c>String → Name</c>, <c>Int → Integer</c>).
+    /// </summary>
+    public static XDocument Edt(
+        string name,
+        string? extends = null,
+        string? baseType = null,
+        int? stringSize = null,
+        string? label = null)
+    {
+        var effectiveExtends = extends;
+        if (string.IsNullOrEmpty(effectiveExtends) && !string.IsNullOrEmpty(baseType))
+        {
+            effectiveExtends = baseType.ToLowerInvariant() switch
+            {
+                "int" or "integer"          => "Integer",
+                "int64"                     => "Int64",
+                "real"                      => "Amount",
+                "date"                      => "Date",
+                "utcdatetime" or "datetime" => "TransDate",
+                "boolean" or "bool"         => "NoYesId",
+                _                           => "Name",
+            };
+        }
+
+        return new XDocument(
+            new XElement("AxEdt",
+                new XElement("Name", name),
+                string.IsNullOrEmpty(effectiveExtends) ? null : new XElement("Extends", effectiveExtends),
+                stringSize.HasValue ? new XElement("StringSize", stringSize.Value.ToString()) : null,
+                string.IsNullOrEmpty(label) ? null : new XElement("Label", label)));
+    }
+
+    /// <summary>Scaffolds an <c>AxEnum</c> with optional values.</summary>
+    public static XDocument Enum(
+        string name,
+        IEnumerable<EnumValueSpec>? values = null,
+        bool isExtensible = true,
+        string? label = null)
+    {
+        var enumVals = (values ?? Enumerable.Empty<EnumValueSpec>()).ToList();
+
+        var valEls = enumVals.Select(v =>
+        {
+            var el = new XElement("AxEnumValue",
+                new XElement("Name", v.Name),
+                new XElement("Value", v.IntValue.ToString()));
+            if (!string.IsNullOrEmpty(v.Label))
+                el.Add(new XElement("Label", v.Label));
+            return el;
+        });
+
+        return new XDocument(
+            new XElement("AxEnum",
+                new XElement("Name", name),
+                string.IsNullOrEmpty(label) ? null : new XElement("Label", label),
+                new XElement("IsExtensible", isExtensible ? "Yes" : "No"),
+                enumVals.Count > 0 ? new XElement("EnumValues", valEls) : null));
+    }
+
     private static bool AppendRefs(XElement root, string containerName, string itemName, IEnumerable<string>? values)
     {
         var items = (values ?? Enumerable.Empty<string>())
@@ -695,6 +759,9 @@ public sealed record ReportSpec(
 }
 
 public sealed record TableFieldSpec(string Name, string? Edt, string? Label, bool Mandatory);
+
+/// <summary>One value within an <c>AxEnum</c>.</summary>
+public sealed record EnumValueSpec(string Name, int IntValue, string? Label = null);
 
 /// <summary>
 /// Writes a scaffolded XML document atomically: a .tmp sibling is written and


### PR DESCRIPTION
Adds generate sysoperation, number-sequence, workflow, menu-item, edt, enum, and query commands covering all items from AUDIT_PLAN.md §2.1–2.7.

Each command follows the existing scaffold pattern: Core scaffolder returns XDocument, CLI command resolves output paths and delegates to ScaffoldFileWriter. Multi-file commands (sysoperation, number-sequence, workflow) use --out-* companions derived from the primary --out directory.

New Core scaffolders:
- SysOperationScaffolder: DataContract + Service + Controller triplet
- NumberSequenceScaffolder: module extension + EDT + form event-handler
- WorkflowScaffolder: WorkflowDocument + AxWorkflow type + canSubmitToWorkflow CoC stub
- MenuItemScaffolder: AxMenuItemDisplay / Action / Output
- QueryScaffolder: AxQuery with nested root + embedded data sources
- XppScaffolder extended with Edt() and Enum() methods

All 173 existing tests pass; no regressions.