### PR TITLE
feat: rename D365FO_PACKAGES_PATH → D365FO_STANDARD_PACKAGES_PATH and…

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,7 +81,7 @@ dotnet publish src/D365FO.Cli -c Release -r win-x64 --self-contained
 
 ```sh
 # Point at your packages folder
-$env:D365FO_PACKAGES_PATH = "K:\AosService\PackagesLocalDirectory"
+$env:D365FO_STANDARD_PACKAGES_PATH = "K:\AosService\PackagesLocalDirectory"
 
 # Build + populate the index
 d365fo index build
@@ -161,7 +161,7 @@ Reference the `SKILL.md` files from `skills/anthropic/` in your session prompt o
       "command": "d365fo-mcp",
       "args": [],
       "env": {
-        "D365FO_PACKAGES_PATH": "K:\\AosService\\PackagesLocalDirectory"
+        "D365FO_STANDARD_PACKAGES_PATH": "K:\\AosService\\PackagesLocalDirectory"
       }
     }
   }
@@ -260,7 +260,7 @@ See [`docs/EXAMPLES.md`](docs/EXAMPLES.md) for one worked example per command.
 
 | Symptom | Fix |
 |---|---|
-| `PACKAGES_PATH_NOT_FOUND` | Set `D365FO_PACKAGES_PATH` or pass `--packages <PATH>` |
+| `PACKAGES_PATH_NOT_FOUND` | Set `D365FO_STANDARD_PACKAGES_PATH` or pass `--packages <PATH>` |
 | `UNSUPPORTED_PLATFORM` | `build` / `sync` / `test` / `bp` require Windows + a D365FO dev VM |
 | `NO_INDEX` | Run `d365fo index build` then `d365fo index extract` |
 | Index appears stale after editing XML | Run `d365fo index refresh --model <Model>` |

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -138,8 +138,8 @@ Use `--category <name>[,<name>…]` to run specific rules. `--format sarif` emit
 
 | Variable | Purpose |
 |---|---|
-| `D365FO_PACKAGES_PATH` | Primary `PackagesLocalDirectory` root |
-| `D365FO_EXTRA_PACKAGES_PATH` | Additional roots (semicolon/comma-separated). Used for UDE dual-folder setups — see [SETUP.md](SETUP.md#ude-unified-developer-experience-setup). |
+| `D365FO_STANDARD_PACKAGES_PATH` | Primary `PackagesLocalDirectory` root |
+| `D365FO_CUSTOM_PACKAGES_PATH` | Additional roots (semicolon/comma-separated). Used for UDE dual-folder setups — see [SETUP.md](SETUP.md#ude-unified-developer-experience-setup). |
 | `D365FO_BIN_PATH` | D365FO binaries directory (resolves metadata assemblies) |
 | `D365FO_BRIDGE_ENABLED` | `1`/`true` enables bridge-primary reads |
 | `D365FO_BRIDGE_PATH` | Override bridge exe location |

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -3,7 +3,7 @@
 `d365fo` resolves settings in the following priority order — first match wins:
 
 1. **Explicit CLI flags** (`--packages`, `--db`, …) — highest priority
-2. **Process environment variables** (`D365FO_PACKAGES_PATH`, …)
+2. **Process environment variables** (`D365FO_STANDARD_PACKAGES_PATH`, …)
 3. **JSON config file** (`%LOCALAPPDATA%\d365fo-cli\settings.json` on Windows, `~/.local/share/d365fo-cli/settings.json` on Linux/macOS)
 4. **Built-in defaults** (e.g. `en-us` language, default SQLite path)
 
@@ -13,8 +13,8 @@
 
 | Variable | Purpose | Default |
 |---|---|---|
-| `D365FO_PACKAGES_PATH` | Primary `PackagesLocalDirectory` root | *(required for indexing)* |
-| `D365FO_EXTRA_PACKAGES_PATH` | Additional `PackagesLocalDirectory` roots (semicolon/comma separated) | — |
+| `D365FO_STANDARD_PACKAGES_PATH` | Primary `PackagesLocalDirectory` root | *(required for indexing)* |
+| `D365FO_CUSTOM_PACKAGES_PATH` | Additional `PackagesLocalDirectory` roots (semicolon/comma separated) | — |
 | `D365FO_LABEL_LANGUAGES` | Label languages to extract, e.g. `en-us,cs,de` | `en-us` |
 | `D365FO_INDEX_DB` | Path to the SQLite index file | `%LOCALAPPDATA%\d365fo-cli\d365fo-index.sqlite` |
 | `D365FO_WORKSPACE_PATH` | Root of your X++ solution (enables scaffold output) | — |
@@ -42,7 +42,7 @@ A flat JSON object mapping variable names to string values:
 
 ```json
 {
-  "D365FO_PACKAGES_PATH": "K:\\AosService\\PackagesLocalDirectory",
+  "D365FO_STANDARD_PACKAGES_PATH": "K:\\AosService\\PackagesLocalDirectory",
   "D365FO_INDEX_DB": "C:\\Users\\you\\AppData\\Local\\d365fo-cli\\d365fo-index.sqlite",
   "D365FO_LABEL_LANGUAGES": "en-us,cs"
 }
@@ -71,7 +71,7 @@ Alternatively, set variables at **machine scope** so they are inherited by every
 
 ```powershell
 [System.Environment]::SetEnvironmentVariable(
-    "D365FO_PACKAGES_PATH",
+    "D365FO_STANDARD_PACKAGES_PATH",
     "K:\AosService\PackagesLocalDirectory",
     [System.EnvironmentVariableTarget]::Machine)
 ```

--- a/docs/EXAMPLES.md
+++ b/docs/EXAMPLES.md
@@ -162,13 +162,13 @@ d365fo init --dry-run                  # show what would be done
 d365fo init --persist-profile          # append env vars to $PROFILE / ~/.profile
 ```
 
-Auto-detects the Windows `PackagesLocalDirectory`, prepares the SQLite schema, and (with `--run-extract`) drives the full extract pipeline. `--persist-profile` writes `D365FO_PACKAGES_PATH` / `D365FO_INDEX_DB` to the user's shell profile.
+Auto-detects the Windows `PackagesLocalDirectory`, prepares the SQLite schema, and (with `--run-extract`) drives the full extract pipeline. `--persist-profile` writes `D365FO_STANDARD_PACKAGES_PATH` / `D365FO_INDEX_DB` to the user's shell profile.
 
 ---
 
 ## Scaffold
 
-`generate` writes atomically (`.tmp` + move) and keeps a `.bak` when `--overwrite` is used. Pass `--install-to <Model>` to drop the artefact straight into a model folder via the bridge (requires `D365FO_BRIDGE_ENABLED=1`, `D365FO_PACKAGES_PATH`, `D365FO_BIN_PATH`).
+`generate` writes atomically (`.tmp` + move) and keeps a `.bak` when `--overwrite` is used. Pass `--install-to <Model>` to drop the artefact straight into a model folder via the bridge (requires `D365FO_BRIDGE_ENABLED=1`, `D365FO_STANDARD_PACKAGES_PATH`, `D365FO_BIN_PATH`).
 
 ### Table
 
@@ -666,7 +666,7 @@ d365fo daemon stop
 
 Transport: Windows named pipe `\\\\.\\ pipe\\d365fo-cli`; Unix socket at `$XDG_RUNTIME_DIR/d365fo-cli.sock` (fallback `$TMPDIR`). The frame format matches `d365fo-mcp`: one newline-terminated JSON-RPC request per connection, one response, close.
 
-The daemon also starts a `FileSystemWatcher` over `D365FO_PACKAGES_PATH` (or `--packages`). When `*.xml` files change, it debounces (default 3 s) and automatically triggers an incremental `index refresh` for the affected model, emitting a JSON notification to stderr:
+The daemon also starts a `FileSystemWatcher` over `D365FO_STANDARD_PACKAGES_PATH` (or `--packages`). When `*.xml` files change, it debounces (default 3 s) and automatically triggers an incremental `index refresh` for the affected model, emitting a JSON notification to stderr:
 
 ```json
 { "event": "index_refreshed", "model": "Contoso" }

