### PR TITLE
Strengthen D365FO agent metadata guardrails

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -34,6 +34,46 @@ d365fo models list --output json      # confirm target model — NEVER guess it
 
 Models are ISV / customer policy boundaries — never infer from search results; always ask or read from `.rnrproj`.
 
+### Model and existing-artifact selection
+
+`D365FO_CUSTOM_MODELS` is a hard boundary for where customizations may be
+installed. It can contain multiple comma-separated models. Before writing,
+resolve the active target model from that list by checking the artifact the user
+named, the model that already contains the related extension/handler, or the
+model currently being edited in the task. Use `--install-to <ActiveCustomModel>`
+only after that resolution. If more than one custom model could own the change,
+stop and ask.
+
+The artifact suffix is a separate decision from the model name. Extract
+`<ExistingSuffix>` from existing related elements in the active model, such as
+`<Target>_<ExistingSuffix>_Extension`, `<Form>_<ExistingSuffix>_Form_EH`, or
+`<Form>_<ExistingSuffix>_Form_EventHandler`. If no existing suffix can be
+derived and the user did not provide one, stop and ask for the suffix. Do
+**not** derive new suffixes from feature names, customer names, tickets, labels,
+or the custom model name.
+
+Before creating any extension or event-handler class, search for an existing
+artifact in the target custom model and reuse it when it already represents
+the same target object or integration family:
+
+```sh
+d365fo find extensions <TargetObject> --output json
+d365fo find handlers <TargetObject> --output json
+d365fo search class <TargetOrPrefix> --output json
+```
+
+Examples:
+- If `<Target>_<ExistingSuffix>_Extension` exists in `<ActiveCustomModel>`, add
+  the new method there. Do not create `<Target>_<Feature>_Extension`.
+- If `<Form>_<ExistingSuffix>_Form_EH` or
+  `<Form>_<ExistingSuffix>_Form_EventHandler` exists for `<Form>` events in
+  `<ActiveCustomModel>`, add the new handler there. Do not create a parallel
+  `<Form>_<Feature>_EH` or `<Form>_<Feature>_EventHandler` unless the user
+  explicitly requests a separate handler class.
+- Feature names, integration names, customer names, and issue titles are allowed
+  in method names and labels, but they are not a reason to create a new
+  suffix when a related artifact already exists.
+
 ### VS / VS Code operating modes
 
 | Environment | How Copilot runs d365fo | Token cost |
@@ -100,6 +140,21 @@ Copilot: "Since I cannot access the codebase, I'll provide generic guidance…"
 6. **Never hardcode strings in `Info()` / `warning()` / `error()`** — use `@Model:Label`. Search first: `d365fo search label`.
 7. **Never nest `while select` loops** — use joins, `exists join`, or pre-load to `Map` / temp table.
 8. **Never use `replace_string_in_file` on `.xml` AOT files without running `d365fo index refresh` after** — stale index returns pre-edit data.
+9. **Never rewrite an existing AOT XML file wholesale.** Preserve all unrelated
+   elements exactly. A diff that removes unrelated `<DataSourceModifications>`,
+   `<DataSourceReferences>`, `<DataSources>`, `<Controls>`, methods, pattern
+   metadata, or extension properties is a failed edit.
+10. **Validate every changed AOT XML file before considering the task done:**
+   parse it with an XML validator, run `d365fo validate xpp --file <file>
+   --code-type xml-any --output json`, refresh the index for the model, and
+   re-read the object with `d365fo get ... --output json`.
+11. **For new forms based on an existing example, preserve the pattern contract.**
+   First read the example with `d365fo get form <Example> --output json`; scaffold
+   with `d365fo generate form --pattern ...`; then verify the generated form has
+   the required pattern scaffolding (datasources, design pattern/version,
+   ActionPane/Body/Tab/FastTab/grid/QuickFilter elements as applicable). Never
+   drop required pattern elements just because they were not mentioned in the
+   prompt.
 
 ---
 

--- a/skills/_source/event-handler-authoring.md
+++ b/skills/_source/event-handler-authoring.md
@@ -22,9 +22,25 @@ appliesWhen: User intent mentions event handler, SubscribesTo, DataEventHandler,
 # 1) Discover existing handlers on the target — avoid duplicates
 d365fo find handlers <TargetObject> --output json
 
