### PR TITLE
feat: support multiple PackagesLocalDirectory roots for UDE setups (#49)

### DIFF
--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -138,7 +138,8 @@ Use `--category <name>[,<name>…]` to run specific rules. `--format sarif` emit
 
 | Variable | Purpose |
 |---|---|
-| `D365FO_PACKAGES_PATH` | Live `PackagesLocalDirectory` |
+| `D365FO_PACKAGES_PATH` | Primary `PackagesLocalDirectory` root |
+| `D365FO_EXTRA_PACKAGES_PATH` | Additional roots (semicolon/comma-separated). Used for UDE dual-folder setups — see [SETUP.md](SETUP.md#ude-unified-developer-experience-setup). |
 | `D365FO_BIN_PATH` | D365FO binaries directory (resolves metadata assemblies) |
 | `D365FO_BRIDGE_ENABLED` | `1`/`true` enables bridge-primary reads |
 | `D365FO_BRIDGE_PATH` | Override bridge exe location |

--- a/docs/SETUP.md
+++ b/docs/SETUP.md
@@ -62,11 +62,55 @@ Three variables matter before you run `index extract`. Set them in your shell pr
 
 | Variable | Purpose | Notes |
 |---|---|---|
-| `D365FO_PACKAGES_PATH` | Root of `PackagesLocalDirectory` | **Required** for indexing |
+| `D365FO_PACKAGES_PATH` | Primary root of `PackagesLocalDirectory` | **Required** for indexing |
+| `D365FO_EXTRA_PACKAGES_PATH` | Additional `PackagesLocalDirectory` root(s) | Optional. Semicolon- or comma-separated. UDE setups typically need this — see [UDE setup](#ude-unified-developer-experience-setup) below. |
 | `D365FO_LABEL_LANGUAGES` | Languages to extract (e.g. `en-us,cs`) | Default: `en-us` only. **Directly controls index size** — each extra language adds significant data. Set this before the first extract. |
 | `D365FO_INDEX_DB` | Path to the SQLite index | Defaults to `%LOCALAPPDATA%\d365fo-cli\d365fo-index.sqlite` (`~/.local/share/…` on Linux/macOS) |
 
 All other variables (`D365FO_CUSTOM_MODELS`, `D365FO_BRIDGE_*`, `D365FO_WORKSPACE_PATH`, `D365FO_XREF_CONNECTIONSTRING`) are optional — see [ARCHITECTURE.md](ARCHITECTURE.md) for details.
+
+### UDE (Unified Developer Experience) setup
+
+The UDE developer topology provides **two separate `PackagesLocalDirectory` folders**:
+
+| Folder | Contents |
+|---|---|
+| Shared / UDE drive (e.g. `K:\AosService\PackagesLocalDirectory`) | Standard Microsoft metadata (ApplicationSuite, Foundation, …) |
+| Local laptop folder (e.g. `C:\LocalMetadata\PackagesLocalDirectory`) | Your custom model XML (edited in VS 2022 locally) |
+
+Visual Studio merges both transparently, but `d365fo-cli` needs to know about both to build a complete index.
+
+**PowerShell (one session):**
+
+```powershell
+$env:D365FO_PACKAGES_PATH         = 'K:\AosService\PackagesLocalDirectory'
+$env:D365FO_EXTRA_PACKAGES_PATH   = 'C:\LocalMetadata\PackagesLocalDirectory'
+d365fo index extract
+```
+
+**Persist in `$PROFILE`:**
+
+```powershell
+Add-Content -Path $PROFILE -Value @"
+
+# d365fo-cli — UDE dual-packages config
+`$env:D365FO_PACKAGES_PATH         = 'K:\AosService\PackagesLocalDirectory'
+`$env:D365FO_EXTRA_PACKAGES_PATH   = 'C:\LocalMetadata\PackagesLocalDirectory'
+"@
+. $PROFILE
+```
+
+**CLI flags (one-shot, no env vars):**
+
+```powershell
+d365fo index extract `
+    --packages       K:\AosService\PackagesLocalDirectory `
+    --extra-packages C:\LocalMetadata\PackagesLocalDirectory
+```
+
+> `--extra-packages` is repeatable. Multiple extra roots can also be given as a single semicolon-separated string in `D365FO_EXTRA_PACKAGES_PATH`. Missing extra roots are silently skipped (the primary root still produces an error if absent). Duplicate model directories across roots are deduplicated automatically.
+
+`d365fo index refresh` supports the same `--extra-packages` / `D365FO_EXTRA_PACKAGES_PATH` mechanism.
 
 ### Step 2 — Build and populate the index
 

--- a/docs/TROUBLESHOOTING.md
+++ b/docs/TROUBLESHOOTING.md
@@ -14,7 +14,27 @@ The `D365FO_PACKAGES_PATH` environment variable (or `--packages <PATH>`) must po
 | Local Hyper-V devbox | `C:\AOSService\PackagesLocalDirectory` |
 | Azure Files share (mounted) | `Z:\PackagesLocalDirectory` (drive letter varies) |
 | Docker container | `/mnt/packages` (depends on volume mount) |
+| UDE (primary — shared drive) | `K:\AosService\PackagesLocalDirectory` |
+| UDE (extra — local laptop) | `C:\LocalMetadata\PackagesLocalDirectory` — set in `D365FO_EXTRA_PACKAGES_PATH` |
 | Custom override | Set `D365FO_PACKAGES_PATH` to any absolute path |
+
+### UDE — two separate `PackagesLocalDirectory` folders
+
+UDE setups split standard Microsoft metadata (on a shared drive) from your custom model XML (on the local laptop). The CLI supports this via `D365FO_EXTRA_PACKAGES_PATH` or `--extra-packages`:
+
+```powershell
+# Environment variables (persist in $PROFILE)
+$env:D365FO_PACKAGES_PATH         = 'K:\AosService\PackagesLocalDirectory'
+$env:D365FO_EXTRA_PACKAGES_PATH   = 'C:\LocalMetadata\PackagesLocalDirectory'
+d365fo index extract
+
+# — or — one-shot CLI flags
+d365fo index extract `
+    --packages       K:\AosService\PackagesLocalDirectory `
+    --extra-packages C:\LocalMetadata\PackagesLocalDirectory
+```
+
+`D365FO_EXTRA_PACKAGES_PATH` accepts semicolon- or comma-separated paths. Extra roots that don't exist are silently skipped. See [SETUP.md — UDE setup](SETUP.md#ude-unified-developer-experience-setup) for the full walkthrough.
 
 ```sh
 # PowerShell — set for the current session

--- a/src/D365FO.Cli/Commands/Index/IndexCommands.cs
+++ b/src/D365FO.Cli/Commands/Index/IndexCommands.cs
@@ -108,16 +108,25 @@ public sealed class IndexExtractCommand : Command<IndexExtractCommand.Settings>
         [CommandOption("--parallelism <N>")]
         [System.ComponentModel.Description("Number of models to parse in parallel. Defaults to half the CPU core count. SQLite writes are always serialized.")]
         public int? Parallelism { get; init; }
+
+        [CommandOption("--extra-packages <PATH>")]
+        [System.ComponentModel.Description("Additional PackagesLocalDirectory root(s) to include alongside --packages. Repeatable. Also reads D365FO_EXTRA_PACKAGES_PATH (semicolon/comma-separated). Supports UDE setups with two separate metadata folders.")]
+        public string[]? ExtraPackagesPaths { get; init; }
     }
 
     public override int Execute(CommandContext ctx, Settings settings)
-        => ExtractCore(
+    {
+        var cfg = D365FoSettings.FromEnvironment(settings.DatabasePath);
+        var extraPaths = MergeExtraPaths(settings.ExtraPackagesPaths, cfg.ExtraPackagesPaths);
+        return ExtractCore(
             OutputMode.Resolve(settings.Output),
             settings.PackagesPath,
             settings.DatabasePath,
             settings.OnlyModel,
             settings.Since,
+            extraPackagesPaths: extraPaths,
             parallelism: settings.Parallelism);
+    }
 
     internal static int ExtractCore(
         OutputMode.Kind kind,
@@ -126,7 +135,8 @@ public sealed class IndexExtractCommand : Command<IndexExtractCommand.Settings>
         string? onlyModel,
         string? sinceIso,
         IReadOnlyDictionary<string, string?>? fingerprintsByModel = null,
-        int? parallelism = null)
+        int? parallelism = null,
+        IReadOnlyList<string>? extraPackagesPaths = null)
     {
         var cfg = D365FoSettings.FromEnvironment(databaseOverride);
         var root = packagesOverride ?? cfg.PackagesPath;
@@ -174,7 +184,22 @@ public sealed class IndexExtractCommand : Command<IndexExtractCommand.Settings>
         // Pre-enumerate candidate model folders so we can report progress
         // *before* each model is parsed (useful when a single model like
         // ApplicationSuite takes many minutes).
+        // For UDE setups (two separate PackagesLocalDirectory folders), callers
+        // can pass extra roots via --extra-packages / D365FO_EXTRA_PACKAGES_PATH.
         var modelDirs = EnumerateModelDirs(root, onlyModel).ToList();
+        var validExtraRoots = new List<string>();
+        foreach (var extra in extraPackagesPaths ?? Array.Empty<string>())
+        {
+            if (string.IsNullOrWhiteSpace(extra)) continue;
+            if (!Directory.Exists(extra)) continue; // silently skip missing extra roots
+            validExtraRoots.Add(extra);
+            modelDirs.AddRange(EnumerateModelDirs(extra, onlyModel));
+        }
+        // Deduplicate: same model dir from overlapping roots should only extract once.
+        modelDirs = modelDirs
+            .GroupBy(d => d, StringComparer.OrdinalIgnoreCase)
+            .Select(g => g.First())
+            .ToList();
         var showProgress = kind != OutputMode.Kind.Json && !System.Console.IsOutputRedirected;
 
         // Per-model fingerprint-based skip list for refresh (§1.1). Callers
@@ -315,6 +340,7 @@ public sealed class IndexExtractCommand : Command<IndexExtractCommand.Settings>
         return RenderHelpers.Render(kind, ToolResult<object>.Success(new
         {
             packagesRoot = root,
+            extraPackagesRoots = validExtraRoots.Count > 0 ? validExtraRoots : null,
             modelsProcessed = modelCount,
             modelsSkipped = skippedCount,
             since = since?.ToString("O"),
@@ -385,8 +411,21 @@ public sealed class IndexExtractCommand : Command<IndexExtractCommand.Settings>
         return $"{count}:{newestTicks}:{langs}";
     }
 
-    private static IEnumerable<string> EnumerateModelDirs(string packagesRoot, string? onlyModel)
+    /// <summary>
+    /// Merges CLI-specified extra packages paths with those from the environment.
+    /// Returns null if the combined list is empty (to avoid allocations in the common case).
+    /// </summary>
+    internal static IReadOnlyList<string>? MergeExtraPaths(string[]? cliPaths, IReadOnlyList<string> envPaths)
     {
+        var all = (cliPaths ?? Array.Empty<string>())
+            .Concat(envPaths)
+            .Where(p => !string.IsNullOrWhiteSpace(p))
+            .Distinct(StringComparer.OrdinalIgnoreCase)
+            .ToList();
+        return all.Count > 0 ? all : null;
+    }
+
+    private static IEnumerable<string> EnumerateModelDirs(string packagesRoot, string? onlyModel)    {
         IEnumerable<string> SafeDirs(string d)
         {
             try { return Directory.EnumerateDirectories(d); }
@@ -454,6 +493,10 @@ public sealed class IndexRefreshCommand : Command<IndexRefreshCommand.Settings>
         [CommandOption("--parallelism <N>")]
         [System.ComponentModel.Description("Number of models to parse in parallel. Defaults to half the CPU core count.")]
         public int? Parallelism { get; init; }
+
+        [CommandOption("--extra-packages <PATH>")]
+        [System.ComponentModel.Description("Additional PackagesLocalDirectory root(s). Repeatable. Also reads D365FO_EXTRA_PACKAGES_PATH.")]
+        public string[]? ExtraPackagesPaths { get; init; }
     }
 
     public override int Execute(CommandContext ctx, Settings settings)
@@ -484,6 +527,8 @@ public sealed class IndexRefreshCommand : Command<IndexRefreshCommand.Settings>
                 }
             }
         }
+        var cfg2 = D365FoSettings.FromEnvironment(settings.DatabasePath);
+        var extraPaths = IndexExtractCommand.MergeExtraPaths(settings.ExtraPackagesPaths, cfg2.ExtraPackagesPaths);
         return IndexExtractCommand.ExtractCore(
             OutputMode.Resolve(settings.Output),
             settings.PackagesPath,
@@ -491,7 +536,8 @@ public sealed class IndexRefreshCommand : Command<IndexRefreshCommand.Settings>
             settings.OnlyModel,
             since,
             fingerprints,
-            parallelism: settings.Parallelism);
+            parallelism: settings.Parallelism,
+            extraPackagesPaths: extraPaths);
     }
 }
 

--- a/src/D365FO.Core/D365FoSettings.cs
+++ b/src/D365FO.Core/D365FoSettings.cs
@@ -10,7 +10,8 @@ public sealed record D365FoSettings(
     string? WorkspacePath,
     string DatabasePath,
     IReadOnlyList<string> CustomModels,
-    IReadOnlyList<string> LabelLanguages)
+    IReadOnlyList<string> LabelLanguages,
+    IReadOnlyList<string> ExtraPackagesPaths)
 {
     public const string DefaultDatabaseFile = "d365fo-index.sqlite";
 
@@ -33,7 +34,8 @@ public sealed record D365FoSettings(
             WorkspacePath: NullIfEmpty(Env("D365FO_WORKSPACE_PATH")),
             DatabasePath: db,
             CustomModels: models,
-            LabelLanguages: langs);
+            LabelLanguages: langs,
+            ExtraPackagesPaths: Split(Env("D365FO_EXTRA_PACKAGES_PATH")));
     }
 
     private static string? NullIfEmpty(string s) => string.IsNullOrWhiteSpace(s) ? null : s;

--- a/tests/D365FO.Cli.Tests/ScaffoldingSnapshotTests.cs
+++ b/tests/D365FO.Cli.Tests/ScaffoldingSnapshotTests.cs
@@ -32,7 +32,7 @@ public class ScaffoldingSnapshotTests
         Assert.Equal("AxClass", root.Name.LocalName);
         Assert.Equal("SysOperationServiceBase", root.Element("Extends")!.Value);
         var methods = root.Element("SourceCode")!.Element("Methods")!.Elements("Method").ToList();
-        Assert.True(methods.Any(m => m.Element("Source")!.Value.Contains("[SysEntryPointAttribute")));
+        Assert.Contains(methods, m => m.Element("Source")!.Value.Contains("[SysEntryPointAttribute"));
     }
 
     [Fact]


### PR DESCRIPTION
Add --extra-packages CLI option and D365FO_EXTRA_PACKAGES_PATH env var to d365fo index extract and d365fo index refresh. Both accept one or more additional PackagesLocalDirectory roots alongside the primary --packages / D365FO_PACKAGES_PATH.

UDE (Unified Developer Experience) setups provide two separate folders:
  - one shared drive with standard Microsoft metadata
  - one local folder with custom model XML

Previously d365fo-cli could only index one at a time. With this change users can index both in a single pass:

  d365fo index extract \
      --packages C:\AosService\PackagesLocalDirectory \
      --extra-packages C:\LocalMetadata\PackagesLocalDirectory

Or via environment variables:
  \    = 'C:\AosService\PackagesLocalDirectory'
  \ = 'C:\LocalMetadata\PackagesLocalDirectory'
  d365fo index extract

Multiple extra roots can be provided comma- or semicolon-separated in D365FO_EXTRA_PACKAGES_PATH, or by repeating --extra-packages on the CLI. Missing extra roots are silently skipped (primary root still errors). Duplicate model dirs across roots are deduplicated (first occurrence wins).

The JSON output gains an extraPackagesRoots array field (null when not used) for tooling inspection.