--- a/docs/SETUP.md
+++ b/docs/SETUP.md
@@ -62,8 +62,8 @@ Three variables matter before you run `index extract`. Set them in your shell pr
 
 | Variable | Purpose | Notes |
 |---|---|---|
-| `D365FO_PACKAGES_PATH` | Primary root of `PackagesLocalDirectory` | **Required** for indexing |
-| `D365FO_EXTRA_PACKAGES_PATH` | Additional `PackagesLocalDirectory` root(s) | Optional. Semicolon- or comma-separated. UDE setups typically need this — see [UDE setup](#ude-unified-developer-experience-setup) below. |
+| `D365FO_STANDARD_PACKAGES_PATH` | Primary root of `PackagesLocalDirectory` | **Required** for indexing |
+| `D365FO_CUSTOM_PACKAGES_PATH` | Additional `PackagesLocalDirectory` root(s) | Optional. Semicolon- or comma-separated. UDE setups typically need this — see [UDE setup](#ude-unified-developer-experience-setup) below. |
 | `D365FO_LABEL_LANGUAGES` | Languages to extract (e.g. `en-us,cs`) | Default: `en-us` only. **Directly controls index size** — each extra language adds significant data. Set this before the first extract. |
 | `D365FO_INDEX_DB` | Path to the SQLite index | Defaults to `%LOCALAPPDATA%\d365fo-cli\d365fo-index.sqlite` (`~/.local/share/…` on Linux/macOS) |
 
@@ -86,7 +86,7 @@ If you set env vars only in one profile they will not be visible in the other. T
 d365fo init --packages K:\AosService\PackagesLocalDirectory --persist-profile
 ```
 
-If you use UDE dual roots, include extra packages during init so `D365FO_EXTRA_PACKAGES_PATH` is persisted too:
+If you use UDE dual roots, include extra packages during init so `D365FO_CUSTOM_PACKAGES_PATH` is persisted too:
 
 ```powershell
 d365fo init --packages K:\AosService\PackagesLocalDirectory --extra-packages C:\LocalMetadata\PackagesLocalDirectory --persist-profile
@@ -98,7 +98,7 @@ Alternatively, set variables as **system-level** (machine-scope) env vars in Win
 
 ```powershell
 [System.Environment]::SetEnvironmentVariable(
-    "D365FO_PACKAGES_PATH",
+    "D365FO_STANDARD_PACKAGES_PATH",
     "K:\AosService\PackagesLocalDirectory",
     [System.EnvironmentVariableTarget]::Machine)
 ```
@@ -117,8 +117,8 @@ Visual Studio merges both transparently, but `d365fo-cli` needs to know about bo
 **PowerShell (one session):**
 
 ```powershell
-$env:D365FO_PACKAGES_PATH         = 'K:\AosService\PackagesLocalDirectory'
-$env:D365FO_EXTRA_PACKAGES_PATH   = 'C:\LocalMetadata\PackagesLocalDirectory'
+$env:D365FO_STANDARD_PACKAGES_PATH         = 'K:\AosService\PackagesLocalDirectory'
+$env:D365FO_CUSTOM_PACKAGES_PATH   = 'C:\LocalMetadata\PackagesLocalDirectory'
 d365fo index extract
 ```
 
@@ -128,8 +128,8 @@ d365fo index extract
 Add-Content -Path $PROFILE -Value @"
 
 # d365fo-cli — UDE dual-packages config
-`$env:D365FO_PACKAGES_PATH         = 'K:\AosService\PackagesLocalDirectory'
-`$env:D365FO_EXTRA_PACKAGES_PATH   = 'C:\LocalMetadata\PackagesLocalDirectory'
+`$env:D365FO_STANDARD_PACKAGES_PATH         = 'K:\AosService\PackagesLocalDirectory'
+`$env:D365FO_CUSTOM_PACKAGES_PATH   = 'C:\LocalMetadata\PackagesLocalDirectory'
 "@
 . $PROFILE
 ```
@@ -142,9 +142,9 @@ d365fo index extract `
     --extra-packages C:\LocalMetadata\PackagesLocalDirectory
 ```
 
-> `--extra-packages` is repeatable. Multiple extra roots can also be given as a single semicolon-separated string in `D365FO_EXTRA_PACKAGES_PATH`. Missing extra roots are silently skipped (the primary root still produces an error if absent). Duplicate model directories across roots are deduplicated automatically.
+> `--extra-packages` is repeatable. Multiple extra roots can also be given as a single semicolon-separated string in `D365FO_CUSTOM_PACKAGES_PATH`. Missing extra roots are silently skipped (the primary root still produces an error if absent). Duplicate model directories across roots are deduplicated automatically.
 
-`d365fo index refresh` supports the same `--extra-packages` / `D365FO_EXTRA_PACKAGES_PATH` mechanism.
+`d365fo index refresh` supports the same `--extra-packages` / `D365FO_CUSTOM_PACKAGES_PATH` mechanism.
 
 ### Step 2 — Build and populate the index
 
@@ -183,7 +183,7 @@ Add-Content -Path $PROFILE -Value @"
 
 # d365fo-cli
 function d365fo { dotnet run --project $Repo\src\D365FO.Cli -- @args }
-`$env:D365FO_PACKAGES_PATH   = "$Pkg"
+`$env:D365FO_STANDARD_PACKAGES_PATH   = "$Pkg"
 `$env:D365FO_LABEL_LANGUAGES = "$Langs"
 `$env:D365FO_INDEX_DB        = "`$env:LOCALAPPDATA\d365fo-cli\index.sqlite"
 "@
@@ -209,7 +209,7 @@ cd "$REPO" && dotnet build d365fo-cli.slnx -c Release
   echo ""
   echo "# d365fo-cli"
   echo "alias d365fo='dotnet run --project $REPO/src/D365FO.Cli --'"
-  echo "export D365FO_PACKAGES_PATH=\"$PKG\""
+  echo "export D365FO_STANDARD_PACKAGES_PATH=\"$PKG\""
   echo "export D365FO_LABEL_LANGUAGES=\"$LANGS\""
   echo "export D365FO_INDEX_DB=\"\$HOME/.d365fo/index.sqlite\""
 } >> "$HOME/.zshrc"
@@ -450,7 +450,7 @@ git commit -m "chore: update d365fo Copilot skills"
 
 | Symptom | Fix |
 |---|---|
-| `PACKAGES_PATH_NOT_FOUND` | Set `D365FO_PACKAGES_PATH` or pass `--packages <PATH>`. |
+| `PACKAGES_PATH_NOT_FOUND` | Set `D365FO_STANDARD_PACKAGES_PATH` or pass `--packages <PATH>`. |
 | `UNSUPPORTED_PLATFORM` | `build` / `sync` / `test` / `bp` require Windows + a D365FO dev VM. Run them there. |
 | Index file appears locked | Stop any running `d365fo daemon` or `d365fo-mcp` process. WAL sidecar files (`-wal`, `-shm`) are normal. |
 | Copilot Chat in VS gives "There was an error executing code search" then generic X++ advice | VS Copilot Chat cannot search AOT XML (it always errors). The `.github/copilot-instructions.md` should prevent the code-search attempt — re-run `Install-D365FoCopilotSkills.ps1` to deploy the latest instructions. For full agent capabilities (auto-running `d365fo`), switch Copilot Chat to **Agent** mode (mode dropdown, top-right of the Chat pane). |

--- a/docs/TROUBLESHOOTING.md
+++ b/docs/TROUBLESHOOTING.md
@@ -6,7 +6,7 @@ Common failure modes and their fixes. For installation details see [SETUP.md](SE
 
 ## Package path patterns
 
-The `D365FO_PACKAGES_PATH` environment variable (or `--packages <PATH>`) must point to the root of `PackagesLocalDirectory`. Common locations:
+The `D365FO_STANDARD_PACKAGES_PATH` environment variable (or `--packages <PATH>`) must point to the root of `PackagesLocalDirectory`. Common locations:
 
 | Environment | Typical path |
 |---|---|
@@ -15,17 +15,17 @@ The `D365FO_PACKAGES_PATH` environment variable (or `--packages <PATH>`) must po
 | Azure Files share (mounted) | `Z:\PackagesLocalDirectory` (drive letter varies) |
 | Docker container | `/mnt/packages` (depends on volume mount) |
 | UDE (primary — shared drive) | `K:\AosService\PackagesLocalDirectory` |
-| UDE (extra — local laptop) | `C:\LocalMetadata\PackagesLocalDirectory` — set in `D365FO_EXTRA_PACKAGES_PATH` |
-| Custom override | Set `D365FO_PACKAGES_PATH` to any absolute path |
+| UDE (extra — local laptop) | `C:\LocalMetadata\PackagesLocalDirectory` — set in `D365FO_CUSTOM_PACKAGES_PATH` |
+| Custom override | Set `D365FO_STANDARD_PACKAGES_PATH` to any absolute path |
 
 ### UDE — two separate `PackagesLocalDirectory` folders
 
-UDE setups split standard Microsoft metadata (on a shared drive) from your custom model XML (on the local laptop). The CLI supports this via `D365FO_EXTRA_PACKAGES_PATH` or `--extra-packages`:
+UDE setups split standard Microsoft metadata (on a shared drive) from your custom model XML (on the local laptop). The CLI supports this via `D365FO_CUSTOM_PACKAGES_PATH` or `--extra-packages`:
 
 ```powershell
 # Environment variables (persist in $PROFILE)
-$env:D365FO_PACKAGES_PATH         = 'K:\AosService\PackagesLocalDirectory'
-$env:D365FO_EXTRA_PACKAGES_PATH   = 'C:\LocalMetadata\PackagesLocalDirectory'
+$env:D365FO_STANDARD_PACKAGES_PATH         = 'K:\AosService\PackagesLocalDirectory'
+$env:D365FO_CUSTOM_PACKAGES_PATH   = 'C:\LocalMetadata\PackagesLocalDirectory'
 d365fo index extract
 
 # — or — one-shot CLI flags
@@ -34,11 +34,11 @@ d365fo index extract `
     --extra-packages C:\LocalMetadata\PackagesLocalDirectory
 ```
 
-`D365FO_EXTRA_PACKAGES_PATH` accepts semicolon- or comma-separated paths. Extra roots that don't exist are silently skipped. See [SETUP.md — UDE setup](SETUP.md#ude-unified-developer-experience-setup) for the full walkthrough.
+`D365FO_CUSTOM_PACKAGES_PATH` accepts semicolon- or comma-separated paths. Extra roots that don't exist are silently skipped. See [SETUP.md — UDE setup](SETUP.md#ude-unified-developer-experience-setup) for the full walkthrough.
 
 ```sh
 # PowerShell — set for the current session
-$env:D365FO_PACKAGES_PATH = "K:\AosService\PackagesLocalDirectory"
+$env:D365FO_STANDARD_PACKAGES_PATH = "K:\AosService\PackagesLocalDirectory"
 
 # Persist across sessions (append to $PROFILE)
 d365fo init --persist-profile
@@ -53,10 +53,10 @@ The CLI also accepts `--packages <PATH>` on every command as a one-shot override
 ### `PACKAGES_PATH_NOT_FOUND`
 
 ```
-error: { "code": "PACKAGES_PATH_NOT_FOUND", "hint": "Set D365FO_PACKAGES_PATH or pass --packages <PATH>" }
+error: { "code": "PACKAGES_PATH_NOT_FOUND", "hint": "Set D365FO_STANDARD_PACKAGES_PATH or pass --packages <PATH>" }
 ```
 
-Fix: set `D365FO_PACKAGES_PATH` or pass `--packages`. Verify the path exists: `Test-Path $env:D365FO_PACKAGES_PATH`.
+Fix: set `D365FO_STANDARD_PACKAGES_PATH` or pass `--packages`. Verify the path exists: `Test-Path $env:D365FO_STANDARD_PACKAGES_PATH`.
 
 ### Unicode characters in the path
 
@@ -64,7 +64,7 @@ Paths containing non-ASCII characters (accented letters, CJK, etc.) can cause th
 
 ```powershell
 New-Item -ItemType Junction -Path "C:\D365Packages" -Target "K:\AosService\PackagesLocalDirectory"
-$env:D365FO_PACKAGES_PATH = "C:\D365Packages"
+$env:D365FO_STANDARD_PACKAGES_PATH = "C:\D365Packages"
 ```
 
 ### Locked AOT files during build
@@ -161,7 +161,7 @@ If `d365fo resolve label @SYS12345 --lang cs-CZ` returns `LABEL_NOT_FOUND`:
 
 1. Check the language code is correct: `d365fo index status --output json` lists indexed languages under `data.languages`.
 2. Re-run extraction with the language included: `d365fo index extract --languages cs-CZ --force`.
-3. Verify the label file exists on disk: `Get-ChildItem $env:D365FO_PACKAGES_PATH -Recurse -Filter "*.cs-CZ.label.txt"`.
+3. Verify the label file exists on disk: `Get-ChildItem $env:D365FO_STANDARD_PACKAGES_PATH -Recurse -Filter "*.cs-CZ.label.txt"`.
 
 ---
 

--- a/src/D365FO.Bridge/Handlers.cs
+++ b/src/D365FO.Bridge/Handlers.cs
@@ -108,7 +108,7 @@ namespace D365FO.Bridge
             {
                 return Fail("METADATA_UNAVAILABLE",
                     MetadataBootstrap.LastError ??
-                    "IMetadataProvider failed to initialise; set D365FO_PACKAGES_PATH on a D365FO VM.");
+                    "IMetadataProvider failed to initialise; set D365FO_STANDARD_PACKAGES_PATH on a D365FO VM.");
             }
 
             var modelInfo = MetadataBootstrap.ReadModelInfo(model);
@@ -187,7 +187,7 @@ namespace D365FO.Bridge
             {
                 return Fail("METADATA_UNAVAILABLE",
                     MetadataBootstrap.LastError ??
-                    "IMetadataProvider failed to initialise; set D365FO_PACKAGES_PATH on a D365FO VM.");
+                    "IMetadataProvider failed to initialise; set D365FO_STANDARD_PACKAGES_PATH on a D365FO VM.");
             }
 
             object artifact;

