### PR TITLE
fix(init): resolve Developer PowerShell settings discrepancy (#62)

### DIFF
--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -1,0 +1,77 @@
+# Configuration
+
+`d365fo` resolves settings in the following priority order — first match wins:
+
+1. **Explicit CLI flags** (`--packages`, `--db`, …) — highest priority
+2. **Process environment variables** (`D365FO_PACKAGES_PATH`, …)
+3. **JSON config file** (`%LOCALAPPDATA%\d365fo-cli\settings.json` on Windows, `~/.local/share/d365fo-cli/settings.json` on Linux/macOS)
+4. **Built-in defaults** (e.g. `en-us` language, default SQLite path)
+
+---
+
+## Environment variables
+
+| Variable | Purpose | Default |
+|---|---|---|
+| `D365FO_PACKAGES_PATH` | Primary `PackagesLocalDirectory` root | *(required for indexing)* |
+| `D365FO_EXTRA_PACKAGES_PATH` | Additional `PackagesLocalDirectory` roots (semicolon/comma separated) | — |
+| `D365FO_LABEL_LANGUAGES` | Label languages to extract, e.g. `en-us,cs,de` | `en-us` |
+| `D365FO_INDEX_DB` | Path to the SQLite index file | `%LOCALAPPDATA%\d365fo-cli\d365fo-index.sqlite` |
+| `D365FO_WORKSPACE_PATH` | Root of your X++ solution (enables scaffold output) | — |
+| `D365FO_CUSTOM_MODELS` | Comma-separated list of custom model names | — |
+| `D365FO_BRIDGE_*` | Bridge server connection settings (see ARCHITECTURE.md) | — |
+| `D365FO_XREF_CONNECTIONSTRING` | Cross-reference DB connection string | — |
+
+---
+
+## JSON config file
+
+The JSON config file is the **recommended** way to persist settings when running `d365fo` from multiple shell hosts (Windows PowerShell 5.1, PowerShell 7, Visual Studio Developer PowerShell, CI, etc.) because it is not tied to any shell profile.
+
+### Location
+
+| OS | Default path |
+|---|---|
+| Windows | `%LOCALAPPDATA%\d365fo-cli\settings.json` |
+| Linux | `~/.local/share/d365fo-cli/settings.json` |
+| macOS | `~/Library/Application Support/d365fo-cli/settings.json` |
+
+### Format
+
+A flat JSON object mapping variable names to string values:
+
+```json
+{
+  "D365FO_PACKAGES_PATH": "K:\\AosService\\PackagesLocalDirectory",
+  "D365FO_INDEX_DB": "C:\\Users\\you\\AppData\\Local\\d365fo-cli\\d365fo-index.sqlite",
+  "D365FO_LABEL_LANGUAGES": "en-us,cs"
+}
+```
+
+### Creating / updating the file
+
+Run `d365fo init --persist-profile` — this writes (or updates) both the JSON config file and the shell profiles for all PowerShell versions found on the machine.
+
+To write the file manually, create it at the path above. Only the keys you need to override have to be present; missing keys fall back to environment variables and then built-in defaults.
+
+---
+
+## Developer PowerShell in Visual Studio
+
+VS Developer PowerShell is **Windows PowerShell 5.1** (`powershell.exe`), which reads a **different** `$PROFILE` than PowerShell 7 (`pwsh.exe`):
+
+| Shell | Profile |
+|---|---|
+| Windows PowerShell 5.1 (VS Developer PowerShell) | `%USERPROFILE%\Documents\WindowsPowerShell\Microsoft.PowerShell_profile.ps1` |
+| PowerShell 7+ (`pwsh`) | `%USERPROFILE%\Documents\PowerShell\Microsoft.PowerShell_profile.ps1` |
+
+If you only set env vars in one profile, `d365fo doctor` will report different results from the other shell. **Use the JSON config file** (via `d365fo init --persist-profile`) to avoid this.
+
+Alternatively, set variables at **machine scope** so they are inherited by every process:
+
+```powershell
+[System.Environment]::SetEnvironmentVariable(
+    "D365FO_PACKAGES_PATH",
+    "K:\AosService\PackagesLocalDirectory",
+    [System.EnvironmentVariableTarget]::Machine)
+```

--- a/docs/SETUP.md
+++ b/docs/SETUP.md
@@ -67,7 +67,35 @@ Three variables matter before you run `index extract`. Set them in your shell pr
 | `D365FO_LABEL_LANGUAGES` | Languages to extract (e.g. `en-us,cs`) | Default: `en-us` only. **Directly controls index size** — each extra language adds significant data. Set this before the first extract. |
 | `D365FO_INDEX_DB` | Path to the SQLite index | Defaults to `%LOCALAPPDATA%\d365fo-cli\d365fo-index.sqlite` (`~/.local/share/…` on Linux/macOS) |
 
-All other variables (`D365FO_CUSTOM_MODELS`, `D365FO_BRIDGE_*`, `D365FO_WORKSPACE_PATH`, `D365FO_XREF_CONNECTIONSTRING`) are optional — see [ARCHITECTURE.md](ARCHITECTURE.md) for details.
+All other variables (`D365FO_CUSTOM_MODELS`, `D365FO_BRIDGE_*`, `D365FO_WORKSPACE_PATH`, `D365FO_XREF_CONNECTIONSTRING`) are optional — see [CONFIGURATION.md](CONFIGURATION.md) for details.
+
+> **Tip — JSON config file (recommended, shell-agnostic):** `d365fo` reads settings from a JSON config file at `%LOCALAPPDATA%\d365fo-cli\settings.json` (environment variables always take priority). Running `d365fo init --persist-profile` writes this file automatically. Because it is not tied to any shell profile, it works identically in **Windows PowerShell 5.1, PowerShell 7, VS Developer PowerShell**, and any other host. See [CONFIGURATION.md](CONFIGURATION.md).
+
+#### Visual Studio Developer PowerShell — common pitfall
+
+VS Developer PowerShell is **Windows PowerShell 5.1** (`powershell.exe`), which reads a different `$PROFILE` than PowerShell 7 (`pwsh.exe`):
+
+| Shell host | Profile path |
+|---|---|
+| Windows PowerShell 5.1 / VS Developer PowerShell | `%USERPROFILE%\Documents\WindowsPowerShell\Microsoft.PowerShell_profile.ps1` |
+| PowerShell 7+ (`pwsh`) | `%USERPROFILE%\Documents\PowerShell\Microsoft.PowerShell_profile.ps1` |
+
+If you set env vars only in one profile they will not be visible in the other. The recommended fix is to use the JSON config file:
+
+```powershell
+d365fo init --packages K:\AosService\PackagesLocalDirectory --persist-profile
+```
+
+`--persist-profile` now writes **both** profile files and the shell-agnostic JSON config at the same time, so all shell hosts pick up the settings without manual duplication.
+
+Alternatively, set variables as **system-level** (machine-scope) env vars in Windows System Properties — those are inherited by every process:
+
+```powershell
+[System.Environment]::SetEnvironmentVariable(
+    "D365FO_PACKAGES_PATH",
+    "K:\AosService\PackagesLocalDirectory",
+    [System.EnvironmentVariableTarget]::Machine)
+```
 
 ### UDE (Unified Developer Experience) setup
 

--- a/src/D365FO.Cli/Commands/Ops/InitCommand.cs
+++ b/src/D365FO.Cli/Commands/Ops/InitCommand.cs
@@ -93,34 +93,59 @@ public sealed class InitCommand : Command<InitCommand.Settings>
             }
         }
 
