### PR TITLE
feat(index): Phase 3 — AOT coverage gaps (schema v11)

### DIFF
--- a/docs/AUDIT_PLAN.md
+++ b/docs/AUDIT_PLAN.md
@@ -42,12 +42,12 @@ documentation, the D365FO Customization Analysis Report (CAR), and full code inv
 
 ---
 
-## Phase 3: AOT Coverage Gaps 🔲
+## Phase 3: AOT Coverage Gaps ✅
 
 The index covers ~20 AOT object types. The full D365FO Application Object Tree has
 additional types that are either not indexed or only partially surfaced.
 
-### 3.1 Business Events (`AxBusinessEvent`) 🔲
+### 3.1 Business Events (`AxBusinessEvent`) ✅
 
 Business events are a first-class extensibility mechanism (subscribers via Power
 Automate, Azure Service Bus, Event Grid, Logic Apps). Currently not in the index.
@@ -72,7 +72,7 @@ Automate, Azure Service Bus, Event Grid, Logic Apps). Currently not in the index
 
 **Reference:** https://learn.microsoft.com/en-us/dynamics365/fin-ops-core/dev-itpro/business-events/home-page
 
-### 3.2 Security Policies / Extensible Data Security (XDS) 🔲
+### 3.2 Security Policies / Extensible Data Security (XDS) ✅
 
 XDS policies restrict what rows a user can read/write. Missing entirely.
 
@@ -91,7 +91,7 @@ XDS policies restrict what rows a user can read/write. Missing entirely.
 - `src/D365FO.Core/Index/MetadataRepository.cs` — `SearchSecurityPolicies`, `GetSecurityPolicy`
 - `src/D365FO.Cli/Commands/Search/SearchCommands.cs`, `GetCommands.cs`
 
-### 3.3 Configuration Keys (`AxConfigurationKey`) 🔲
+### 3.3 Configuration Keys (`AxConfigurationKey`) ✅
 
 Configuration keys gate feature availability; important for completeness analysis.
 
@@ -106,7 +106,7 @@ Configuration keys gate feature availability; important for completeness analysi
 - `src/D365FO.Core/Index/MetadataRepository.cs` — `SearchConfigurationKeys`
 - `src/D365FO.Cli/Commands/Search/SearchCommands.cs`
 
-### 3.4 Tiles and Workspace Descriptors 🔲
+### 3.4 Tiles and Workspace Descriptors ✅
 
 Tiles and workspaces are visible in the navigation experience. Low query frequency
 but useful for impact analysis.
@@ -117,7 +117,7 @@ but useful for impact analysis.
 
 **Files:** Same pattern — schema tables + extractor walk + search commands.
 
-### 3.5 Table AOT Properties Gap-fill 🔲
+### 3.5 Table AOT Properties Gap-fill ✅
 
 Currently extracted table properties are missing several columns important for lint:
 
@@ -138,7 +138,7 @@ Currently extracted table properties are missing several columns important for l
 - `src/D365FO.Core/Index/Models.cs` — extend `TableDetails`
 - `src/D365FO.Core/Index/MetadataRepository.cs` — extend `GetTableDetails` projection
 
-### 3.6 EDT Properties Gap-fill 🔲
+### 3.6 EDT Properties Gap-fill ✅
 
 | Property | Schema Column | Needed For |
 |----------|--------------|------------|
@@ -149,7 +149,7 @@ Currently extracted table properties are missing several columns important for l
 
 **Files:** Same pattern as 3.5.
 
-### 3.7 `search any` gap: Maps not included 🔲
+### 3.7 `search any` gap: Maps not included ✅
 
 `SearchMaps` exists in `MetadataRepository` but `search any` and `search batch` do
 not include maps in the union. Add `Maps` to the multi-kind union query.

--- a/src/D365FO.Cli/Commands/Get/GetCommands.cs
+++ b/src/D365FO.Cli/Commands/Get/GetCommands.cs
@@ -547,3 +547,41 @@ public sealed class GetObjectCommand : Command<GetObjectCommand.Settings>
                 deleteActions = details.DeleteActions,
             }));
 }
+
+public sealed class GetBusinessEventCommand : Command<GetBusinessEventCommand.Settings>
+{
+    public sealed class Settings : D365OutputSettings
+    {
+        [CommandArgument(0, "<NAME>")]
+        public string Name { get; init; } = "";
+    }
+
+    public override int Execute(CommandContext ctx, Settings settings)
+    {
+        var kind = OutputMode.Resolve(settings.Output);
+        var repo = RepoFactory.Create();
+        var item = repo.GetBusinessEvent(settings.Name);
+        return RenderHelpers.Render(kind, item is null
+            ? ToolResult<object>.Fail("NOT_FOUND", $"Business event '{settings.Name}' not found.")
+            : ToolResult<object>.Success(item));
+    }
+}
+
+public sealed class GetSecurityPolicyCommand : Command<GetSecurityPolicyCommand.Settings>
+{
+    public sealed class Settings : D365OutputSettings
+    {
+        [CommandArgument(0, "<NAME>")]
+        public string Name { get; init; } = "";
+    }
+
+    public override int Execute(CommandContext ctx, Settings settings)
+    {
+        var kind = OutputMode.Resolve(settings.Output);
+        var repo = RepoFactory.Create();
+        var item = repo.GetSecurityPolicy(settings.Name);
+        return RenderHelpers.Render(kind, item is null
+            ? ToolResult<object>.Fail("NOT_FOUND", $"Security policy '{settings.Name}' not found.")
+            : ToolResult<object>.Success(item));
+    }
+}

--- a/src/D365FO.Cli/Commands/Search/SearchCommands.cs
+++ b/src/D365FO.Cli/Commands/Search/SearchCommands.cs
@@ -289,6 +289,110 @@ public sealed class SearchAnyCommand : Command<SearchAnyCommand.Settings>
     }
 }
 
