### PR TITLE
fix: skills coverage audit — add menu-item, security scaffolding, Sys…

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -1,605 +1,117 @@
 # D365 Finance & Operations X++ Development — `d365fo` CLI
 
 <!--
-  Mirrors the X++ rule canon from `d365fo-mcp-server`'s system prompt
-  (src/prompts/systemInstructions.ts) and `.github/copilot-instructions.md`.
-  When that upstream repo updates the X++ rules, sync them here.
+  Deployed to your X++ project via Install-D365FoCopilotSkills.ps1.
+  Primary target: GitHub Copilot in Visual Studio 2022 / 2026 (agent mode with built-in tools).
+  Secondary target: VS Code with Copilot in agent mode (can run d365fo directly via terminal).
   References in the form `[learn:<page>]` link to Microsoft Learn pages
   (see "Authoritative X++ syntax source" at the bottom).
 -->
 
-This workspace is the **`d365fo` CLI** — a metadata-aware command-line tool for D365 Finance & Operations. It exposes the same knowledge as `d365fo-mcp-server` but as deterministic shell commands instead of MCP tool calls. Use it whenever you need to reason about a D365FO codebase without burning conversation tokens on long XML or AOT dumps.
+This file gives **GitHub Copilot** the rules for assisting with D365 Finance & Operations X++ development. It is deployed to your X++ project's `.github/` folder by `Install-D365FoCopilotSkills.ps1` and is read automatically by Copilot in Visual Studio.
 
