### PR TITLE
fix(scaffold,bridge): reject abstract AxEdt/AxEdtExtension root (#70)

### DIFF
--- a/src/D365FO.Bridge/Handlers.cs
+++ b/src/D365FO.Bridge/Handlers.cs
@@ -127,13 +127,36 @@ namespace D365FO.Bridge
                 return new JsonObject { ["ok"] = true, ["kind"] = kind, ["name"] = name, ["model"] = model, ["source"] = "bridge", ["op"] = "delete" };
             }
 
-            // Create/Update — need an Ax* instance.
-            var axType = MetadataBootstrap.GetMetaModelType(kind);
-            if (axType == null) return Fail("TYPE_NOT_FOUND", "Could not resolve Ax type for kind '" + kind + "'.");
-
+            // Create/Update — need an Ax* instance. For polymorphic kinds (edt, edtExtension)
+            // the kind→base-type mapping resolves to an abstract class; the concrete subtype
+            // must come from the input XML's root element name (e.g. AxEdtString).
+            Type axType;
             object ax;
             if (!string.IsNullOrEmpty(xml))
             {
+                string rootLocalName;
+                try
+                {
+                    using (var sr = new StringReader(xml))
+                    using (var xr = System.Xml.XmlReader.Create(sr, new System.Xml.XmlReaderSettings { DtdProcessing = System.Xml.DtdProcessing.Prohibit }))
+                    {
+                        xr.MoveToContent();
+                        rootLocalName = xr.NodeType == System.Xml.XmlNodeType.Element ? xr.LocalName : null;
+                    }
+                }
+                catch (Exception ex)
+                {
+                    return Fail("XML_PARSE_FAILED", ex.Message);
+                }
+                if (string.IsNullOrEmpty(rootLocalName))
+                    return Fail("XML_PARSE_FAILED", "Could not read root element of input xml.");
+
+                axType = MetadataBootstrap.GetMetaModelTypeByShortName(rootLocalName)
+                         ?? MetadataBootstrap.GetMetaModelType(kind);
+                if (axType == null) return Fail("TYPE_NOT_FOUND", "Could not resolve Ax type for root element '" + rootLocalName + "'.");
+                if (axType.IsAbstract)
+                    return Fail("ABSTRACT_TYPE", "Root element '" + rootLocalName + "' maps to abstract type '" + axType.FullName + "'. Use a concrete subtype root such as AxEdtString.");
+
                 try
                 {
                     var serializer = new XmlSerializer(axType);
@@ -150,6 +173,10 @@ namespace D365FO.Bridge
             }
             else
             {
+                axType = MetadataBootstrap.GetMetaModelType(kind);
+                if (axType == null) return Fail("TYPE_NOT_FOUND", "Could not resolve Ax type for kind '" + kind + "'.");
+                if (axType.IsAbstract)
+                    return Fail("ABSTRACT_TYPE", "Cannot construct kind '" + kind + "' without xml — base type '" + axType.FullName + "' is abstract. Provide xml with a concrete root element such as AxEdtString.");
                 var ctor = axType.GetConstructor(Type.EmptyTypes);
                 if (ctor == null) return Fail("TYPE_NOT_FOUND", "Ax type '" + axType.Name + "' has no parameterless ctor.");
                 ax = ctor.Invoke(null);

--- a/src/D365FO.Bridge/MetadataBootstrap.cs
+++ b/src/D365FO.Bridge/MetadataBootstrap.cs
@@ -337,6 +337,24 @@ namespace D365FO.Bridge
         internal static Type GetMetaModelType(string kind)
         {
             if (!KindToTypeName.TryGetValue(kind, out var typeName)) return null;
+            return ResolveMetaModelType(typeName);
+        }
+
+        /// <summary>
+        /// Look up a concrete MetaModel type by its short class name (e.g.
+        /// <c>AxEdtString</c>). Used when the input XML's root element pins
+        /// the precise subtype — the abstract <c>AxEdt</c> base cannot be
+        /// constructed or deserialized.
+        /// </summary>
+        internal static Type GetMetaModelTypeByShortName(string shortName)
+        {
+            if (string.IsNullOrWhiteSpace(shortName)) return null;
+            return ResolveMetaModelType("Microsoft.Dynamics.AX.Metadata.MetaModel." + shortName);
+        }
+
+        private static Type ResolveMetaModelType(string typeName)
+        {
+            if (string.IsNullOrEmpty(typeName)) return null;
             var assemblies = AppDomain.CurrentDomain.GetAssemblies();
             foreach (var asm in assemblies)
             {

--- a/src/D365FO.Core/Scaffolding/XppScaffolder.cs
+++ b/src/D365FO.Core/Scaffolding/XppScaffolder.cs
@@ -826,9 +826,20 @@ public static class ScaffoldFileWriter
 {
     public sealed record WriteResult(string Path, long Bytes, string? BackupPath);
 
+    // AOT root elements that are abstract bases in Microsoft.Dynamics.AX.Metadata.MetaModel.
+    // Writing one of these as the document root makes VS metadata reader throw
+    // "Cannot create an abstract class" when the file is opened — callers must use the
+    // concrete subtype (AxEdtString, AxEdtInt, AxEdtStringExtension, …).
+    private static readonly HashSet<string> _abstractAxRoots = new(StringComparer.Ordinal)
+    {
+        "AxEdt",
+        "AxEdtExtension",
+    };
+
     public static WriteResult Write(XDocument doc, string path, bool overwrite = false)
     {
         ArgumentNullException.ThrowIfNull(doc);
+        EnsureConcreteAxRoot(doc.Root?.Name.LocalName);
         return WriteCore(doc.ToString(SaveOptions.None), path, overwrite, declarationOnSaveFromXDoc: true, doc);
     }
 
@@ -840,7 +851,33 @@ public static class ScaffoldFileWriter
     public static WriteResult Write(string xml, string path, bool overwrite = false)
     {
         ArgumentException.ThrowIfNullOrEmpty(xml);
+        EnsureConcreteAxRoot(SniffRootLocalName(xml));
         return WriteCore(xml, path, overwrite, declarationOnSaveFromXDoc: false, null);
+    }
+
+    private static void EnsureConcreteAxRoot(string? rootLocalName)
+    {
+        if (rootLocalName is not null && _abstractAxRoots.Contains(rootLocalName))
+            throw new InvalidOperationException(
+                $"Refusing to write AOT XML with abstract root element <{rootLocalName}>. " +
+                "Use the concrete subtype (e.g. AxEdtString, AxEdtInt, AxEdtReal, AxEdtDate, " +
+                "AxEdtDateTime, AxEdtBoolean). Visual Studio's metadata reader throws " +
+                "\"Cannot create an abstract class\" on this root.");
+    }
+
+    private static string? SniffRootLocalName(string xml)
+    {
+        try
+        {
+            using var sr = new StringReader(xml);
+            using var xr = System.Xml.XmlReader.Create(sr, new System.Xml.XmlReaderSettings { DtdProcessing = System.Xml.DtdProcessing.Prohibit });
+            xr.MoveToContent();
+            return xr.NodeType == System.Xml.XmlNodeType.Element ? xr.LocalName : null;
+        }
+        catch
+        {
+            return null;
+        }
     }
 
     private static WriteResult WriteCore(string xml, string path, bool overwrite, bool declarationOnSaveFromXDoc, XDocument? doc)

--- a/tests/D365FO.Cli.Tests/ScaffoldingSnapshotTests.cs
+++ b/tests/D365FO.Cli.Tests/ScaffoldingSnapshotTests.cs
@@ -66,6 +66,26 @@ public class ScaffoldingSnapshotTests
         Assert.Equal("50", doc.Root.Element("StringSize")!.Value);
     }
 
+    [Fact]
+    public void ScaffoldFileWriter_rejects_abstract_AxEdt_root()
+    {
+        var doc = new XDocument(new XElement("AxEdt", new XElement("Name", "Bad")));
+        var tmp = System.IO.Path.Combine(System.IO.Path.GetTempPath(), "d365fo-cli-test-abstract-edt.xml");
+        var ex = Assert.Throws<System.InvalidOperationException>(() => ScaffoldFileWriter.Write(doc, tmp, overwrite: true));
+        Assert.Contains("AxEdt", ex.Message);
+        Assert.False(System.IO.File.Exists(tmp));
+    }
+
+    [Fact]
+    public void ScaffoldFileWriter_rejects_abstract_AxEdtExtension_root()
+    {
+        var raw = "<?xml version=\"1.0\" encoding=\"utf-8\"?><AxEdtExtension><Name>Bad.Extension</Name></AxEdtExtension>";
+        var tmp = System.IO.Path.Combine(System.IO.Path.GetTempPath(), "d365fo-cli-test-abstract-edt-ext.xml");
+        var ex = Assert.Throws<System.InvalidOperationException>(() => ScaffoldFileWriter.Write(raw, tmp, overwrite: true));
+        Assert.Contains("AxEdtExtension", ex.Message);
+        Assert.False(System.IO.File.Exists(tmp));
+    }
+
     // ---- Enum (Phase 2) ----
 
     [Fact]


### PR DESCRIPTION
ScaffoldFileWriter now refuses to write AOT XML whose root is an abstract MetaModel base class (AxEdt, AxEdtExtension). VS metadata reader throws 'Cannot create an abstract class' on such files. Validation runs in both the XDocument and raw-string overloads so any path through the writer is covered, not only XppScaffolder.

Bridge write path (Handlers.WriteArtifact) now resolves the concrete Ax* type from the input XML's root element name instead of the kind->base mapping (which pointed edt -> abstract AxEdt). When XML is missing for an abstract kind, the bridge fails fast with ABSTRACT_TYPE and a hint to use a concrete subtype root such as AxEdtString.

- XppScaffolder.ScaffoldFileWriter: EnsureConcreteAxRoot, SniffRootLocalName
- MetadataBootstrap: extracted ResolveMetaModelType, added GetMetaModelTypeByShortName
- Handlers: derive axType from XML root; refuse abstract types
- ScaffoldingSnapshotTests: cover AxEdt and AxEdtExtension rejection