--- a/src/D365FO.Bridge/MetadataBootstrap.cs
+++ b/src/D365FO.Bridge/MetadataBootstrap.cs
@@ -12,7 +12,7 @@ namespace D365FO.Bridge
     /// <summary>
     /// Late-bound accessor for Microsoft's <c>IMetadataProvider</c> stack.
     /// Resolves the Microsoft.Dynamics.AX.Metadata.* assemblies from the
-    /// configured <c>D365FO_BIN_PATH</c> (or <c>D365FO_PACKAGES_PATH\bin</c>)
+    /// configured <c>D365FO_BIN_PATH</c> (or <c>D365FO_STANDARD_PACKAGES_PATH\bin</c>)
     /// at runtime, so this net48 console exe can be built on a workstation
     /// without the D365FO assemblies available and only actually wire up to
     /// them on a real VM.
@@ -50,7 +50,7 @@ namespace D365FO.Bridge
                 _binPath = ResolveBinPath(out _packagesPath);
                 if (string.IsNullOrEmpty(_binPath) || !Directory.Exists(_binPath))
                 {
-                    _lastError = "D365FO_BIN_PATH (or D365FO_PACKAGES_PATH\\bin) is not set or does not exist.";
+                    _lastError = "D365FO_BIN_PATH (or D365FO_STANDARD_PACKAGES_PATH\\bin) is not set or does not exist.";
                     return false;
                 }
 