+public sealed class SearchBusinessEventCommand : Command<SearchBusinessEventCommand.Settings>
+{
+    public sealed class Settings : D365OutputSettings
+    {
+        [CommandArgument(0, "<QUERY>")]
+        public string Query { get; init; } = "";
+
+        [CommandOption("-c|--category <CAT>")]
+        [System.ComponentModel.Description("Filter by business event category (partial match).")]
+        public string? Category { get; init; }
+
+        [CommandOption("-l|--limit <N>")]
+        public int Limit { get; init; } = 50;
+    }
+
+    public override int Execute(CommandContext ctx, Settings settings)
+    {
+        var kind = OutputMode.Resolve(settings.Output);
+        var repo = RepoFactory.Create();
+        var items = repo.SearchBusinessEvents(settings.Query, settings.Category, settings.Limit);
+        return RenderHelpers.Render(kind, ToolResult<object>.Success(new { count = items.Count, items }));
+    }
+}
+
+public sealed class SearchSecurityPolicyCommand : Command<SearchSecurityPolicyCommand.Settings>
+{
+    public sealed class Settings : D365OutputSettings
+    {
+        [CommandArgument(0, "<QUERY>")]
+        public string Query { get; init; } = "";
+
+        [CommandOption("-l|--limit <N>")]
+        public int Limit { get; init; } = 50;
+    }
+
+    public override int Execute(CommandContext ctx, Settings settings)
+    {
+        var kind = OutputMode.Resolve(settings.Output);
+        var repo = RepoFactory.Create();
+        var items = repo.SearchSecurityPolicies(settings.Query, settings.Limit);
+        return RenderHelpers.Render(kind, ToolResult<object>.Success(new { count = items.Count, items }));
+    }
+}
+
+public sealed class SearchConfigurationKeyCommand : Command<SearchConfigurationKeyCommand.Settings>
+{
+    public sealed class Settings : D365OutputSettings
+    {
+        [CommandArgument(0, "<QUERY>")]
+        public string Query { get; init; } = "";
+
+        [CommandOption("-l|--limit <N>")]
+        public int Limit { get; init; } = 50;
+    }
+
+    public override int Execute(CommandContext ctx, Settings settings)
+    {
+        var kind = OutputMode.Resolve(settings.Output);
+        var repo = RepoFactory.Create();
+        var items = repo.SearchConfigurationKeys(settings.Query, settings.Limit);
+        return RenderHelpers.Render(kind, ToolResult<object>.Success(new { count = items.Count, items }));
+    }
+}
+
+public sealed class SearchTileCommand : Command<SearchTileCommand.Settings>
+{
+    public sealed class Settings : D365OutputSettings
+    {
+        [CommandArgument(0, "<QUERY>")]
+        public string Query { get; init; } = "";
+
+        [CommandOption("-l|--limit <N>")]
+        public int Limit { get; init; } = 50;
+    }
+
+    public override int Execute(CommandContext ctx, Settings settings)
+    {
+        var kind = OutputMode.Resolve(settings.Output);
+        var repo = RepoFactory.Create();
+        var items = repo.SearchTiles(settings.Query, settings.Limit);
+        return RenderHelpers.Render(kind, ToolResult<object>.Success(new { count = items.Count, items }));
+    }
+}
+
+public sealed class SearchWorkspaceCommand : Command<SearchWorkspaceCommand.Settings>
+{
+    public sealed class Settings : D365OutputSettings
+    {
+        [CommandArgument(0, "<QUERY>")]
+        public string Query { get; init; } = "";
+
+        [CommandOption("-l|--limit <N>")]
+        public int Limit { get; init; } = 50;
+    }
+
+    public override int Execute(CommandContext ctx, Settings settings)
+    {
+        var kind = OutputMode.Resolve(settings.Output);
+        var repo = RepoFactory.Create();
+        var items = repo.SearchWorkspaces(settings.Query, settings.Limit);
+        return RenderHelpers.Render(kind, ToolResult<object>.Success(new { count = items.Count, items }));
+    }
+}
+
 public sealed class SearchBatchCommand : Command<SearchBatchCommand.Settings>
 {
     public sealed class Settings : D365OutputSettings

--- a/src/D365FO.Cli/Program.cs
+++ b/src/D365FO.Cli/Program.cs
@@ -41,6 +41,11 @@ app.Configure(cfg =>
         b.AddCommand<SearchWorkflowCommand>("workflow").WithDescription("Find workflow types.");
         b.AddCommand<SearchAnyCommand>("any").WithDescription("Scope-agnostic search across every indexed kind.");
         b.AddCommand<SearchBatchCommand>("batch").WithDescription("Run several scope-agnostic searches in one CLI call.");
+        b.AddCommand<SearchBusinessEventCommand>("business-event").WithDescription("Find business events (classes extending BusinessEventsBase).");
+        b.AddCommand<SearchSecurityPolicyCommand>("security-policy").WithDescription("Find XDS security policies.");
+        b.AddCommand<SearchConfigurationKeyCommand>("configuration-key").WithDescription("Find configuration keys.");
+        b.AddCommand<SearchTileCommand>("tile").WithDescription("Find navigation tiles.");
+        b.AddCommand<SearchWorkspaceCommand>("workspace").WithDescription("Find workspace descriptors.");
     });
 
     cfg.AddBranch("get", b =>
@@ -64,6 +69,8 @@ app.Configure(cfg =>
         b.AddCommand<GetServiceCommand>("service").WithDescription("SOAP service: operations.");
         b.AddCommand<GetServiceGroupCommand>("service-group").WithDescription("Service group: members.");
         b.AddCommand<GetObjectCommand>("object").WithDescription("Generic get by kind/name for agent workflows.");
+        b.AddCommand<GetBusinessEventCommand>("business-event").WithDescription("Business event: class, category, contract.");
+        b.AddCommand<GetSecurityPolicyCommand>("security-policy").WithDescription("XDS security policy: constrained table, query, operation type.");
     });
 
     cfg.AddBranch("find", b =>

--- a/src/D365FO.Core/Extract/MetadataExtractor.cs
+++ b/src/D365FO.Core/Extract/MetadataExtractor.cs
@@ -127,8 +127,13 @@ public sealed class MetadataExtractor
         List<ExtractedReport>            reports       = null!;
         List<ExtractedService>           services      = null!;
         List<ExtractedServiceGroup>      serviceGroups = null!;
-        List<ExtractedWorkflowType>      workflowTypes = null!;
-        List<ExtractedMap>               maps          = null!;
+        List<ExtractedWorkflowType>      workflowTypes    = null!;
+        List<ExtractedMap>               maps             = null!;
+        List<ExtractedBusinessEvent>     businessEvents   = null!;
+        List<ExtractedSecurityPolicy>    securityPolicies = null!;
+        List<ExtractedConfigurationKey>  configKeys       = null!;
+        List<ExtractedTile>              tiles            = null!;
+        List<ExtractedWorkspace>         workspaces       = null!;
 
         Parallel.Invoke(
             () => tables       = ReadAll(Path.Combine(modelRoot, "AxTable"), ParseTable),
@@ -214,12 +219,17 @@ public sealed class MetadataExtractor
             },
             () => services     = ReadAll(Path.Combine(modelRoot, "AxService"),      ParseService),
             () => serviceGroups = ReadAll(Path.Combine(modelRoot, "AxServiceGroup"), ParseServiceGroup),
-            () => workflowTypes = ReadAll(Path.Combine(modelRoot, "AxWorkflowType"), ParseWorkflowType),
-            () => maps          = ReadAll(Path.Combine(modelRoot, "AxMap"),          ParseMap)
+            () => workflowTypes    = ReadAll(Path.Combine(modelRoot, "AxWorkflowType"),    ParseWorkflowType),
+            () => maps             = ReadAll(Path.Combine(modelRoot, "AxMap"),             ParseMap),
+            () => securityPolicies = ReadAll(Path.Combine(modelRoot, "AxSecurityPolicy"),  ParseSecurityPolicy),
+            () => configKeys       = ReadAll(Path.Combine(modelRoot, "AxConfigurationKey"),ParseConfigurationKey),
+            () => tiles            = ReadAll(Path.Combine(modelRoot, "AxTile"),            ParseTile),
+            () => workspaces       = ReadAll(Path.Combine(modelRoot, "AxWorkspace"),       ParseWorkspace)
         );
 
         var coc = classes.SelectMany(DetectCoc).ToList();
         var subscribers = classes.SelectMany(DetectSubscribers).ToList();
+        businessEvents = DeriveBusinessEvents(classes);
 
         return new ExtractBatch(
             Model: modelName,
@@ -246,8 +256,13 @@ public sealed class MetadataExtractor
             Reports = reports,
             Services = services,
             ServiceGroups = serviceGroups,
-            WorkflowTypes = workflowTypes,
-            Maps = maps,
+            WorkflowTypes    = workflowTypes,
+            Maps             = maps,
+            BusinessEvents   = businessEvents,
+            SecurityPolicies = securityPolicies,
+            ConfigurationKeys = configKeys,
+            Tiles            = tiles,
+            Workspaces       = workspaces,
         };
     }
 
