### PR TITLE
fix: preserve CLI assembly from trimmer to fix PublishTrimmed publish

### DIFF
--- a/src/D365FO.Cli/D365FO.Cli.csproj
+++ b/src/D365FO.Cli/D365FO.Cli.csproj
@@ -28,4 +28,11 @@
     <InvariantGlobalization>true</InvariantGlobalization>
   </PropertyGroup>
 
+  <ItemGroup>
+    <!-- Spectre.Console.Cli resolves Settings types via reflection on generic
+         type arguments. The trimmer cannot track these statically, so preserve
+         the whole CLI assembly to avoid CommandRuntimeException at startup. -->
+    <TrimmerRootDescriptor Include="TrimmerRootDescriptor.xml" />
+  </ItemGroup>
+
 </Project>

--- a/src/D365FO.Cli/TrimmerRootDescriptor.xml
+++ b/src/D365FO.Cli/TrimmerRootDescriptor.xml
@@ -1,0 +1,15 @@
+<linker>
+  <!--
+    Spectre.Console.Cli resolves CommandSettings types via reflection on generic
+    type arguments at runtime.  The .NET trimmer cannot see these reflection-based
+    lookups statically, so it silently removes the Settings inner classes, which
+    causes CommandRuntimeException: "could not get settings type for command of
+    type …" when the trimmed binary starts.
+
+    Preserving the whole CLI assembly ensures every Command<TSettings> and its
+    nested Settings class survives trimming regardless of which /p:PublishTrimmed
+    flag the caller passes.  Core and Bridge are untouched — they are plain data
+    libraries whose referenced members the trimmer can track statically.
+  -->
+  <assembly fullname="d365fo" preserve="all" />
+</linker>


### PR DESCRIPTION
Spectre.Console.Cli resolves each command's Settings type at startup via reflection on generic type arguments.  PublishTrimmed=true strips that metadata, causing CommandRuntimeException: "could not get settings type for command of type …" (reported in issue #38).

Added TrimmerRootDescriptor.xml with preserve="all" for the d365fo assembly and wired it into the .csproj so the fix applies automatically whenever trimming is enabled.