@@ -104,7 +104,7 @@ namespace D365FO.Bridge
 
         private static string ResolveBinPath(out string packagesPath)
         {
-            packagesPath = Environment.GetEnvironmentVariable("D365FO_PACKAGES_PATH");
+            packagesPath = Environment.GetEnvironmentVariable("D365FO_STANDARD_PACKAGES_PATH");
             var bin = Environment.GetEnvironmentVariable("D365FO_BIN_PATH");
             if (string.IsNullOrEmpty(bin) && !string.IsNullOrEmpty(packagesPath))
             {

--- a/src/D365FO.Cli/Commands/Daemon/DaemonCommands.cs
+++ b/src/D365FO.Cli/Commands/Daemon/DaemonCommands.cs
@@ -62,7 +62,7 @@ public sealed class DaemonStartCommand : AsyncCommand<DaemonStartCommand.Setting
         public string? DatabasePath { get; init; }
 
         [CommandOption("--packages <PATH>")]
-        [System.ComponentModel.Description("PackagesLocalDirectory to watch for XML changes. Defaults to D365FO_PACKAGES_PATH.")]
+        [System.ComponentModel.Description("PackagesLocalDirectory to watch for XML changes. Defaults to D365FO_STANDARD_PACKAGES_PATH.")]
         public string? PackagesPath { get; init; }
 
         [CommandOption("--foreground")]
@@ -113,7 +113,7 @@ public sealed class DaemonStartCommand : AsyncCommand<DaemonStartCommand.Setting
 
         // Resolve packages path for the file watcher.
         var packagesPath = settings.PackagesPath
-            ?? D365FoSettings.FromEnvironment(settings.DatabasePath).PackagesPath;
+            ?? D365FoSettings.FromEnvironment(settings.DatabasePath).StandardPackagesPath;
 
         var summary = ToolResult<object>.Success(new
         {

--- a/src/D365FO.Cli/Commands/Generate/GenerateCommands.cs
+++ b/src/D365FO.Cli/Commands/Generate/GenerateCommands.cs
@@ -43,7 +43,7 @@ internal static class GenerateInstaller
         {
             failure = RenderHelpers.Render(kind, ToolResult<object>.Fail(
                 "INSTALL_FAILED",
-                $"Could not resolve folder for model '{model}'. Set D365FO_BRIDGE_ENABLED=1 and D365FO_PACKAGES_PATH on a D365FO VM, and make sure the model exists."));
+                $"Could not resolve folder for model '{model}'. Set D365FO_BRIDGE_ENABLED=1 and D365FO_STANDARD_PACKAGES_PATH on a D365FO VM, and make sure the model exists."));
             return null;
         }
         return System.IO.Path.Combine(folder!, axSubfolder, name + ".xml");

--- a/src/D365FO.Cli/Commands/Index/IndexCommands.cs
+++ b/src/D365FO.Cli/Commands/Index/IndexCommands.cs
@@ -23,14 +23,14 @@ public sealed class IndexBuildCommand : Command<IndexBuildCommand.Settings>
         var repo = new MetadataRepository(cfg.DatabasePath);
         var applied = repo.EnsureSchema();
 
-        var extraNote = cfg.ExtraPackagesPaths.Count > 0
-            ? $" Extra roots ({cfg.ExtraPackagesPaths.Count}): {string.Join("; ", cfg.ExtraPackagesPaths)}."
+        var extraNote = cfg.CustomPackagesPaths.Count > 0
+            ? $" Extra roots ({cfg.CustomPackagesPaths.Count}): {string.Join("; ", cfg.CustomPackagesPaths)}."
             : string.Empty;
         var result = ToolResult<object>.Success(new
         {
             databasePath = cfg.DatabasePath,
-            packagesPath = cfg.PackagesPath,
-            extraPackagesPaths = cfg.ExtraPackagesPaths.Count > 0 ? cfg.ExtraPackagesPaths : null,
+            packagesPath = cfg.StandardPackagesPath,
+            extraPackagesPaths = cfg.CustomPackagesPaths.Count > 0 ? cfg.CustomPackagesPaths : null,
             schemaVersion = MetadataRepository.CurrentSchemaVersion,
             schemaApplied = applied,
             note = applied
@@ -44,8 +44,8 @@ public sealed class IndexBuildCommand : Command<IndexBuildCommand.Settings>
                 AnsiConsole.MarkupLine($"[green]OK[/] schema v{MetadataRepository.CurrentSchemaVersion} applied at [bold]{cfg.DatabasePath}[/]");
             else
                 AnsiConsole.MarkupLine($"[green]OK[/] index ready at [bold]{cfg.DatabasePath}[/] (schema v{MetadataRepository.CurrentSchemaVersion})");
-            if (cfg.PackagesPath is null)
-                AnsiConsole.MarkupLine("[yellow]warn[/] D365FO_PACKAGES_PATH not set; extraction will require --packages.");
+            if (cfg.StandardPackagesPath is null)
+                AnsiConsole.MarkupLine("[yellow]warn[/] D365FO_STANDARD_PACKAGES_PATH not set; extraction will require --packages.");
         });
     }
 }
@@ -72,8 +72,8 @@ public sealed class IndexStatusCommand : Command<IndexStatusCommand.Settings>
 
                 // Staleness check: newest metadata mtime vs. index bookkeeping.
                 var roots = new List<string>();
-                if (!string.IsNullOrEmpty(cfg.PackagesPath)) roots.Add(cfg.PackagesPath!);
-                roots.AddRange(cfg.ExtraPackagesPaths);
+                if (!string.IsNullOrEmpty(cfg.StandardPackagesPath)) roots.Add(cfg.StandardPackagesPath!);
+                roots.AddRange(cfg.CustomPackagesPaths);
                 if (roots.Count > 0)
                     staleness = IndexStaleness.Check(repo, roots);
             }
@@ -92,8 +92,8 @@ public sealed class IndexStatusCommand : Command<IndexStatusCommand.Settings>
             databasePath = cfg.DatabasePath,
             exists,
             sizeBytes,
-            packagesPath = cfg.PackagesPath,
-            extraPackagesPaths = cfg.ExtraPackagesPaths.Count > 0 ? cfg.ExtraPackagesPaths : null,
+            packagesPath = cfg.StandardPackagesPath,
+            extraPackagesPaths = cfg.CustomPackagesPaths.Count > 0 ? cfg.CustomPackagesPaths : null,
             workspacePath = cfg.WorkspacePath,
             customModels = cfg.CustomModels,
             labelLanguages = cfg.LabelLanguages,
@@ -137,14 +137,14 @@ public sealed class IndexExtractCommand : Command<IndexExtractCommand.Settings>
         public int? Parallelism { get; init; }
 
         [CommandOption("--extra-packages <PATH>")]
