### PR TITLE
feat(mcp): add generate_table/class/coc/form write-to-disk tools; fix…

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -10,9 +10,11 @@
 
 This file gives **GitHub Copilot** the rules for assisting with D365 Finance & Operations X++ development. It is deployed to your X++ project's `.github/` folder by `Install-D365FoCopilotSkills.ps1` and is read automatically by Copilot in Visual Studio.
 
-> **Primary environment:** GitHub Copilot in **Visual Studio 2022 / 2026** in agent mode — has `run_command_in_terminal`, `replace_string_in_file`, `get_errors`, etc. Run `d365fo` commands directly via the terminal tool.
+> **Primary environment — VS 2022 / VS 2026 agent mode:** GitHub Copilot runs `d365fo` commands via the built-in terminal tool (`run_command_in_terminal`). Skills in `.github/instructions/` load on demand and tell Copilot exactly which commands to run. No copy-paste, no MCP overhead.
 >
-> **Secondary environment:** VS Code with Copilot in agent mode. Same capabilities, different tool names (`run_in_terminal` instead of `run_command_in_terminal`, `read_file` instead of `get_file`).
+> **Secondary environment — VS Code agent mode:** Same approach, different terminal tool name (`run_in_terminal`). Identical experience.
+>
+> **Fallback — VS Chat mode (no agent tools):** Copilot must ask the user to run `d365fo` commands manually and paste back JSON output. See the fallback workflow section below.
 
 ---
 
@@ -32,9 +34,19 @@ d365fo list models --output json      # confirm target model — NEVER guess it
 
 Models are ISV / customer policy boundaries — never infer from search results; always ask or read from `.rnrproj`.
 
-### ⛔ VS Chat mode (no agent tools) — fallback workflow
+### VS / VS Code operating modes
 