@@ -279,7 +294,7 @@ public sealed class MetadataExtractor
             "AxMenuItemDisplay", "AxMenuItemAction", "AxMenuItemOutput",
             "AxQuery", "AxQuerySimple", "AxView", "AxDataEntityView",
             "AxReport", "AxReportSsrs", "AxService", "AxServiceGroup", "AxWorkflowType",
-            "AxMap",
+            "AxMap", "AxSecurityPolicy", "AxConfigurationKey", "AxTile", "AxWorkspace",
         })
             if (Directory.Exists(Path.Combine(dir, s))) return true;
         return false;
@@ -431,6 +446,15 @@ public sealed class MetadataExtractor
             Indexes = indexes,
             DeleteActions = deleteActions,
             Methods = methods,
+            SaveDataPerCompany      = Local(root, "SaveDataPerCompany"),
+            CacheLookup             = Local(root, "CacheLookup"),
+            OccEnabled              = string.Equals(Local(root, "OccEnabled"), "Yes", StringComparison.OrdinalIgnoreCase),
+            ValidTimeStateFieldType = Local(root, "ValidTimeStateFieldType"),
+            TableExtends            = Local(root, "Extends"),
+            AOSAuthorization        = Local(root, "AOSAuthorization"),
+            FormRef                 = Local(root, "FormRef"),
+            ListPageRef             = Local(root, "ListPageRef"),
+            SystemTable             = string.Equals(Local(root, "SystemTable"), "Yes", StringComparison.OrdinalIgnoreCase),
         };
     }
 
@@ -520,7 +544,13 @@ public sealed class MetadataExtractor
             : null;
         var label = Local(root, "Label");
         int? stringSize = int.TryParse(Local(root, "StringSize"), out var s) ? s : null;
-        return new ExtractedEdt(name, extends, baseType, label, stringSize);
+        return new ExtractedEdt(name, extends, baseType, label, stringSize)
+        {
+            ReferenceTable = Local(root, "ReferenceTable"),
+            FormHelp       = Local(root, "FormHelp"),
+            AnalysisUsage  = Local(root, "AnalysisUsage"),
+            EnumType       = Local(root, "EnumType"),
+        };
     }
 
     private static ExtractedEnum? ParseEnum(XDocument doc, string file)
@@ -1195,5 +1225,105 @@ public sealed class MetadataExtractor
         {
             MappedTables = mappedTables,
         };
+    }
+
+    // -------- v11: security policies --------
+
+    private static ExtractedSecurityPolicy? ParseSecurityPolicy(XDocument doc, string file)
+    {
+        var root = doc.Root;
+        if (root is null) return null;
+        var name = Local(root, "Name") ?? Path.GetFileNameWithoutExtension(file);
+        return new ExtractedSecurityPolicy(
+            name,
+            ConstrainedTable: Local(root, "ConstrainedTable"),
+            PolicyQuery:      Local(root, "Query") ?? Local(root, "PolicyQuery"),
+            OperationType:    Local(root, "Operation") ?? Local(root, "OperationType"),
+            ContextType:      Local(root, "ContextType"),
+            IsEnabled:        !string.Equals(Local(root, "IsEnabled"), "No", StringComparison.OrdinalIgnoreCase),
+            IsMandatory:      string.Equals(Local(root, "IsMandatory"), "Yes", StringComparison.OrdinalIgnoreCase),
+            SourcePath:       file);
+    }
+
+    // -------- v11: configuration keys --------
+
+    private static ExtractedConfigurationKey? ParseConfigurationKey(XDocument doc, string file)
+    {
+        var root = doc.Root;
+        if (root is null) return null;
+        var name = Local(root, "Name") ?? Path.GetFileNameWithoutExtension(file);
+        return new ExtractedConfigurationKey(
+            name,
+            Label:       Local(root, "Label"),
+            IsEnabled:   !string.Equals(Local(root, "IsEnabled"), "No", StringComparison.OrdinalIgnoreCase),
+            ParentKey:   Local(root, "Parent") ?? Local(root, "ParentKey"),
+            LicenseCode: Local(root, "LicenseCode"));
+    }
+
+    // -------- v11: tiles --------
+
+    private static ExtractedTile? ParseTile(XDocument doc, string file)
+    {
+        var root = doc.Root;
+        if (root is null) return null;
+        var name = Local(root, "Name") ?? Path.GetFileNameWithoutExtension(file);
+        return new ExtractedTile(
+            name,
+            MenuItemName: Local(root, "MenuItemName"),
+            MenuItemType: Local(root, "MenuItemType"),
+            Label:        Local(root, "Label"),
+            TileType:     Local(root, "Type") ?? Local(root, "TileType"),
+            SourcePath:   file);
+    }
+
+    // -------- v11: workspaces --------
+
+    private static ExtractedWorkspace? ParseWorkspace(XDocument doc, string file)
+    {
+        var root = doc.Root;
+        if (root is null) return null;
+        var name = Local(root, "Name") ?? Path.GetFileNameWithoutExtension(file);
+        return new ExtractedWorkspace(name, Local(root, "Label"), file);
+    }
+
+    // -------- v11: business events derived from classes --------
+
+    private static readonly System.Text.RegularExpressions.Regex ClassStrRx =
+        new(@"classStr\s*\(\s*([A-Za-z_][A-Za-z0-9_]*)\s*\)", System.Text.RegularExpressions.RegexOptions.Compiled);
+
+    private static readonly System.Text.RegularExpressions.Regex QuotedStringRx =
+        new(@"""([^""\\]*(?:\\.[^""\\]*)*)""", System.Text.RegularExpressions.RegexOptions.Compiled);
+
+    private static List<ExtractedBusinessEvent> DeriveBusinessEvents(IReadOnlyList<ExtractedClass> classes)
+    {
+        var result = new List<ExtractedBusinessEvent>();
+        foreach (var cls in classes)
+        {
+            if (!string.Equals(cls.Extends, "BusinessEventsBase", StringComparison.OrdinalIgnoreCase))
+                continue;
+
+            var attr = cls.Attributes.FirstOrDefault(a =>
+                a.MethodName is null &&
+                string.Equals(a.AttributeName, "BusinessEvents", StringComparison.OrdinalIgnoreCase));
+
+            string? contractClass = null;
+            string? category = null;
+
+            if (attr is not null)
+            {
+                var classStrMatches = ClassStrRx.Matches(attr.RawArgs ?? string.Empty);
+                // First classStr() is the event class itself; second is the contract class.
+                if (classStrMatches.Count >= 2)
+                    contractClass = classStrMatches[1].Groups[1].Value;
+
+                var quotedMatches = QuotedStringRx.Matches(attr.RawArgs ?? string.Empty);
+                // First quoted string is the category label.
+                if (quotedMatches.Count >= 1)
+                    category = quotedMatches[0].Groups[1].Value;
+            }
+
+            result.Add(new ExtractedBusinessEvent(cls.Name, category, contractClass, cls.SourcePath));
+        }
+        return result;
     }
 }