-        [System.ComponentModel.Description("Additional PackagesLocalDirectory root(s) to include alongside --packages. Repeatable. Also reads D365FO_EXTRA_PACKAGES_PATH (semicolon/comma-separated). Supports UDE setups with two separate metadata folders.")]
+        [System.ComponentModel.Description("Additional PackagesLocalDirectory root(s) to include alongside --packages. Repeatable. Also reads D365FO_CUSTOM_PACKAGES_PATH (semicolon/comma-separated). Supports UDE setups with two separate metadata folders.")]
         public string[]? ExtraPackagesPaths { get; init; }
     }
 
     public override int Execute(CommandContext ctx, Settings settings)
     {
         var cfg = D365FoSettings.FromEnvironment(settings.DatabasePath);
-        var extraPaths = MergeExtraPaths(settings.ExtraPackagesPaths, cfg.ExtraPackagesPaths);
+        var extraPaths = MergeExtraPaths(settings.ExtraPackagesPaths, cfg.CustomPackagesPaths);
         return ExtractCore(
             OutputMode.Resolve(settings.Output),
             settings.PackagesPath,
@@ -166,13 +166,13 @@ public sealed class IndexExtractCommand : Command<IndexExtractCommand.Settings>
         IReadOnlyList<string>? extraPackagesPaths = null)
     {
         var cfg = D365FoSettings.FromEnvironment(databaseOverride);
-        var root = packagesOverride ?? cfg.PackagesPath;
+        var root = packagesOverride ?? cfg.StandardPackagesPath;
         if (string.IsNullOrWhiteSpace(root))
         {
             return RenderHelpers.Render(kind, ToolResult<object>.Fail(
                 "MISSING_PACKAGES_PATH",
                 "No packages path provided.",
-                "Pass --packages <PATH> or set D365FO_PACKAGES_PATH."));
+                "Pass --packages <PATH> or set D365FO_STANDARD_PACKAGES_PATH."));
         }
         if (!Directory.Exists(root))
         {
@@ -212,7 +212,7 @@ public sealed class IndexExtractCommand : Command<IndexExtractCommand.Settings>
         // *before* each model is parsed (useful when a single model like
         // ApplicationSuite takes many minutes).
         // For UDE setups (two separate PackagesLocalDirectory folders), callers
-        // can pass extra roots via --extra-packages / D365FO_EXTRA_PACKAGES_PATH.
+        // can pass extra roots via --extra-packages / D365FO_CUSTOM_PACKAGES_PATH.
         var modelDirs = EnumerateModelDirs(root, onlyModel).ToList();
         var validExtraRoots = new List<string>();
         foreach (var extra in extraPackagesPaths ?? Array.Empty<string>())
@@ -546,7 +546,7 @@ public sealed class IndexRefreshCommand : Command<IndexRefreshCommand.Settings>
         public int? Parallelism { get; init; }
 
         [CommandOption("--extra-packages <PATH>")]
-        [System.ComponentModel.Description("Additional PackagesLocalDirectory root(s). Repeatable. Also reads D365FO_EXTRA_PACKAGES_PATH.")]
+        [System.ComponentModel.Description("Additional PackagesLocalDirectory root(s). Repeatable. Also reads D365FO_CUSTOM_PACKAGES_PATH.")]
         public string[]? ExtraPackagesPaths { get; init; }
     }
 
@@ -579,7 +579,7 @@ public sealed class IndexRefreshCommand : Command<IndexRefreshCommand.Settings>
             }
         }
         var cfg2 = D365FoSettings.FromEnvironment(settings.DatabasePath);
-        var extraPaths = IndexExtractCommand.MergeExtraPaths(settings.ExtraPackagesPaths, cfg2.ExtraPackagesPaths);
+        var extraPaths = IndexExtractCommand.MergeExtraPaths(settings.ExtraPackagesPaths, cfg2.CustomPackagesPaths);
         return IndexExtractCommand.ExtractCore(
             OutputMode.Resolve(settings.Output),
             settings.PackagesPath,

--- a/src/D365FO.Cli/Commands/Label/LabelWriteCommands.cs
+++ b/src/D365FO.Cli/Commands/Label/LabelWriteCommands.cs
@@ -23,7 +23,7 @@ public sealed class LabelCreateCommand : Command<LabelCreateCommand.Settings>
         public string? File { get; init; }
 
         [CommandOption("--install-to <MODEL>")]
-        [System.ComponentModel.Description("Model name. Auto-resolves the label file path to <PackagesPath>/<MODEL>/<MODEL>/AxLabelFile/LabelResources/<lang>/<MODEL>.<lang>.label.txt. Requires D365FO_PACKAGES_PATH.")]
+        [System.ComponentModel.Description("Model name. Auto-resolves the label file path to <PackagesPath>/<MODEL>/<MODEL>/AxLabelFile/LabelResources/<lang>/<MODEL>.<lang>.label.txt. Requires D365FO_CUSTOM_PACKAGES_PATH or D365FO_STANDARD_PACKAGES_PATH.")]
         public string? InstallTo { get; init; }
 
         [CommandOption("--lang <LANG>")]
@@ -51,7 +51,7 @@ public sealed class LabelCreateCommand : Command<LabelCreateCommand.Settings>
         if (!hasFile && !hasInstall)
             return RenderHelpers.Render(kind, ToolResult<object>.Fail(D365FoErrorCodes.BadInput,
                 "--file <PATH> or --install-to <MODEL> is required.",
-                hint: "Use --file for an explicit absolute path, or --install-to <MODEL> to resolve the path automatically from D365FO_PACKAGES_PATH."));
+                hint: "Use --file for an explicit absolute path, or --install-to <MODEL> to resolve the path automatically from D365FO_CUSTOM_PACKAGES_PATH or D365FO_STANDARD_PACKAGES_PATH."));
 
         var resolvedFiles = new List<string>();
         if (hasFile)
@@ -61,15 +61,21 @@ public sealed class LabelCreateCommand : Command<LabelCreateCommand.Settings>
         else
         {
             var cfg = D365FoSettings.FromEnvironment();
-            if (string.IsNullOrEmpty(cfg.PackagesPath))
+            // Search custom paths first (write target for git repo models), then standard path.
+            var allRoots = cfg.CustomPackagesPaths.Concat(new[] { cfg.StandardPackagesPath });
+            var root = allRoots
+                .FirstOrDefault(r => !string.IsNullOrEmpty(r) && Directory.Exists(Path.Combine(r!, settings.InstallTo!)))
+                ?? cfg.CustomPackagesPaths.FirstOrDefault()
+                ?? cfg.StandardPackagesPath;
+            if (string.IsNullOrEmpty(root))
                 return RenderHelpers.Render(kind, ToolResult<object>.Fail("INSTALL_FAILED",
-                    $"Cannot resolve label file path for model '{settings.InstallTo}': D365FO_PACKAGES_PATH is not set.",
-                    hint: "Set D365FO_PACKAGES_PATH to your PackagesLocalDirectory, or use --file with an absolute path."));
+                    $"Cannot resolve label file path for model '{settings.InstallTo}': neither D365FO_CUSTOM_PACKAGES_PATH nor D365FO_STANDARD_PACKAGES_PATH is set.",
+                    hint: "Set D365FO_CUSTOM_PACKAGES_PATH to your git repo PackagesLocalDirectory, or use --file with an absolute path."));
 
             var langs = (string.IsNullOrWhiteSpace(settings.Lang) ? "en-us" : settings.Lang!)
                 .Split(',', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries);
             var lf = string.IsNullOrWhiteSpace(settings.LabelFile) ? settings.InstallTo! : settings.LabelFile!;
