### PR TITLE
fix: expose extraPackagesPaths in index build and status output (#58)

### DIFF
--- a/src/D365FO.Cli/Commands/Index/IndexCommands.cs
+++ b/src/D365FO.Cli/Commands/Index/IndexCommands.cs
@@ -23,15 +23,19 @@ public sealed class IndexBuildCommand : Command<IndexBuildCommand.Settings>
         var repo = new MetadataRepository(cfg.DatabasePath);
         var applied = repo.EnsureSchema();
 
+        var extraNote = cfg.ExtraPackagesPaths.Count > 0
+            ? $" Extra roots ({cfg.ExtraPackagesPaths.Count}): {string.Join("; ", cfg.ExtraPackagesPaths)}."
+            : string.Empty;
         var result = ToolResult<object>.Success(new
         {
             databasePath = cfg.DatabasePath,
             packagesPath = cfg.PackagesPath,
+            extraPackagesPaths = cfg.ExtraPackagesPaths.Count > 0 ? cfg.ExtraPackagesPaths : null,
             schemaVersion = MetadataRepository.CurrentSchemaVersion,
             schemaApplied = applied,
             note = applied
-                ? $"Schema v{MetadataRepository.CurrentSchemaVersion} applied. Run 'd365fo index extract' to ingest metadata from PACKAGES_PATH."
-                : $"Schema already at v{MetadataRepository.CurrentSchemaVersion}. Run 'd365fo index extract' to ingest metadata from PACKAGES_PATH.",
+                ? $"Schema v{MetadataRepository.CurrentSchemaVersion} applied. Run 'd365fo index extract' to ingest metadata from PACKAGES_PATH.{extraNote}"
+                : $"Schema already at v{MetadataRepository.CurrentSchemaVersion}. Run 'd365fo index extract' to ingest metadata from PACKAGES_PATH.{extraNote}",
         });
 
         return RenderHelpers.Render(kind, result, _ =>
@@ -77,6 +81,7 @@ public sealed class IndexStatusCommand : Command<IndexStatusCommand.Settings>
             exists,
             sizeBytes,
             packagesPath = cfg.PackagesPath,
+            extraPackagesPaths = cfg.ExtraPackagesPaths.Count > 0 ? cfg.ExtraPackagesPaths : null,
             workspacePath = cfg.WorkspacePath,
             customModels = cfg.CustomModels,
             labelLanguages = cfg.LabelLanguages,


### PR DESCRIPTION
IndexBuildCommand and IndexStatusCommand did not include extraPackagesPaths in their JSON output, causing UDE users to believe D365FO_EXTRA_PACKAGES_PATH was being ignored.

- IndexBuildCommand: add extraPackagesPaths field; extend note text with extra-root count and paths when the env var is set
- IndexStatusCommand: add extraPackagesPaths field (null when not configured, list when set) so 'd365fo index status --output json' acts as a full config health-check

The actual extraction logic (IndexExtractCommand / IndexRefreshCommand) was already correct -- this is a pure observability fix.

Fixes #58, refs #59