-        string? profilePath = null;
         if (settings.PersistProfile && packages is not null)
         {
+            var vars = new Dictionary<string, string>
+            {
+                ["D365FO_PACKAGES_PATH"] = packages!,
+                ["D365FO_INDEX_DB"]      = cfg.DatabasePath,
+            };
+            if (!string.IsNullOrEmpty(workspace))
+                vars["D365FO_WORKSPACE"] = workspace;
+
+            // --- JSON config file (shell-agnostic, solves Developer PowerShell issue) ---
             try
             {
-                profilePath = ResolveProfilePath();
+                var configPath = D365FO.Core.D365FoSettings.GetDefaultConfigPath();
                 if (settings.DryRun)
                 {
-                    Log("profile.persist", true, $"Would append to {profilePath} (dry-run).");
+                    Log("config.persist", true, $"Would write {configPath} (dry-run).");
                 }
                 else
                 {
-                    var vars = new Dictionary<string, string>
-                    {
-                        ["D365FO_PACKAGES_PATH"] = packages!,
-                        ["D365FO_INDEX_DB"] = cfg.DatabasePath,
-                    };
-                    if (!string.IsNullOrEmpty(workspace))
-                        vars["D365FO_WORKSPACE"] = workspace;
-                    var added = WriteProfileBlock(profilePath, vars);
-                    Log("profile.persist", true, added
-                        ? $"Appended d365fo-cli block to {profilePath}"
-                        : $"Profile block already present in {profilePath}");
+                    D365FO.Core.D365FoSettings.SaveJsonConfig(vars);
+                    Log("config.persist", true, $"Written to {configPath}");
                 }
             }
             catch (Exception ex)
             {
-                Log("profile.persist", false, ex.Message);
+                Log("config.persist", false, ex.Message);
+            }
+
+            // --- Shell profiles (for interactive shell sessions that source $PROFILE) ---
+            // Write to all profile paths that exist or can be created so that both
+            // Windows PowerShell 5.1 (used by VS Developer PowerShell) and
+            // PowerShell 7+ pick up the env vars automatically.
+            foreach (var profilePath in ResolveAllProfilePaths())
+            {
+                try
+                {
+                    if (settings.DryRun)
+                    {
+                        Log("profile.persist", true, $"Would append to {profilePath} (dry-run).");
+                    }
+                    else
+                    {
+                        var added = WriteProfileBlock(profilePath, vars);
+                        Log("profile.persist", true, added
+                            ? $"Appended d365fo-cli block to {profilePath}"
+                            : $"Profile block already present in {profilePath}");
+                    }
+                }
+                catch (Exception ex)
+                {
+                    Log("profile.persist", false, $"{profilePath}: {ex.Message}");
+                }
             }
         }
 