-            var resourcesDir = System.IO.Path.Combine(cfg.PackagesPath!, settings.InstallTo!, settings.InstallTo!, "AxLabelFile", "LabelResources");
+            var resourcesDir = System.IO.Path.Combine(root!, settings.InstallTo!, settings.InstallTo!, "AxLabelFile", "LabelResources");
             foreach (var lang in langs)
             {
                 var diskLang = ResolveOnDiskCasing(resourcesDir, lang);

--- a/src/D365FO.Cli/Commands/Ops/BuildCommands.cs
+++ b/src/D365FO.Cli/Commands/Ops/BuildCommands.cs
@@ -203,7 +203,7 @@ public sealed class BpCheckCommand : Command<BpCheckCommand.Settings>
         public string? Model { get; init; }
 
         [CommandOption("--packages <PATH>")]
-        [System.ComponentModel.Description("PackagesLocalDirectory (or FrameworkDirectory on UDE). Defaults to D365FO_PACKAGES_PATH.")]
+        [System.ComponentModel.Description("PackagesLocalDirectory (or FrameworkDirectory on UDE). Defaults to D365FO_STANDARD_PACKAGES_PATH.")]
         public string? PackagesPath { get; init; }
 
         [CommandOption("--metadata <PATH>")]
@@ -228,7 +228,7 @@ public sealed class BpCheckCommand : Command<BpCheckCommand.Settings>
         //   metadataPath = ModelStoreFolder   (where custom source XML lives)
         // In traditional environments both roles are served by packagesRoot.
         var packagesRoot = settings.PackagesPath
-            ?? Environment.GetEnvironmentVariable("D365FO_PACKAGES_PATH")
+            ?? Environment.GetEnvironmentVariable("D365FO_STANDARD_PACKAGES_PATH")
             ?? @"K:\AosService\PackagesLocalDirectory";
         var metadataPath = settings.MetadataPath ?? packagesRoot;
 
@@ -239,7 +239,7 @@ public sealed class BpCheckCommand : Command<BpCheckCommand.Settings>
             return RenderHelpers.Render(kind, ToolResult<object>.Fail(
                 "XPPBP_NOT_FOUND",
                 $"xppbp.exe not found at: {bp}",
-                "Set D365FO_PACKAGES_PATH (or --packages) to the FrameworkDirectory that contains Bin\\xppbp.exe."));
+                "Set D365FO_STANDARD_PACKAGES_PATH (or --packages) to the FrameworkDirectory that contains Bin\\xppbp.exe."));
 
         // Build argument list using modern -metadata: flag.
         // Falls back to legacy -packagesroot: when the modern flag is not recognised.

--- a/src/D365FO.Cli/Commands/Ops/InitCommand.cs
+++ b/src/D365FO.Cli/Commands/Ops/InitCommand.cs
@@ -20,7 +20,7 @@ public sealed class InitCommand : Command<InitCommand.Settings>
         public string? PackagesPath { get; init; }
 
         [CommandOption("--extra-packages <PATH>")]
-        [System.ComponentModel.Description("Additional PackagesLocalDirectory root(s). Repeatable. Also writes D365FO_EXTRA_PACKAGES_PATH when used with --persist-profile.")]
+        [System.ComponentModel.Description("Additional PackagesLocalDirectory root(s). Repeatable. Also writes D365FO_CUSTOM_PACKAGES_PATH when used with --persist-profile.")]
         public string[]? ExtraPackagesPaths { get; init; }
 
         [CommandOption("--db <PATH>")]
@@ -35,7 +35,7 @@ public sealed class InitCommand : Command<InitCommand.Settings>
         public bool DryRun { get; init; }
 
         [CommandOption("--persist-profile")]
-        [System.ComponentModel.Description("Append D365FO_PACKAGES_PATH / D365FO_INDEX_DB to the user's shell profile (PowerShell $PROFILE on Windows, ~/.profile otherwise).")]
+        [System.ComponentModel.Description("Append D365FO_STANDARD_PACKAGES_PATH / D365FO_INDEX_DB to the user's shell profile (PowerShell $PROFILE on Windows, ~/.profile otherwise).")]
         public bool PersistProfile { get; init; }
     }
 
@@ -52,10 +52,10 @@ public sealed class InitCommand : Command<InitCommand.Settings>
         var kind = OutputMode.Resolve(settings.Output);
         var cfg = D365FoSettings.FromEnvironment(settings.DatabasePath);
 
-        var packages = settings.PackagesPath ?? cfg.PackagesPath ?? AutoDetectPackages();
+        var packages = settings.PackagesPath ?? cfg.StandardPackagesPath ?? AutoDetectPackages();
         var extraPackages = D365FO.Cli.Commands.Index.IndexExtractCommand.MergeExtraPaths(
             settings.ExtraPackagesPaths,
-            cfg.ExtraPackagesPaths);
+            cfg.CustomPackagesPaths);
         var workspace = cfg.WorkspacePath ?? (packages is null ? null : Path.GetFullPath(Path.Combine(packages, "..")));
         var steps = new List<object>();
 
@@ -64,7 +64,7 @@ public sealed class InitCommand : Command<InitCommand.Settings>
 
         Log("resolve.packages", packages is not null,
             detail: packages,
-            hint: packages is null ? "Pass --packages <PATH> or set D365FO_PACKAGES_PATH." : null);
+            hint: packages is null ? "Pass --packages <PATH> or set D365FO_STANDARD_PACKAGES_PATH." : null);
         Log("resolve.workspace", workspace is not null, workspace);
         Log("resolve.database", !string.IsNullOrEmpty(cfg.DatabasePath), cfg.DatabasePath);
 
