### PR TITLE
fix: add --install-to support for label create to fix path resolution…

### DIFF
--- a/src/D365FO.Cli/Commands/Label/LabelWriteCommands.cs
+++ b/src/D365FO.Cli/Commands/Label/LabelWriteCommands.cs
@@ -19,8 +19,20 @@ public sealed class LabelCreateCommand : Command<LabelCreateCommand.Settings>
         public string Value { get; init; } = "";
 
         [CommandOption("--file <PATH>")]
-        [System.ComponentModel.Description("Target <Name>.<lang>.label.txt file. Created if missing.")]
+        [System.ComponentModel.Description("Target <Name>.<lang>.label.txt file (absolute path). Created if missing. Required unless --install-to is used.")]
         public string? File { get; init; }
+
+        [CommandOption("--install-to <MODEL>")]
+        [System.ComponentModel.Description("Model name. Auto-resolves the label file path to <PackagesPath>/<MODEL>/<MODEL>/AxLabelFile/LabelResources/<lang>/<MODEL>.<lang>.label.txt. Requires D365FO_PACKAGES_PATH.")]
+        public string? InstallTo { get; init; }
+
+        [CommandOption("--lang <LANG>")]
+        [System.ComponentModel.Description("Language code for --install-to path resolution (default: en-us).")]
+        public string? Lang { get; init; }
+
+        [CommandOption("--label-file <NAME>")]
+        [System.ComponentModel.Description("Label file name (without extension) used with --install-to (default: model name).")]
+        public string? LabelFile { get; init; }
 
         [CommandOption("--overwrite")]
         [System.ComponentModel.Description("Replace an existing value. Default: fail with KEY_EXISTS.")]
@@ -32,12 +44,36 @@ public sealed class LabelCreateCommand : Command<LabelCreateCommand.Settings>
         var kind = OutputMode.Resolve(settings.Output);
         if (string.IsNullOrWhiteSpace(settings.Key))
             return RenderHelpers.Render(kind, ToolResult<object>.Fail(D365FoErrorCodes.BadInput, "Label key required."));