@@ -170,18 +195,33 @@ public sealed class InitCommand : Command<InitCommand.Settings>
     private const string BlockBegin = "# >>> d365fo-cli init (auto-generated) >>>";
     private const string BlockEnd   = "# <<< d365fo-cli init <<<";
 
-    /// <summary>Pick the canonical shell profile for the current OS.</summary>
-    internal static string ResolveProfilePath()
+    /// <summary>
+    /// Returns all PowerShell profile paths that should receive the d365fo-cli
+    /// env-var block. On Windows this includes both the Windows PowerShell 5.1
+    /// profile (used by the VS Developer PowerShell) and the PowerShell 7+
+    /// profile so that neither shell host is left unconfigured.
+    /// </summary>
+    internal static IEnumerable<string> ResolveAllProfilePaths()
     {
         if (OperatingSystem.IsWindows())
         {
-            // PowerShell 5.1 + 7 agree on this path.
             var docs = Environment.GetFolderPath(Environment.SpecialFolder.MyDocuments);
-            return Path.Combine(docs, "PowerShell", "Microsoft.PowerShell_profile.ps1");
+            // Windows PowerShell 5.1 — used by Visual Studio Developer PowerShell
+            yield return Path.Combine(docs, "WindowsPowerShell", "Microsoft.PowerShell_profile.ps1");
+            // PowerShell 7+ (pwsh)
+            yield return Path.Combine(docs, "PowerShell", "Microsoft.PowerShell_profile.ps1");
         }
-        var home = Environment.GetEnvironmentVariable("HOME") ?? "~";
-        return Path.Combine(home, ".profile");
+        else
+        {
+            var home = Environment.GetEnvironmentVariable("HOME") ?? "~";
+            yield return Path.Combine(home, ".profile");
+        }
     }
+
+    /// <summary>Pick the canonical shell profile for the current OS.</summary>
+    [Obsolete("Use ResolveAllProfilePaths() to handle both PS5.1 (VS Developer PowerShell) and PS7+.")]
+    internal static string ResolveProfilePath()
+        => ResolveAllProfilePaths().First();
 
     /// <summary>
     /// Append (or replace) a marker-delimited block of env-var exports to the

--- a/src/D365FO.Core/D365FoSettings.cs
+++ b/src/D365FO.Core/D365FoSettings.cs
@@ -1,8 +1,11 @@
+using System.Text.Json;
+
 namespace D365FO.Core;
 
 /// <summary>
 /// Resolved runtime configuration. Values are sourced, in order:
-/// (1) explicit CLI flags, (2) process environment, (3) optional JSON profile,
+/// (1) explicit CLI flags, (2) process environment variables,
+/// (3) JSON config file at <see cref="GetDefaultConfigPath"/>,
 /// (4) built-in defaults. See docs/CONFIGURATION.md.
 /// </summary>
 public sealed record D365FoSettings(
@@ -14,10 +17,29 @@ public sealed record D365FoSettings(
     IReadOnlyList<string> ExtraPackagesPaths)
 {
     public const string DefaultDatabaseFile = "d365fo-index.sqlite";
+    public const string ConfigFileName      = "settings.json";
+
+    /// <summary>
+    /// Returns the path to the JSON config file used as a fallback when
+    /// environment variables are not set. Typically
+    /// <c>%LOCALAPPDATA%\d365fo-cli\settings.json</c> on Windows.
+    /// </summary>
+    public static string GetDefaultConfigPath() =>
+        Path.Combine(
+            Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData),
+            "d365fo-cli", ConfigFileName);
 
     public static D365FoSettings FromEnvironment(string? databaseOverride = null)
     {
-        string Env(string k) => Environment.GetEnvironmentVariable(k) ?? string.Empty;
+        // Load JSON config file as fallback; env vars always take priority.
+        var jsonConfig = LoadJsonConfig();
+
+        string Env(string k)
+        {
+            var v = Environment.GetEnvironmentVariable(k);
+            if (!string.IsNullOrWhiteSpace(v)) return v;
+            return jsonConfig.TryGetValue(k, out var jv) ? jv ?? string.Empty : string.Empty;
+        }
 
         var models = Split(Env("D365FO_CUSTOM_MODELS"));
         var langs = Split(Env("D365FO_LABEL_LANGUAGES"));
@@ -36,6 +58,42 @@ public sealed record D365FoSettings(
             CustomModels: models,
             LabelLanguages: langs,
             ExtraPackagesPaths: Split(Env("D365FO_EXTRA_PACKAGES_PATH")));
+    }
+
+    /// <summary>
+    /// Persists the supplied key/value pairs to the JSON config file,
+    /// merging with any values already present. Existing keys are overwritten;
+    /// keys absent from <paramref name="values"/> are preserved.
+    /// </summary>
+    public static void SaveJsonConfig(IReadOnlyDictionary<string, string> values)
+    {
+        var path = GetDefaultConfigPath();
+        var dir  = Path.GetDirectoryName(path);
+        if (!string.IsNullOrEmpty(dir)) Directory.CreateDirectory(dir);
+
+        var existing = LoadJsonConfig();
+        var merged   = new Dictionary<string, string>(existing, StringComparer.OrdinalIgnoreCase);
+        foreach (var (k, v) in values) merged[k] = v;
+
+        File.WriteAllText(path, JsonSerializer.Serialize(merged, D365Json.Pretty));
+    }
+
+    // ---- private helpers -----------------------------------------------------
+
+    private static Dictionary<string, string> LoadJsonConfig()
+    {
+        var path = GetDefaultConfigPath();
+        if (!File.Exists(path)) return new();
+        try
+        {
+            var json = File.ReadAllText(path);
+            return JsonSerializer.Deserialize<Dictionary<string, string>>(json, D365Json.Options)
+                   ?? new();
+        }
+        catch
+        {
+            return new();
+        }
     }
 
     private static string? NullIfEmpty(string s) => string.IsNullOrWhiteSpace(s) ? null : s;


### PR DESCRIPTION
Root causes:
- ResolveProfilePath() always targeted the PS7 profile (Documents\PowerShell\…). VS Developer PowerShell is Windows PowerShell 5.1, which reads Documents\WindowsPowerShell\… so --persist-profile silently wrote to the wrong file.
- D365FoSettings.FromEnvironment() only read env vars despite the code comment promising a JSON profile fallback.
- docs/CONFIGURATION.md was referenced but did not exist.

Changes:
- D365FoSettings: implement JSON config file fallback at %LOCALAPPDATA%\d365fo-cli\settings.json (env vars still win). Add SaveJsonConfig() and GetDefaultConfigPath() helpers.
- InitCommand: replace ResolveProfilePath() with ResolveAllProfilePaths() that yields both the PS5.1 profile (WindowsPowerShell\…) and the PS7 profile (PowerShell\…). --persist-profile now also writes the JSON config so settings are shell-agnostic by default.
- docs/SETUP.md: add "Developer PowerShell — common pitfall" section with profile path table and recommended workarounds.
- docs/CONFIGURATION.md: new file documenting env vars, JSON config format, and the Developer PowerShell profile difference.

Fixes #62