@@ -104,13 +104,13 @@ public sealed class InitCommand : Command<InitCommand.Settings>
         {
             var vars = new Dictionary<string, string>
             {
-                ["D365FO_PACKAGES_PATH"] = packages!,
+                ["D365FO_STANDARD_PACKAGES_PATH"] = packages!,
                 ["D365FO_INDEX_DB"]      = cfg.DatabasePath,
             };
             if (!string.IsNullOrEmpty(workspace))
                 vars["D365FO_WORKSPACE_PATH"] = workspace;
             if (extraPackages is { Count: > 0 })
-                vars["D365FO_EXTRA_PACKAGES_PATH"] = string.Join(";", extraPackages);
+                vars["D365FO_CUSTOM_PACKAGES_PATH"] = string.Join(";", extraPackages);
 
             // --- JSON config file (shell-agnostic, solves Developer PowerShell issue) ---
             try
@@ -169,7 +169,7 @@ public sealed class InitCommand : Command<InitCommand.Settings>
                 extracted = settings.RunExtract && !settings.DryRun && extractExit == 0,
                 nextSteps = new[]
                 {
-                    "Set D365FO_PACKAGES_PATH to persist the discovered path.",
+                    "Set D365FO_STANDARD_PACKAGES_PATH to persist the discovered path.",
                     "Run 'd365fo index extract' to ingest metadata.",
                     "Run 'd365fo doctor' to verify environment.",
                 },

--- a/src/D365FO.Cli/Commands/Ops/OpsCommands.cs
+++ b/src/D365FO.Cli/Commands/Ops/OpsCommands.cs
@@ -19,8 +19,8 @@ public sealed class DoctorCommand : Command<DoctorCommand.Settings>
         void Add(string name, bool ok, string? detail = null) => checks.Add(new DoctorCheck(name, ok, detail));
 
         Add("config.databasePath resolvable", !string.IsNullOrEmpty(cfg.DatabasePath), cfg.DatabasePath);
-        Add("config.packagesPath set", !string.IsNullOrEmpty(cfg.PackagesPath),
-            cfg.PackagesPath ?? "Set D365FO_PACKAGES_PATH or use --packages.");
+        Add("config.packagesPath set", !string.IsNullOrEmpty(cfg.StandardPackagesPath),
+            cfg.StandardPackagesPath ?? "Set D365FO_STANDARD_PACKAGES_PATH or use --packages.");
         Add("config.workspacePath set", !string.IsNullOrEmpty(cfg.WorkspacePath),
             cfg.WorkspacePath ?? "Set D365FO_WORKSPACE_PATH to enable scaffold output.");
         Add("index db exists", File.Exists(cfg.DatabasePath),
@@ -32,13 +32,13 @@ public sealed class DoctorCommand : Command<DoctorCommand.Settings>
 
         // Index freshness — the index is the single source of truth for
         // grounding, but only while it reflects the current workspace.
-        if (File.Exists(cfg.DatabasePath) && !string.IsNullOrEmpty(cfg.PackagesPath))
+        if (File.Exists(cfg.DatabasePath) && !string.IsNullOrEmpty(cfg.StandardPackagesPath))
         {
             try
             {
                 var repo = RepoFactory.Create();
-                var roots = new List<string> { cfg.PackagesPath! };
-                roots.AddRange(cfg.ExtraPackagesPaths);
+                var roots = new List<string> { cfg.StandardPackagesPath! };
+                roots.AddRange(cfg.CustomPackagesPaths);
                 var staleness = D365FO.Core.Index.IndexStaleness.Check(repo, roots);
                 Add("index freshness (stale-index)", !staleness.IsStale,
                     staleness.IsStale ? staleness.Detail : $"index extracted {staleness.LastExtractedUtc:O}");

--- a/src/D365FO.Core/D365FoSettings.cs
+++ b/src/D365FO.Core/D365FoSettings.cs
@@ -9,12 +9,12 @@ namespace D365FO.Core;
 /// (4) built-in defaults. See docs/CONFIGURATION.md.
 /// </summary>
 public sealed record D365FoSettings(
-    string? PackagesPath,
+    string? StandardPackagesPath,
     string? WorkspacePath,
     string DatabasePath,
     IReadOnlyList<string> CustomModels,
     IReadOnlyList<string> LabelLanguages,
-    IReadOnlyList<string> ExtraPackagesPaths)
+    IReadOnlyList<string> CustomPackagesPaths)
 {
     public const string DefaultDatabaseFile = "d365fo-index.sqlite";
     public const string ConfigFileName      = "settings.json";
@@ -52,12 +52,12 @@ public sealed record D365FoSettings(
                         "d365fo-cli", DefaultDatabaseFile);
 
         return new D365FoSettings(
-            PackagesPath: NullIfEmpty(Env("D365FO_PACKAGES_PATH")),
+            StandardPackagesPath: NullIfEmpty(Env("D365FO_STANDARD_PACKAGES_PATH")),
             WorkspacePath: NullIfEmpty(Env("D365FO_WORKSPACE_PATH")),
             DatabasePath: db,
             CustomModels: models,
             LabelLanguages: langs,
-            ExtraPackagesPaths: Split(Env("D365FO_EXTRA_PACKAGES_PATH")));
+            CustomPackagesPaths: Split(Env("D365FO_CUSTOM_PACKAGES_PATH")));
     }
 
     /// <summary>

--- a/src/D365FO.Core/Labels/LabelFileWriter.cs
+++ b/src/D365FO.Core/Labels/LabelFileWriter.cs
@@ -165,7 +165,7 @@ public static class LabelFileWriter
 
         // Prevent directory traversal: output must stay within packages or workspace.
         var cfg = D365FoSettings.FromEnvironment();
-        PathGuard.EnsureWithinBoundary(fullPath, cfg.PackagesPath, cfg.WorkspacePath);
+        PathGuard.EnsureWithinBoundary(fullPath, new[] { cfg.StandardPackagesPath, cfg.WorkspacePath }.Concat(cfg.CustomPackagesPaths).ToArray());
 
         var dir = Path.GetDirectoryName(fullPath);
         if (!string.IsNullOrEmpty(dir)) Directory.CreateDirectory(dir);

--- a/src/D365FO.Core/Scaffolding/XppScaffolder.cs
+++ b/src/D365FO.Core/Scaffolding/XppScaffolder.cs
@@ -851,7 +851,7 @@ public static class ScaffoldFileWriter
 
         // Prevent directory traversal: output must stay within packages or workspace.
         var cfg = D365FoSettings.FromEnvironment();
-        PathGuard.EnsureWithinBoundary(full, cfg.PackagesPath, cfg.WorkspacePath);
+        PathGuard.EnsureWithinBoundary(full, new[] { cfg.StandardPackagesPath, cfg.WorkspacePath }.Concat(cfg.CustomPackagesPaths).ToArray());
 
         var dir = Path.GetDirectoryName(full);
         if (!string.IsNullOrEmpty(dir)) Directory.CreateDirectory(dir);

--- a/src/D365FO.Mcp/ToolCatalog.cs
+++ b/src/D365FO.Mcp/ToolCatalog.cs
@@ -323,7 +323,7 @@ public static class ToolCatalog
             (h, p) => h.Lint(StrArray(p, "categories"), Bool(p, "onlyCustomModels", true))),
 
         new Descriptor("create_label",
-            "Create or update a key=value entry in a *.label.txt file. Supply either 'file' (absolute path to the .label.txt) or 'installTo' (model name — auto-resolves <PackagesPath>/<model>/<model>/AxLabelFile/LabelResources/<lang>/<model>.<lang>.label.txt from D365FO_PACKAGES_PATH). Fails with KEY_EXISTS unless overwrite=true.",
+            "Create or update a key=value entry in a *.label.txt file. Supply either 'file' (absolute path to the .label.txt) or 'installTo' (model name — auto-resolves <PackagesPath>/<model>/<model>/AxLabelFile/LabelResources/<lang>/<model>.<lang>.label.txt from D365FO_CUSTOM_PACKAGES_PATH or D365FO_STANDARD_PACKAGES_PATH). Fails with KEY_EXISTS unless overwrite=true.",
             Schema(("file", "string", false), ("key", "string", true), ("value", "string", true), ("overwrite", "boolean", false),
                    ("installTo", "string", false), ("lang", "string", false), ("labelFile", "string", false)),
             (h, p) => h.CreateLabel(StrOrNull(p, "file"), Str(p, "key"), Str(p, "value"), Bool(p, "overwrite"),
@@ -444,11 +444,11 @@ public static class ToolCatalog
 
         // ---- write-to-disk scaffolding tools ----
         // These tools generate XML AND write it directly into the AOT at
-        //   <D365FO_PACKAGES_PATH>/<model>/<model>/Ax<Kind>/<name>.xml
+        //   <D365FO_CUSTOM_PACKAGES_PATH>/<model>/<model>/Ax<Kind>/<name>.xml
         // Either `installTo` (model name) or `out` (explicit path) is required.
 
         new Descriptor("generate_table",
-            "Scaffold an AxTable and write it into the AOT. Requires either installTo (model name, resolves path automatically from D365FO_PACKAGES_PATH) or out (explicit file path). Fields format: \"<name>:<edt>[:mandatory]\". Pattern aliases: main, transaction, parameter, group, reference, miscellaneous.",
+            "Scaffold an AxTable and write it into the AOT. Requires either installTo (model name, resolves path automatically from D365FO_CUSTOM_PACKAGES_PATH or D365FO_STANDARD_PACKAGES_PATH) or out (explicit file path). Fields format: \"<name>:<edt>[:mandatory]\". Pattern aliases: main, transaction, parameter, group, reference, miscellaneous.",
             Schema(("name", "string", true), ("label", "string", false), ("fields", "array", false),
                    ("pattern", "string", false), ("installTo", "string", false),
                    ("out", "string", false), ("overwrite", "boolean", false)),

--- a/src/D365FO.Mcp/ToolHandlers.cs
+++ b/src/D365FO.Mcp/ToolHandlers.cs
@@ -347,14 +347,14 @@ public sealed class ToolHandlers
         var cfg = D365FoSettings.FromEnvironment();
         return ToolResult<object>.Success(new
         {
-            packagesPath = cfg.PackagesPath,
+            packagesPath = cfg.StandardPackagesPath,
             workspacePath = cfg.WorkspacePath,
             databasePath = cfg.DatabasePath,
             databaseExists = File.Exists(cfg.DatabasePath),
             customModelPatterns = cfg.CustomModels,
             labelLanguages = cfg.LabelLanguages,
-            hint = string.IsNullOrEmpty(cfg.PackagesPath)
-                ? "Set D365FO_PACKAGES_PATH before calling `index extract`."
+            hint = string.IsNullOrEmpty(cfg.StandardPackagesPath)
+                ? "Set D365FO_STANDARD_PACKAGES_PATH before calling `index extract`."
                 : null,
         });
     }
@@ -484,13 +484,13 @@ public sealed class ToolHandlers
             resolvedFile = ResolveLabelPath(installTo!, resolvedLang, labelFile);
             if (resolvedFile is null)
                 return ToolResult<object>.Fail("INSTALL_FAILED",
-                    $"Cannot resolve label file path for model '{installTo}': D365FO_PACKAGES_PATH is not set.",
-                    "Set D365FO_PACKAGES_PATH before using installTo.");
+                    $"Cannot resolve label file path for model '{installTo}': neither D365FO_CUSTOM_PACKAGES_PATH nor D365FO_STANDARD_PACKAGES_PATH is set.",
+                    "Set D365FO_CUSTOM_PACKAGES_PATH to your git repo PackagesLocalDirectory before using installTo.");
         }
         if (string.IsNullOrWhiteSpace(resolvedFile))
             return ToolResult<object>.Fail(D365FoErrorCodes.BadInput,
                 "Either 'file' (absolute path to the .label.txt) or 'installTo' (model name) is required.",
-                "Use 'file' for an explicit path, or 'installTo' to resolve the path automatically from D365FO_PACKAGES_PATH.");
+                "Use 'file' for an explicit path, or 'installTo' to resolve the path automatically from D365FO_CUSTOM_PACKAGES_PATH or D365FO_STANDARD_PACKAGES_PATH.");
         if (string.IsNullOrWhiteSpace(key)) return ToolResult<object>.Fail(D365FoErrorCodes.BadInput, "key required");
         try
         {
@@ -787,27 +787,45 @@ public sealed class ToolHandlers
 
     /// <summary>
     /// Resolve the canonical AOT install path:
-    /// <c>&lt;PackagesPath&gt;/&lt;model&gt;/&lt;model&gt;/&lt;axSubfolder&gt;/&lt;name&gt;.xml</c>.
-    /// Returns <c>null</c> when <c>D365FO_PACKAGES_PATH</c> is not set.
+    /// <c>&lt;root&gt;/&lt;model&gt;/&lt;model&gt;/&lt;axSubfolder&gt;/&lt;name&gt;.xml</c>.
+    /// Searches <c>D365FO_CUSTOM_PACKAGES_PATH</c> first (write target), then
+    /// <c>D365FO_STANDARD_PACKAGES_PATH</c>. Returns <c>null</c> when neither is set.
     /// </summary>
     private static string? ResolveAotPath(string model, string axSubfolder, string name)
     {
         var cfg = D365FoSettings.FromEnvironment();
-        if (string.IsNullOrEmpty(cfg.PackagesPath)) return null;
-        return Path.Combine(cfg.PackagesPath, model, model, axSubfolder, name + ".xml");
+        // Prefer custom paths (git repo / write target); fall back to standard path.
+        var candidates = cfg.CustomPackagesPaths.Concat(new[] { cfg.StandardPackagesPath });
+        foreach (var root in candidates)
+        {
+            if (string.IsNullOrEmpty(root)) continue;
+            if (Directory.Exists(Path.Combine(root, model, model)))
+                return Path.Combine(root, model, model, axSubfolder, name + ".xml");
+        }
+        // Model not found — default to first custom path, then standard for new model creation.
+        var writeRoot = cfg.CustomPackagesPaths.FirstOrDefault() ?? cfg.StandardPackagesPath;
+        return writeRoot is null ? null : Path.Combine(writeRoot, model, model, axSubfolder, name + ".xml");
     }
 
     /// <summary>
     /// Resolve the canonical label file path:
-    /// <c>&lt;PackagesPath&gt;/&lt;model&gt;/&lt;model&gt;/AxLabelFile/LabelResources/&lt;lang&gt;/&lt;labelFile&gt;.&lt;lang&gt;.label.txt</c>.
-    /// Returns <c>null</c> when <c>D365FO_PACKAGES_PATH</c> is not set.
+    /// <c>&lt;root&gt;/&lt;model&gt;/&lt;model&gt;/AxLabelFile/LabelResources/&lt;lang&gt;/&lt;labelFile&gt;.&lt;lang&gt;.label.txt</c>.
+    /// Searches <c>D365FO_CUSTOM_PACKAGES_PATH</c> first (write target), then
+    /// <c>D365FO_STANDARD_PACKAGES_PATH</c>. Returns <c>null</c> when neither is set.
     /// </summary>
     private static string? ResolveLabelPath(string model, string lang, string? labelFile)
     {
         var cfg = D365FoSettings.FromEnvironment();
-        if (string.IsNullOrEmpty(cfg.PackagesPath)) return null;
         var lf = string.IsNullOrWhiteSpace(labelFile) ? model : labelFile!;
-        return Path.Combine(cfg.PackagesPath, model, model, "AxLabelFile", "LabelResources", lang, $"{lf}.{lang}.label.txt");
+        var candidates = cfg.CustomPackagesPaths.Concat(new[] { cfg.StandardPackagesPath });
+        foreach (var root in candidates)
+        {
+            if (string.IsNullOrEmpty(root)) continue;
+            if (Directory.Exists(Path.Combine(root, model, model)))
+                return Path.Combine(root, model, model, "AxLabelFile", "LabelResources", lang, $"{lf}.{lang}.label.txt");
+        }
+        var writeRoot = cfg.CustomPackagesPaths.FirstOrDefault() ?? cfg.StandardPackagesPath;
+        return writeRoot is null ? null : Path.Combine(writeRoot, model, model, "AxLabelFile", "LabelResources", lang, $"{lf}.{lang}.label.txt");
     }
 
     private static ToolResult<object> WriteScaffold(
@@ -820,8 +838,8 @@ public sealed class ToolHandlers
             path = ResolveAotPath(installTo!, axSubfolder, name);
             if (path is null)
                 return ToolResult<object>.Fail("INSTALL_FAILED",
-                    $"Cannot resolve install path for model '{installTo}': D365FO_PACKAGES_PATH is not set.",
-                    "Set D365FO_PACKAGES_PATH before using installTo.");
+                    $"Cannot resolve install path for model '{installTo}': neither D365FO_CUSTOM_PACKAGES_PATH nor D365FO_STANDARD_PACKAGES_PATH is set.",
+                    "Set D365FO_CUSTOM_PACKAGES_PATH to your git repo PackagesLocalDirectory before using installTo.");
         }
         if (string.IsNullOrWhiteSpace(path))
             return ToolResult<object>.Fail("BAD_INPUT", "Either 'out' or 'installTo' is required.");