-# 2) Confirm the target exists (for tables) and which events it emits
+# 2) Search likely handler classes in the target model/prefix
+d365fo search class <TargetObject> --output json
+
+# 3) Confirm the target exists (for tables) and which events it emits
 d365fo get table <Table> --output json
 ```
+
+If a suitable handler class already exists in the target custom model, add the
+new method to that class instead of creating another handler. `D365FO_CUSTOM_MODELS`
+can contain multiple models, so first resolve the active target model from the
+artifact named by the user, the model that already contains the related handler,
+or the model currently being edited. The handler suffix is separate from the
+model name: extract `<ExistingSuffix>` from existing related handler classes in
+the active model, such as `<Form>_<ExistingSuffix>_Form_EH` or
+`<Form>_<ExistingSuffix>_Form_EventHandler`. If no suffix can be derived and
+the user did not provide one, stop and ask for the suffix. If both `_EH` and
+`_EventHandler` naming styles exist, follow the existing style in that model.
+Do not create `<Form>_<Feature>_EH` or `<Form>_<Feature>_EventHandler` unless
+the user explicitly requests a separate class.
 
 ## Standard data events on tables → `[DataEventHandler]`
 
@@ -85,6 +101,8 @@ Attribute: `[SubscribesTo(classStr(SalesFormLetter), delegateStr(SalesFormLetter
 - Handlers do NOT chain via `next` — they are notification-only.
 - Handler methods must be `public static` (the runtime invokes them
   reflectively).
+- Never create a parallel handler class when an existing target/model handler
+  class already owns the same object/event family.
 - Never modify the buffer in a `Validating*` / `*ing` event without intent —
   changes leak into the persisted record.
 - Pre-flight `find handlers <Target>` to detect duplicates and ordering risks.

--- a/skills/_source/form-pattern-scaffolding.md
+++ b/skills/_source/form-pattern-scaffolding.md
@@ -50,6 +50,21 @@ every indexed AxForm. Use it instead of guessing — pass the most-common peer
 pattern straight into `--pattern` on the next step. With no flags it returns
 a histogram so you can see what shapes exist before drilling in.
 
+When the user provides an existing form as an example, treat it as a pattern
+contract, not as optional inspiration:
+
+```sh
+d365fo get form <ExampleForm> --output json
+d365fo find form-patterns --similar-to <ExampleForm> --output json
+```
+
+Use the same pattern family unless the user explicitly requests a different
+one. After generation, verify that the new form still contains the pattern's
+required scaffolding: datasource(s), design pattern/version metadata, required
+ActionPane/Body/Tab/FastTab/grid/QuickFilter controls, and required line/header
+datasources for transaction forms. Missing pattern elements are a failed
+generation even if the XML is well-formed.
+
 ## Pattern catalog
 
 | Pattern | When to use | Required |
@@ -105,6 +120,16 @@ section template is `--section Name:Caption` (split on the first `:`).
 
 - Never hand-roll AxForm XML — always use `--pattern`.
 - Never skip the primary datasource for SimpleList / Lookup / ListPage / Master / Transaction patterns.
+- Never drop required pattern controls or metadata from a generated form copied
+  from an example. Validate against the example's pattern before finishing.
+- Never rewrite an existing AxForm or AxFormExtension XML file wholesale.
+  Preserve unrelated `<Controls>`, `<DataSourceModifications>`,
+  `<DataSourceReferences>`, `<DataSources>`, methods, extension properties,
+  and pattern metadata exactly.
+- After changing form XML, validate XML well-formedness, run
+  `d365fo validate xpp --file <file> --code-type xml-any --output json`, run
+  `d365fo index refresh --model <Model>`, and re-read with
+  `d365fo get form <Form> --output json`.
 - Never use `Dialog` or `TableOfContents` patterns for transactional grids.
 - Pre-flight `search form <Name>` before scaffolding to avoid collisions.
 - Caption strings must be labels (BP `BPErrorLabelIsText`) — never raw text.

--- a/skills/_source/object-extension-authoring.md
+++ b/skills/_source/object-extension-authoring.md
@@ -57,6 +57,31 @@ If `count > 0`, list the existing extensions to the user. The naming
 convention is `<Target>.<Suffix>` (dot-separated; `Suffix` typically is the
 model short-name or the feature name).
 
+## Reuse before creating
+
+`D365FO_CUSTOM_MODELS` constrains the model, not the feature suffix. If the
+variable contains multiple models, resolve the active target model first from
+the artifact named by the user, the model that already contains the related
+extension, or the model currently being edited. If more than one custom model
+could own the change, stop and ask. The extension suffix is separate from the
+model name: extract `<ExistingSuffix>` from existing related extensions in the
+active model, such as `<Target>.<ExistingSuffix>` or
+`<Target>_<ExistingSuffix>_Extension`. If no suffix can be derived and the user
+did not provide one, stop and ask for the suffix. Do not create a feature-named
+extension such as `<Target>.<Feature>` or a class such as
+`<Target>_<Feature>_Extension` merely because the request mentions a feature,
+ticket, integration, customer name, or model name.
+
+Before scaffolding a new extension, inspect the existing result from
+`d365fo find extensions <Target> --output json`:
+
+- If an extension already exists in the target model and suffix family, modify
+  that existing extension.
+- If multiple extensions exist, stop and ask which artifact should own the
+  change unless the user has named one explicitly.
+- Create a new extension only when no existing extension owns that target/model
+  concern or when the user explicitly asks for isolation.
+
 ## Scaffolding
 
 ```sh
@@ -134,6 +159,13 @@ d365fo get security-policy CustCustomSecurityPolicy --output json
 
 - Never have two extensions with the same `<Target>.<Suffix>` in the same
   model — `d365fo find extensions` first.
+- Never create a feature-specific extension when a model-level extension for
+  the same target already exists and is the natural owner of the change.
+- Never rewrite an existing extension XML file wholesale. Preserve unrelated
+  nodes and only add the requested structural element(s).
+- After changing extension XML, validate XML well-formedness, run
+  `d365fo validate xpp --file <file> --code-type xml-any --output json`, run
+  `d365fo index refresh --model <Model>`, and re-read the target metadata.
 - Never use `extension` for class behaviour changes — that is CoC's job
   (`d365fo generate coc <Class>`).
 - Never modify the standard object directly (over-layering) — extensions are

--- a/skills/_source/review-and-checkpoint-workflow.md
+++ b/skills/_source/review-and-checkpoint-workflow.md
@@ -39,6 +39,12 @@ so you can recover the previous version if Git history isn't enough.
 After each scaffold or edit, run a quick `git diff` to confirm the change is
 contained.
 
+For AOT XML, the diff must be additive or narrowly targeted. If unrelated XML
+nodes disappear, the edit is wrong and must be reverted before continuing.
+Treat removals of `<DataSourceModifications>`, `<DataSourceReferences>`,
+`<DataSources>`, `<Controls>`, methods, pattern metadata, or extension
+properties as high-risk unless the user explicitly requested that removal.
+
 **Hand-written X++ never reaches a file unvalidated:**
 
 ```sh
@@ -47,6 +53,20 @@ d365fo validate xpp --file <f> --output json          # offline BP rules (today(
 ```
 
 Fix all errors, re-run, only then write. Both gates run in <200 ms with no VM.
+
+**Changed AOT XML has its own gate:**
+
+```sh
+# Parse with an XML validator first. Then:
+d365fo validate xpp --file <f> --code-type xml-any --output json
+d365fo index refresh --model <Model>
+d365fo get form <Form> --output json      # for AxForm/AxFormExtension changes
+d365fo get table <Table> --output json    # for AxTable/AxTableExtension changes
+```
+
+For new forms based on an example, compare the pattern metadata and required
+controls/datasources from the example. Missing ActionPane/Body/Tab/FastTab/grid
+or QuickFilter elements are not acceptable just because the XML parses.
 
 ## 3. After the task — AOT-semantic review
 

--- a/skills/anthropic/event-handler-authoring/SKILL.md
+++ b/skills/anthropic/event-handler-authoring/SKILL.md
@@ -18,9 +18,25 @@ applies_when: User intent mentions event handler, SubscribesTo, DataEventHandler
 # 1) Discover existing handlers on the target — avoid duplicates
 d365fo find handlers <TargetObject> --output json
 
-# 2) Confirm the target exists (for tables) and which events it emits
+# 2) Search likely handler classes in the target model/prefix
+d365fo search class <TargetObject> --output json
+
+# 3) Confirm the target exists (for tables) and which events it emits
 d365fo get table <Table> --output json
 ```
+
+If a suitable handler class already exists in the target custom model, add the
+new method to that class instead of creating another handler. `D365FO_CUSTOM_MODELS`
+can contain multiple models, so first resolve the active target model from the
+artifact named by the user, the model that already contains the related handler,
+or the model currently being edited. The handler suffix is separate from the
+model name: extract `<ExistingSuffix>` from existing related handler classes in
+the active model, such as `<Form>_<ExistingSuffix>_Form_EH` or
+`<Form>_<ExistingSuffix>_Form_EventHandler`. If no suffix can be derived and
+the user did not provide one, stop and ask for the suffix. If both `_EH` and
+`_EventHandler` naming styles exist, follow the existing style in that model.
+Do not create `<Form>_<Feature>_EH` or `<Form>_<Feature>_EventHandler` unless
+the user explicitly requests a separate class.
 
 ## Standard data events on tables → `[DataEventHandler]`
 
@@ -81,6 +97,8 @@ Attribute: `[SubscribesTo(classStr(SalesFormLetter), delegateStr(SalesFormLetter
 - Handlers do NOT chain via `next` — they are notification-only.
 - Handler methods must be `public static` (the runtime invokes them
   reflectively).
+- Never create a parallel handler class when an existing target/model handler
+  class already owns the same object/event family.
 - Never modify the buffer in a `Validating*` / `*ing` event without intent —
   changes leak into the persisted record.
 - Pre-flight `find handlers <Target>` to detect duplicates and ordering risks.

--- a/skills/anthropic/form-pattern-scaffolding/SKILL.md
+++ b/skills/anthropic/form-pattern-scaffolding/SKILL.md
@@ -43,6 +43,21 @@ every indexed AxForm. Use it instead of guessing — pass the most-common peer
 pattern straight into `--pattern` on the next step. With no flags it returns
 a histogram so you can see what shapes exist before drilling in.
 
+When the user provides an existing form as an example, treat it as a pattern
+contract, not as optional inspiration:
+
+```sh
+d365fo get form <ExampleForm> --output json
+d365fo find form-patterns --similar-to <ExampleForm> --output json
+```
+
+Use the same pattern family unless the user explicitly requests a different
+one. After generation, verify that the new form still contains the pattern's
+required scaffolding: datasource(s), design pattern/version metadata, required
+ActionPane/Body/Tab/FastTab/grid/QuickFilter controls, and required line/header
+datasources for transaction forms. Missing pattern elements are a failed
+generation even if the XML is well-formed.
+
 ## Pattern catalog
 
 | Pattern | When to use | Required |
@@ -98,6 +113,16 @@ section template is `--section Name:Caption` (split on the first `:`).
 
 - Never hand-roll AxForm XML — always use `--pattern`.
 - Never skip the primary datasource for SimpleList / Lookup / ListPage / Master / Transaction patterns.
+- Never drop required pattern controls or metadata from a generated form copied
+  from an example. Validate against the example's pattern before finishing.
+- Never rewrite an existing AxForm or AxFormExtension XML file wholesale.
+  Preserve unrelated `<Controls>`, `<DataSourceModifications>`,
+  `<DataSourceReferences>`, `<DataSources>`, methods, extension properties,
+  and pattern metadata exactly.
+- After changing form XML, validate XML well-formedness, run
+  `d365fo validate xpp --file <file> --code-type xml-any --output json`, run
+  `d365fo index refresh --model <Model>`, and re-read with
+  `d365fo get form <Form> --output json`.
 - Never use `Dialog` or `TableOfContents` patterns for transactional grids.
 - Pre-flight `search form <Name>` before scaffolding to avoid collisions.
 - Caption strings must be labels (BP `BPErrorLabelIsText`) — never raw text.

--- a/skills/anthropic/object-extension-authoring/SKILL.md
+++ b/skills/anthropic/object-extension-authoring/SKILL.md
@@ -46,6 +46,31 @@ If `count > 0`, list the existing extensions to the user. The naming
 convention is `<Target>.<Suffix>` (dot-separated; `Suffix` typically is the
 model short-name or the feature name).
 
+## Reuse before creating
+
+`D365FO_CUSTOM_MODELS` constrains the model, not the feature suffix. If the
+variable contains multiple models, resolve the active target model first from
+the artifact named by the user, the model that already contains the related
+extension, or the model currently being edited. If more than one custom model
+could own the change, stop and ask. The extension suffix is separate from the
+model name: extract `<ExistingSuffix>` from existing related extensions in the
+active model, such as `<Target>.<ExistingSuffix>` or
+`<Target>_<ExistingSuffix>_Extension`. If no suffix can be derived and the user
+did not provide one, stop and ask for the suffix. Do not create a feature-named
+extension such as `<Target>.<Feature>` or a class such as
+`<Target>_<Feature>_Extension` merely because the request mentions a feature,
+ticket, integration, customer name, or model name.
+
+Before scaffolding a new extension, inspect the existing result from
+`d365fo find extensions <Target> --output json`:
+
+- If an extension already exists in the target model and suffix family, modify
+  that existing extension.
+- If multiple extensions exist, stop and ask which artifact should own the
+  change unless the user has named one explicitly.
+- Create a new extension only when no existing extension owns that target/model
+  concern or when the user explicitly asks for isolation.
+
 ## Scaffolding
 
 ```sh
@@ -123,6 +148,13 @@ d365fo get security-policy CustCustomSecurityPolicy --output json
 
 - Never have two extensions with the same `<Target>.<Suffix>` in the same
   model — `d365fo find extensions` first.
+- Never create a feature-specific extension when a model-level extension for
+  the same target already exists and is the natural owner of the change.
+- Never rewrite an existing extension XML file wholesale. Preserve unrelated
+  nodes and only add the requested structural element(s).
+- After changing extension XML, validate XML well-formedness, run
+  `d365fo validate xpp --file <file> --code-type xml-any --output json`, run
+  `d365fo index refresh --model <Model>`, and re-read the target metadata.
 - Never use `extension` for class behaviour changes — that is CoC's job
   (`d365fo generate coc <Class>`).
 - Never modify the standard object directly (over-layering) — extensions are

--- a/skills/anthropic/review-and-checkpoint-workflow/SKILL.md
+++ b/skills/anthropic/review-and-checkpoint-workflow/SKILL.md
@@ -32,6 +32,12 @@ so you can recover the previous version if Git history isn't enough.
 After each scaffold or edit, run a quick `git diff` to confirm the change is
 contained.
 
+For AOT XML, the diff must be additive or narrowly targeted. If unrelated XML
+nodes disappear, the edit is wrong and must be reverted before continuing.
+Treat removals of `<DataSourceModifications>`, `<DataSourceReferences>`,
+`<DataSources>`, `<Controls>`, methods, pattern metadata, or extension
+properties as high-risk unless the user explicitly requested that removal.
+
 **Hand-written X++ never reaches a file unvalidated:**
 
 ```sh
@@ -40,6 +46,20 @@ d365fo validate xpp --file <f> --output json          # offline BP rules (today(
 ```
 
 Fix all errors, re-run, only then write. Both gates run in <200 ms with no VM.
+
+**Changed AOT XML has its own gate:**
+
+```sh
+# Parse with an XML validator first. Then:
+d365fo validate xpp --file <f> --code-type xml-any --output json
+d365fo index refresh --model <Model>
+d365fo get form <Form> --output json      # for AxForm/AxFormExtension changes
+d365fo get table <Table> --output json    # for AxTable/AxTableExtension changes
+```
+
+For new forms based on an example, compare the pattern metadata and required
+controls/datasources from the example. Missing ActionPane/Body/Tab/FastTab/grid
+or QuickFilter elements are not acceptable just because the XML parses.
 
 ## 3. After the task — AOT-semantic review
 

--- a/skills/copilot/event-handler-authoring.instructions.md
+++ b/skills/copilot/event-handler-authoring.instructions.md
@@ -17,9 +17,25 @@ applyTo: '**/AxClass/**EventHandler*.xml,**/AxClass/**Handler*.xml'
 # 1) Discover existing handlers on the target — avoid duplicates
 d365fo find handlers <TargetObject> --output json
 
-# 2) Confirm the target exists (for tables) and which events it emits
+# 2) Search likely handler classes in the target model/prefix
+d365fo search class <TargetObject> --output json
+
+# 3) Confirm the target exists (for tables) and which events it emits
 d365fo get table <Table> --output json
 ```
+
+If a suitable handler class already exists in the target custom model, add the
+new method to that class instead of creating another handler. `D365FO_CUSTOM_MODELS`
+can contain multiple models, so first resolve the active target model from the
+artifact named by the user, the model that already contains the related handler,
+or the model currently being edited. The handler suffix is separate from the
+model name: extract `<ExistingSuffix>` from existing related handler classes in
+the active model, such as `<Form>_<ExistingSuffix>_Form_EH` or
+`<Form>_<ExistingSuffix>_Form_EventHandler`. If no suffix can be derived and
+the user did not provide one, stop and ask for the suffix. If both `_EH` and
+`_EventHandler` naming styles exist, follow the existing style in that model.
+Do not create `<Form>_<Feature>_EH` or `<Form>_<Feature>_EventHandler` unless
+the user explicitly requests a separate class.
 
 ## Standard data events on tables → `[DataEventHandler]`
 
@@ -80,6 +96,8 @@ Attribute: `[SubscribesTo(classStr(SalesFormLetter), delegateStr(SalesFormLetter
 - Handlers do NOT chain via `next` — they are notification-only.
 - Handler methods must be `public static` (the runtime invokes them
   reflectively).
+- Never create a parallel handler class when an existing target/model handler
+  class already owns the same object/event family.
 - Never modify the buffer in a `Validating*` / `*ing` event without intent —
   changes leak into the persisted record.
 - Pre-flight `find handlers <Target>` to detect duplicates and ordering risks.

--- a/skills/copilot/form-pattern-scaffolding.instructions.md
+++ b/skills/copilot/form-pattern-scaffolding.instructions.md
@@ -42,6 +42,21 @@ every indexed AxForm. Use it instead of guessing — pass the most-common peer
 pattern straight into `--pattern` on the next step. With no flags it returns
 a histogram so you can see what shapes exist before drilling in.
 
+When the user provides an existing form as an example, treat it as a pattern
+contract, not as optional inspiration:
+
+```sh
+d365fo get form <ExampleForm> --output json
+d365fo find form-patterns --similar-to <ExampleForm> --output json
+```
+
+Use the same pattern family unless the user explicitly requests a different
+one. After generation, verify that the new form still contains the pattern's
+required scaffolding: datasource(s), design pattern/version metadata, required
+ActionPane/Body/Tab/FastTab/grid/QuickFilter controls, and required line/header
+datasources for transaction forms. Missing pattern elements are a failed
+generation even if the XML is well-formed.
+
 ## Pattern catalog
 
 | Pattern | When to use | Required |
@@ -97,6 +112,16 @@ section template is `--section Name:Caption` (split on the first `:`).
 
 - Never hand-roll AxForm XML — always use `--pattern`.
 - Never skip the primary datasource for SimpleList / Lookup / ListPage / Master / Transaction patterns.
+- Never drop required pattern controls or metadata from a generated form copied
+  from an example. Validate against the example's pattern before finishing.
+- Never rewrite an existing AxForm or AxFormExtension XML file wholesale.
+  Preserve unrelated `<Controls>`, `<DataSourceModifications>`,
+  `<DataSourceReferences>`, `<DataSources>`, methods, extension properties,
+  and pattern metadata exactly.
+- After changing form XML, validate XML well-formedness, run
+  `d365fo validate xpp --file <file> --code-type xml-any --output json`, run
+  `d365fo index refresh --model <Model>`, and re-read with
+  `d365fo get form <Form> --output json`.
 - Never use `Dialog` or `TableOfContents` patterns for transactional grids.
 - Pre-flight `search form <Name>` before scaffolding to avoid collisions.
 - Caption strings must be labels (BP `BPErrorLabelIsText`) — never raw text.

--- a/skills/copilot/object-extension-authoring.instructions.md
+++ b/skills/copilot/object-extension-authoring.instructions.md
@@ -45,6 +45,31 @@ If `count > 0`, list the existing extensions to the user. The naming
 convention is `<Target>.<Suffix>` (dot-separated; `Suffix` typically is the
 model short-name or the feature name).
 
+## Reuse before creating
+
+`D365FO_CUSTOM_MODELS` constrains the model, not the feature suffix. If the
+variable contains multiple models, resolve the active target model first from
+the artifact named by the user, the model that already contains the related
+extension, or the model currently being edited. If more than one custom model
+could own the change, stop and ask. The extension suffix is separate from the
+model name: extract `<ExistingSuffix>` from existing related extensions in the
+active model, such as `<Target>.<ExistingSuffix>` or
+`<Target>_<ExistingSuffix>_Extension`. If no suffix can be derived and the user
+did not provide one, stop and ask for the suffix. Do not create a feature-named
+extension such as `<Target>.<Feature>` or a class such as
+`<Target>_<Feature>_Extension` merely because the request mentions a feature,
+ticket, integration, customer name, or model name.
+
+Before scaffolding a new extension, inspect the existing result from
+`d365fo find extensions <Target> --output json`:
+
+- If an extension already exists in the target model and suffix family, modify
+  that existing extension.
+- If multiple extensions exist, stop and ask which artifact should own the
+  change unless the user has named one explicitly.
+- Create a new extension only when no existing extension owns that target/model
+  concern or when the user explicitly asks for isolation.
+
 ## Scaffolding
 
 ```sh
@@ -122,6 +147,13 @@ d365fo get security-policy CustCustomSecurityPolicy --output json
 
 - Never have two extensions with the same `<Target>.<Suffix>` in the same
   model — `d365fo find extensions` first.
+- Never create a feature-specific extension when a model-level extension for
+  the same target already exists and is the natural owner of the change.
+- Never rewrite an existing extension XML file wholesale. Preserve unrelated
+  nodes and only add the requested structural element(s).
+- After changing extension XML, validate XML well-formedness, run
+  `d365fo validate xpp --file <file> --code-type xml-any --output json`, run
+  `d365fo index refresh --model <Model>`, and re-read the target metadata.
 - Never use `extension` for class behaviour changes — that is CoC's job
   (`d365fo generate coc <Class>`).
 - Never modify the standard object directly (over-layering) — extensions are

--- a/skills/copilot/review-and-checkpoint-workflow.instructions.md
+++ b/skills/copilot/review-and-checkpoint-workflow.instructions.md
@@ -31,6 +31,12 @@ so you can recover the previous version if Git history isn't enough.
 After each scaffold or edit, run a quick `git diff` to confirm the change is
 contained.
 
+For AOT XML, the diff must be additive or narrowly targeted. If unrelated XML
+nodes disappear, the edit is wrong and must be reverted before continuing.
+Treat removals of `<DataSourceModifications>`, `<DataSourceReferences>`,
+`<DataSources>`, `<Controls>`, methods, pattern metadata, or extension
+properties as high-risk unless the user explicitly requested that removal.
+
 **Hand-written X++ never reaches a file unvalidated:**
 
 ```sh
@@ -39,6 +45,20 @@ d365fo validate xpp --file <f> --output json          # offline BP rules (today(
 ```
 
 Fix all errors, re-run, only then write. Both gates run in <200 ms with no VM.
+
+**Changed AOT XML has its own gate:**
+
+```sh
+# Parse with an XML validator first. Then:
+d365fo validate xpp --file <f> --code-type xml-any --output json
+d365fo index refresh --model <Model>
+d365fo get form <Form> --output json      # for AxForm/AxFormExtension changes
+d365fo get table <Table> --output json    # for AxTable/AxTableExtension changes
+```
+
+For new forms based on an example, compare the pattern metadata and required
+controls/datasources from the example. Missing ActionPane/Body/Tab/FastTab/grid
+or QuickFilter elements are not acceptable just because the XML parses.
 
 ## 3. After the task — AOT-semantic review
 

--- a/src/D365FO.Cli/Commands/Agent/AgentPromptCommand.cs
+++ b/src/D365FO.Cli/Commands/Agent/AgentPromptCommand.cs
@@ -67,6 +67,14 @@ not invent a name.
    - `warnings: ["stale-index"]` → `d365fo index refresh`.
 3. Pass `--install-to <Model>` (bridge writes into model folder) **or**
    `--out <PATH>`. Never guess the model — ask.
+4. Treat `D365FO_CUSTOM_MODELS` as the hard customization boundary. It can
+   contain multiple comma-separated models. Resolve the active target model from
+   the artifact named by the user, the model that already contains the related
+   extension/handler, or the model currently being edited. If more than one
+   custom model could own the change, ask. The artifact suffix is separate from
+   the model name: extract `<ExistingSuffix>` from existing related artifacts.
+   If no suffix can be derived and the user did not provide one, ask for it.
+   Feature names in the request are not suffixes.
 
 ────────────────────────────────────────────────────────────────────────────
 ## 🎯 The loop — minimum agentic rounds
@@ -102,6 +110,7 @@ not invent a name.
 | Existing CoC wrappers | `d365fo find coc <Class>::<method> --output json` |
 | Event handlers | `d365fo find handlers <Target> --output json` |
 | Relations | `d365fo find relations <Table> --output json` |
+| Existing object extensions | `d365fo find extensions <Target> --output json` |
 | Resolve label | `d365fo resolve label @SYS12345 --lang en-us,cs` |
 | Security trace | `d365fo get security <Object> --type <Kind>` |
 
@@ -227,6 +236,28 @@ public void salute(str message = "Hi") // ❌ forbidden
 - Form-nested wrapping (`formdatasourcestr`, `formdatafieldstr`,
   `formControlStr`) cannot ADD new methods.
 - Wrappers can read `protected` (PU9+); not `private`.
+- Reuse existing target/model extension and handler classes before creating new
+  ones. Example: with active target model `<ActiveCustomModel>`, add to
+  `<Target>_<ExistingSuffix>_Extension`,
+  `<Form>_<ExistingSuffix>_Form_EH`, or
+  `<Form>_<ExistingSuffix>_Form_EventHandler` if they already own the target.
+  If no existing suffix can be derived and the user did not provide one, ask;
+  do not create parallel feature-named artifacts unless the user explicitly
+  requests that separation.
+
+────────────────────────────────────────────────────────────────────────────
+## 🧾 AOT XML safety
+
+- Never rewrite an existing AOT XML file wholesale. Preserve unrelated
+  `<DataSourceModifications>`, `<DataSourceReferences>`, `<DataSources>`,
+  `<Controls>`, methods, extension properties, and pattern metadata.
+- Validate every changed XML file: XML parser first, then
+  `d365fo validate xpp --file <f> --code-type xml-any --output json`, then
+  `d365fo index refresh --model <Model>`, then re-read the object with
+  `d365fo get ... --output json`.
+- For new forms based on an example, read the example and keep the same pattern
+  contract unless the user asked otherwise. Required pattern controls/datasources
+  are mandatory, not optional inspiration.
 
 ────────────────────────────────────────────────────────────────────────────
 ## 🏛️ Class & method rules


### PR DESCRIPTION
This change strengthens the D365FO agent guardrails for metadata-safe generation.

Key updates:
- Treats `D365FO_CUSTOM_MODELS` as a list of allowed custom models and requires resolving the active target model before writing.
- Separates the write model from the artifact suffix. The suffix must be extracted from existing related artifacts, or the agent must ask the user.
- Requires reuse of existing extension/event-handler classes when they already own the target.
- Supports both handler naming styles: `_EH` and `_EventHandler`.
- Adds stronger AOT XML safety rules: avoid wholesale XML rewrites, preserve unrelated nodes, validate XML, refresh the index, and re-read metadata.
- Adds form pattern preservation guidance when generating a form from an existing example.

Validation:
- `dotnet build d365fo-cli.slnx` passed with 0 warnings and 0 errors.