--- a/src/D365FO.Core/Index/ExtractModels.cs
+++ b/src/D365FO.Core/Index/ExtractModels.cs
@@ -34,6 +34,12 @@ public sealed record ExtractBatch(
     public IReadOnlyList<string> Dependencies { get; init; } = Array.Empty<string>();
     /// <summary>AxMap objects found in the model's AxMap folder.</summary>
     public IReadOnlyList<ExtractedMap> Maps { get; init; } = Array.Empty<ExtractedMap>();
+    // v11 additions
+    public IReadOnlyList<ExtractedBusinessEvent>    BusinessEvents    { get; init; } = Array.Empty<ExtractedBusinessEvent>();
+    public IReadOnlyList<ExtractedSecurityPolicy>   SecurityPolicies  { get; init; } = Array.Empty<ExtractedSecurityPolicy>();
+    public IReadOnlyList<ExtractedConfigurationKey> ConfigurationKeys { get; init; } = Array.Empty<ExtractedConfigurationKey>();
+    public IReadOnlyList<ExtractedTile>             Tiles             { get; init; } = Array.Empty<ExtractedTile>();
+    public IReadOnlyList<ExtractedWorkspace>        Workspaces        { get; init; } = Array.Empty<ExtractedWorkspace>();
 
     public static ExtractBatch Empty(string model) => new(
         model, null, null, false,
@@ -52,6 +58,16 @@ public sealed record ExtractedTable(string Name, string? Label, string? SourcePa
     public IReadOnlyList<ExtractedTableIndex> Indexes { get; init; } = Array.Empty<ExtractedTableIndex>();
     public IReadOnlyList<ExtractedTableDeleteAction> DeleteActions { get; init; } = Array.Empty<ExtractedTableDeleteAction>();
     public IReadOnlyList<ExtractedMethod> Methods { get; init; } = Array.Empty<ExtractedMethod>();
+    // v11 gap-fill properties
+    public string? SaveDataPerCompany { get; init; }
+    public string? CacheLookup { get; init; }
+    public bool OccEnabled { get; init; }
+    public string? ValidTimeStateFieldType { get; init; }
+    public string? TableExtends { get; init; }
+    public string? AOSAuthorization { get; init; }
+    public string? FormRef { get; init; }
+    public string? ListPageRef { get; init; }
+    public bool SystemTable { get; init; }
 }
 public sealed record ExtractedTableField(string Name, string? Type, string? EdtName, string? Label, bool Mandatory);
 public sealed record ExtractedTableRelation(string? Name, string RelatedTable, string? Cardinality, string? RelationshipType);
@@ -73,7 +89,14 @@ public sealed record ExtractedEventSubscriber(
     string? SourceMember,
     string? EventType);
 
-public sealed record ExtractedEdt(string Name, string? Extends, string? BaseType, string? Label, int? StringSize);
+public sealed record ExtractedEdt(string Name, string? Extends, string? BaseType, string? Label, int? StringSize)
+{
+    // v11 gap-fill properties
+    public string? ReferenceTable { get; init; }
+    public string? FormHelp { get; init; }
+    public string? AnalysisUsage { get; init; }
+    public string? EnumType { get; init; }
+}
 public sealed record ExtractedEnum(string Name, string? Label, IReadOnlyList<ExtractedEnumValue> Values);
 public sealed record ExtractedEnumValue(string Name, int? Value, string? Label);
 public sealed record ExtractedMenuItem(string Name, string Kind, string? Object, string? ObjectType, string? Label);
@@ -151,6 +174,49 @@ public sealed record ExtractedServiceOperation(string OperationName, string? Met
 public sealed record ExtractedServiceGroup(string Name, string? SourcePath, IReadOnlyList<string> Members);
 
 public sealed record ExtractedWorkflowType(string Name, string? Category, string? DocumentClass, string? SourcePath);
+
+// ---- v11 extract records ------------------------------------------------
+
+/// <summary>A D365FO Business Event (class extending BusinessEventsBase).</summary>
+public sealed record ExtractedBusinessEvent(
+    string Name,
+    string? Category,
+    string? ContractClass,
+    string? SourcePath);
+
+/// <summary>An AxSecurityPolicy (XDS row-level security policy).</summary>
+public sealed record ExtractedSecurityPolicy(
+    string Name,
+    string? ConstrainedTable,
+    string? PolicyQuery,
+    string? OperationType,
+    string? ContextType,
+    bool IsEnabled,
+    bool IsMandatory,
+    string? SourcePath);
+
+/// <summary>An AxConfigurationKey gating feature availability.</summary>
+public sealed record ExtractedConfigurationKey(
+    string Name,
+    string? Label,
+    bool IsEnabled,
+    string? ParentKey,
+    string? LicenseCode);
+
+/// <summary>An AxTile used in navigation tile panels.</summary>
+public sealed record ExtractedTile(
+    string Name,
+    string? MenuItemName,
+    string? MenuItemType,
+    string? Label,
+    string? TileType,
+    string? SourcePath);
+
+/// <summary>An AxWorkspace navigation descriptor.</summary>
+public sealed record ExtractedWorkspace(
+    string Name,
+    string? Label,
+    string? SourcePath);
 
 public sealed record ExtractCounts(
     long Models,

--- a/src/D365FO.Core/Index/MetadataRepository.cs
+++ b/src/D365FO.Core/Index/MetadataRepository.cs
@@ -14,7 +14,7 @@ namespace D365FO.Core.Index;
 public sealed class MetadataRepository
 {
     /// <summary>Current schema version tracked in PRAGMA user_version.</summary>
-    public const int CurrentSchemaVersion = 10;
+    public const int CurrentSchemaVersion = 11;
 
     private static readonly Lazy<string> SchemaSql = new(LoadEmbeddedSchema);
 
@@ -178,6 +178,35 @@ public sealed class MetadataRepository
             }
         }
 
+        if (current < 11)
+        {
+            // v11: Table property gap-fill — new columns on pre-existing Tables/Edts.
+            var tableCols = conn.Query<string>("SELECT name FROM pragma_table_info('Tables')", transaction: tx)
+                .ToHashSet(StringComparer.OrdinalIgnoreCase);
+            if (tableCols.Count > 0)
+            {
+                if (!tableCols.Contains("SaveDataPerCompany"))      conn.Execute("ALTER TABLE Tables ADD COLUMN SaveDataPerCompany TEXT", transaction: tx);
+                if (!tableCols.Contains("CacheLookup"))             conn.Execute("ALTER TABLE Tables ADD COLUMN CacheLookup TEXT", transaction: tx);
+                if (!tableCols.Contains("OccEnabled"))              conn.Execute("ALTER TABLE Tables ADD COLUMN OccEnabled INTEGER NOT NULL DEFAULT 0", transaction: tx);
+                if (!tableCols.Contains("ValidTimeStateFieldType")) conn.Execute("ALTER TABLE Tables ADD COLUMN ValidTimeStateFieldType TEXT", transaction: tx);
+                if (!tableCols.Contains("TableExtends"))            conn.Execute("ALTER TABLE Tables ADD COLUMN TableExtends TEXT", transaction: tx);
+                if (!tableCols.Contains("AOSAuthorization"))        conn.Execute("ALTER TABLE Tables ADD COLUMN AOSAuthorization TEXT", transaction: tx);
+                if (!tableCols.Contains("FormRef"))                 conn.Execute("ALTER TABLE Tables ADD COLUMN FormRef TEXT", transaction: tx);
+                if (!tableCols.Contains("ListPageRef"))             conn.Execute("ALTER TABLE Tables ADD COLUMN ListPageRef TEXT", transaction: tx);
+                if (!tableCols.Contains("SystemTable"))             conn.Execute("ALTER TABLE Tables ADD COLUMN SystemTable INTEGER NOT NULL DEFAULT 0", transaction: tx);
+            }
+
+            var edtCols = conn.Query<string>("SELECT name FROM pragma_table_info('Edts')", transaction: tx)
+                .ToHashSet(StringComparer.OrdinalIgnoreCase);
+            if (edtCols.Count > 0)
+            {
+                if (!edtCols.Contains("ReferenceTable")) conn.Execute("ALTER TABLE Edts ADD COLUMN ReferenceTable TEXT", transaction: tx);
+                if (!edtCols.Contains("FormHelp"))       conn.Execute("ALTER TABLE Edts ADD COLUMN FormHelp TEXT", transaction: tx);
+                if (!edtCols.Contains("AnalysisUsage"))  conn.Execute("ALTER TABLE Edts ADD COLUMN AnalysisUsage TEXT", transaction: tx);
+                if (!edtCols.Contains("EnumType"))       conn.Execute("ALTER TABLE Edts ADD COLUMN EnumType TEXT", transaction: tx);
+            }
+        }
+
         conn.Execute($"PRAGMA user_version = {CurrentSchemaVersion}", transaction: tx);
         conn.Execute(
             "INSERT OR IGNORE INTO SchemaVersion(Version, AppliedUtc) VALUES(@v, @t)",
@@ -250,7 +279,9 @@ public sealed class MetadataRepository
     {
         using var conn = OpenReadOnly();
         var table = conn.QueryFirstOrDefault<TableInfo>(@"
-            SELECT t.TableId, t.Name, m.Name AS Model, t.Label, t.SourcePath
+            SELECT t.TableId, t.Name, m.Name AS Model, t.Label, t.SourcePath,
+                   t.SaveDataPerCompany, t.CacheLookup, t.OccEnabled, t.ValidTimeStateFieldType,
+                   t.TableExtends, t.AOSAuthorization, t.FormRef, t.ListPageRef, t.SystemTable
             FROM Tables t JOIN Models m ON m.ModelId = t.ModelId
             WHERE t.Name = @name LIMIT 1", new { name });
         if (table is null) return null;
@@ -288,7 +319,8 @@ public sealed class MetadataRepository
         using var conn = OpenReadOnly();
         return conn.QueryFirstOrDefault<EdtInfo>(@"
             SELECT e.Name, m.Name AS Model, e.ExtendsName AS Extends,
-                   e.BaseType, e.Label, e.StringSize
+                   e.BaseType, e.Label, e.StringSize,
+                   e.ReferenceTable, e.FormHelp, e.AnalysisUsage, e.EnumType
             FROM Edts e JOIN Models m ON m.ModelId = e.ModelId
             WHERE e.Name = @name LIMIT 1", new { name });
     }
@@ -914,6 +946,89 @@ public sealed class MetadataRepository
         return new MapDetails(map, fields, tables);
     }
 
+    // ---- v11 query methods ----
+
+    public IReadOnlyList<BusinessEventInfo> SearchBusinessEvents(string query, string? category = null, int limit = 50)
+    {
+        using var conn = OpenReadOnly();
+        var like = $"%{query}%";
+        return conn.Query<BusinessEventInfo>(@"
+            SELECT be.Id, be.Name, be.Category, be.ContractClass, m.Name AS Model, be.SourcePath
+            FROM BusinessEvents be JOIN Models m ON m.ModelId = be.ModelId
+            WHERE (be.Name LIKE @like OR be.ContractClass LIKE @like)
+              AND (@category IS NULL OR be.Category LIKE @catLike)
+            ORDER BY be.Name LIMIT @limit",
+            new { like, category, catLike = category is not null ? $"%{category}%" : null, limit }).ToList();
+    }
+
+    public BusinessEventInfo? GetBusinessEvent(string name)
+    {
+        using var conn = OpenReadOnly();
+        return conn.QueryFirstOrDefault<BusinessEventInfo>(@"
+            SELECT be.Id, be.Name, be.Category, be.ContractClass, m.Name AS Model, be.SourcePath
+            FROM BusinessEvents be JOIN Models m ON m.ModelId = be.ModelId
+            WHERE be.Name = @name LIMIT 1", new { name });
+    }
+
+    public IReadOnlyList<SecurityPolicyInfo> SearchSecurityPolicies(string query, int limit = 50)
+    {
+        using var conn = OpenReadOnly();
+        var like = $"%{query}%";
+        return conn.Query<SecurityPolicyInfo>(@"
+            SELECT sp.Id, sp.Name, sp.ConstrainedTable, sp.PolicyQuery, sp.OperationType, sp.ContextType,
+                   sp.IsEnabled, sp.IsMandatory, m.Name AS Model, sp.SourcePath
+            FROM SecurityPolicies sp JOIN Models m ON m.ModelId = sp.ModelId
+            WHERE sp.Name LIKE @like OR sp.ConstrainedTable LIKE @like
+            ORDER BY sp.Name LIMIT @limit",
+            new { like, limit }).ToList();
+    }
+
+    public SecurityPolicyInfo? GetSecurityPolicy(string name)
+    {
+        using var conn = OpenReadOnly();
+        return conn.QueryFirstOrDefault<SecurityPolicyInfo>(@"
+            SELECT sp.Id, sp.Name, sp.ConstrainedTable, sp.PolicyQuery, sp.OperationType, sp.ContextType,
+                   sp.IsEnabled, sp.IsMandatory, m.Name AS Model, sp.SourcePath
+            FROM SecurityPolicies sp JOIN Models m ON m.ModelId = sp.ModelId
+            WHERE sp.Name = @name LIMIT 1", new { name });
+    }
+
+    public IReadOnlyList<ConfigurationKeyInfo> SearchConfigurationKeys(string query, int limit = 50)
+    {
+        using var conn = OpenReadOnly();
+        var like = $"%{query}%";
+        return conn.Query<ConfigurationKeyInfo>(@"
+            SELECT ck.Id, ck.Name, ck.Label, ck.IsEnabled, ck.ParentKey, ck.LicenseCode, m.Name AS Model
+            FROM ConfigurationKeys ck JOIN Models m ON m.ModelId = ck.ModelId
+            WHERE ck.Name LIKE @like
+            ORDER BY ck.Name LIMIT @limit",
+            new { like, limit }).ToList();
+    }
+
+    public IReadOnlyList<TileInfo> SearchTiles(string query, int limit = 50)
+    {
+        using var conn = OpenReadOnly();
+        var like = $"%{query}%";
+        return conn.Query<TileInfo>(@"
+            SELECT t.Id, t.Name, t.MenuItemName, t.MenuItemType, t.Label, t.TileType, m.Name AS Model, t.SourcePath
+            FROM Tiles t JOIN Models m ON m.ModelId = t.ModelId
+            WHERE t.Name LIKE @like OR t.MenuItemName LIKE @like
+            ORDER BY t.Name LIMIT @limit",
+            new { like, limit }).ToList();
+    }
+
+    public IReadOnlyList<WorkspaceInfo> SearchWorkspaces(string query, int limit = 50)
+    {
+        using var conn = OpenReadOnly();
+        var like = $"%{query}%";
+        return conn.Query<WorkspaceInfo>(@"
+            SELECT ws.Id, ws.Name, ws.Label, m.Name AS Model, ws.SourcePath
+            FROM Workspaces ws JOIN Models m ON m.ModelId = ws.ModelId
+            WHERE ws.Name LIKE @like
+            ORDER BY ws.Name LIMIT @limit",
+            new { like, limit }).ToList();
+    }
+
     public IReadOnlyList<ModelInfo> ListModels()
     {
         using var conn = OpenReadOnly();
@@ -979,7 +1094,9 @@ public sealed class MetadataRepository
         using var conn = OpenReadOnly();
         var like = $"%{query}%";
         return conn.Query<TableInfo>(@"
-            SELECT t.TableId, t.Name, m.Name AS Model, t.Label, t.SourcePath
+            SELECT t.TableId, t.Name, m.Name AS Model, t.Label, t.SourcePath,
+                   t.SaveDataPerCompany, t.CacheLookup, t.OccEnabled, t.ValidTimeStateFieldType,
+                   t.TableExtends, t.AOSAuthorization, t.FormRef, t.ListPageRef, t.SystemTable
             FROM Tables t JOIN Models m ON m.ModelId = t.ModelId
             WHERE t.Name LIKE @like
               AND (@model IS NULL OR m.Name = @model)
@@ -993,7 +1110,8 @@ public sealed class MetadataRepository
         var like = $"%{query}%";
         return conn.Query<EdtInfo>(@"
             SELECT e.Name, m.Name AS Model, e.ExtendsName AS Extends,
-                   e.BaseType, e.Label, e.StringSize
+                   e.BaseType, e.Label, e.StringSize,
+                   e.ReferenceTable, e.FormHelp, e.AnalysisUsage, e.EnumType
             FROM Edts e JOIN Models m ON m.ModelId = e.ModelId
             WHERE e.Name LIKE @like
             ORDER BY e.Name
@@ -1143,6 +1261,8 @@ public sealed class MetadataRepository
             SELECT 'Service', s.Name, m.Name FROM Services s JOIN Models m ON m.ModelId=s.ModelId WHERE s.Name LIKE @like
             UNION ALL
             SELECT 'Workflow', w.Name, m.Name FROM WorkflowTypes w JOIN Models m ON m.ModelId=w.ModelId WHERE w.Name LIKE @like
+            UNION ALL
+            SELECT 'Map', mp.Name, m.Name FROM Maps mp JOIN Models m ON m.ModelId=mp.ModelId WHERE mp.Name LIKE @like
             ORDER BY Name
             LIMIT @limit", new { like, limit });
         return rows.Select(r => (r.Kind, r.Name, r.Model)).ToList();
@@ -1349,6 +1469,11 @@ public sealed class MetadataRepository
         conn.Execute("DELETE FROM MapFields WHERE MapId IN (SELECT MapId FROM Maps WHERE ModelId=@m)", new { m = modelId }, tx);
         conn.Execute("DELETE FROM MapTables WHERE MapId IN (SELECT MapId FROM Maps WHERE ModelId=@m)", new { m = modelId }, tx);
         conn.Execute("DELETE FROM Maps WHERE ModelId=@m", new { m = modelId }, tx);
+        conn.Execute("DELETE FROM BusinessEvents WHERE ModelId=@m", new { m = modelId }, tx);
+        conn.Execute("DELETE FROM SecurityPolicies WHERE ModelId=@m", new { m = modelId }, tx);
+        conn.Execute("DELETE FROM ConfigurationKeys WHERE ModelId=@m", new { m = modelId }, tx);
+        conn.Execute("DELETE FROM Tiles WHERE ModelId=@m", new { m = modelId }, tx);
+        conn.Execute("DELETE FROM Workspaces WHERE ModelId=@m", new { m = modelId }, tx);
         conn.Execute("DELETE FROM ModelDependencies WHERE ModelId=@m", new { m = modelId }, tx);
         // Labels are keyed by file+lang, not model; we delete by file instead.
         foreach (var file in batch.Labels.Select(l => l.File).Distinct(StringComparer.OrdinalIgnoreCase))
@@ -1360,11 +1485,23 @@ public sealed class MetadataRepository
         // Tables main insert — prepared statement (30k+ rows for large models).
         using var tableCmd = conn.CreateCommand();
         tableCmd.Transaction = (Microsoft.Data.Sqlite.SqliteTransaction)tx;
-        tableCmd.CommandText = "INSERT INTO Tables(Name, ModelId, Label, SourcePath) VALUES($n, $m, $l, $p)";
-        var tblName    = tableCmd.Parameters.Add("$n", Microsoft.Data.Sqlite.SqliteType.Text);
-        var tblModelId = tableCmd.Parameters.Add("$m", Microsoft.Data.Sqlite.SqliteType.Integer);
-        var tblLabel   = tableCmd.Parameters.Add("$l", Microsoft.Data.Sqlite.SqliteType.Text);
-        var tblPath    = tableCmd.Parameters.Add("$p", Microsoft.Data.Sqlite.SqliteType.Text);
+        tableCmd.CommandText = @"INSERT INTO Tables(Name, ModelId, Label, SourcePath,
+            SaveDataPerCompany, CacheLookup, OccEnabled, ValidTimeStateFieldType, TableExtends,
+            AOSAuthorization, FormRef, ListPageRef, SystemTable)
+            VALUES($n, $m, $l, $p, $sdc, $cl, $occ, $vts, $tx, $aos, $fr, $lpr, $st)";
+        var tblName    = tableCmd.Parameters.Add("$n",   Microsoft.Data.Sqlite.SqliteType.Text);
+        var tblModelId = tableCmd.Parameters.Add("$m",   Microsoft.Data.Sqlite.SqliteType.Integer);
+        var tblLabel   = tableCmd.Parameters.Add("$l",   Microsoft.Data.Sqlite.SqliteType.Text);
+        var tblPath    = tableCmd.Parameters.Add("$p",   Microsoft.Data.Sqlite.SqliteType.Text);
+        var tblSdc     = tableCmd.Parameters.Add("$sdc", Microsoft.Data.Sqlite.SqliteType.Text);
+        var tblCl      = tableCmd.Parameters.Add("$cl",  Microsoft.Data.Sqlite.SqliteType.Text);
+        var tblOcc     = tableCmd.Parameters.Add("$occ", Microsoft.Data.Sqlite.SqliteType.Integer);
+        var tblVts     = tableCmd.Parameters.Add("$vts", Microsoft.Data.Sqlite.SqliteType.Text);
+        var tblTx      = tableCmd.Parameters.Add("$tx",  Microsoft.Data.Sqlite.SqliteType.Text);
+        var tblAos     = tableCmd.Parameters.Add("$aos", Microsoft.Data.Sqlite.SqliteType.Text);
+        var tblFr      = tableCmd.Parameters.Add("$fr",  Microsoft.Data.Sqlite.SqliteType.Text);
+        var tblLpr     = tableCmd.Parameters.Add("$lpr", Microsoft.Data.Sqlite.SqliteType.Text);
+        var tblSt      = tableCmd.Parameters.Add("$st",  Microsoft.Data.Sqlite.SqliteType.Integer);
         tableCmd.Prepare();
 
         using var tableFieldCmd = conn.CreateCommand();
@@ -1395,8 +1532,17 @@ public sealed class MetadataRepository
         {
             tblName.Value    = t.Name;
             tblModelId.Value = modelId;
-            tblLabel.Value   = (object?)t.Label      ?? DBNull.Value;
-            tblPath.Value    = (object?)t.SourcePath ?? DBNull.Value;
+            tblLabel.Value   = (object?)t.Label           ?? DBNull.Value;
+            tblPath.Value    = (object?)t.SourcePath      ?? DBNull.Value;
+            tblSdc.Value     = (object?)t.SaveDataPerCompany ?? DBNull.Value;
+            tblCl.Value      = (object?)t.CacheLookup     ?? DBNull.Value;
+            tblOcc.Value     = t.OccEnabled ? 1 : 0;
+            tblVts.Value     = (object?)t.ValidTimeStateFieldType ?? DBNull.Value;
+            tblTx.Value      = (object?)t.TableExtends    ?? DBNull.Value;
+            tblAos.Value     = (object?)t.AOSAuthorization ?? DBNull.Value;
+            tblFr.Value      = (object?)t.FormRef          ?? DBNull.Value;
+            tblLpr.Value     = (object?)t.ListPageRef      ?? DBNull.Value;
+            tblSt.Value      = t.SystemTable ? 1 : 0;
             tableCmd.ExecuteNonQuery();
             var tableId = conn.ExecuteScalar<long>("SELECT last_insert_rowid()", transaction: tx);
             tfTid.Value = tableId;
@@ -1513,9 +1659,10 @@ public sealed class MetadataRepository
 
         foreach (var e in batch.Edts)
         {
-            conn.Execute(@"INSERT INTO Edts(Name, ModelId, ExtendsName, BaseType, Label, StringSize)
-                           VALUES(@n, @m, @e, @b, @l, @s)",
-                         new { n = e.Name, m = modelId, e = e.Extends, b = e.BaseType, l = e.Label, s = e.StringSize }, tx);
+            conn.Execute(@"INSERT INTO Edts(Name, ModelId, ExtendsName, BaseType, Label, StringSize, ReferenceTable, FormHelp, AnalysisUsage, EnumType)
+                           VALUES(@n, @m, @e, @b, @l, @s, @rt, @fh, @au, @et)",
+                         new { n = e.Name, m = modelId, e = e.Extends, b = e.BaseType, l = e.Label, s = e.StringSize,
+                               rt = e.ReferenceTable, fh = e.FormHelp, au = e.AnalysisUsage, et = e.EnumType }, tx);
         }
 
         foreach (var en in batch.Enums)
@@ -1709,6 +1856,40 @@ public sealed class MetadataRepository
                              new { mid = mapId, t = tname }, tx);
             }
         }
+        foreach (var be in batch.BusinessEvents)
+        {
+            conn.Execute(@"INSERT INTO BusinessEvents(Name, Category, ContractClass, ModelId, SourcePath)
+                           VALUES(@n, @c, @cc, @m, @p)",
+                         new { n = be.Name, c = be.Category, cc = be.ContractClass, m = modelId, p = be.SourcePath }, tx);
+        }
+        foreach (var sp in batch.SecurityPolicies)
+        {
+            conn.Execute(@"INSERT INTO SecurityPolicies(Name, ConstrainedTable, PolicyQuery, OperationType, ContextType, IsEnabled, IsMandatory, ModelId, SourcePath)
+                           VALUES(@n, @ct, @pq, @ot, @cx, @ie, @im, @m, @p)",
+                         new { n = sp.Name, ct = sp.ConstrainedTable, pq = sp.PolicyQuery, ot = sp.OperationType,
+                               cx = sp.ContextType, ie = sp.IsEnabled ? 1 : 0, im = sp.IsMandatory ? 1 : 0,
+                               m = modelId, p = sp.SourcePath }, tx);
+        }
+        foreach (var ck in batch.ConfigurationKeys)
+        {
+            conn.Execute(@"INSERT INTO ConfigurationKeys(Name, Label, IsEnabled, ParentKey, LicenseCode, ModelId)
+                           VALUES(@n, @l, @ie, @pk, @lc, @m)",
+                         new { n = ck.Name, l = ck.Label, ie = ck.IsEnabled ? 1 : 0, pk = ck.ParentKey, lc = ck.LicenseCode, m = modelId }, tx);
+        }
+        foreach (var tile in batch.Tiles)
+        {
+            conn.Execute(@"INSERT INTO Tiles(Name, MenuItemName, MenuItemType, Label, TileType, ModelId, SourcePath)
+                           VALUES(@n, @mn, @mt, @l, @tt, @m, @p)",
+                         new { n = tile.Name, mn = tile.MenuItemName, mt = tile.MenuItemType, l = tile.Label,
+                               tt = tile.TileType, m = modelId, p = tile.SourcePath }, tx);
+        }
+        foreach (var ws in batch.Workspaces)
+        {
+            conn.Execute(@"INSERT INTO Workspaces(Name, Label, ModelId, SourcePath)
+                           VALUES(@n, @l, @m, @p)",
+                         new { n = ws.Name, l = ws.Label, m = modelId, p = ws.SourcePath }, tx);
+        }
+
         foreach (var dep in batch.Dependencies.Distinct(StringComparer.OrdinalIgnoreCase))
         {
             conn.Execute(@"INSERT INTO ModelDependencies(ModelId, Target) VALUES(@m, @t)",

--- a/src/D365FO.Core/Index/Models.cs
+++ b/src/D365FO.Core/Index/Models.cs
@@ -49,7 +49,16 @@ public sealed record TableInfo(
     string Name,
     string Model,
     string? Label,
-    string? SourcePath);
+    string? SourcePath,
+    string? SaveDataPerCompany = null,
+    string? CacheLookup = null,
+    bool OccEnabled = false,
+    string? ValidTimeStateFieldType = null,
+    string? TableExtends = null,
+    string? AOSAuthorization = null,
+    string? FormRef = null,
+    string? ListPageRef = null,
+    bool SystemTable = false);
 
 public sealed record TableFieldInfo(
     string Name,
@@ -89,7 +98,11 @@ public sealed record EdtInfo(
     string? Extends,
     string? BaseType,
     string? Label,
-    long? StringSize);
+    long? StringSize,
+    string? ReferenceTable = null,
+    string? FormHelp = null,
+    string? AnalysisUsage = null,
+    string? EnumType = null);
 
 public sealed record EnumInfo(string Name, string Model, string? Label);
 
@@ -229,6 +242,54 @@ public sealed record MapFieldInfo(string Name, string? Type, string? EdtName, st
 
 /// <summary>Full detail of an AxMap including fields and mapped tables.</summary>
 public sealed record MapDetails(MapInfo Map, IReadOnlyList<MapFieldInfo> Fields, IReadOnlyList<string> MappedTables);
+
+// ---- v11 DTOs -----------------------------------------------------------
+
+public sealed record BusinessEventInfo(
+    long Id,
+    string Name,
+    string? Category,
+    string? ContractClass,
+    string Model,
+    string? SourcePath);
+
+public sealed record SecurityPolicyInfo(
+    long Id,
+    string Name,
+    string? ConstrainedTable,
+    string? PolicyQuery,
+    string? OperationType,
+    string? ContextType,
+    bool IsEnabled,
+    bool IsMandatory,
+    string Model,
+    string? SourcePath);
+
+public sealed record ConfigurationKeyInfo(
+    long Id,
+    string Name,
+    string? Label,
+    bool IsEnabled,
+    string? ParentKey,
+    string? LicenseCode,
+    string Model);
+
+public sealed record TileInfo(
+    long Id,
+    string Name,
+    string? MenuItemName,
+    string? MenuItemType,
+    string? Label,
+    string? TileType,
+    string Model,
+    string? SourcePath);
+
+public sealed record WorkspaceInfo(
+    long Id,
+    string Name,
+    string? Label,
+    string Model,
+    string? SourcePath);
 
 // ---- Index maintenance DTOs ----------------------------------------------
 

--- a/src/D365FO.Core/Index/Schema.sql
+++ b/src/D365FO.Core/Index/Schema.sql
@@ -23,11 +23,20 @@ CREATE TABLE IF NOT EXISTS Models (
 );
 
 CREATE TABLE IF NOT EXISTS Tables (
-    TableId     INTEGER PRIMARY KEY AUTOINCREMENT,
-    Name        TEXT NOT NULL,
-    ModelId     INTEGER NOT NULL,
-    Label       TEXT,
-    SourcePath  TEXT,
+    TableId                 INTEGER PRIMARY KEY AUTOINCREMENT,
+    Name                    TEXT NOT NULL,
+    ModelId                 INTEGER NOT NULL,
+    Label                   TEXT,
+    SourcePath              TEXT,
+    SaveDataPerCompany      TEXT,
+    CacheLookup             TEXT,
+    OccEnabled              INTEGER NOT NULL DEFAULT 0,
+    ValidTimeStateFieldType TEXT,
+    TableExtends            TEXT,
+    AOSAuthorization        TEXT,
+    FormRef                 TEXT,
+    ListPageRef             TEXT,
+    SystemTable             INTEGER NOT NULL DEFAULT 0,
     FOREIGN KEY (ModelId) REFERENCES Models(ModelId)
 );
 CREATE INDEX IF NOT EXISTS IX_Tables_Name ON Tables(Name);
@@ -81,13 +90,17 @@ CREATE TABLE IF NOT EXISTS CocExtensions (
 CREATE INDEX IF NOT EXISTS IX_Coc_Target ON CocExtensions(TargetClass, TargetMethod);
 
 CREATE TABLE IF NOT EXISTS Edts (
-    EdtId       INTEGER PRIMARY KEY AUTOINCREMENT,
-    Name        TEXT NOT NULL,
-    ModelId     INTEGER NOT NULL,
-    ExtendsName TEXT,
-    BaseType    TEXT,
-    Label       TEXT,
-    StringSize  INTEGER,
+    EdtId           INTEGER PRIMARY KEY AUTOINCREMENT,
+    Name            TEXT NOT NULL,
+    ModelId         INTEGER NOT NULL,
+    ExtendsName     TEXT,
+    BaseType        TEXT,
+    Label           TEXT,
+    StringSize      INTEGER,
+    ReferenceTable  TEXT,
+    FormHelp        TEXT,
+    AnalysisUsage   TEXT,
+    EnumType        TEXT,
     FOREIGN KEY (ModelId) REFERENCES Models(ModelId)
 );
 CREATE INDEX IF NOT EXISTS IX_Edts_Name ON Edts(Name);
@@ -534,4 +547,76 @@ CREATE TABLE IF NOT EXISTS MapTables (
     TableName  TEXT NOT NULL,
     FOREIGN KEY (MapId) REFERENCES Maps(MapId) ON DELETE CASCADE
 );
+
+-- v11 additions ----------------------------------------------------------
+
+-- Business events: classes extending BusinessEventsBase. Derived from AxClass
+-- during extraction; the [BusinessEvents(...)] attribute provides category and
+-- contract class name.
+CREATE TABLE IF NOT EXISTS BusinessEvents (
+    Id              INTEGER PRIMARY KEY AUTOINCREMENT,
+    Name            TEXT NOT NULL,
+    Category        TEXT,
+    ContractClass   TEXT,
+    ModelId         INTEGER NOT NULL,
+    SourcePath      TEXT,
+    FOREIGN KEY (ModelId) REFERENCES Models(ModelId)
+);
+CREATE INDEX IF NOT EXISTS IX_BusinessEvents_Name     ON BusinessEvents(Name);
+CREATE INDEX IF NOT EXISTS IX_BusinessEvents_Category ON BusinessEvents(Category);
+
+-- XDS / AxSecurityPolicy objects restrict row-level data access.
+CREATE TABLE IF NOT EXISTS SecurityPolicies (
+    Id               INTEGER PRIMARY KEY AUTOINCREMENT,
+    Name             TEXT NOT NULL,
+    ConstrainedTable TEXT,
+    PolicyQuery      TEXT,
+    OperationType    TEXT,
+    ContextType      TEXT,
+    IsEnabled        INTEGER NOT NULL DEFAULT 1,
+    IsMandatory      INTEGER NOT NULL DEFAULT 0,
+    ModelId          INTEGER NOT NULL,
+    SourcePath       TEXT,
+    FOREIGN KEY (ModelId) REFERENCES Models(ModelId)
+);
+CREATE INDEX IF NOT EXISTS IX_SecurityPolicies_Name  ON SecurityPolicies(Name);
+CREATE INDEX IF NOT EXISTS IX_SecurityPolicies_Table ON SecurityPolicies(ConstrainedTable);
+
+-- AxConfigurationKey objects gate feature availability.
+CREATE TABLE IF NOT EXISTS ConfigurationKeys (
+    Id          INTEGER PRIMARY KEY AUTOINCREMENT,
+    Name        TEXT NOT NULL,
+    Label       TEXT,
+    IsEnabled   INTEGER NOT NULL DEFAULT 1,
+    ParentKey   TEXT,
+    LicenseCode TEXT,
+    ModelId     INTEGER NOT NULL,
+    FOREIGN KEY (ModelId) REFERENCES Models(ModelId)
+);
+CREATE INDEX IF NOT EXISTS IX_ConfigurationKeys_Name ON ConfigurationKeys(Name);
+
+-- AxTile objects used in workspaces / navigation tile panels.
+CREATE TABLE IF NOT EXISTS Tiles (
+    Id              INTEGER PRIMARY KEY AUTOINCREMENT,
+    Name            TEXT NOT NULL,
+    MenuItemName    TEXT,
+    MenuItemType    TEXT,
+    Label           TEXT,
+    TileType        TEXT,
+    ModelId         INTEGER NOT NULL,
+    SourcePath      TEXT,
+    FOREIGN KEY (ModelId) REFERENCES Models(ModelId)
+);
+CREATE INDEX IF NOT EXISTS IX_Tiles_Name ON Tiles(Name);
+
+-- AxWorkspace descriptors (navigation workspace declarations, not AxForm).
+CREATE TABLE IF NOT EXISTS Workspaces (
+    Id          INTEGER PRIMARY KEY AUTOINCREMENT,
+    Name        TEXT NOT NULL,
+    Label       TEXT,
+    ModelId     INTEGER NOT NULL,
+    SourcePath  TEXT,
+    FOREIGN KEY (ModelId) REFERENCES Models(ModelId)
+);
+CREATE INDEX IF NOT EXISTS IX_Workspaces_Name ON Workspaces(Name);
 


### PR DESCRIPTION
- BusinessEvents: detect classes extending BusinessEventsBase, extract [BusinessEvents(...)] category + contract class; new search/get commands
- SecurityPolicies: walk AxSecurityPolicy, extract constrained table + query + operation type + XDS flags; new search/get commands
- ConfigurationKeys: walk AxConfigurationKey; search command
- Tiles/Workspaces: walk AxTile + AxWorkspace; search commands
- Tables gap-fill: 9 new columns (SaveDataPerCompany, CacheLookup, OccEnabled, ValidTimeStateFieldType, TableExtends, AOSAuthorization, FormRef, ListPageRef, SystemTable) — exposed in get table output
- EDTs gap-fill: 4 new columns (ReferenceTable, FormHelp, AnalysisUsage, EnumType) — exposed in search edt + get edt output
- FindUsages (search any/batch): Maps UNION added
- Schema bumped to v11 with backward-compatible ALTER TABLE migrations

All 173 tests pass (80 CLI + 93 Core).