### PR TITLE
fix: generate EDT with concrete root element to resolve abstract clas…

### DIFF
--- a/src/D365FO.Core/Scaffolding/NumberSequenceScaffolder.cs
+++ b/src/D365FO.Core/Scaffolding/NumberSequenceScaffolder.cs
@@ -68,7 +68,7 @@ public static class NumberSequenceScaffolder
         string? label = null)
     {
         return new XDocument(
-            new XElement("AxEdt",
+            new XElement("AxEdtString",
                 new XElement("Name", edtName),
                 new XElement("Extends", "Num"),
                 string.IsNullOrEmpty(label) ? null : new XElement("Label", label),

--- a/src/D365FO.Core/Scaffolding/XppScaffolder.cs
+++ b/src/D365FO.Core/Scaffolding/XppScaffolder.cs
@@ -643,13 +643,47 @@ public static class XppScaffolder
             };
         }
 
+        // D365FO's DataContractSerializer requires the root element to be the concrete
+        // subtype name (e.g. AxEdtString) — not the abstract base AxEdt.  Without the
+        // concrete root element the metadata parser throws "Cannot create an abstract class".
+        // Derive the concrete type suffix from --base-type; when only --extends is given,
+        // apply a heuristic over well-known system EDTs so common cases work without flags.
+        var concreteTypeSuffix = !string.IsNullOrEmpty(baseType)
+            ? baseType.ToLowerInvariant() switch
+            {
+                "int" or "integer"          => "Int",
+                "int64"                     => "Int64",
+                "real"                      => "Real",
+                "date"                      => "Date",
+                "utcdatetime" or "datetime" => "DateTime",
+                "boolean" or "bool"         => "Boolean",
+                _                           => "String",
+            }
+            : InferConcreteTypeSuffixFromExtends(effectiveExtends);
+
         return new XDocument(
-            new XElement("AxEdt",
+            new XElement($"AxEdt{concreteTypeSuffix}",
                 new XElement("Name", name),
                 string.IsNullOrEmpty(effectiveExtends) ? null : new XElement("Extends", effectiveExtends),
                 stringSize.HasValue ? new XElement("StringSize", stringSize.Value.ToString()) : null,
                 string.IsNullOrEmpty(label) ? null : new XElement("Label", label)));
     }
+
+    /// <summary>
+    /// Infers the concrete <c>AxEdt*</c> type suffix from a well-known system EDT name.
+    /// Returns <c>"String"</c> as the safe default for unknown or custom parent EDTs.
+    /// </summary>
+    private static string InferConcreteTypeSuffixFromExtends(string? extends) =>
+        extends?.ToLowerInvariant() switch
+        {
+            "integer" or "int"                                      => "Int",
+            "int64" or "recid"                                      => "Int64",
+            "amount" or "amountmst" or "qty" or "weight" or "real"  => "Real",
+            "date" or "transdate"                                   => "Date",
+            "utcdatetime"                                           => "DateTime",
+            "noyes" or "noyesid" or "boolean"                      => "Boolean",
+            _                                                       => "String",
+        } ?? "String";
 
     /// <summary>Scaffolds an <c>AxEnum</c> with optional values.</summary>
     public static XDocument Enum(

--- a/tests/D365FO.Cli.Tests/ScaffoldingSnapshotTests.cs
+++ b/tests/D365FO.Cli.Tests/ScaffoldingSnapshotTests.cs
@@ -53,7 +53,7 @@ public class ScaffoldingSnapshotTests
     {
         var doc = XppScaffolder.Edt("MyEdt", "Name");
         var root = doc.Root!;
-        Assert.Equal("AxEdt", root.Name.LocalName);
+        Assert.Equal("AxEdtString", root.Name.LocalName);
         Assert.Equal("MyEdt", root.Element("Name")!.Value);
         Assert.Equal("Name", root.Element("Extends")!.Value);
     }


### PR DESCRIPTION
…s error

D365FO's DataContractSerializer requires the root element of an EDT XML file to be the concrete subtype name (AxEdtString, AxEdtInt, etc.). Using the abstract base AxEdt as root caused:
  MemberAccessException: Cannot create an abstract class

Changes:
- XppScaffolder.Edt: derive root element name from --base-type parameter (AxEdtString / AxEdtInt / AxEdtInt64 / AxEdtReal / AxEdtDate / AxEdtDateTime / AxEdtBoolean); fall back to a heuristic over well-known system EDT names when only --extends is provided
- NumberSequenceScaffolder.Edt: fix same issue (Num is string-based ->
  AxEdtString)
- ScaffoldingSnapshotTests: update expected root LocalName to AxEdtString

Fixes #40