-        if (string.IsNullOrWhiteSpace(settings.File))
-            return RenderHelpers.Render(kind, ToolResult<object>.Fail(D365FoErrorCodes.BadInput, "--file <PATH> required."));
+
+        var hasFile    = !string.IsNullOrWhiteSpace(settings.File);
+        var hasInstall = !string.IsNullOrWhiteSpace(settings.InstallTo);
+
+        if (!hasFile && !hasInstall)
+            return RenderHelpers.Render(kind, ToolResult<object>.Fail(D365FoErrorCodes.BadInput,
+                "--file <PATH> or --install-to <MODEL> is required.",
+                hint: "Use --file for an explicit absolute path, or --install-to <MODEL> to resolve the path automatically from D365FO_PACKAGES_PATH."));
+
+        string resolvedFile;
+        if (hasFile)
+        {
+            resolvedFile = settings.File!;
+        }
+        else
+        {
+            var cfg = D365FoSettings.FromEnvironment();
+            if (string.IsNullOrEmpty(cfg.PackagesPath))
+                return RenderHelpers.Render(kind, ToolResult<object>.Fail("INSTALL_FAILED",
+                    $"Cannot resolve label file path for model '{settings.InstallTo}': D365FO_PACKAGES_PATH is not set.",
+                    hint: "Set D365FO_PACKAGES_PATH to your PackagesLocalDirectory, or use --file with an absolute path."));
+
+            var lang = string.IsNullOrWhiteSpace(settings.Lang) ? "en-us" : settings.Lang!;
+            var lf   = string.IsNullOrWhiteSpace(settings.LabelFile) ? settings.InstallTo! : settings.LabelFile!;
+            resolvedFile = System.IO.Path.Combine(cfg.PackagesPath!, settings.InstallTo!, settings.InstallTo!, "AxLabelFile", "LabelResources", lang, $"{lf}.{lang}.label.txt");
+        }
 
         try
         {
-            var res = LabelFileWriter.CreateOrUpdate(settings.File!, settings.Key, settings.Value, settings.Overwrite);
+            var res = LabelFileWriter.CreateOrUpdate(resolvedFile, settings.Key, settings.Value, settings.Overwrite);
             if (res.Outcome == WriteOutcome.KeyExists)
                 return RenderHelpers.Render(kind, ToolResult<object>.Fail(
                     "KEY_EXISTS",

--- a/src/D365FO.Mcp/ToolCatalog.cs
+++ b/src/D365FO.Mcp/ToolCatalog.cs
@@ -290,9 +290,11 @@ public static class ToolCatalog
             (h, p) => h.Lint(StrArray(p, "categories"), Bool(p, "onlyCustomModels", true))),
 
         new Descriptor("create_label",
-            "Create or update a key=value entry in a *.label.txt file. Fails with KEY_EXISTS unless overwrite=true.",
-            Schema(("file", "string", true), ("key", "string", true), ("value", "string", true), ("overwrite", "boolean", false)),
-            (h, p) => h.CreateLabel(Str(p, "file"), Str(p, "key"), Str(p, "value"), Bool(p, "overwrite"))),
+            "Create or update a key=value entry in a *.label.txt file. Supply either 'file' (absolute path to the .label.txt) or 'installTo' (model name — auto-resolves <PackagesPath>/<model>/<model>/AxLabelFile/LabelResources/<lang>/<model>.<lang>.label.txt from D365FO_PACKAGES_PATH). Fails with KEY_EXISTS unless overwrite=true.",
+            Schema(("file", "string", false), ("key", "string", true), ("value", "string", true), ("overwrite", "boolean", false),
+                   ("installTo", "string", false), ("lang", "string", false), ("labelFile", "string", false)),
+            (h, p) => h.CreateLabel(StrOrNull(p, "file"), Str(p, "key"), Str(p, "value"), Bool(p, "overwrite"),
+                StrOrNull(p, "installTo"), StrOrNull(p, "lang"), StrOrNull(p, "labelFile"))),
 
         new Descriptor("rename_label",
             "Rename a label key in place, preserving its value.",

--- a/src/D365FO.Mcp/ToolHandlers.cs
+++ b/src/D365FO.Mcp/ToolHandlers.cs
@@ -475,13 +475,26 @@ public sealed class ToolHandlers
 
     // ---- label write-ops (ROADMAP §4.2) ----
 
-    public ToolResult<object> CreateLabel(string file, string key, string value, bool overwrite = false)
+    public ToolResult<object> CreateLabel(string? file, string key, string value, bool overwrite = false, string? installTo = null, string? lang = null, string? labelFile = null)
     {
-        if (string.IsNullOrWhiteSpace(file)) return ToolResult<object>.Fail(D365FoErrorCodes.BadInput, "file required");
+        var resolvedFile = file;
+        if (string.IsNullOrWhiteSpace(resolvedFile) && !string.IsNullOrWhiteSpace(installTo))
+        {
+            var resolvedLang = string.IsNullOrWhiteSpace(lang) ? "en-us" : lang!;
+            resolvedFile = ResolveLabelPath(installTo!, resolvedLang, labelFile);
+            if (resolvedFile is null)
+                return ToolResult<object>.Fail("INSTALL_FAILED",
+                    $"Cannot resolve label file path for model '{installTo}': D365FO_PACKAGES_PATH is not set.",
+                    "Set D365FO_PACKAGES_PATH before using installTo.");
+        }
+        if (string.IsNullOrWhiteSpace(resolvedFile))
+            return ToolResult<object>.Fail(D365FoErrorCodes.BadInput,
+                "Either 'file' (absolute path to the .label.txt) or 'installTo' (model name) is required.",
+                "Use 'file' for an explicit path, or 'installTo' to resolve the path automatically from D365FO_PACKAGES_PATH.");
         if (string.IsNullOrWhiteSpace(key)) return ToolResult<object>.Fail(D365FoErrorCodes.BadInput, "key required");
         try
         {
-            var res = D365FO.Core.Labels.LabelFileWriter.CreateOrUpdate(file, key, value, overwrite);
+            var res = D365FO.Core.Labels.LabelFileWriter.CreateOrUpdate(resolvedFile!, key, value, overwrite);
             if (res.Outcome == D365FO.Core.Labels.WriteOutcome.KeyExists)
                 return ToolResult<object>.Fail("KEY_EXISTS",
                     $"Label '{key}' already exists; pass overwrite=true to replace.",
@@ -782,6 +795,19 @@ public sealed class ToolHandlers
         var cfg = D365FoSettings.FromEnvironment();
         if (string.IsNullOrEmpty(cfg.PackagesPath)) return null;
         return Path.Combine(cfg.PackagesPath, model, model, axSubfolder, name + ".xml");
+    }
+
+    /// <summary>
+    /// Resolve the canonical label file path:
+    /// <c>&lt;PackagesPath&gt;/&lt;model&gt;/&lt;model&gt;/AxLabelFile/LabelResources/&lt;lang&gt;/&lt;labelFile&gt;.&lt;lang&gt;.label.txt</c>.
+    /// Returns <c>null</c> when <c>D365FO_PACKAGES_PATH</c> is not set.
+    /// </summary>
+    private static string? ResolveLabelPath(string model, string lang, string? labelFile)
+    {
+        var cfg = D365FoSettings.FromEnvironment();
+        if (string.IsNullOrEmpty(cfg.PackagesPath)) return null;
+        var lf = string.IsNullOrWhiteSpace(labelFile) ? model : labelFile!;
+        return Path.Combine(cfg.PackagesPath, model, model, "AxLabelFile", "LabelResources", lang, $"{lf}.{lang}.label.txt");
     }
 
     private static ToolResult<object> WriteScaffold(


### PR DESCRIPTION
… (fixes #52)

- LabelCreateCommand: add --install-to <MODEL>, --lang, --label-file options so the label file path can be auto-resolved from D365FO_PACKAGES_PATH without requiring users (or AI) to supply the full absolute path. Resolves to: <PackagesPath>/<model>/<model>/AxLabelFile/LabelResources/<lang>/<model>.<lang>.label.txt
- ToolHandlers.CreateLabel: add installTo, lang, labelFile params and ResolveLabelPath() helper (mirrors ResolveAotPath() for XML scaffolds)
- ToolCatalog create_label: make 'file' optional, add installTo/lang/labelFile schema entries so the MCP tool can use auto-resolved paths
- Improves error messages: BAD_INPUT hint explains both options; INSTALL_FAILED tells user to set D365FO_PACKAGES_PATH