@@ -856,8 +874,8 @@ public sealed class ToolHandlers
             path = ResolveAotPath(installTo!, axSubfolder, name);
             if (path is null)
                 return ToolResult<object>.Fail("INSTALL_FAILED",
-                    $"Cannot resolve install path for model '{installTo}': D365FO_PACKAGES_PATH is not set.",
-                    "Set D365FO_PACKAGES_PATH before using installTo.");
+                    $"Cannot resolve install path for model '{installTo}': neither D365FO_CUSTOM_PACKAGES_PATH nor D365FO_STANDARD_PACKAGES_PATH is set.",
+                    "Set D365FO_CUSTOM_PACKAGES_PATH to your git repo PackagesLocalDirectory before using installTo.");
         }
         if (string.IsNullOrWhiteSpace(path))
             return ToolResult<object>.Fail("BAD_INPUT", "Either 'out' or 'installTo' is required.");


### PR DESCRIPTION
… D365FO_EXTRA_PACKAGES_PATH → D365FO_CUSTOM_PACKAGES_PATH

- Rename env vars across all C# source, docs, and README for clarity
- D365FO_STANDARD_PACKAGES_PATH: platform/ISV packages (read-only, indexing)
- D365FO_CUSTOM_PACKAGES_PATH: custom/git models (write target for generate --install-to)
- generate --install-to now searches custom paths first, falls back to standard
- PathGuard EnsureWithinBoundary now allows writes to both custom and standard paths
- ResolveAotPath and ResolveLabelPath updated to prefer custom paths

Fixes the UDE dual-folder confusion reported in issue #65