-If Copilot is running in **chat mode without agent tools** (no terminal access), it cannot execute `d365fo` directly. The built-in code search / `@workspace` **always fails on AOT XML** — do not attempt it.
+| Environment | How Copilot runs d365fo | Token cost |
+|---|---|---|
+| **VS 2022/2026 agent mode** | Built-in terminal tool → `d365fo` CLI | ~100 tokens |
+| **VS Code agent mode** | `run_in_terminal` → `d365fo` CLI | ~100 tokens |
+| **VS Chat mode** (no agent tools) | User runs manually, pastes JSON | collaborative |
+
+In agent mode Copilot calls `d365fo` commands autonomously — it reads skills from `.github/instructions/`, decides which commands to run, executes them in the terminal, and interprets the JSON output. No copy-paste required.
+
+### ⛔ Chat mode only (no agent tools) — fallback workflow
+
+If Copilot is running in **chat mode without agent tools** (no tool list visible), it cannot call `d365fo` directly. The built-in code search / `@workspace` **always fails on AOT XML** — do not attempt it.
 
 ```
 // ❌ WRONG — do not attempt this

--- a/docs/SETUP.md
+++ b/docs/SETUP.md
@@ -188,13 +188,72 @@ External Tools let you run any CLI command from the **Tools** menu without leavi
 
 > **Tip.** Add a second entry with **Arguments** = `doctor --output json` to run a health check straight from the menu.
 
-### How Copilot Chat works in Visual Studio vs VS Code
+### How Copilot works in Visual Studio and VS Code
 
-> ⚠️ **Important limitation:** GitHub Copilot Chat in Visual Studio runs in **chat mode only** — it cannot execute terminal commands or use agent tools. When you ask it to add a table, it will try to search the codebase with built-in "code search", which **always fails on AOT XML files** with "There was an error executing code search". If you then see "Since I cannot access the codebase…" followed by generic X++ guidance, the instructions are not being followed correctly.
->
-> **Correct VS Chat behaviour:** Copilot should ask you to run `d365fo` commands in your terminal and paste back the JSON output. It must never generate raw X++ code without first seeing real metadata from `d365fo`.
->
-> **To get full agent capabilities** (Copilot runs `d365fo` commands automatically), use **VS Code** with the GitHub Copilot extension in agent mode.
+In **agent mode** Copilot has a terminal tool and executes `d365fo` commands autonomously — the Skills in `.github/instructions/` tell it exactly what to run and in what order. No copy-paste required.
+
+| Environment | How Copilot runs d365fo | Token cost |
+|---|---|---|
+| **VS 2022 / VS 2026 agent mode** | Built-in terminal tool → `d365fo` CLI | ~100 tokens |
+| **VS Code agent mode** | `run_in_terminal` → `d365fo` CLI | ~100 tokens |
+| **VS Chat mode** (no agent tools) | Asks user to run commands, pastes JSON | collaborative |
+
+To activate agent mode in Visual Studio: open the Copilot Chat pane, click the mode dropdown (top-right), and select **Agent**. No additional configuration is needed — `d365fo` must simply be on `PATH`.
+
+> ⚠️ **Never** use the built-in VS code search or `@workspace` on an X++ / AOT project. It always fails on AOT XML files. Copilot must use `d365fo` commands exclusively for all codebase queries.
+
+#### Agent mode — example session ("Add a new table")
+
+1. **You ask** in Copilot Chat (agent mode):
+   ```
+   Add a new table MyVendorRating to model MyCustomModel with fields VendAccount (string), Rating (int), RatingDate (date).
+   ```
+
+2. **Copilot** runs pre-flight checks autonomously:
+   ```sh
+   d365fo doctor --output json
+   d365fo list models --output json
+   ```
+
+3. **Copilot** confirms the index is healthy and model exists, then scaffolds directly:
+   ```sh
+   d365fo generate table MyVendorRating --install-to MyCustomModel \
+     --field "VendAccount:VendAccountNum" --field "Rating:int" --field "RatingDate:date" \
+     --output json
+   d365fo index refresh --model MyCustomModel --output json
+   ```
+
+No copy-paste. The skill `table-scaffolding.instructions.md` guides the exact field/pattern choices.
+
+#### Chat mode — step-by-step workflow (no agent tools)
+
+When agent mode is not available the interaction is **collaborative**: Copilot tells you which `d365fo` commands to run, you run them in **Developer PowerShell**, and you paste the JSON output back.
+
+**Is Copilot smart enough to ask on its own?**  
+Yes — *if* `copilot-instructions.md` is deployed to your X++ project's `.github/` folder (via `Install-D365FoCopilotSkills.ps1`). If Copilot jumps straight to generating X++ code without requesting `d365fo` output first, the file is either missing or not being picked up — re-run the install script and restart Visual Studio.
+
+**Example (same task, chat mode):**
+
+1. **You ask:** `Add a new table MyVendorRating to model MyCustomModel …`
+
+2. **Copilot responds:**
+   ```
+   Please run these commands in Developer PowerShell and paste the output:
+
+   d365fo doctor --output json
+   d365fo list models --output json
+   ```
+
+3. **You run** them and paste the JSON.
+
+4. **Copilot** reviews the output, then asks:
+   ```
+   d365fo generate table MyVendorRating --install-to MyCustomModel --output json
+   ```
+
+5. **You run** it and paste back. Copilot confirms and tells you any follow-up steps.
+
+**Key principle:** you are the hands, Copilot is the brain. You never type `d365fo` commands unprompted — wait for Copilot to tell you exactly what to run.
 
 ### Copy Skills and Copilot instructions to your X++ project
 
@@ -316,7 +375,7 @@ git commit -m "chore: update d365fo Copilot skills"
 | `PACKAGES_PATH_NOT_FOUND` | Set `D365FO_PACKAGES_PATH` or pass `--packages <PATH>`. |
 | `UNSUPPORTED_PLATFORM` | `build` / `sync` / `test` / `bp` require Windows + a D365FO dev VM. Run them there. |
 | Index file appears locked | Stop any running `d365fo daemon` or `d365fo-mcp` process. WAL sidecar files (`-wal`, `-shm`) are normal. |
-| Copilot Chat in VS gives "There was an error executing code search" then generic X++ advice | VS Copilot Chat cannot search AOT XML (it always errors). The `.github/copilot-instructions.md` should prevent the code-search attempt — re-run `Install-D365FoCopilotSkills.ps1` to deploy the latest instructions. For full agent capabilities (auto-running `d365fo`), switch to **VS Code agent mode**. |
+| Copilot Chat in VS gives "There was an error executing code search" then generic X++ advice | VS Copilot Chat cannot search AOT XML (it always errors). The `.github/copilot-instructions.md` should prevent the code-search attempt — re-run `Install-D365FoCopilotSkills.ps1` to deploy the latest instructions. For full agent capabilities (auto-running `d365fo`), switch Copilot Chat to **Agent** mode (mode dropdown, top-right of the Chat pane). |
 | Extract missed a package | Confirm the `<root>/<Package>/<Model>/AxTable/…` layout and point `--packages` at the real `PackagesLocalDirectory`. |
 | Label values contain junk | `search label` / `get label` strip control characters by default — pass `--raw-text` to see the unfiltered value. |
 | Self-contained binary won't start on Linux | `chmod +x d365fo` after copying out of the publish folder. |

--- a/src/D365FO.Mcp/ToolCatalog.cs
+++ b/src/D365FO.Mcp/ToolCatalog.cs
@@ -314,7 +314,7 @@ public static class ToolCatalog
             Schema(("topN", "integer", false), ("onlyCycles", "boolean", false)),
             (h, p) => h.ModelsCoupling(Int(p, "topN", 20), Bool(p, "onlyCycles"))),
 
-        // ---- Phase 3: v11 search/get tools ----
+        // ---- search / get tools ----
 
         new Descriptor("search_business_events",
             "Search indexed D365FO business events by name or contract class.",
@@ -346,7 +346,7 @@ public static class ToolCatalog
             Schema(("query", "string", true), ("limit", "integer", false)),
             (h, p) => h.SearchWorkspaces(Str(p, "query"), Int(p, "limit", 50))),
 
-        // ---- Phase 5: integration analysis tools ----
+        // ---- integration analysis tools ----
 
         new Descriptor("analyze_integration",
             "Cross-check indexed data entities for OData/DMF integration readiness. Returns issues such as duplicate PublicEntityName, missing staging table, and zero-field entities.",
@@ -358,7 +358,7 @@ public static class ToolCatalog
             Schema(("model", "string", false)),
             (h, p) => h.ReportIntegrations(StrOrNull(p, "model"))),
 
-        // ---- Phase 7: developer experience tools ----
+        // ---- developer experience tools ----
 
         new Descriptor("analyze_impact",
             "Change-impact analysis: list all downstream consumers (CoC wrappers, event handlers, extensions, form datasources, data entities, queries) of an AOT object.",
@@ -370,7 +370,7 @@ public static class ToolCatalog
             Schema(("model", "string", false)),
             (h, p) => h.FindBatchJobs(StrOrNull(p, "model"))),
 
-        // ---- Phase 2 + 6: scaffolding tools (return XML content) ----
+        // ---- scaffolding tools (return XML content) ----
 
         new Descriptor("generate_edt",
             "Scaffold an AxEdt Extended Data Type. Returns the XML content as a string.",
@@ -406,6 +406,42 @@ public static class ToolCatalog
             "Scaffold an AxSecurityPolicy (XDS) XML. Returns XML content.",
             Schema(("name", "string", true), ("constrainedTable", "string", true), ("policyQuery", "string", false)),
             (h, p) => h.GenerateSecurityPolicy(Str(p, "name"), Str(p, "constrainedTable"), StrOrNull(p, "policyQuery"))),
+
+        // ---- write-to-disk scaffolding tools ----
+        // These tools generate XML AND write it directly into the AOT at
+        //   <D365FO_PACKAGES_PATH>/<model>/<model>/Ax<Kind>/<name>.xml
+        // Either `installTo` (model name) or `out` (explicit path) is required.
+
+        new Descriptor("generate_table",
+            "Scaffold an AxTable and write it into the AOT. Requires either installTo (model name, resolves path automatically from D365FO_PACKAGES_PATH) or out (explicit file path). Fields format: \"<name>:<edt>[:mandatory]\". Pattern aliases: main, transaction, parameter, group, reference, miscellaneous.",
+            Schema(("name", "string", true), ("label", "string", false), ("fields", "array", false),
+                   ("pattern", "string", false), ("installTo", "string", false),
+                   ("out", "string", false), ("overwrite", "boolean", false)),
+            (h, p) => h.GenerateTable(Str(p, "name"), StrOrNull(p, "label"), StrArray(p, "fields"),
+                StrOrNull(p, "pattern"), StrOrNull(p, "installTo"), StrOrNull(p, "out"), Bool(p, "overwrite"))),
+
+        new Descriptor("generate_class",
+            "Scaffold an AxClass and write it into the AOT. Requires either installTo (model name) or out (explicit path).",
+            Schema(("name", "string", true), ("extends", "string", false), ("nonFinal", "boolean", false),
+                   ("installTo", "string", false), ("out", "string", false), ("overwrite", "boolean", false)),
+            (h, p) => h.GenerateClass(Str(p, "name"), StrOrNull(p, "extends"), Bool(p, "nonFinal"),
+                StrOrNull(p, "installTo"), StrOrNull(p, "out"), Bool(p, "overwrite"))),
+
+        new Descriptor("generate_coc",
+            "Scaffold a Chain-of-Command extension class (<target>_Extension) and write it into the AOT. Wraps the given methods with next calls. Requires either installTo or out.",
+            Schema(("target", "string", true), ("methods", "array", true),
+                   ("installTo", "string", false), ("out", "string", false), ("overwrite", "boolean", false)),
+            (h, p) => h.GenerateCoc(Str(p, "target"), StrArray(p, "methods") ?? Array.Empty<string>(),
+                StrOrNull(p, "installTo"), StrOrNull(p, "out"), Bool(p, "overwrite"))),
+
+        new Descriptor("generate_form",
+            "Scaffold a pattern-correct AxForm and write it into the AOT. Patterns: SimpleList, SimpleListDetails, DetailsMaster, DetailsTransaction, Dialog, TableOfContents, Lookup, ListPage, Workspace. Requires either installTo or out.",
+            Schema(("name", "string", true), ("table", "string", false), ("pattern", "string", false),
+                   ("caption", "string", false), ("fields", "array", false), ("linesTable", "string", false),
+                   ("installTo", "string", false), ("out", "string", false), ("overwrite", "boolean", false)),
+            (h, p) => h.GenerateForm(Str(p, "name"), StrOrNull(p, "table"), StrOrNull(p, "pattern"),
+                StrOrNull(p, "caption"), StrArray(p, "fields"), StrOrNull(p, "linesTable"),
+                StrOrNull(p, "installTo"), StrOrNull(p, "out"), Bool(p, "overwrite"))),
     };
 
     // ---- JSON helpers ----

--- a/src/D365FO.Mcp/ToolHandlers.cs
+++ b/src/D365FO.Mcp/ToolHandlers.cs
@@ -600,7 +600,7 @@ public sealed class ToolHandlers
         });
     }
 
-    // ---- Phase 3: v11 search/get handlers ----
+    // ---- search / get handlers ----
 
     public ToolResult<object> SearchBusinessEvents(string query, string? category, int limit)
     {
@@ -640,7 +640,7 @@ public sealed class ToolHandlers
         return ToolResult<object>.Success(new { count = items.Count, items });
     }
 
-    // ---- Phase 5: integration analysis handlers ----
+    // ---- integration analysis handlers ----
 
     public ToolResult<object> AnalyzeIntegration(string? model)
     {
@@ -661,7 +661,7 @@ public sealed class ToolHandlers
         });
     }
 
-    // ---- Phase 7: developer experience handlers ----
+    // ---- developer experience handlers ----
 
     public ToolResult<object> AnalyzeImpact(string objectName)
     {
@@ -682,7 +682,7 @@ public sealed class ToolHandlers
         return ToolResult<object>.Success(new { count = items.Count, items });
     }
 
-    // ---- Phase 2 + 6: scaffolding handlers (return XML as string) ----
+    // ---- scaffolding handlers (return XML as string) ----
 
     public ToolResult<object> GenerateEdt(string name, string? extends, string? label, int size)
     {
@@ -767,5 +767,197 @@ public sealed class ToolHandlers
         var pq = string.IsNullOrWhiteSpace(policyQuery) ? name + "Query" : policyQuery!;
         var doc = D365FO.Core.Scaffolding.SecurityPolicyScaffolder.Policy(name, constrainedTable, pq);
         return ToolResult<object>.Success(new { name, xml = doc.ToString() });
+    }
+
+    // ---- write-to-disk scaffolding handlers ----
+
+    /// <summary>
+    /// Resolve the canonical AOT install path:
+    /// <c>&lt;PackagesPath&gt;/&lt;model&gt;/&lt;model&gt;/&lt;axSubfolder&gt;/&lt;name&gt;.xml</c>.
+    /// Returns <c>null</c> when <c>D365FO_PACKAGES_PATH</c> is not set.
+    /// </summary>
+    private static string? ResolveAotPath(string model, string axSubfolder, string name)
+    {
+        var cfg = D365FoSettings.FromEnvironment();
+        if (string.IsNullOrEmpty(cfg.PackagesPath)) return null;
+        return Path.Combine(cfg.PackagesPath, model, model, axSubfolder, name + ".xml");
+    }
+
+    private static ToolResult<object> WriteScaffold(
+        System.Xml.Linq.XDocument doc, string name, string kind, string axSubfolder,
+        string? installTo, string? outPath, bool overwrite, object extra)
+    {
+        var path = outPath;
+        if (string.IsNullOrWhiteSpace(path) && !string.IsNullOrWhiteSpace(installTo))
+        {
+            path = ResolveAotPath(installTo!, axSubfolder, name);
+            if (path is null)
+                return ToolResult<object>.Fail("INSTALL_FAILED",
+                    $"Cannot resolve install path for model '{installTo}': D365FO_PACKAGES_PATH is not set.",
+                    "Set D365FO_PACKAGES_PATH before using installTo.");
+        }
+        if (string.IsNullOrWhiteSpace(path))
+            return ToolResult<object>.Fail("BAD_INPUT", "Either 'out' or 'installTo' is required.");
+
+        try
+        {
+            var res = D365FO.Core.Scaffolding.ScaffoldFileWriter.Write(doc, path!, overwrite);
+            return ToolResult<object>.Success(new
+            {
+                kind,
+                name,
+                path = res.Path,
+                bytes = res.Bytes,
+                backup = res.BackupPath,
+                model = installTo,
+                extra,
+            });
+        }
+        catch (Exception ex)
+        {
+            return ToolResult<object>.Fail(D365FoErrorCodes.WriteFailed, ex.Message);
+        }
+    }
+
+    private static ToolResult<object> WriteScaffoldString(
+        string xml, string name, string kind, string axSubfolder,
+        string? installTo, string? outPath, bool overwrite, object extra)
+    {
+        var path = outPath;
+        if (string.IsNullOrWhiteSpace(path) && !string.IsNullOrWhiteSpace(installTo))
+        {
+            path = ResolveAotPath(installTo!, axSubfolder, name);
+            if (path is null)
+                return ToolResult<object>.Fail("INSTALL_FAILED",
+                    $"Cannot resolve install path for model '{installTo}': D365FO_PACKAGES_PATH is not set.",
+                    "Set D365FO_PACKAGES_PATH before using installTo.");
+        }
+        if (string.IsNullOrWhiteSpace(path))
+            return ToolResult<object>.Fail("BAD_INPUT", "Either 'out' or 'installTo' is required.");
+
+        try
+        {
+            var res = D365FO.Core.Scaffolding.ScaffoldFileWriter.Write(xml, path!, overwrite);
+            return ToolResult<object>.Success(new
+            {
+                kind,
+                name,
+                path = res.Path,
+                bytes = res.Bytes,
+                backup = res.BackupPath,
+                model = installTo,
+                extra,
+            });
+        }
+        catch (Exception ex)
+        {
+            return ToolResult<object>.Fail(D365FoErrorCodes.WriteFailed, ex.Message);
+        }
+    }
+
+    private static D365FO.Core.Scaffolding.TableFieldSpec ParseTableField(string raw)
+    {
+        var parts = raw.Split(':', StringSplitOptions.TrimEntries);
+        var fname = parts.Length > 0 ? parts[0] : "";
+        var edt   = parts.Length > 1 && !string.IsNullOrWhiteSpace(parts[1]) ? parts[1] : null;
+        var mand  = parts.Length > 2 && string.Equals(parts[2], "mandatory", StringComparison.OrdinalIgnoreCase);
+        return new D365FO.Core.Scaffolding.TableFieldSpec(fname, edt, null, mand);
+    }
+
+    public ToolResult<object> GenerateTable(
+        string name, string? label, string[]? fields, string? pattern,
+        string? installTo, string? outPath, bool overwrite)
+    {
+        if (string.IsNullOrWhiteSpace(name))
+            return ToolResult<object>.Fail("BAD_INPUT", "name is required.");
+
+        if (!D365FO.Core.Scaffolding.TablePatternNormalizer.TryNormalize(pattern, out var pat, out var perr))
+            return ToolResult<object>.Fail("BAD_INPUT", perr!);
+
+        var fieldSpecs = (fields ?? Array.Empty<string>()).Select(ParseTableField).ToList();
+
+        // Guardrail: warn if table already exists in index.
+        var warnings = new List<string>();
+        try
+        {
+            var existing = _repo.GetTableDetails(name);
+            if (existing is not null)
+                warnings.Add($"Table '{name}' already exists in the index (model: {existing.Table.Model}). Use overwrite=true to replace.");
+        }
+        catch { /* index may not contain the table — not fatal */ }
+
+        var doc = D365FO.Core.Scaffolding.XppScaffolder.Table(name, label, fieldSpecs, pat,
+            D365FO.Core.Scaffolding.TableStorage.RegularTable, null);
+        var extra = new { fieldCount = fieldSpecs.Count > 0 ? fieldSpecs.Count : (int?)null, pattern = pat == D365FO.Core.Scaffolding.TablePattern.None ? null : pat.ToString() };
+        return WriteScaffold(doc, name, "AxTable", "AxTable", installTo, outPath, overwrite, extra);
+    }
+
+    public ToolResult<object> GenerateClass(
+        string name, string? extends, bool nonFinal,
+        string? installTo, string? outPath, bool overwrite)
+    {
+        if (string.IsNullOrWhiteSpace(name))
+            return ToolResult<object>.Fail("BAD_INPUT", "name is required.");
+        var doc = D365FO.Core.Scaffolding.XppScaffolder.Class(name, extends, !nonFinal);
+        return WriteScaffold(doc, name, "AxClass", "AxClass", installTo, outPath, overwrite, new { extends });
+    }
+
+    public ToolResult<object> GenerateCoc(
+        string target, string[] methods,
+        string? installTo, string? outPath, bool overwrite)
+    {
+        if (string.IsNullOrWhiteSpace(target))
+            return ToolResult<object>.Fail("BAD_INPUT", "target is required.");
+        if (methods is null || methods.Length == 0)
+            return ToolResult<object>.Fail("BAD_INPUT", "At least one method is required.");
+
+        // Guardrail: warn if CoC wrappers already exist.
+        var warnings = new List<string>();
+        try
+        {
+            var existing = _repo.FindCocExtensions(target);
+            if (existing.Count > 0)
+                warnings.Add($"There are already {existing.Count} CoC extension(s) of '{target}'. Consider extending an existing one instead.");
+        }
+        catch { /* not fatal */ }
+
+        var extensionName = target + "_Extension";
+        var doc = D365FO.Core.Scaffolding.XppScaffolder.CocExtension(target, methods);
+        var result = WriteScaffold(doc, extensionName, "AxClass", "AxClass", installTo, outPath, overwrite,
+            new { target, methodCount = methods.Length });
+
+        // Attach warnings to a successful result envelope.
+        if (warnings.Count > 0 && result.Ok)
+        {
+            return ToolResult<object>.Success(new
+            {
+                kind = "AxClass",
+                name = extensionName,
+                target,
+                methodCount = methods.Length,
+                model = installTo,
+                warnings,
+            });
+        }
+        return result;
+    }
+
+    public ToolResult<object> GenerateForm(
+        string name, string? table, string? pattern, string? caption,
+        string[]? fields, string? linesTable,
+        string? installTo, string? outPath, bool overwrite)
+    {
+        if (string.IsNullOrWhiteSpace(name))
+            return ToolResult<object>.Fail("BAD_INPUT", "name is required.");
+
+        var fp = D365FO.Core.Scaffolding.FormPatternNormalizer.Normalize(pattern);
+
+        var xml = D365FO.Core.Scaffolding.XppScaffolder.Form(
+            name, table, fp, caption,
+            fields ?? Array.Empty<string>(),
+            Array.Empty<D365FO.Core.Scaffolding.FormSectionSpec>(), linesTable);
+
+        return WriteScaffoldString(xml, name, "AxForm", "AxForm", installTo, outPath, overwrite,
+            new { table, pattern = fp.ToString() });
     }
 }


### PR DESCRIPTION
… VS docs

- D365FO.Mcp: add generate_table, generate_class, generate_coc, generate_form handlers that write scaffolded AOT XML directly to disk via ScaffoldFileWriter. Accepts installTo (model name, path resolved from D365FO_PACKAGES_PATH) or out (explicit path). CoC warns if existing extension found; table warns if name already in index. These tools serve environments without a shell tool (Path C).

- docs/SETUP.md: rewrite 'How Copilot works' section — agent mode via terminal tool is the primary path for both VS 2022/2026 and VS Code; chat mode is the fallback. Adds agent mode example session. Fixes troubleshooting row that incorrectly pointed users to VS Code as the only agent-capable IDE.

- .github/copilot-instructions.md: restore correct primary/secondary/fallback hierarchy (CLI via terminal tool first, chat mode fallback); fix fallback section condition from 'no MCP tools' to 'no agent tools'.

Closes #41