-> **Audience.** This file gives an AI assistant (GitHub Copilot, Claude Code, Codex CLI, …) the rules for using the `d365fo` CLI to author X++ correctly. Human-facing docs live in the [d365fo-cli repository](https://github.com/dynamics365ninja/d365fo-cli).
-
----
-
-## 🚨 Core principle — never guess D365FO metadata
-
-Your training data is **outdated and incomplete** for D365FO. Every D365FO environment has hundreds of thousands of tables, classes, EDTs, labels — most of them custom or model-specific. **Before generating any X++ code, query the index** through `d365fo` and ground your answer in real names / signatures.
-
-Concretely: the `d365fo` CLI ships with a SQLite mirror of the AOT (and on Windows D365FO VMs, a live bridge to `IMetadataProvider` + `DYNAMICSXREFDB`). It returns:
-
-- ✅ Real-time metadata from the user's environment (when bridge is running).
-- ✅ Pre-indexed SQLite mirror as fallback (Linux/Mac, Azure pipelines, write-only mode).
-- ✅ JSON envelopes (`ToolResult<T>`) — fast to parse, cheap on context.
-
-## 🔌 Read-path policy (how `d365fo` resolves info)
-
-`get` / `find` / `search` commands consult sources in this order:
-
-1. **C# bridge** — live `IMetadataProvider` from a running D365FO instance (Windows VM only). Authoritative when available.
-2. **SQLite symbol index** — pre-built mirror under `~/.d365fo/index.sqlite` (or `--db`). Used when the bridge is offline.
-3. **Filesystem parse** — last resort for objects created in the current session and not yet indexed.
-
-You never pick the source manually. If a result includes `warnings: ["served-from-index"]` the bridge was unavailable and the tool already fell back. If a result is `ok: false` with code `*_NOT_FOUND`, **stop and ask** — do not invent a name.
-
-## 🛡️ Write-path safety
-
-Every `d365fo generate …` command writes XML atomically (`.tmp` + move; `.bak` retained when `--overwrite`). Two modes:
-
-| Mode | When | What happens |
-|---|---|---|
-| `--out <PATH>` | Standalone scaffolds | Writes to the path you give. Path must be inside the workspace. |
-| `--install-to <Model>` | Bridge-installed | Asks the bridge for the model's on-disk location and composes `<modelFolder>/Ax<Type>/<Name>.xml`. Requires `D365FO_BRIDGE_ENABLED=1`. |
-
-Generated files live under `PackagesLocalDirectory/<Model>/<Model>/Ax<Type>/<Name>.xml` — the canonical D365FO layout that Visual Studio and the build tools expect.
+> **Primary environment:** GitHub Copilot in **Visual Studio 2022 / 2026** in agent mode — has `run_command_in_terminal`, `replace_string_in_file`, `get_errors`, etc. Run `d365fo` commands directly via the terminal tool.
+>
+> **Secondary environment:** VS Code with Copilot in agent mode. Same capabilities, different tool names (`run_in_terminal` instead of `run_command_in_terminal`, `read_file` instead of `get_file`).
 
 ---
 
-## 🏁 Mandatory first steps
+## Mandatory first steps
 
-1. **Verify the index is healthy.**
-   ```sh
-   d365fo doctor --output json
-   d365fo index status --output json
-   ```
-   - `ok: false` with `code: NO_INDEX` → run `d365fo index extract` first.
-   - `warnings: ["stale-index"]` → run `d365fo index refresh` (incremental).
+```sh
+d365fo doctor --output json           # confirm index is healthy
+d365fo list models --output json      # confirm target model — NEVER guess it
+```
 
-2. **Ground the active model.** When generating files into a workspace, pass either `--install-to <Model>` or `--out <PATH>` explicitly. Never guess the model from search results — ask the user if unclear.
+| Result | Action |
+|---|---|
+| `ok: false / NO_INDEX` | Run `d365fo index extract` first |
+| `warnings: ["stale-index"]` | Run `d365fo index refresh` (incremental) |
+| `⛔ CONFIGURATION PROBLEM` | Stop. Relay message to user. Wait. |
+| Healthy + model confirmed | Note model name. Proceed. |
 
-3. **Stale index = wrong answers.** When the user has just edited an XML file, `d365fo get` may return pre-edit data until you re-extract. If results contradict what the user just wrote, re-run `d365fo index refresh --model <Model>`.
+Models are ISV / customer policy boundaries — never infer from search results; always ask or read from `.rnrproj`.
+
+### ⛔ VS Chat mode (no agent tools) — fallback workflow
+
+If Copilot is running in **chat mode without agent tools** (no terminal access), it cannot execute `d365fo` directly. The built-in code search / `@workspace` **always fails on AOT XML** — do not attempt it.
+
+```
+// ❌ WRONG — do not attempt this
+Copilot: "Let me search for existing table examples in your codebase…"
+         → "There was an error executing code search"
+Copilot: "Since I cannot access the codebase, I'll provide generic guidance…"
+         → hallucinated X++ templates
+```
+
+- ❌ **Never** attempt code search / `@workspace` on a D365FO project.
+- ❌ **Never** say "Since I cannot access the codebase" and fall back to generic guidance.
+
+**Instead:** ask the user to run the required `d365fo` commands in their Developer PowerShell and paste back the JSON output before you proceed with code generation.
 
 ---
 
-## ✏️ Editing D365FO files
-
-The CLI's surface is *generation-first*: it scaffolds new XML; it does **not** yet provide an in-place AOT-aware mutator equivalent to MCP's `modify_d365fo_file`. For incremental edits to existing AOT XML you have two options:
-
-1. **Hand-edit XML** with the regular editor tools (`replace_string_in_file`, etc.). Always re-run `d365fo get <kind> <name>` afterwards to confirm the index sees your change once `index refresh` is run.
-2. **Drop in a fresh scaffold** with `d365fo generate <kind> --install-to <Model> --overwrite` when you really want to replace the whole file.
-
-When the user just wants to *understand* code, never edit:
+## Core tool mapping
 
 | Need | Command |
 |---|---|
-| Read a class's methods | `d365fo get class <Name> --output json` |
-| Read a table's fields / indexes / relations | `d365fo get table <Name> --output json` |
+| Read class structure (methods, signatures) | `d365fo get class <Name> --output json` |
 | Read X++ method body | `d365fo read class <Name> --method <M>` |
-| Find existing CoC wrappers on a class/method | `d365fo find coc <Class>::<method> --output json` |
-| Find event handlers for a target | `d365fo find handlers <Target> --output json` |
-| Find which Microsoft pattern peers already use | `d365fo find form-patterns --table <T> --output json` |
-| Find forms similar to a known one | `d365fo find form-patterns --similar-to <Form> --output json` |
-| Find inbound/outbound table relations | `d365fo find relations <Table> --output json` |
-| Resolve a label token | `d365fo resolve label @SYS12345 --lang en-us,cs` |
-| Trace security coverage | `d365fo get security <Object> --type <Kind>` |
-| Discover CLI surface (compact agent manifest) | `d365fo schema --output json` |
-| Discover CLI surface (full parity catalog) | `d365fo schema --full --output json` |
-| Search multiple names at once | `d365fo search batch <q1> <q2> … --output json` |
-| Generic object fetch (agent shortcut) | `d365fo get object <kind> <name> --output json` |
-| Generic relation lookup (agent shortcut) | `d365fo find related <relation> <name> --output json` |
-| Find business events by name or category | `d365fo search business-event <query> --output json` |
-| Inspect a business event's contract class | `d365fo get business-event <Name> --output json` |
-| Find XDS security policies | `d365fo search security-policy <query> --output json` |
-| Inspect an XDS security policy | `d365fo get security-policy <Name> --output json` |
-| Find configuration keys | `d365fo search configuration-key <query> --output json` |
-| Find tiles by name | `d365fo search tile <query> --output json` |
-| Find workspace descriptors | `d365fo search workspace <query> --output json` |
+| Read table fields / indexes / relations | `d365fo get table <Name> --output json` |
+| Read form controls / data sources | `d365fo get form <Name> --output json` |
+| Search objects by name | `d365fo search class\|table\|form\|edt\|enum <query> --output json` |
+| Multiple searches in one call | `d365fo search batch <q1> <q2> … --output json` |
+| Check existing CoC wrappers | `d365fo find coc <Class>::<method> --output json` |
+| Find event handlers | `d365fo find handlers <Target> --output json` |
+| Find label | `d365fo search label "<text>" --output json` |
+| Resolve label token | `d365fo resolve label @SYS12345 --lang en-us,cs` |
+| Trace security (Role → Duty → Privilege) | `d365fo get security <Role> --type Role --output json` |
+| Find table relations | `d365fo find relations <Table> --output json` |
+| Create new AOT object | `d365fo generate table\|class\|form\|coc\|entity\|edt\|enum … --install-to <Model>` |
+| Edit method body (CDATA only) | `replace_string_in_file` — then `d365fo index refresh --model <Model>` |
+| Structural change (add field, index, relation) | `d365fo generate … --overwrite` — NEVER `replace_string_in_file` on XML structure |
+| Discover all CLI commands | `d365fo schema --output json` |
+| Index health check | `d365fo doctor --output json` |
 
-> **`--output json` is mandatory** in agent contexts. Without it the CLI may render rich console output that wastes tokens.
+> **`--output json` is mandatory** in agent contexts. Write-path: `--install-to <Model>` for bridge-installed scaffolds; `--out <PATH>` for standalone. Generated files land at `PackagesLocalDirectory/<Model>/<Model>/Ax<Type>/<Name>.xml`.
 
-## 🧱 Scaffolding catalog
+---
 
-### Core objects
+## Key rules (condensed)
 
-| Need | Command |
+1. **Never create/edit AOT XML by hand or via scripts** (`Set-Content`, `Out-File`, `New-Item`, PS/Python scripts). If `d365fo` fails, stop and report — do not fall back to scripts.
+2. **Never use code search / `@workspace` / `file_search` / `grep_search` on AOT XML.** Always `d365fo search`.
+3. **Never auto-run `d365fo build`, `sync`, `bp check`, or `test run`** — slow, blocks the user. Only on explicit request.
+4. **Never copy default parameter values into CoC wrapper signatures.** Causes compile errors.
+5. **Never use `today()`** — use `DateTimeUtil::getToday(DateTimeUtil::getUserPreferredTimeZone())`.
+6. **Never hardcode strings in `Info()` / `warning()` / `error()`** — use `@Model:Label`. Search first: `d365fo search label`.
+7. **Never nest `while select` loops** — use joins, `exists join`, or pre-load to `Map` / temp table.
+8. **Never use `replace_string_in_file` on `.xml` AOT files without running `d365fo index refresh` after** — stale index returns pre-edit data.
+
+---
+
+## Full X++ rules — loaded on demand from skills
+
+Detailed rules are in `.github/instructions/` (lazy-loaded by Copilot when relevant):
+
+| Skill file | Covers |
 |---|---|
-| New table | `d365fo generate table <Name> --pattern main --field VIN:VinEdt:mandatory --field Make:Name --label "@Fleet:Vehicle" --out …` |
-| New class (optionally with `extends`) | `d365fo generate class <Name> [--extends Base] [--non-final] --out …` |
-| Chain-of-Command extension | `d365fo generate coc <TargetClass> --method <m1> --method <m2> --out …` |
-| Form (any of 9 D365FO patterns) | `d365fo generate form <Name> --pattern <P> --table <T> --field … --section Name:Caption --lines-table … --out …` |
-| Data entity (`AxDataEntityView`) | `d365fo generate entity <Name> --table <T> --all-fields --public-entity-name … --out …` |
-| Object extension (Table / Form / Edt / Enum) | `d365fo generate extension <Kind> <Target> <Suffix> --out …` |
-| Event handler class | `d365fo generate event-handler --source-kind <K> --source <Object> --event <E> --out …` |
-| Security: privilege / duty / role | `d365fo generate privilege/duty/role <Name> [--into-role <Role>] --out …` |
-
-### Phase 2 — additional scaffolding
-
-| Need | Command |
-|---|---|
-| SysOperation batch job (contract + service + controller) | `d365fo generate sysoperation <Name> --param "name:EdtType" --execution-mode Asynchronous --out-contract … --out-service … --out …` |
-| Number sequence integration (module extension + EDT + form handler) | `d365fo generate number-sequence <ModuleName> --edt <EdtName> --scope Company --table <Table> --out … --out-edt … --out-handler …` |
-| Workflow type (workflow XML + document class + submit stub) | `d365fo generate workflow <Name> --table <T> --approval-name <A> --out … --out-document … --out-submit …` |
-| Display / Action / Output menu item | `d365fo generate menu-item <Name> --kind Display --object <FormName> --object-type Form --label "@File:Key" --out …` |
-| EDT (Extended Data Type) | `d365fo generate edt <Name> --base-type String --size 20 --label "@File:Key" [--extends <BaseEdt>] --out …` |
-| Enum (extensible by default) | `d365fo generate enum <Name> --value "None:0:@SYS000" --value "Active:1:@SYS001" --out …` |
-| AOT Query with joins | `d365fo generate query <Name> --ds <RootTable> --join "<Table>:<JoinKind>:<ParentDs>" --out …` |
-
-### Phase 6 — integration and migration scaffolding
-
-| Need | Command |
-|---|---|
-| Custom business event (event class + contract class) | `d365fo generate business-event <Name> --contract-name <Contract> --payload "field:EdtType" --category <Cat> --primary-table <T> --out … --out-contract …` |
-| Custom JSON/SOAP service (service XML + class + service group) | `d365fo generate custom-service <Name> --class-name <Class> --group-name <Group> --operation "method:ReturnType" --out … --out-class … --out-group …` |
-| Data migration runnable with batching | `d365fo generate migration-script <Name> --source-table <Src> --target-table <Tgt> --batch-size 500 --mode Upsert --out …` |
-| Legacy RunBase/RunBaseBatch class | `d365fo generate runbase <Name> [--batch] --dialog-param "name:EdtType" --out …` |
-| XDS security policy | `d365fo generate security-policy <Name> --constrained-table <T> --policy-query <Q> --operation Select --context-type RoleName --context-value <Role> --out …` |
-
-`--install-to <Model>` swaps `--out` for atomic install into the model folder via the bridge.
-
-## ⚡ Token discipline
-
-- **Always** pass `--output json`.
-- **Never** request the full XML back from a `generate` command — stdout returns only `{path, bytes, backup}`.
-- **Never** dump entire indexes; use `--limit N` (most search commands default to 25).
-- **Pipe through `jq`** when the user wants a specific field: `d365fo get table CustTable -o json | jq '.data.fields[].name'`.
-- **One scope per call:** prefer two narrow `search` calls over one broad search with thousands of hits.
-
-## 🚫 Never-auto rules
-
-- **NEVER auto-run `d365fo build`, `sync`, `bp check`, or `test run`.** They block the user (Windows VM, slow). After scaffolding, say *"Changes scaffolded. Run `d365fo build` when you're ready to validate."* Only build on explicit request ("build", "compile", "check errors").
-- **NEVER use `replace_string_in_file` on `.xml` AOT files when an `index refresh` has not been run since the last edit.** You'll get pre-edit data back from `d365fo get`.
-- **NEVER infer the target model from search results.** Models are policy boundaries (ISV vs customer). Ask, or read from the project's `.rnrproj`.
-
----
-
-## ⛔ Forbidden agent actions — D365FO XML files
-
-### 5. Forbidden built-in tools for AOT objects
-
-For any D365FO object (`.xml` AOT files, `.xpp` source):
-
-| Tool / action | Why forbidden | Use instead |
-|---|---|---|
-| `create_file` | Wrong location, spaces in path, causes "not valid metadata elements" | `d365fo generate … --out <PATH>` or `--install-to <Model>` |
-| `edit_file` / `apply_patch` / `replace_string_in_file` on raw AOT XML | Corrupts `<SourceCode>` escaping, breaks `<Methods>` nesting | `d365fo generate … --overwrite` for full replace; hand-edit only after `index refresh` |
-| `read_file` on AOT XML to understand object shape | Objects live in SQL index, not as readable source | `d365fo get class/table/form <Name> --output json` |
-| `file_search` / `grep_search` across AOT XML | Can't parse the schema; returns misleading snippets | `d365fo search <type> <query> --output json` |
-| Any shell command to **write** AOT XML (`Set-Content`, `Out-File`, `[IO.File]::WriteAllText`, `New-Item`) | VS 2022 MCP does not support interactive terminal sessions — spawned PowerShell/Python processes hang forever waiting for stdin, causing an infinite spinner with no output | `d365fo generate …` |
-
-### 6. NEVER use scripts as a fallback — and NEVER read-then-write
-
-When `d365fo` is unavailable or returns an error, **NEVER**:
-
-- ❌ Write or run PowerShell scripts (`.ps1`) to modify D365FO XML files
-- ❌ Write or run Python scripts to patch XML
-- ❌ Use any shell execution (`run_in_terminal`, terminal tools) to write AOT files
-- ❌ Generate `Set-Content`, `Out-File`, `[System.IO.File]::WriteAllText` or similar file-write commands targeting `.xml` AOT files
-
-**Critical anti-pattern — NEVER do this:**
-
-```
-// ❌ WRONG — looks reasonable, always fails in VS 2022
-read_file(path)                      // reads XML for "context" — succeeds
-→ manually construct XML edit        // LLM guesses the schema — wrong
-→ generate PowerShell Set-Content    // process spawns, hangs forever, no output
-```
-
-`read_file` exists in VS 2022 but `write_file`/`edit_file` do not. The only correct path to produce AOT XML is `d365fo generate …`.
-
-**Second critical anti-pattern — "CLI failed but I have metadata from open files":**
-
-```
-// ❌ WRONG — a common escalation that must NEVER happen
-d365fo get class Foo --output json   // returns ok:false, internal error
-→ "I verified the metadata from open XML files"   // agent reads raw XML instead
-→ "I have everything I need, proceeding with refactoring"  // agent writes XML directly
-```
-
-**This is forbidden regardless of where the metadata came from.** Even when you can read the correct field names, method signatures, or enum values from open files — the *write path* is still broken without `d365fo generate`. Metadata from open files does **not** substitute for the CLI. Stop and report the `d365fo` error to the user.
-
-**Instead, when a `d365fo` command cannot complete the operation:**
-
-1. Report the exact error to the user (`ok: false` + `error.message`).
-2. Suggest the correct `d365fo` command to use next.
-3. **Skip the step entirely** — never attempt a workaround via scripts or shell.
-4. If no `d365fo` command exists for the operation, tell the user to perform it manually in Visual Studio AOT.
-
----
-
-## 🌿 Git-checkpoint review workflow
-
-Visual Studio 2022 has no inline accept/reject UI for AI edits. Use Git as the review layer:
-
-1. **Before starting** — clean tree, then `git switch -c d365fo/<short-task>` (or at minimum `git commit -am "checkpoint"` first).
-2. **During the task** — every scaffold writes `.bak` for overwritten files; review `git diff` after each command.
-3. **After the task** — `d365fo review diff --base <ref>` summarises AOT changes structurally (added classes, modified table fields, …). This is *complementary* to `git diff`, not a replacement: `git diff` shows raw bytes, `review diff` shows AOT semantics.
-4. **Accept** = commit + merge. **Reject** = `git restore` or `git branch -D`.
-
-Do NOT create branches autonomously — propose and wait.
-
-### ⛔ Escalating-workarounds anti-pattern
-
-If the right tool is `d365fo generate form` but you feel tempted to hand-roll XML, **stop**. Use the canonical pattern templates:
-
-```
-WRONG SPIRAL (each step is MORE wrong):
- Step 1: "I'll write the AxForm XML by hand"
- Step 2: "It's only 3 elements, I'll skip ActionPane / QuickFilter"
- Step 3: "PatternVersion 1.0 is fine instead of 1.1"
- Step 4: "I'll add SimpleList without grid columns"
-
-CORRECT (always, immediately):
- d365fo generate form <Name> --pattern <P> --table <T> --field <F1> --field <F2> --out …
-```
-
-Pattern templates are validated against real AOT forms (`CustGroup`, `PaymTerm`, `CustTable`, `SalesTable`, …). Hand-rolled XML loses ActionPane, QuickFilter, FastTabs, the right `PatternVersion`, and the design-time hooks that VS 2022 needs.
-
----
-
-## 📜 Non-negotiable X++ rules
-
-These apply to every X++ snippet you generate, regardless of how it gets to disk.
-
-1. **NEVER guess method signatures.** Run `d365fo get class <Name>` (or `d365fo read class <Name> --declaration`) before writing a CoC wrapper or override.
-2. **NEVER use `today()`** — it ignores user time-zone. Use `DateTimeUtil::getToday(DateTimeUtil::getUserPreferredTimeZone())`.
-3. **NEVER call functions in `where` clauses** — assign to a local first. The query optimizer can't index function expressions.
-4. **NEVER use hardcoded strings in `Info()` / `warning()` / `error()`** — every UI string must be `@File:Label`. Use `d365fo search label "<text>"` first; `d365fo resolve label @SYS<key>` to confirm.
-5. **NEVER nest `while select` loops** — use `join` clauses, `exists join` / `notExists join`, or pre-load to a `Map` / temp table.
-6. **ALWAYS** search labels with `d365fo search label` before introducing a new one. **Exception:** when adding a field whose EDT already has a label, do **NOT** set `--label` on the field — it inherits from the EDT. Override only deliberately.
-7. **ALWAYS** write meaningful `/// <summary>` on public/protected classes and methods (BP: `BPXmlDocNoDocumentationComments`).
-8. **NEVER call `[SysObsolete]` methods.** Read the attribute message for the replacement.
-9. **NEVER make instance fields `public`** — default visibility is `protected`; expose via `parmFoo` accessors. Public fields tightly couple consumers to internal layout.
-10. **NEVER use `doInsert` / `doUpdate` / `doDelete` for normal business logic.** They bypass overridden table methods, framework validation, and event handlers. Reserved for data-fix / migration scripts only.
-11. Standard data events use `[DataEventHandler]` — NOT `[SubscribesTo + delegateStr]`. `delegateStr` is for *custom* delegates only.
-12. **NEVER pass `tableGroup="TempDB"`.** `TableGroup` = business role (`Main`, `Transaction`, `Parameter`, `WorksheetHeader`, `WorksheetLine`, `Reference`, `Framework`, `Group`, `Miscellaneous`). `TableType` = storage (`RegularTable`, `TempDB`, `InMemory`). For temp tables: `tableType=TempDB`, `tableGroup=Main`.
-13. Class member variables go **inside** the class `{ }` in `sourceCode`; methods stay at top level. Variables outside the class block are silently dropped.
-
----
-
-## 📐 X++ Database query rules (`select` / `while select`)
-
-Verified against [learn:xpp-select-statement](https://learn.microsoft.com/en-us/dynamics365/fin-ops-core/dev-itpro/dev-ref/xpp-data/xpp-select-statement). When generating a `select`, follow these contracts.
-
-**Statement order (grammar-enforced):**
-```
-select [FindOption…] [FieldList from] tableBuffer [index…] [order by / group by] [where …] [join … [where …]]
-```
-
-- **`FindOption` keywords** (`crossCompany`, `firstOnly`, `forUpdate`, `forceNestedLoop`, `forceSelectOrder`, `forcePlaceholders`, `pessimisticLock`, `optimisticLock`, `repeatableRead`, `validTimeState`, `noFetch`, `reverse`, `firstFast`) sit **between `select` and the buffer / field list** — never on a joined buffer (with the documented exception of `forUpdate` which can target a specific buffer in a join).
-- **`order by` / `group by` / `where`** must appear **after the LAST `join` clause**, never between joins.
-
-**`crossCompany` belongs on the OUTER (driving) buffer.** It's a query-level option, not per-table:
-```xpp
-// ✅ CORRECT
-select crossCompany custTable
-    join custInvoiceJour
-    where custInvoiceJour.OrderAccount == custTable.AccountNum;
-
-// ❌ WRONG — crossCompany on the joined buffer
-select custTable
-    join crossCompany custInvoiceJour
-    where …;
-```
-
-Optional company filter: `select crossCompany : myContainer custTable …` where `myContainer` is a `container` literal `(['dat'] + ['dmo'])`. Empty container = scan all authorised companies.
-
-**`in` operator:** grammar is `where Expression in List`, where `List` is an X++ **`container`**, not a `Set` / `List` / `Map` / sub-query. Works with **any primitive** that fits in a container (`str`, `int`, `int64`, `real`, `enum`, `boolean`, `date`, `utcDateTime`, `RecId`) — *not enum-only*. One `in` clause per `where`; AND multiple set filters together.
-
-```xpp
-container postingTypes = [LedgerPostingType::PurchStdProfit, LedgerPostingType::PurchStdLoss];
-container accounts     = ['1000', '2000', '3000'];
-select sum(CostAmountAdjustment) from inventSettlement
-    where inventSettlement.OperationsPosting in postingTypes
-       && inventSettlement.LedgerAccount     in accounts;
-```
-
-❌ Never expand `in` into `OR == OR ==` chains.
-
-**Other Learn-confirmed rules:**
-
-- **Field list before table** when you don't need the full row: `select FieldA, FieldB from myTable where …`. Never `select * from`.
-- **`firstOnly`** when at most one row is expected. Cannot be combined with the `next` statement.
-- **`forUpdate`** required before any `.update()` / `.delete()` inside the same transaction; pair with `ttsbegin` / `ttscommit`.
-- **`exists join` / `notExists join`** instead of nested `while select` for filter-only joins.
-- **Outer join** — only LEFT outer; no RIGHT outer, no `left` keyword. Default values fill non-matching rows (0 for int, "" for str). Distinguish "no match" from "real zero" by checking the joined buffer's `RecId`.
-- **Join criteria use `where`, not `on`.** X++ has no `on` keyword.
-- **`index hint`** requires `myTable.allowIndexHint(true)` *before* the select; otherwise silently ignored. Only when measured.
-- **Aggregates** (`sum`, `avg`, `count`, `minof`, `maxof`):
-  - `sum` / `avg` / `count` work only on integer/real fields (Learn explicit).
-  - When `sum` would return null (no matching rows), X++ returns NO row — guard `if (buffer)` after.
-  - Non-aggregated fields in the select list must be in `group by`.
-- **`forceLiterals`** is forbidden — SQL injection. Use `forcePlaceholders` (default for non-join selects) or omit.
-- **`validTimeState(dateFrom, dateTo)`** for date-effective tables (`ValidTimeStateFieldType ≠ None`). Don't query without it unless you specifically want all historical rows.
-- **Set-based ops** (`RecordInsertList`, `insert_recordset`, `update_recordset`, `delete_from`) over row-by-row loops for performance.
-- **SQL injection mitigation** — `executeQueryWithParameters` for dynamic queries, never string concat into `where`.
-- **Timeouts** — interactive 30 min, batch/services/OData 3 h. Override with `queryTimeout`. Catch `Exception::Timeout`.
-
-## 📦 SysDa Framework — fluent query API
-
-Use SysDa when query shape depends on runtime conditions or when building reusable framework logic. For static, compile-time queries prefer `select`.
-
-**Core classes:** `SysDaQueryObject` (root builder), `SysDaSearchStatement` (iterate), `SysDaFindStatement` (`firstOnly` equivalent), `SysDaUpdateStatement` / `SysDaInsertStatement` / `SysDaDeleteStatement` (set-based ops).
-
-```xpp
-CustTable custTable;
-var qe = new SysDaQueryObject(custTable);
-qe.whereClause(new SysDaEqualsExpression(
-    new SysDaFieldExpression(custTable, fieldStr(CustTable, AccountNum)),
-    new SysDaValueExpression('US-001')));
-var so = new SysDaSearchStatement();
-while (so.nextRecord(qe))
-{
-    info(custTable.AccountNum);
-}
-```
-
-**Joins:** `qe.joinClause(SysDaJoinKind::InnerJoin, joinQe)` — supports `InnerJoin`, `OuterJoin`, `ExistsJoin`, `NotExistsJoin`.
-
-## 🔎 Query Object Model — `Query` / `QueryRun`
-
-Use when forms/reports bind to a shared query or the user modifies filters dynamically (`SysQueryForm`).
-
-```xpp
-Query query = new Query();
-QueryBuildDataSource qbds = query.addDataSource(tableNum(CustTable));
-qbds.addRange(fieldNum(CustTable, CustGroup)).value(queryValue('10'));
-QueryRun qr = new QueryRun(query);
-while (qr.next())
-{
-    CustTable ct = qr.get(tableNum(CustTable));
-}
-```
-
-**Key APIs:** `SysQuery::findOrCreateRange(qbds, fieldNum)`, `qbds.joinMode(JoinMode::ExistsJoin)`, `query.allowCrossCompany(true)` + `query.addCompanyRange('dat')`.
-
----
-
-## 🪝 Chain of Command (CoC) authoring rules
-
-Verified against [learn:method-wrapping-coc](https://learn.microsoft.com/en-us/dynamics365/fin-ops-core/dev-itpro/extensibility/method-wrapping-coc).
-
-**🚨 NEVER copy default parameter values into the wrapper signature.** This is the most common bug:
-
-```xpp
-// Base method
-class Person
-{
-    public void salute(str message = "Hi") { … }
-}
-
-// ✅ CORRECT — wrapper omits the default value
-[ExtensionOf(classStr(Person))]
-final class APerson_Extension
-{
-    public void salute(str message)        // no  "= 'Hi'" here
-    {
-        next salute(message);
-    }
-}
-
-// ❌ WRONG — copying the default breaks the contract / does not compile
-public void salute(str message = "Hi")     // ← forbidden
-```
-
-**Other CoC non-negotiables:**
-
-- **Wrapper must call `next`** unconditionally — except on `[Replaceable]` methods (chain may be conditionally broken).
-- **`next` must be at first-level statement scope** — NOT inside `if`, `while`, `for`, `do-while`, NOT after `return`, NOT inside a logical expression. Platform Update 21+: `next` is permitted inside `try` / `catch` / `finally`.
-- **Signature otherwise matches base exactly** — same return type, parameter types/order, same `static` modifier. Use `d365fo get class <Target>` (or `d365fo read class <Target> --method <m> --declaration`) before authoring.
-- **Static method wrapping** — repeat `static` on the wrapper. Forms cannot be wrapped statically (no class semantics for forms).
-- **Cannot wrap constructors.** A new no-arg method on an extension class becomes the extension's own constructor (must be `public`).
-- **Extension class shape:** `[ExtensionOf(classStr|tableStr|formStr|formDataSourceStr|formDataFieldStr|formControlStr(...))] final class <Target>_<Suffix>`. Class is `final`; name ends with `_Extension` (or descriptive suffix).
-- **`[Hookable(false)]`** on a base method blocks CoC and pre/post handlers. Cannot wrap.
-- **`[Wrappable(false)]`** blocks wrapping (still allows pre/post). `final` methods need explicit `[Wrappable(true)]` to be wrappable.
-- **Form-nested wrapping:** `formdatasourcestr`, `formdatafieldstr`, `formControlStr`. Cannot add NEW methods via CoC on these — only wrap methods that already exist.
-- **Visibility:** wrappers can read/call **protected** members of the augmented class (Platform Update 9+). Cannot reach `private`.
-
----
-
-## 🏛️ X++ Class & Method rules
-
-Verified against [learn:xpp-classes-methods](https://learn.microsoft.com/en-us/dynamics365/fin-ops-core/dev-itpro/dev-ref/xpp-classes-methods).
-
-- **Class default access = `public`.** Removing `public` does not make a class non-public. Use `internal` to limit to the same model, `final` to prevent extension via inheritance, `abstract` for base-only types.
-- **Instance fields default = `protected`.** **NEVER make them `public`** (rule 9 above).
-- **Constructor pattern:** one `new()` per class (compiler generates an empty default if absent). Convention: `new()` is `protected`, exposed via a `public static construct()` factory. `init()` does post-construction setup.
-- **Method modifier order in the header:** `[edit | display] [public | protected | private | internal] [static | abstract | final]`. `static final` is permitted; `abstract` cannot mix with `final` / `static`.
-- **Override visibility rule:** an override must be at least as accessible as the base method. `public` → `public` only; `protected` → `public` or `protected`; `private` → not overridable.
-- **Optional parameters** must come after all required parameters. Callers cannot skip — all preceding parameters must be supplied. Use `prmIsDefault(_x)` inside a `parmX(_x = x)` accessor to detect "was this passed".
-- **All parameters are pass-by-value.** Mutating a parameter inside the method does NOT affect the caller's variable. Return modified state explicitly or wrap in a class.
-- **`this` rules:**
-  - Required (or qualified) for instance method calls.
-  - Cannot qualify class-declaration member variables (write the bare name).
-  - Cannot be used in a static method.
-  - Cannot qualify static methods (use `ClassName::method()`).
-- **Extension methods** (separate from CoC, target = Class / Table / View / Map):
-  - Extension class must be `static` (not `final`), name ends with `_Extension`.
-  - Every extension method is `public static`.
-  - First parameter is the target type — runtime supplies the receiver; caller does not pass it.
-- **Constants over macros.** `public const str FOO = 'bar';` at class scope (cross-referenced, scoped, IntelliSense-aware) instead of `#define.FOO('bar')`. Reference via `ClassName::FOO`.
-- **`var` keyword** for type-inferred locals when the type is obvious from the right-hand side (`var sum = decimal + amount;`). Skip `var` when the type is non-obvious — readability beats brevity.
-- **Declare-anywhere encouraged** — declare close to first use, smallest scope. Compiler rejects shadowing of an outer-scope variable with the same name.
-
----
-
-## 🖼️ FormRun lifecycle & extension points
-
-Forms follow a strict initialization order:
-1. `form.init()` — structure loaded; data sources NOT yet active.
-2. `FormDataSource.init()` — each data source initializes.
-3. `form.run()` — form becomes visible.
-4. `FormDataSource.executeQuery()` — initial data load.
-
-**Common extension points:**
-
-| Method | When |
-|---|---|
-| `FormDataSource.init()` | Add ranges, modify query before first execution |
-| `FormDataSource.executeQuery()` | Modify query on each refresh |
-| `FormDataSource.active()` | Cursor moves to new record |
-| `FormDataSource.validateWrite()` | Custom validation before save |
-| `FormControl.clicked()` / `modified()` | Button/field interaction |
-
-**Key APIs:** `FormDataSource.research(retainPosition: true)`, `element.args()`, `FormDataSource.queryBuildDataSource()`, `FormDataSource.filter(fieldNum, value)` / `removeFilter(fieldNum)`.
-
-NEVER guess control names — use `d365fo get form <Name> --output json`. Cannot add new methods via CoC on form data sources/controls — only wrap existing ones.
-
----
-
-## 🧮 X++ Statement & Type rules
-
-Verified against [learn:xpp-conditional](https://learn.microsoft.com/en-us/dynamics365/fin-ops-core/dev-itpro/dev-ref/xpp-conditional) and [learn:xpp-variables-data-types](https://learn.microsoft.com/en-us/dynamics365/fin-ops-core/dev-itpro/dev-ref/xpp-variables-data-types).
-
-- **`switch` `break` is required.** Implicit fall-through compiles but is misleading. To match multiple values to one branch use the **comma-list** form: `case 13, 17, 21: …; break;` — never the empty-fall-through chain.
-- **Ternary `cond ? a : b`** — both branches must have the same type. No implicit widening of `int` ↔ `real`.
-- **X++ has NO database null.** Each primitive has a "null-equivalent" sentinel: `int 0`, `real 0.0`, `str ""`, `date 1900-01-01`, `utcDateTime` with date-part `1900-01-01`, `enum` element with value `0`. In SQL `where` clauses these compare as false; in plain expressions as ordinary values. Don't write `if (myDate == null)` — use `if (!myDate)` or `if (myDate == dateNull())`.
-- **Casting:** prefer `as` (returns `null` on type mismatch) and `is` (boolean test) over hard down-casts. Down-casts on object-typed expressions throw `InvalidCastException`. Late binding exists for `Object` and `FormRun` only — accept the runtime cost if you use it.
-- **`using` blocks** for `IDisposable` resources (`StreamReader`, …). Equivalent to `try` + `finally { x.Dispose(); }` but shorter and exception-safe.
-- **Embedded function declarations** (local functions inside a method) can read variables declared earlier in the enclosing method but cannot leak their own variables out. Prefer them over private helper methods only when the helper truly does not belong to the class API.
-
----
-
-## 🚦 Best-practice (BP) rules — generated code must be BP-clean
-
-`d365fo bp check` runs `xppbp.exe` on the Windows VM and is the source of truth. Code you generate should pass these BP rules out of the box:
-
-| Rule | What it enforces |
-|---|---|
-| `BPUpgradeCodeToday` | `today()` is forbidden — use `DateTimeUtil::getToday(DateTimeUtil::getUserPreferredTimeZone())`. |
-| `BPErrorLabelIsText` | `Info() / warning() / error()` must take a label, not a hardcoded string. |
-| `BPErrorEDTNotMigrated` | EDT relations must use `EDT.Relations` element, not legacy table-level relations. |
-| `BPCheckNestedLoopinCode` | No nested `while select` loops — use joins. |
-| `BPCheckAlternateKeyAbsent` | Every table needs an alternate key (`AlternateKey = Yes` on a unique index). |
-| `BPErrorUnknownLabel` | Label IDs referenced in code must exist in the indexed label files. Run `d365fo resolve label @File+Key` to confirm. |
-| `BPXmlDocNoDocumentationComments` | Public/protected members need meaningful `/// <summary>` doc comments. |
-| `BPDuplicateMethod` | No duplicate method definitions across the inheritance chain in the same model. |
-
-Always linting before you scaffold:
-
-```sh
-d365fo lint --output sarif > lint.sarif      # in-process heuristics for CI
-# then on Windows VM:
-d365fo bp check --output json
-```
-
----
-
-## 🔁 Workflow templates
-
-### Refactoring an existing X++ class
-
-```sh
-d365fo get class <Class> --output json                  # 1. signatures
-d365fo read class <Class> --method <method>             # 2. full body of methods to change
-d365fo find usages <method> --output json               # 3. caller sites (refactor risk)
-# 4. edit XML / regenerate via `d365fo generate ... --overwrite`
-d365fo build && d365fo bp check                         # 5. validate (only on user request)
-```
-
-- **NEVER** delete a method without `d365fo find usages` first.
-- **NEVER** guess method bodies from signatures — read the source.
-
-### Authoring a CoC extension
-
-```sh
-d365fo find coc <Target>::<method> --output json        # 1. duplicate check
-d365fo get class <Target> --output json                 # 2. exact signature (no defaults!)
-d365fo generate coc <Target> --method <method> \
-       --install-to <Model>                             # 3. scaffold
-# Hand-edit the wrapper body, then:
-d365fo build                                            # 4. on user request only
-```
-
-### Adding fields to a table
-
-```sh
-d365fo get table <Table> --output json                  # 1. existing shape
-d365fo get edt <Edt> --output json                      # 2. EDT to assign (verify baseType)
-d365fo search label "<text>" --output json              # 3. label reuse
-# Hand-edit XML or regenerate with `--overwrite`. Then:
-d365fo index refresh --model <Model>                    # 4. re-index so subsequent `get` is fresh
-```
-
-### Subscribing to a table data event
-
-```sh
-d365fo find handlers <Table> --output json              # 1. existing handlers
-d365fo generate event-handler --source-kind Table \
-       --source <Table> --event Inserted \
-       --install-to <Model>                             # 2. scaffold subscriber
-# Standard events: [DataEventHandler(tableStr(T), DataEventType::Inserted)]
-# Custom delegates: [SubscribesTo(tableStr(T), delegateStr(T, myDelegate))]
-```
-
-### Building a form
-
-```sh
-d365fo search form <Name> --output json                 # 1. avoid name collision
-d365fo get table <PrimaryTable> --output json           # 2. fields for grid
-d365fo generate form <Name> --pattern <P> --table <T> \
-       --field <F1> --field <F2> --install-to <Model>   # 3. pattern-correct scaffold
-```
-
-Pattern catalogue: `SimpleList`, `SimpleListDetails`, `DetailsMaster`, `DetailsTransaction`, `Dialog`, `TableOfContents`, `Lookup`, `ListPage`, `Workspace`. See [docs/EXAMPLES.md](https://github.com/dynamics365ninja/d365fo-cli/blob/main/docs/EXAMPLES.md#form-any-of-nine-d365fo-patterns).
-
-### Tracing security
-
-```sh
-d365fo get security <Role>   --type Role     --output json    # top-down
-d365fo get security <Object> --type Menuitem --output json    # bottom-up
-```
-
-The response contains `routes[*]` of shape `{ role, duty, privilege, entryPoint }`. Duplicate `role` entries indicate multiple paths — all must be removed to revoke access.
-
----
-
-## ⚙️ Advanced X++ patterns
-
-### SysOperation — standard for new batch operations
-Modern replacement for `RunBaseBatch`. Structure: **DataContract** (params, `[DataMemberAttribute]`, never `pack()`/`unpack()`) + **Service** (`[SysEntryPointAttribute(true)]`) + **Controller** (execution mode: `Synchronous` / `Asynchronous` / `ScheduledBatch`). For SSRS: extend `SRSReportDataProviderBase`. Custom dialog: `SysOperationAutomaticUIBuilder` linked via `[SysOperationContractProcessingAttribute(...)]`.
-
-### SysPlugin — extensible dispatch without `if`/`else`
-1. Define extensible enum (`IsExtensible=Yes`), one value per strategy.
-2. Decorate implementations with `[ExportMetadataAttribute(enumStr(MyEnum), MyEnum::Value)]`.
-3. Resolve: `SysPluginFactory::Instance(enumStr(MyEnum), enumValue)`. New strategies need only a new class + enum value.
-
-### Number Sequence Integration
-Extend `NumberSeqApplicationModule` via CoC → `loadModule()`. Create EDT with `NumberSequence=Yes` + `NumberSequenceModule`. Consumption:
-```xpp
-NumberSeq numSeq = NumberSeq::newGetNum(CompanyInfo::numRefMySequence());
-numSeq.used();   // or numSeq.abort() to roll back
-```
-
-### Workflow Development
-Structure: `WorkflowDocument` subclass → `WorkflowType` → Approvals/Tasks → EventHandlers. Every workflow needs: `WorkflowDocument` subclass, `SubmitToWorkflowMenuItem` action menu item, `canSubmitToWorkflow()` on the table. Use `WorkflowWorkItemActionManager` for complete/reject/delegate.
-
----
-
-## 📚 Authoritative X++ syntax source — Microsoft Learn
-
-When uncertain about X++ syntax, language constructs, framework APIs, or platform behaviour, the **only** authoritative source is the Microsoft Learn `dynamics365/fin-ops-core/dev-itpro` documentation tree. Do NOT guess, and do NOT rely on AX 2012 / older training data.
-
-Key entry points:
-
-- General developer landing — <https://learn.microsoft.com/en-us/dynamics365/fin-ops-core/dev-itpro/dev-tools/developer-home-page>
-- X++ language reference root — <https://learn.microsoft.com/en-us/dynamics365/fin-ops-core/dev-itpro/dev-ref/xpp-language-reference>
-- `select` statement — <https://learn.microsoft.com/en-us/dynamics365/fin-ops-core/dev-itpro/dev-ref/xpp-data/xpp-select-statement>
-- Classes & methods — <https://learn.microsoft.com/en-us/dynamics365/fin-ops-core/dev-itpro/dev-ref/xpp-classes-methods>
-- Conditional statements — <https://learn.microsoft.com/en-us/dynamics365/fin-ops-core/dev-itpro/dev-ref/xpp-conditional>
-- Variables & data types — <https://learn.microsoft.com/en-us/dynamics365/fin-ops-core/dev-itpro/dev-ref/xpp-variables-data-types>
-- Chain of Command / method wrapping — <https://learn.microsoft.com/en-us/dynamics365/fin-ops-core/dev-itpro/extensibility/method-wrapping-coc>
-
-Combine Learn (syntax authority) with `d365fo` (real metadata: table/field/method names from THIS environment). Learn for "how is `while select` written"; `d365fo` for "does field `BalanceMST` exist on `CustTable`".
-
----
-
-## 📦 See also
-
-- [README.md](https://github.com/dynamics365ninja/d365fo-cli/blob/main/README.md) — features, install, agent integration.
-- [docs/SETUP.md](https://github.com/dynamics365ninja/d365fo-cli/blob/main/docs/SETUP.md) — install + configure the CLI and bridge.
-- [docs/EXAMPLES.md](https://github.com/dynamics365ninja/d365fo-cli/blob/main/docs/EXAMPLES.md) — one worked example per command.
-- [docs/MIGRATION_FROM_MCP.md](https://github.com/dynamics365ninja/d365fo-cli/blob/main/docs/MIGRATION_FROM_MCP.md) — moving from `d365fo-mcp-server`.
-- [docs/ROADMAP.md](https://github.com/dynamics365ninja/d365fo-cli/blob/main/docs/ROADMAP.md) — what's still planned.
-- `.github/instructions/*.instructions.md` — focused workflow skills installed by `Install-D365FoCopilotSkills.ps1` into this repo (Copilot reads them automatically from `.github/instructions/`).
+| `coc-extension-authoring` | CoC wrapper rules, `next` placement, signature matching, `[Hookable]`/`[Wrappable]` |
+| `xpp-database-queries` | `select` grammar, `crossCompany`, `in` operator, joins, aggregates, SysDa, QueryRun |
+| `x++-class-authoring` | Class structure, visibility, constructor patterns, extension methods, `var`, constants |
+| `xpp-class-and-method-rules` | Method modifiers, override visibility, optional params, `this`, pass-by-value |
+| `xpp-statement-and-type-rules` | `switch`, ternary, null handling, `using`, casting, `is`/`as` |
+| `xpp-best-practice-rules` | BP rules: `today()`, labels, nested loops, alternate keys, `[SysObsolete]` |
+| `form-pattern-scaffolding` | FormRun lifecycle, 9 form patterns, Display/Action/Output menu items |
+| `table-scaffolding` | Table creation, EDT assignment, relations, indexes, number sequences, `TableGroup` vs `TableType` |
+| `data-entity-scaffolding` | Data entity (`AxDataEntityView`) patterns, OData exposure |
+| `event-handler-authoring` | `[DataEventHandler]`, `[SubscribesTo]`, pre/post handlers |
+| `object-extension-authoring` | Table / Form / EDT / Enum extensions; new EDT and Enum creation |
+| `security-hierarchy-trace` | Role → Duty → Privilege → Entry Point tracing; scaffold privilege/duty/role |
+| `sysoperation-batch-patterns` | SysOperation batch jobs, RunBase/RunBaseBatch, data migration scripts |
+| `business-events-authoring` | Custom business event contract + class scaffolding |
+| `custom-service-authoring` | JSON/SOAP custom service scaffolding |
+| `integration-patterns` | OData, DMF, business events, number sequences |
+| `label-translation` | Label search, reuse, creation, multi-language |
+| `model-dependency-and-coupling` | Model reference chains, ISV/customer boundary rules |
+| `review-and-checkpoint-workflow` | Git checkpoint, `d365fo review diff`, accept/reject workflow |

--- a/docs/SETUP.md
+++ b/docs/SETUP.md
@@ -188,6 +188,14 @@ External Tools let you run any CLI command from the **Tools** menu without leavi
 
 > **Tip.** Add a second entry with **Arguments** = `doctor --output json` to run a health check straight from the menu.
 
+### How Copilot Chat works in Visual Studio vs VS Code
+
+> ⚠️ **Important limitation:** GitHub Copilot Chat in Visual Studio runs in **chat mode only** — it cannot execute terminal commands or use agent tools. When you ask it to add a table, it will try to search the codebase with built-in "code search", which **always fails on AOT XML files** with "There was an error executing code search". If you then see "Since I cannot access the codebase…" followed by generic X++ guidance, the instructions are not being followed correctly.
+>
+> **Correct VS Chat behaviour:** Copilot should ask you to run `d365fo` commands in your terminal and paste back the JSON output. It must never generate raw X++ code without first seeing real metadata from `d365fo`.
+>
+> **To get full agent capabilities** (Copilot runs `d365fo` commands automatically), use **VS Code** with the GitHub Copilot extension in agent mode.
+
 ### Copy Skills and Copilot instructions to your X++ project
 
 GitHub Copilot in Visual Studio reads `.github/copilot-instructions.md` and `.github/instructions/*.instructions.md` from the root of your solution (repository). Deploying these files gives Copilot the full X++ rule canon — D365FO table/method names, CoC rules, BP rules, label rules — without burning context tokens.
@@ -308,6 +316,7 @@ git commit -m "chore: update d365fo Copilot skills"
 | `PACKAGES_PATH_NOT_FOUND` | Set `D365FO_PACKAGES_PATH` or pass `--packages <PATH>`. |
 | `UNSUPPORTED_PLATFORM` | `build` / `sync` / `test` / `bp` require Windows + a D365FO dev VM. Run them there. |
 | Index file appears locked | Stop any running `d365fo daemon` or `d365fo-mcp` process. WAL sidecar files (`-wal`, `-shm`) are normal. |
+| Copilot Chat in VS gives "There was an error executing code search" then generic X++ advice | VS Copilot Chat cannot search AOT XML (it always errors). The `.github/copilot-instructions.md` should prevent the code-search attempt — re-run `Install-D365FoCopilotSkills.ps1` to deploy the latest instructions. For full agent capabilities (auto-running `d365fo`), switch to **VS Code agent mode**. |
 | Extract missed a package | Confirm the `<root>/<Package>/<Model>/AxTable/…` layout and point `--packages` at the real `PackagesLocalDirectory`. |
 | Label values contain junk | `search label` / `get label` strip control characters by default — pass `--raw-text` to see the unfiltered value. |
 | Self-contained binary won't start on Linux | `chmod +x d365fo` after copying out of the publish folder. |

--- a/skills/_source/form-pattern-scaffolding.md
+++ b/skills/_source/form-pattern-scaffolding.md
@@ -1,10 +1,13 @@
 ---
 id: form-pattern-scaffolding
-description: Scaffold an AxForm in D365 Finance & Operations using one of the nine canonical patterns (SimpleList, SimpleListDetails, DetailsMaster, DetailsTransaction, Dialog, TableOfContents, Lookup, ListPage, Workspace). Invoke whenever the user asks to "create a form", "scaffold a list page", "make a dialog", or "build a workspace".
+description: Scaffold an AxForm in D365 Finance & Operations using one of the nine canonical patterns (SimpleList, SimpleListDetails, DetailsMaster, DetailsTransaction, Dialog, TableOfContents, Lookup, ListPage, Workspace), or create a Display / Action / Output menu item. Invoke whenever the user asks to "create a form", "scaffold a list page", "make a dialog", "build a workspace", "create a menu item", "add a Display menu item", or "add an Action menu item".
 applyTo:
   - "**/AxForm/**"
   - "**/*Form.xml"
-appliesWhen: User intent mentions creating an AxForm, choosing a form pattern, list pages, master records, dialogs, lookups, workspaces, or details/transaction (header+lines) forms.
+  - "**/AxMenuItemDisplay/**"
+  - "**/AxMenuItemAction/**"
+  - "**/AxMenuItemOutput/**"
+appliesWhen: User intent mentions creating an AxForm, choosing a form pattern, list pages, master records, dialogs, lookups, workspaces, details/transaction (header+lines) forms, or creating a Display / Action / Output menu item.
 ---
 
 > ⛔ **NEVER write X++ AOT XML files directly** via PowerShell, terminal file commands (`Set-Content`, `Out-File`, `New-Item`), editor write tools, or any raw text approach. The XML schema (`<AxClass>`, `<AxTable>`, `<AxForm>`, `<Methods>`, `<SourceCode>`) is proprietary — LLMs have not been trained on it reliably. **ALWAYS use `d365fo generate …` commands** to produce correct AOT XML. If `d365fo` is unavailable in PATH, stop and ask the user to install it.
@@ -139,3 +142,32 @@ Forms follow a strict initialization order. Extension code must respect it.
 - Use `d365fo get form <Name> --output json` to find exact control names before wrapping.
 - NEVER guess control names — they differ from field names and are often prefixed.
 - Cannot add new methods via CoC on `formdatasourcestr`/`formdatafieldstr`/`formControlStr` — only wrap methods that already exist.
+
+## Menu items
+
+Menu items are the AOT entry points that open a form, call a class action, or trigger a report. Always scaffold the menu item alongside or after the target form.
+
+```sh
+# Display menu item — opens a form (most common)
+d365fo generate menu-item FmCustomersMenuItem \
+  --kind Display --object FmCustomers --object-type Form \
+  --label "@Fleet:Customers" \
+  --install-to FleetManagement
+
+# Action menu item — calls a class runnable (batch/service)
+d365fo generate menu-item FmPostOrdersAction \
+  --kind Action --object FmPostOrdersService --object-type Class \
+  --label "@Fleet:PostOrders" \
+  --install-to FleetManagement
+
+# Output menu item — triggers a report
+d365fo generate menu-item FmOrdersReportMenuItem \
+  --kind Output --object FmOrdersReport --object-type Report \
+  --label "@Fleet:OrdersReport" \
+  --install-to FleetManagement
+```
+
+**Hard rules:**
+- One menu item per AOT type (`AxMenuItemDisplay`, `AxMenuItemAction`, `AxMenuItemOutput`) — naming convention `<ObjectName>MenuItem` or `<ObjectName>Action`.
+- Do not create an `Action` menu item pointing to a form — use `Display`.
+- After creating a menu item, it must be added to a menu or a security privilege to be reachable.

--- a/skills/_source/object-extension-authoring.md
+++ b/skills/_source/object-extension-authoring.md
@@ -1,13 +1,17 @@
 ---
 id: object-extension-authoring
-description: Create a Table / Form / Edt / Enum extension (NOT a class CoC extension) in D365 Finance & Operations. Use when the user asks to "extend a table", "add a field to standard CustTable", "extend an EDT", "add an enum value", or "extend a form via FormExtension".
+description: Create a Table / Form / Edt / Enum extension, a new EDT (Extended Data Type), or a new base enum in D365 Finance & Operations. Use when the user asks to "extend a table", "add a field to standard CustTable", "extend an EDT", "add an enum value", "extend a form via FormExtension", "create an EDT", "create a new EDT", "create an enum", "generate edt", or "generate enum".
 applyTo:
   - "**/AxTableExtension/**"
   - "**/AxFormExtension/**"
   - "**/AxEdtExtension/**"
   - "**/AxEnumExtension/**"
+  - "**/AxEdt/**"
+  - "**/AxEnum/**"
   - "**/*.Extension.xml"
-appliesWhen: User intent mentions extending a Table / Form / Edt / Enum (not a class) — adding fields to a standard table, adding controls to a standard form, extending an enum or EDT.
+  - "**/*Edt.xml"
+  - "**/*Enum.xml"
+appliesWhen: User intent mentions extending a Table / Form / Edt / Enum, adding fields to a standard table, adding controls to a standard form, extending an enum or EDT, creating a new EDT (Extended Data Type), or creating a new base enum.
 ---
 
 > ⛔ **NEVER write X++ AOT XML files directly** via PowerShell, terminal file commands (`Set-Content`, `Out-File`, `New-Item`), editor write tools, or any raw text approach. The XML schema (`<AxClass>`, `<AxTable>`, `<AxForm>`, `<Methods>`, `<SourceCode>`) is proprietary — LLMs have not been trained on it reliably. **ALWAYS use `d365fo generate …` commands** to produce correct AOT XML. If `d365fo` is unavailable in PATH, stop and ask the user to install it.

--- a/skills/_source/security-hierarchy-trace.md
+++ b/skills/_source/security-hierarchy-trace.md
@@ -1,11 +1,11 @@
 ---
 id: security-hierarchy-trace
-description: Trace D365FO security from a Role all the way down to Entry Points, or discover which roles reach a given object. Use when the user asks about permissions, security coverage, roles, duties, or privileges.
+description: Trace D365FO security from a Role all the way down to Entry Points, discover which roles reach a given object, or scaffold new security objects (privilege, duty, role, XDS policy). Use when the user asks about permissions, security coverage, roles, duties, privileges, "create a security privilege", "scaffold a security role", "generate a duty", or "create a security policy".
 applyTo:
   - "**/AxSecurityRole/**"
   - "**/AxSecurityDuty/**"
   - "**/AxSecurityPrivilege/**"
-appliesWhen: User intent mentions security, roles, duties, privileges, entry points, or access control analysis.
+appliesWhen: User intent mentions security, roles, duties, privileges, entry points, access control analysis, creating a security role/duty/privilege, scaffolding a security policy, or XDS data security policy.
 ---
 
 > ⛔ **NEVER write X++ AOT XML files directly** via PowerShell, terminal file commands (`Set-Content`, `Out-File`, `New-Item`), editor write tools, or any raw text approach. The XML schema (`<AxClass>`, `<AxTable>`, `<AxForm>`, `<Methods>`, `<SourceCode>`) is proprietary — LLMs have not been trained on it reliably. **ALWAYS use `d365fo generate …` commands** to produce correct AOT XML. If `d365fo` is unavailable in PATH, stop and ask the user to install it.
@@ -34,3 +34,38 @@ appliesWhen: User intent mentions security, roles, duties, privileges, entry poi
 - Do not recommend granting `-System Administrator` for troubleshooting.
 - Do not infer; always run `get security` before making claims.
 - Report paths verbatim; do not collapse `duty` or `privilege` steps.
+
+## Scaffolding security objects
+
+Trace first — understand the existing hierarchy — then scaffold new objects to fit it.
+
+```sh
+# 1. Create a privilege granting a specific access level to a menu item entry point
+d365fo generate privilege FmManageVehiclesPrivilege \
+  --entry-point FmVehiclesMenuItem --entry-kind MenuItemDisplay \
+  --access Update \
+  --label "@Fleet:ManageVehicles" \
+  --install-to FleetManagement
+
+# 2. Bundle privileges into a duty
+d365fo generate duty FmMaintainVehiclesDuty \
+  --privilege FmManageVehiclesPrivilege \
+  --privilege FmViewCustomersPrivilege \
+  --label "@Fleet:MaintainVehicles" \
+  --install-to FleetManagement
+
+# 3. Create a role and assign duties
+d365fo generate role FmFleetClerkRole \
+  --duty FmMaintainVehiclesDuty \
+  --label "@Fleet:FleetClerk" \
+  --description "Fleet management operator" \
+  --install-to FleetManagement
+
+# 4. Merge a duty into an existing role XML after the fact
+d365fo generate duty FmNewDuty --privilege FmSomePrivilege \
+  --into-role c:/AOT/FleetManagement/AxSecurityRole/FmFleetClerkRole.xml \
+  --install-to FleetManagement
+```
+
+**Scaffold order:** menu item → privilege (references the menu item) → duty (bundles privileges) → role (bundles duties).
+Always run `d365fo get security <Name> --type Role --output json` after to verify the new objects appear in the hierarchy.

--- a/skills/_source/sysoperation-batch-patterns.md
+++ b/skills/_source/sysoperation-batch-patterns.md
@@ -1,0 +1,125 @@
+---
+id: sysoperation-batch-patterns
+description: Scaffold batch jobs, SysOperation triplets (DataContract + Service + Controller), RunBase/RunBaseBatch classes, or data migration scripts in D365 Finance & Operations. Invoke when the user asks to "create a batch job", "scaffold a SysOperation", "create a RunBase class", "build a batch class", "generate a migration script", "migrate data between tables", or "create a scheduled batch".
+applyTo:
+  - "**/AxClass/**Controller*.xml"
+  - "**/AxClass/**Service*.xml"
+  - "**/AxClass/**Contract*.xml"
+  - "**/AxClass/**RunBase*.xml"
+  - "**/AxClass/**Migration*.xml"
+  - "**/AxClass/**Batch*.xml"
+appliesWhen: User intent mentions batch job, SysOperation, RunBase, RunBaseBatch, scheduled batch, data migration script, DataContract class, batch controller, or SysRunnable.
+---
+
+> ⛔ **NEVER write X++ AOT XML files directly** via PowerShell, terminal file commands (`Set-Content`, `Out-File`, `New-Item`), editor write tools, or any raw text approach. The XML schema is proprietary. **ALWAYS use `d365fo generate …` commands** to produce correct AOT XML. If `d365fo` is unavailable in PATH, stop and ask the user to install it.
+
+# Batch and SysOperation patterns
+
+> **Prefer SysOperation** for all new batch jobs. Use `RunBase`/`RunBaseBatch` only
+> when extending legacy code that already uses that pattern.
+
+---
+
+## 1. SysOperation — preferred pattern for new batch jobs
+
+SysOperation separates concerns into three classes:
+
+| Class | Role |
+|---|---|
+| `DataContract` | Parameter bag — `[DataContractAttribute]` + `[DataMemberAttribute]` on each `parmXxx()` |
+| `Service` | Business logic — extends `SysOperationServiceBase`, contains the `process()` method |
+| `Controller` | Entry point — extends `SysOperationServiceController`, sets menu item and execution mode |
+
+**CLI workflow:**
+
+```sh
+# Pre-flight — name collision check
+d365fo search class FmInvoiceBatch --output json
+
+# Scaffold all three classes in one command
+d365fo generate sysoperation FmInvoiceBatch \
+  --param AccountNum:CustAccount \
+  --param FromDate:TransDate \
+  --param ToDate:TransDate \
+  --execution-mode ScheduledBatch \
+  --install-to FleetManagement
+
+# Default class names derived from <NAME>:
+#   FmInvoiceBatchContract   (DataContract)
+#   FmInvoiceBatchService    (Service)
+#   FmInvoiceBatchController (Controller)
+
+# Override names if needed
+d365fo generate sysoperation FmInvoiceBatch \
+  --contract-name FmInvoiceBatchDataContract \
+  --service-name  FmInvoiceBatchSvc \
+  --controller-name FmInvoiceBatchCtrl \
+  --execution-mode ScheduledBatch \
+  --install-to FleetManagement
+```
+
+**Execution modes:** `Synchronous` (default, blocks until done) | `Asynchronous` (fire-and-forget, returns immediately) | `ScheduledBatch` (adds to batch framework queue).
+
+**Hard rules:**
+
+- The `process()` method on the Service class is the only method that should contain business logic.
+- The Contract class must NOT hold state between calls — it is a simple data transfer object.
+- Do NOT use `today()` anywhere in the service — use `DateTimeUtil::getToday(DateTimeUtil::getUserPreferredTimeZone())`.
+- Never call `ttsbegin` / `ttscommit` in the Contract or Controller — only in the Service's `process()`.
+- Add a `[SysEntryPointAttribute(true)]` on the Service entry method to control security access.
+
+---
+
+## 2. RunBase / RunBaseBatch — legacy pattern
+
+Use only when extending existing code that inherits from `RunBase` or `RunBaseBatch`.
+
+```sh
+# Simple RunBase (synchronous dialog)
+d365fo generate runbase FmLegacyProcessor \
+  --dialog-param FromDate:TransDate \
+  --dialog-param AccountNum:CustAccount \
+  --install-to FleetManagement
+
+# RunBaseBatch (can be sent to batch queue via canGoBatch)
+d365fo generate runbase FmLegacyBatch \
+  --batch \
+  --dialog-param FromDate:TransDate \
+  --install-to FleetManagement
+```
+
+**When to prefer SysOperation over RunBase:**
+
+- SysOperation supports `[DataContractAttribute]` serialisation — parameters survive AOS restart.
+- SysOperation is unit-testable without a dialog.
+- RunBase `pack()`/`unpack()` is fragile — adding a new parameter requires version bumping.
+
+---
+
+## 3. Data migration scripts — `SysRunnable`
+
+Use for one-time data migration during upgrades or post-deployment data fixes.
+
+```sh
+# Pre-flight — confirm source and target table structure
+d365fo get table FmVehicleOld --output json
+d365fo get table FmVehicle    --output json
+
+# Scaffold migration script
+d365fo generate migration-script FmVehicleMigration \
+  --source-table FmVehicleOld \
+  --target-table FmVehicle \
+  --batch-size 500 \
+  --mode Upsert \
+  --install-to FleetManagement
+```
+
+**Modes:** `Insert` (default, fails on duplicate) | `Update` (updates existing records) | `Upsert` (insert or update).
+
+**Hard rules:**
+
+- Always run migration scripts in a test environment before production.
+- Use `--batch-size` to avoid long-running transactions. Default is 1000.
+- Migration classes implement `SysRunnable` — run via `SysRunnable::run()` or from a `RunBase` dialog.
+- Never delete source data in the same script — use a separate cleanup script after validation.
+- After migration, validate row counts: `select count(*) from FmVehicle`.

--- a/skills/anthropic/form-pattern-scaffolding/SKILL.md
+++ b/skills/anthropic/form-pattern-scaffolding/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: form-pattern-scaffolding
-description: Scaffold an AxForm in D365 Finance & Operations using one of the nine canonical patterns (SimpleList, SimpleListDetails, DetailsMaster, DetailsTransaction, Dialog, TableOfContents, Lookup, ListPage, Workspace). Invoke whenever the user asks to "create a form", "scaffold a list page", "make a dialog", or "build a workspace".
-applies_when: User intent mentions creating an AxForm, choosing a form pattern, list pages, master records, dialogs, lookups, workspaces, or details/transaction (header+lines) forms.
+description: Scaffold an AxForm in D365 Finance & Operations using one of the nine canonical patterns (SimpleList, SimpleListDetails, DetailsMaster, DetailsTransaction, Dialog, TableOfContents, Lookup, ListPage, Workspace), or create a Display / Action / Output menu item. Invoke whenever the user asks to "create a form", "scaffold a list page", "make a dialog", "build a workspace", "create a menu item", "add a Display menu item", or "add an Action menu item".
+applies_when: User intent mentions creating an AxForm, choosing a form pattern, list pages, master records, dialogs, lookups, workspaces, details/transaction (header+lines) forms, or creating a Display / Action / Output menu item.
 ---
 > ⛔ **NEVER write X++ AOT XML files directly** via PowerShell, terminal file commands (`Set-Content`, `Out-File`, `New-Item`), editor write tools, or any raw text approach. The XML schema (`<AxClass>`, `<AxTable>`, `<AxForm>`, `<Methods>`, `<SourceCode>`) is proprietary — LLMs have not been trained on it reliably. **ALWAYS use `d365fo generate …` commands** to produce correct AOT XML. If `d365fo` is unavailable in PATH, stop and ask the user to install it.
 
@@ -135,3 +135,32 @@ Forms follow a strict initialization order. Extension code must respect it.
 - Use `d365fo get form <Name> --output json` to find exact control names before wrapping.
 - NEVER guess control names — they differ from field names and are often prefixed.
 - Cannot add new methods via CoC on `formdatasourcestr`/`formdatafieldstr`/`formControlStr` — only wrap methods that already exist.
+
+## Menu items
+
+Menu items are the AOT entry points that open a form, call a class action, or trigger a report. Always scaffold the menu item alongside or after the target form.
+
+```sh
+# Display menu item — opens a form (most common)
+d365fo generate menu-item FmCustomersMenuItem \
+  --kind Display --object FmCustomers --object-type Form \
+  --label "@Fleet:Customers" \
+  --install-to FleetManagement
+
+# Action menu item — calls a class runnable (batch/service)
+d365fo generate menu-item FmPostOrdersAction \
+  --kind Action --object FmPostOrdersService --object-type Class \
+  --label "@Fleet:PostOrders" \
+  --install-to FleetManagement
+
+# Output menu item — triggers a report
+d365fo generate menu-item FmOrdersReportMenuItem \
+  --kind Output --object FmOrdersReport --object-type Report \
+  --label "@Fleet:OrdersReport" \
+  --install-to FleetManagement
+```
+
+**Hard rules:**
+- One menu item per AOT type (`AxMenuItemDisplay`, `AxMenuItemAction`, `AxMenuItemOutput`) — naming convention `<ObjectName>MenuItem` or `<ObjectName>Action`.
+- Do not create an `Action` menu item pointing to a form — use `Display`.
+- After creating a menu item, it must be added to a menu or a security privilege to be reachable.

--- a/skills/anthropic/object-extension-authoring/SKILL.md
+++ b/skills/anthropic/object-extension-authoring/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: object-extension-authoring
-description: Create a Table / Form / Edt / Enum extension (NOT a class CoC extension) in D365 Finance & Operations. Use when the user asks to "extend a table", "add a field to standard CustTable", "extend an EDT", "add an enum value", or "extend a form via FormExtension".
-applies_when: User intent mentions extending a Table / Form / Edt / Enum (not a class) — adding fields to a standard table, adding controls to a standard form, extending an enum or EDT.
+description: Create a Table / Form / Edt / Enum extension, a new EDT (Extended Data Type), or a new base enum in D365 Finance & Operations. Use when the user asks to "extend a table", "add a field to standard CustTable", "extend an EDT", "add an enum value", "extend a form via FormExtension", "create an EDT", "create a new EDT", "create an enum", "generate edt", or "generate enum".
+applies_when: User intent mentions extending a Table / Form / Edt / Enum, adding fields to a standard table, adding controls to a standard form, extending an enum or EDT, creating a new EDT (Extended Data Type), or creating a new base enum.
 ---
 > ⛔ **NEVER write X++ AOT XML files directly** via PowerShell, terminal file commands (`Set-Content`, `Out-File`, `New-Item`), editor write tools, or any raw text approach. The XML schema (`<AxClass>`, `<AxTable>`, `<AxForm>`, `<Methods>`, `<SourceCode>`) is proprietary — LLMs have not been trained on it reliably. **ALWAYS use `d365fo generate …` commands** to produce correct AOT XML. If `d365fo` is unavailable in PATH, stop and ask the user to install it.
 

--- a/skills/anthropic/security-hierarchy-trace/SKILL.md
+++ b/skills/anthropic/security-hierarchy-trace/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: security-hierarchy-trace
-description: Trace D365FO security from a Role all the way down to Entry Points, or discover which roles reach a given object. Use when the user asks about permissions, security coverage, roles, duties, or privileges.
-applies_when: User intent mentions security, roles, duties, privileges, entry points, or access control analysis.
+description: Trace D365FO security from a Role all the way down to Entry Points, discover which roles reach a given object, or scaffold new security objects (privilege, duty, role, XDS policy). Use when the user asks about permissions, security coverage, roles, duties, privileges, "create a security privilege", "scaffold a security role", "generate a duty", or "create a security policy".
+applies_when: User intent mentions security, roles, duties, privileges, entry points, access control analysis, creating a security role/duty/privilege, scaffolding a security policy, or XDS data security policy.
 ---
 > ⛔ **NEVER write X++ AOT XML files directly** via PowerShell, terminal file commands (`Set-Content`, `Out-File`, `New-Item`), editor write tools, or any raw text approach. The XML schema (`<AxClass>`, `<AxTable>`, `<AxForm>`, `<Methods>`, `<SourceCode>`) is proprietary — LLMs have not been trained on it reliably. **ALWAYS use `d365fo generate …` commands** to produce correct AOT XML. If `d365fo` is unavailable in PATH, stop and ask the user to install it.
 
@@ -29,3 +29,38 @@ applies_when: User intent mentions security, roles, duties, privileges, entry po
 - Do not recommend granting `-System Administrator` for troubleshooting.
 - Do not infer; always run `get security` before making claims.
 - Report paths verbatim; do not collapse `duty` or `privilege` steps.
+
+## Scaffolding security objects
+
+Trace first — understand the existing hierarchy — then scaffold new objects to fit it.
+
+```sh
+# 1. Create a privilege granting a specific access level to a menu item entry point
+d365fo generate privilege FmManageVehiclesPrivilege \
+  --entry-point FmVehiclesMenuItem --entry-kind MenuItemDisplay \
+  --access Update \
+  --label "@Fleet:ManageVehicles" \
+  --install-to FleetManagement
+
+# 2. Bundle privileges into a duty
+d365fo generate duty FmMaintainVehiclesDuty \
+  --privilege FmManageVehiclesPrivilege \
+  --privilege FmViewCustomersPrivilege \
+  --label "@Fleet:MaintainVehicles" \
+  --install-to FleetManagement
+
+# 3. Create a role and assign duties
+d365fo generate role FmFleetClerkRole \
+  --duty FmMaintainVehiclesDuty \
+  --label "@Fleet:FleetClerk" \
+  --description "Fleet management operator" \
+  --install-to FleetManagement
+
+# 4. Merge a duty into an existing role XML after the fact
+d365fo generate duty FmNewDuty --privilege FmSomePrivilege \
+  --into-role c:/AOT/FleetManagement/AxSecurityRole/FmFleetClerkRole.xml \
+  --install-to FleetManagement
+```
+
+**Scaffold order:** menu item → privilege (references the menu item) → duty (bundles privileges) → role (bundles duties).
+Always run `d365fo get security <Name> --type Role --output json` after to verify the new objects appear in the hierarchy.

--- a/skills/anthropic/sysoperation-batch-patterns/SKILL.md
+++ b/skills/anthropic/sysoperation-batch-patterns/SKILL.md
@@ -1,0 +1,117 @@
+---
+name: sysoperation-batch-patterns
+description: Scaffold batch jobs, SysOperation triplets (DataContract + Service + Controller), RunBase/RunBaseBatch classes, or data migration scripts in D365 Finance & Operations. Invoke when the user asks to "create a batch job", "scaffold a SysOperation", "create a RunBase class", "build a batch class", "generate a migration script", "migrate data between tables", or "create a scheduled batch".
+applies_when: User intent mentions batch job, SysOperation, RunBase, RunBaseBatch, scheduled batch, data migration script, DataContract class, batch controller, or SysRunnable.
+---
+> ⛔ **NEVER write X++ AOT XML files directly** via PowerShell, terminal file commands (`Set-Content`, `Out-File`, `New-Item`), editor write tools, or any raw text approach. The XML schema is proprietary. **ALWAYS use `d365fo generate …` commands** to produce correct AOT XML. If `d365fo` is unavailable in PATH, stop and ask the user to install it.
+
+# Batch and SysOperation patterns
+
+> **Prefer SysOperation** for all new batch jobs. Use `RunBase`/`RunBaseBatch` only
+> when extending legacy code that already uses that pattern.
+
+---
+
+## 1. SysOperation — preferred pattern for new batch jobs
+
+SysOperation separates concerns into three classes:
+
+| Class | Role |
+|---|---|
+| `DataContract` | Parameter bag — `[DataContractAttribute]` + `[DataMemberAttribute]` on each `parmXxx()` |
+| `Service` | Business logic — extends `SysOperationServiceBase`, contains the `process()` method |
+| `Controller` | Entry point — extends `SysOperationServiceController`, sets menu item and execution mode |
+
+**CLI workflow:**
+
+```sh
+# Pre-flight — name collision check
+d365fo search class FmInvoiceBatch --output json
+
+# Scaffold all three classes in one command
+d365fo generate sysoperation FmInvoiceBatch \
+  --param AccountNum:CustAccount \
+  --param FromDate:TransDate \
+  --param ToDate:TransDate \
+  --execution-mode ScheduledBatch \
+  --install-to FleetManagement
+
+# Default class names derived from <NAME>:
+#   FmInvoiceBatchContract   (DataContract)
+#   FmInvoiceBatchService    (Service)
+#   FmInvoiceBatchController (Controller)
+
+# Override names if needed
+d365fo generate sysoperation FmInvoiceBatch \
+  --contract-name FmInvoiceBatchDataContract \
+  --service-name  FmInvoiceBatchSvc \
+  --controller-name FmInvoiceBatchCtrl \
+  --execution-mode ScheduledBatch \
+  --install-to FleetManagement
+```
+
+**Execution modes:** `Synchronous` (default, blocks until done) | `Asynchronous` (fire-and-forget, returns immediately) | `ScheduledBatch` (adds to batch framework queue).
+
+**Hard rules:**
+
+- The `process()` method on the Service class is the only method that should contain business logic.
+- The Contract class must NOT hold state between calls — it is a simple data transfer object.
+- Do NOT use `today()` anywhere in the service — use `DateTimeUtil::getToday(DateTimeUtil::getUserPreferredTimeZone())`.
+- Never call `ttsbegin` / `ttscommit` in the Contract or Controller — only in the Service's `process()`.
+- Add a `[SysEntryPointAttribute(true)]` on the Service entry method to control security access.
+
+---
+
+## 2. RunBase / RunBaseBatch — legacy pattern
+
+Use only when extending existing code that inherits from `RunBase` or `RunBaseBatch`.
+
+```sh
+# Simple RunBase (synchronous dialog)
+d365fo generate runbase FmLegacyProcessor \
+  --dialog-param FromDate:TransDate \
+  --dialog-param AccountNum:CustAccount \
+  --install-to FleetManagement
+
+# RunBaseBatch (can be sent to batch queue via canGoBatch)
+d365fo generate runbase FmLegacyBatch \
+  --batch \
+  --dialog-param FromDate:TransDate \
+  --install-to FleetManagement
+```
+
+**When to prefer SysOperation over RunBase:**
+
+- SysOperation supports `[DataContractAttribute]` serialisation — parameters survive AOS restart.
+- SysOperation is unit-testable without a dialog.
+- RunBase `pack()`/`unpack()` is fragile — adding a new parameter requires version bumping.
+
+---
+
+## 3. Data migration scripts — `SysRunnable`
+
+Use for one-time data migration during upgrades or post-deployment data fixes.
+
+```sh
+# Pre-flight — confirm source and target table structure
+d365fo get table FmVehicleOld --output json
+d365fo get table FmVehicle    --output json
+
+# Scaffold migration script
+d365fo generate migration-script FmVehicleMigration \
+  --source-table FmVehicleOld \
+  --target-table FmVehicle \
+  --batch-size 500 \
+  --mode Upsert \
+  --install-to FleetManagement
+```
+
+**Modes:** `Insert` (default, fails on duplicate) | `Update` (updates existing records) | `Upsert` (insert or update).
+
+**Hard rules:**
+
+- Always run migration scripts in a test environment before production.
+- Use `--batch-size` to avoid long-running transactions. Default is 1000.
+- Migration classes implement `SysRunnable` — run via `SysRunnable::run()` or from a `RunBase` dialog.
+- Never delete source data in the same script — use a separate cleanup script after validation.
+- After migration, validate row counts: `select count(*) from FmVehicle`.

--- a/skills/copilot/form-pattern-scaffolding.instructions.md
+++ b/skills/copilot/form-pattern-scaffolding.instructions.md
@@ -1,6 +1,6 @@
 ---
-description: Scaffold an AxForm in D365 Finance & Operations using one of the nine canonical patterns (SimpleList, SimpleListDetails, DetailsMaster, DetailsTransaction, Dialog, TableOfContents, Lookup, ListPage, Workspace). Invoke whenever the user asks to "create a form", "scaffold a list page", "make a dialog", or "build a workspace".
-applyTo: '**/AxForm/**,**/*Form.xml'
+description: Scaffold an AxForm in D365 Finance & Operations using one of the nine canonical patterns (SimpleList, SimpleListDetails, DetailsMaster, DetailsTransaction, Dialog, TableOfContents, Lookup, ListPage, Workspace), or create a Display / Action / Output menu item. Invoke whenever the user asks to "create a form", "scaffold a list page", "make a dialog", "build a workspace", "create a menu item", "add a Display menu item", or "add an Action menu item".
+applyTo: '**/AxForm/**,**/*Form.xml,**/AxMenuItemDisplay/**,**/AxMenuItemAction/**,**/AxMenuItemOutput/**'
 ---
 > ⛔ **NEVER write X++ AOT XML files directly** via PowerShell, terminal file commands (`Set-Content`, `Out-File`, `New-Item`), editor write tools, or any raw text approach. The XML schema (`<AxClass>`, `<AxTable>`, `<AxForm>`, `<Methods>`, `<SourceCode>`) is proprietary — LLMs have not been trained on it reliably. **ALWAYS use `d365fo generate …` commands** to produce correct AOT XML. If `d365fo` is unavailable in PATH, stop and ask the user to install it.
 
@@ -134,3 +134,32 @@ Forms follow a strict initialization order. Extension code must respect it.
 - Use `d365fo get form <Name> --output json` to find exact control names before wrapping.
 - NEVER guess control names — they differ from field names and are often prefixed.
 - Cannot add new methods via CoC on `formdatasourcestr`/`formdatafieldstr`/`formControlStr` — only wrap methods that already exist.
+
+## Menu items
+
+Menu items are the AOT entry points that open a form, call a class action, or trigger a report. Always scaffold the menu item alongside or after the target form.
+
+```sh
+# Display menu item — opens a form (most common)
+d365fo generate menu-item FmCustomersMenuItem \
+  --kind Display --object FmCustomers --object-type Form \
+  --label "@Fleet:Customers" \
+  --install-to FleetManagement
+
+# Action menu item — calls a class runnable (batch/service)
+d365fo generate menu-item FmPostOrdersAction \
+  --kind Action --object FmPostOrdersService --object-type Class \
+  --label "@Fleet:PostOrders" \
+  --install-to FleetManagement
+
+# Output menu item — triggers a report
+d365fo generate menu-item FmOrdersReportMenuItem \
+  --kind Output --object FmOrdersReport --object-type Report \
+  --label "@Fleet:OrdersReport" \
+  --install-to FleetManagement
+```
+
+**Hard rules:**
+- One menu item per AOT type (`AxMenuItemDisplay`, `AxMenuItemAction`, `AxMenuItemOutput`) — naming convention `<ObjectName>MenuItem` or `<ObjectName>Action`.
+- Do not create an `Action` menu item pointing to a form — use `Display`.
+- After creating a menu item, it must be added to a menu or a security privilege to be reachable.

--- a/skills/copilot/object-extension-authoring.instructions.md
+++ b/skills/copilot/object-extension-authoring.instructions.md
@@ -1,6 +1,6 @@
 ---
-description: Create a Table / Form / Edt / Enum extension (NOT a class CoC extension) in D365 Finance & Operations. Use when the user asks to "extend a table", "add a field to standard CustTable", "extend an EDT", "add an enum value", or "extend a form via FormExtension".
-applyTo: '**/AxTableExtension/**,**/AxFormExtension/**,**/AxEdtExtension/**,**/AxEnumExtension/**,**/*.Extension.xml'
+description: Create a Table / Form / Edt / Enum extension, a new EDT (Extended Data Type), or a new base enum in D365 Finance & Operations. Use when the user asks to "extend a table", "add a field to standard CustTable", "extend an EDT", "add an enum value", "extend a form via FormExtension", "create an EDT", "create a new EDT", "create an enum", "generate edt", or "generate enum".
+applyTo: '**/AxTableExtension/**,**/AxFormExtension/**,**/AxEdtExtension/**,**/AxEnumExtension/**,**/AxEdt/**,**/AxEnum/**,**/*.Extension.xml,**/*Edt.xml,**/*Enum.xml'
 ---
 > ⛔ **NEVER write X++ AOT XML files directly** via PowerShell, terminal file commands (`Set-Content`, `Out-File`, `New-Item`), editor write tools, or any raw text approach. The XML schema (`<AxClass>`, `<AxTable>`, `<AxForm>`, `<Methods>`, `<SourceCode>`) is proprietary — LLMs have not been trained on it reliably. **ALWAYS use `d365fo generate …` commands** to produce correct AOT XML. If `d365fo` is unavailable in PATH, stop and ask the user to install it.
 

--- a/skills/copilot/security-hierarchy-trace.instructions.md
+++ b/skills/copilot/security-hierarchy-trace.instructions.md
@@ -1,5 +1,5 @@
 ---
-description: Trace D365FO security from a Role all the way down to Entry Points, or discover which roles reach a given object. Use when the user asks about permissions, security coverage, roles, duties, or privileges.
+description: Trace D365FO security from a Role all the way down to Entry Points, discover which roles reach a given object, or scaffold new security objects (privilege, duty, role, XDS policy). Use when the user asks about permissions, security coverage, roles, duties, privileges, "create a security privilege", "scaffold a security role", "generate a duty", or "create a security policy".
 applyTo: '**/AxSecurityRole/**,**/AxSecurityDuty/**,**/AxSecurityPrivilege/**'
 ---
 > ⛔ **NEVER write X++ AOT XML files directly** via PowerShell, terminal file commands (`Set-Content`, `Out-File`, `New-Item`), editor write tools, or any raw text approach. The XML schema (`<AxClass>`, `<AxTable>`, `<AxForm>`, `<Methods>`, `<SourceCode>`) is proprietary — LLMs have not been trained on it reliably. **ALWAYS use `d365fo generate …` commands** to produce correct AOT XML. If `d365fo` is unavailable in PATH, stop and ask the user to install it.
@@ -28,3 +28,38 @@ applyTo: '**/AxSecurityRole/**,**/AxSecurityDuty/**,**/AxSecurityPrivilege/**'
 - Do not recommend granting `-System Administrator` for troubleshooting.
 - Do not infer; always run `get security` before making claims.
 - Report paths verbatim; do not collapse `duty` or `privilege` steps.
+
+## Scaffolding security objects
+
+Trace first — understand the existing hierarchy — then scaffold new objects to fit it.
+
+```sh
+# 1. Create a privilege granting a specific access level to a menu item entry point
+d365fo generate privilege FmManageVehiclesPrivilege \
+  --entry-point FmVehiclesMenuItem --entry-kind MenuItemDisplay \
+  --access Update \
+  --label "@Fleet:ManageVehicles" \
+  --install-to FleetManagement
+
+# 2. Bundle privileges into a duty
+d365fo generate duty FmMaintainVehiclesDuty \
+  --privilege FmManageVehiclesPrivilege \
+  --privilege FmViewCustomersPrivilege \
+  --label "@Fleet:MaintainVehicles" \
+  --install-to FleetManagement
+
+# 3. Create a role and assign duties
+d365fo generate role FmFleetClerkRole \
+  --duty FmMaintainVehiclesDuty \
+  --label "@Fleet:FleetClerk" \
+  --description "Fleet management operator" \
+  --install-to FleetManagement
+
+# 4. Merge a duty into an existing role XML after the fact
+d365fo generate duty FmNewDuty --privilege FmSomePrivilege \
+  --into-role c:/AOT/FleetManagement/AxSecurityRole/FmFleetClerkRole.xml \
+  --install-to FleetManagement
+```
+
+**Scaffold order:** menu item → privilege (references the menu item) → duty (bundles privileges) → role (bundles duties).
+Always run `d365fo get security <Name> --type Role --output json` after to verify the new objects appear in the hierarchy.

--- a/skills/copilot/sysoperation-batch-patterns.instructions.md
+++ b/skills/copilot/sysoperation-batch-patterns.instructions.md
@@ -1,0 +1,116 @@
+---
+description: Scaffold batch jobs, SysOperation triplets (DataContract + Service + Controller), RunBase/RunBaseBatch classes, or data migration scripts in D365 Finance & Operations. Invoke when the user asks to "create a batch job", "scaffold a SysOperation", "create a RunBase class", "build a batch class", "generate a migration script", "migrate data between tables", or "create a scheduled batch".
+applyTo: '**/AxClass/**Controller*.xml,**/AxClass/**Service*.xml,**/AxClass/**Contract*.xml,**/AxClass/**RunBase*.xml,**/AxClass/**Migration*.xml,**/AxClass/**Batch*.xml'
+---
+> ⛔ **NEVER write X++ AOT XML files directly** via PowerShell, terminal file commands (`Set-Content`, `Out-File`, `New-Item`), editor write tools, or any raw text approach. The XML schema is proprietary. **ALWAYS use `d365fo generate …` commands** to produce correct AOT XML. If `d365fo` is unavailable in PATH, stop and ask the user to install it.
+
+# Batch and SysOperation patterns
+
+> **Prefer SysOperation** for all new batch jobs. Use `RunBase`/`RunBaseBatch` only
+> when extending legacy code that already uses that pattern.
+
+---
+
+## 1. SysOperation — preferred pattern for new batch jobs
+
+SysOperation separates concerns into three classes:
+
+| Class | Role |
+|---|---|
+| `DataContract` | Parameter bag — `[DataContractAttribute]` + `[DataMemberAttribute]` on each `parmXxx()` |
+| `Service` | Business logic — extends `SysOperationServiceBase`, contains the `process()` method |
+| `Controller` | Entry point — extends `SysOperationServiceController`, sets menu item and execution mode |
+
+**CLI workflow:**
+
+```sh
+# Pre-flight — name collision check
+d365fo search class FmInvoiceBatch --output json
+
+# Scaffold all three classes in one command
+d365fo generate sysoperation FmInvoiceBatch \
+  --param AccountNum:CustAccount \
+  --param FromDate:TransDate \
+  --param ToDate:TransDate \
+  --execution-mode ScheduledBatch \
+  --install-to FleetManagement
+
+# Default class names derived from <NAME>:
+#   FmInvoiceBatchContract   (DataContract)
+#   FmInvoiceBatchService    (Service)
+#   FmInvoiceBatchController (Controller)
+
+# Override names if needed
+d365fo generate sysoperation FmInvoiceBatch \
+  --contract-name FmInvoiceBatchDataContract \
+  --service-name  FmInvoiceBatchSvc \
+  --controller-name FmInvoiceBatchCtrl \
+  --execution-mode ScheduledBatch \
+  --install-to FleetManagement
+```
+
+**Execution modes:** `Synchronous` (default, blocks until done) | `Asynchronous` (fire-and-forget, returns immediately) | `ScheduledBatch` (adds to batch framework queue).
+
+**Hard rules:**
+
+- The `process()` method on the Service class is the only method that should contain business logic.
+- The Contract class must NOT hold state between calls — it is a simple data transfer object.
+- Do NOT use `today()` anywhere in the service — use `DateTimeUtil::getToday(DateTimeUtil::getUserPreferredTimeZone())`.
+- Never call `ttsbegin` / `ttscommit` in the Contract or Controller — only in the Service's `process()`.
+- Add a `[SysEntryPointAttribute(true)]` on the Service entry method to control security access.
+
+---
+
+## 2. RunBase / RunBaseBatch — legacy pattern
+
+Use only when extending existing code that inherits from `RunBase` or `RunBaseBatch`.
+
+```sh
+# Simple RunBase (synchronous dialog)
+d365fo generate runbase FmLegacyProcessor \
+  --dialog-param FromDate:TransDate \
+  --dialog-param AccountNum:CustAccount \
+  --install-to FleetManagement
+
+# RunBaseBatch (can be sent to batch queue via canGoBatch)
+d365fo generate runbase FmLegacyBatch \
+  --batch \
+  --dialog-param FromDate:TransDate \
+  --install-to FleetManagement
+```
+
+**When to prefer SysOperation over RunBase:**
+
+- SysOperation supports `[DataContractAttribute]` serialisation — parameters survive AOS restart.
+- SysOperation is unit-testable without a dialog.
+- RunBase `pack()`/`unpack()` is fragile — adding a new parameter requires version bumping.
+
+---
+
+## 3. Data migration scripts — `SysRunnable`
+
+Use for one-time data migration during upgrades or post-deployment data fixes.
+
+```sh
+# Pre-flight — confirm source and target table structure
+d365fo get table FmVehicleOld --output json
+d365fo get table FmVehicle    --output json
+
+# Scaffold migration script
+d365fo generate migration-script FmVehicleMigration \
+  --source-table FmVehicleOld \
+  --target-table FmVehicle \
+  --batch-size 500 \
+  --mode Upsert \
+  --install-to FleetManagement
+```
+
+**Modes:** `Insert` (default, fails on duplicate) | `Update` (updates existing records) | `Upsert` (insert or update).
+
+**Hard rules:**
+
+- Always run migration scripts in a test environment before production.
+- Use `--batch-size` to avoid long-running transactions. Default is 1000.
+- Migration classes implement `SysRunnable` — run via `SysRunnable::run()` or from a `RunBase` dialog.
+- Never delete source data in the same script — use a separate cleanup script after validation.
+- After migration, validate row counts: `select count(*) from FmVehicle`.


### PR DESCRIPTION
…Operation, EDT/Enum; remove issue reference

- object-extension-authoring: description + applyTo covers new EDT/Enum creation
- form-pattern-scaffolding: add menu-item section (Display/Action/Output) + description
- security-hierarchy-trace: add scaffolding section (privilege/duty/role) + description
- sysoperation-batch-patterns: new skill covering SysOperation, RunBase, migration-script
- copilot-instructions.md: remove issue #41 reference; update skills table (19 skills)
- docs/SETUP.md: VS Chat warning + troubleshooting row
- emit: 19 skills regenerated to copilot/ and anthropic/