### PR TITLE
fix(init): persist extra packages in profile/json config

### DIFF
--- a/docs/SETUP.md
+++ b/docs/SETUP.md
@@ -86,6 +86,12 @@ If you set env vars only in one profile they will not be visible in the other. T
 d365fo init --packages K:\AosService\PackagesLocalDirectory --persist-profile
 ```
 
+If you use UDE dual roots, include extra packages during init so `D365FO_EXTRA_PACKAGES_PATH` is persisted too:
+
+```powershell
+d365fo init --packages K:\AosService\PackagesLocalDirectory --extra-packages C:\LocalMetadata\PackagesLocalDirectory --persist-profile
+```
+
 `--persist-profile` now writes **both** profile files and the shell-agnostic JSON config at the same time, so all shell hosts pick up the settings without manual duplication.
 
 Alternatively, set variables as **system-level** (machine-scope) env vars in Windows System Properties — those are inherited by every process:

--- a/src/D365FO.Cli/Commands/Agent/SchemaCommand.cs
+++ b/src/D365FO.Cli/Commands/Agent/SchemaCommand.cs
@@ -190,7 +190,7 @@ public sealed class SchemaCommand : Command<SchemaCommand.Settings>
         C("daemon stop", "Stop daemon.", [], [], []),
         C("daemon status", "Report daemon status.", [], [], []),
         C("doctor", "Diagnose environment.", [], ["--output"], []),
-        C("init", "Quickstart index/profile setup.", [], ["--packages", "--db", "--run-extract", "--dry-run", "--persist-profile"], []),
+        C("init", "Quickstart index/profile setup.", [], ["--packages", "--extra-packages", "--db", "--run-extract", "--dry-run", "--persist-profile"], []),
         C("version", "Print version information.", [], ["--output"], []),
     ];
 

--- a/src/D365FO.Cli/Commands/Ops/InitCommand.cs
+++ b/src/D365FO.Cli/Commands/Ops/InitCommand.cs
@@ -19,6 +19,10 @@ public sealed class InitCommand : Command<InitCommand.Settings>
         [System.ComponentModel.Description("Explicit PackagesLocalDirectory path. Skips auto-detect.")]
         public string? PackagesPath { get; init; }
 
+        [CommandOption("--extra-packages <PATH>")]
+        [System.ComponentModel.Description("Additional PackagesLocalDirectory root(s). Repeatable. Also writes D365FO_EXTRA_PACKAGES_PATH when used with --persist-profile.")]
+        public string[]? ExtraPackagesPaths { get; init; }
+
         [CommandOption("--db <PATH>")]
         public string? DatabasePath { get; init; }
 
@@ -49,6 +53,9 @@ public sealed class InitCommand : Command<InitCommand.Settings>
         var cfg = D365FoSettings.FromEnvironment(settings.DatabasePath);
 
         var packages = settings.PackagesPath ?? cfg.PackagesPath ?? AutoDetectPackages();
+        var extraPackages = D365FO.Cli.Commands.Index.IndexExtractCommand.MergeExtraPaths(
+            settings.ExtraPackagesPaths,
+            cfg.ExtraPackagesPaths);
         var workspace = cfg.WorkspacePath ?? (packages is null ? null : Path.GetFullPath(Path.Combine(packages, "..")));
         var steps = new List<object>();
 
@@ -101,7 +108,9 @@ public sealed class InitCommand : Command<InitCommand.Settings>
                 ["D365FO_INDEX_DB"]      = cfg.DatabasePath,
             };
             if (!string.IsNullOrEmpty(workspace))
-                vars["D365FO_WORKSPACE"] = workspace;
+                vars["D365FO_WORKSPACE_PATH"] = workspace;
+            if (extraPackages is { Count: > 0 })
+                vars["D365FO_EXTRA_PACKAGES_PATH"] = string.Join(";", extraPackages);
 
             // --- JSON config file (shell-agnostic, solves Developer PowerShell issue) ---
             try


### PR DESCRIPTION
This pull request adds support for specifying extra package directories during initialization and ensures that these are properly persisted in the environment configuration. The changes update both the CLI and documentation to support the new `--extra-packages` option, and ensure environment variables are written consistently.

**Feature: Support for extra package directories**

* Added a new `--extra-packages` CLI option (repeatable) to the `init` command, allowing users to specify additional `PackagesLocalDirectory` roots. This also ensures that the `D365FO_EXTRA_PACKAGES_PATH` environment variable is written when used with `--persist-profile`. [[1]](diffhunk://#diff-67a4e4d8196e63875d371559e881c5ab45e60f8362a834208b863fc57a7c0964R22-R25) [[2]](diffhunk://#diff-3ce950c523d90bcd2199759e481c2a0042be6f974462547f8ca32dfabda27256L193-R193)
* Updated the `init` command logic to merge extra package paths from both the command line and existing configuration, and to persist the combined list in the environment variables and config files. [[1]](diffhunk://#diff-67a4e4d8196e63875d371559e881c5ab45e60f8362a834208b863fc57a7c0964R56-R58) [[2]](diffhunk://#diff-67a4e4d8196e63875d371559e881c5ab45e60f8362a834208b863fc57a7c0964L104-R113)

**Documentation improvements**

* Updated `docs/SETUP.md` to document the new `--extra-packages` option and clarify how to persist extra package paths during initialization.