### PR TITLE
Feature/unified config resolution

### DIFF
--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -19,8 +19,12 @@
 | `D365FO_INDEX_DB` | Path to the SQLite index file | `%LOCALAPPDATA%\d365fo-cli\d365fo-index.sqlite` |
 | `D365FO_WORKSPACE_PATH` | Root of your X++ solution (enables scaffold output) | — |
 | `D365FO_CUSTOM_MODELS` | Comma-separated list of custom model names | — |
-| `D365FO_BRIDGE_*` | Bridge server connection settings (see ARCHITECTURE.md) | — |
+| `D365FO_BRIDGE_ENABLED` | `1`/`true` enables the metadata bridge (required for `generate --install-to` and `find refs --xref`) | `false` |
+| `D365FO_BRIDGE_PATH` | Path to `D365FO.Bridge.exe` (auto-detected next to `d365fo.exe` when unset) | *(auto)* |
+| `D365FO_BIN_PATH` | Folder containing `Microsoft.Dynamics.AX.Metadata.*.dll` (usually `<PackagesLocalDirectory>\bin`) | — |
 | `D365FO_XREF_CONNECTIONSTRING` | Cross-reference DB connection string | — |
+| `D365FO_FORCE_JSON` | `1` forces machine-readable JSON output even on a TTY | — |
+| `D365FO_HOME` | Root for the provenance/grounding token store | `%USERPROFILE%\.d365fo` |
 | `D365FO_GROUNDING_ENFORCE` | `true` = `generate` rejects writes without a valid grounding token or with unresolved references / BP errors | `false` (warn only) |
 | `D365FO_FORM_PATTERN_ENFORCE` | `false` = disable the form-pattern write gate; by default `generate form` rejects structural pattern violations (FP001–FP005, FP007) | `true` |
 
@@ -55,6 +59,8 @@ A flat JSON object mapping variable names to string values:
 Run `d365fo init --persist-profile` — this writes (or updates) both the JSON config file and the shell profiles for all PowerShell versions found on the machine.
 
 To write the file manually, create it at the path above. Only the keys you need to override have to be present; missing keys fall back to environment variables and then built-in defaults.
+
+> **Every variable in the table above can be set in the JSON config file** — it is a complete alternative to environment variables. Each key is resolved with the same precedence (CLI flag → environment variable → JSON config → default), so a value set only in `settings.json` is honored everywhere, including the bridge stack (`D365FO_BRIDGE_ENABLED`, `D365FO_BRIDGE_PATH`, `D365FO_BIN_PATH`).
 
 ---
 

--- a/src/D365FO.Cli/Commands/Get/BridgeGate.cs
+++ b/src/D365FO.Cli/Commands/Get/BridgeGate.cs
@@ -1,4 +1,5 @@
 using System.Text.Json.Nodes;
+using D365FO.Core;
 using D365FO.Core.Bridge;
 
 namespace D365FO.Cli.Commands.Get;
@@ -12,17 +13,18 @@ namespace D365FO.Cli.Commands.Get;
 /// </summary>
 internal static class BridgeGate
 {
-    internal static bool ShouldTry()
-    {
-        var flag = System.Environment.GetEnvironmentVariable("D365FO_BRIDGE_ENABLED");
-        if (string.IsNullOrWhiteSpace(flag))
-        {
-            return false;
-        }
+    internal static bool ShouldTry() => D365FoSettings.ResolveFlag("D365FO_BRIDGE_ENABLED");
 
-        return flag == "1"
-            || string.Equals(flag, "true", System.StringComparison.OrdinalIgnoreCase);
-    }
+    /// <summary>
+    /// Build bridge options from the unified config resolver so values set in
+    /// settings.json (not just real env vars) reach the bridge child process.
+    /// </summary>
+    private static BridgeOptions DefaultOptions() => new()
+    {
+        MetadataBinPath = D365FoSettings.Resolve("D365FO_BIN_PATH"),
+        PackagesPath = D365FoSettings.Resolve("D365FO_PACKAGES_PATH"),
+        XrefConnectionString = D365FoSettings.Resolve("D365FO_XREF_CONNECTIONSTRING"),
+    };
 
     internal static object? TryReadClass(string name) => TryRead("readClass", name);
     internal static object? TryReadTable(string name) => TryRead("readTable", name);
@@ -46,10 +48,7 @@ internal static class BridgeGate
 
         try
         {
-            var options = new BridgeOptions
-            {
-                MetadataBinPath = System.Environment.GetEnvironmentVariable("D365FO_BIN_PATH"),
-            };
+            var options = DefaultOptions();
             using var client = new BridgeClient(options);
             var args = new JsonObject
             {
@@ -88,10 +87,7 @@ internal static class BridgeGate
         if (!BridgeClient.IsAvailable()) return null;
         try
         {
-            var options = new BridgeOptions
-            {
-                MetadataBinPath = System.Environment.GetEnvironmentVariable("D365FO_BIN_PATH"),
-            };
+            var options = DefaultOptions();
             using var client = new BridgeClient(options);
             var args = new JsonObject { ["symbol"] = symbol, ["limit"] = limit };
             if (!string.IsNullOrEmpty(kind)) args["kind"] = kind;
@@ -117,10 +113,7 @@ internal static class BridgeGate
         if (!BridgeClient.IsAvailable()) return null;
         try
         {
-            var options = new BridgeOptions
-            {
-                MetadataBinPath = System.Environment.GetEnvironmentVariable("D365FO_BIN_PATH"),
-            };
+            var options = DefaultOptions();
             using var client = new BridgeClient(options);
             var result = client.SendAsync("getModelFolder", new JsonObject { ["name"] = model })
                 .GetAwaiter().GetResult();
@@ -144,10 +137,7 @@ internal static class BridgeGate
 
         try
         {
-            var options = new BridgeOptions
-            {
-                MetadataBinPath = System.Environment.GetEnvironmentVariable("D365FO_BIN_PATH"),
-            };
+            var options = DefaultOptions();
             using var client = new BridgeClient(options);
             var result = client.SendAsync(method, new JsonObject { ["name"] = name })
                 .GetAwaiter()

--- a/src/D365FO.Cli/Commands/Ops/BuildCommands.cs
+++ b/src/D365FO.Cli/Commands/Ops/BuildCommands.cs
@@ -228,8 +228,8 @@ public sealed class BpCheckCommand : Command<BpCheckCommand.Settings>
         //   metadataPath = ModelStoreFolder   (where custom source XML lives)
         // In traditional environments both roles are served by packagesRoot.
         var packagesRoot = settings.PackagesPath
-            ?? Environment.GetEnvironmentVariable("D365FO_PACKAGES_PATH")
-            ?? @"K:\AosService\PackagesLocalDirectory";
+            ?? D365FoSettings.Resolve("D365FO_PACKAGES_PATH")
+            ?? DefaultPackagesRoot();
         var metadataPath = settings.MetadataPath ?? packagesRoot;
 
         var bp = settings.BpToolPath
@@ -274,6 +274,25 @@ public sealed class BpCheckCommand : Command<BpCheckCommand.Settings>
             : ToolResult<object>.Fail("BP_FAILED",
                 $"Best practice check exited with {exit}.",
                 string.Join('\n', stderr.Split('\n').TakeLast(5))));
+    }
+
+    // Well-known D365FO PackagesLocalDirectory locations, used only as a
+    // last-resort fallback when neither --packages nor D365FO_PACKAGES_PATH
+    // (env or settings.json) is set. K:\ is the cloud-hosted layout; C:\ is the
+    // standard local VHD layout.
+    private static readonly string[] DefaultPackageRoots =
+    {
+        @"K:\AosService\PackagesLocalDirectory",
+        @"C:\AosService\PackagesLocalDirectory",
+    };
+
+    private static string DefaultPackagesRoot()
+    {
+        foreach (var root in DefaultPackageRoots)
+        {
+            if (Directory.Exists(root)) return root;
+        }
+        return DefaultPackageRoots[0];
     }
 }
 

--- a/src/D365FO.Cli/Commands/Ops/OpsCommands.cs
+++ b/src/D365FO.Cli/Commands/Ops/OpsCommands.cs
@@ -77,12 +77,20 @@ public sealed class DoctorCommand : Command<DoctorCommand.Settings>
                     : DoctorSeverity.Ok,
                 bridgeExe ?? "D365FO.Bridge.exe not found next to d365fo.exe; set D365FO_BRIDGE_PATH.");
 
+            // Mirror the bridge's own resolution (MetadataBootstrap.ResolveBinPath):
+            // D365FO_BIN_PATH when set, otherwise <D365FO_PACKAGES_PATH>\bin.
             var binPath = D365FoSettings.Resolve("D365FO_BIN_PATH");
+            var binSource = "D365FO_BIN_PATH";
+            if (string.IsNullOrWhiteSpace(binPath) && !string.IsNullOrEmpty(cfg.PackagesPath))
+            {
+                binPath = Path.Combine(cfg.PackagesPath, "bin");
+                binSource = "D365FO_PACKAGES_PATH\\bin";
+            }
             var binOk = !string.IsNullOrWhiteSpace(binPath) && Directory.Exists(binPath);
             Add("bridge.binPath",
                 binOk ? DoctorSeverity.Ok : DoctorSeverity.Warn,
                 binOk
-                    ? binPath
+                    ? $"{binPath} (from {binSource})"
                     : "Set D365FO_BIN_PATH to the folder containing Microsoft.Dynamics.AX.Metadata.*.dll (e.g. <PackagesLocalDirectory>\\bin).");
         }
 

--- a/src/D365FO.Cli/Commands/Ops/OpsCommands.cs
+++ b/src/D365FO.Cli/Commands/Ops/OpsCommands.cs
@@ -58,10 +58,9 @@ public sealed class DoctorCommand : Command<DoctorCommand.Settings>
 
         // Bridge — required for `generate --install-to <Model>` and `find refs --xref`.
         // Reports Warn (not Fail) when missing because read-only operations work
-        // without it via the SQLite index.
-        var bridgeFlag = Environment.GetEnvironmentVariable("D365FO_BRIDGE_ENABLED");
-        var bridgeEnabled = !string.IsNullOrWhiteSpace(bridgeFlag)
-            && (bridgeFlag == "1" || string.Equals(bridgeFlag, "true", StringComparison.OrdinalIgnoreCase));
+        // without it via the SQLite index. Resolved via the unified config chain
+        // (env var → settings.json) so a value set in settings.json is honored.
+        var bridgeEnabled = D365FoSettings.ResolveFlag("D365FO_BRIDGE_ENABLED");
         Add("bridge.enabled (required for `generate --install-to`)",
             bridgeEnabled ? DoctorSeverity.Ok : DoctorSeverity.Warn,
             bridgeEnabled
@@ -71,14 +70,14 @@ public sealed class DoctorCommand : Command<DoctorCommand.Settings>
         if (bridgeEnabled)
         {
             var bridgeExe = BridgeOptions.ResolveExecutable(
-                Environment.GetEnvironmentVariable("D365FO_BRIDGE_PATH"));
+                D365FoSettings.Resolve("D365FO_BRIDGE_PATH"));
             Add("bridge.executable",
                 bridgeExe is null
                     ? (OperatingSystem.IsWindows() ? DoctorSeverity.Fail : DoctorSeverity.Warn)
                     : DoctorSeverity.Ok,
                 bridgeExe ?? "D365FO.Bridge.exe not found next to d365fo.exe; set D365FO_BRIDGE_PATH.");
 
-            var binPath = Environment.GetEnvironmentVariable("D365FO_BIN_PATH");
+            var binPath = D365FoSettings.Resolve("D365FO_BIN_PATH");
             var binOk = !string.IsNullOrWhiteSpace(binPath) && Directory.Exists(binPath);
             Add("bridge.binPath",
                 binOk ? DoctorSeverity.Ok : DoctorSeverity.Warn,

--- a/src/D365FO.Cli/OutputMode.cs
+++ b/src/D365FO.Cli/OutputMode.cs
@@ -1,5 +1,6 @@
 using Spectre.Console;
 using Spectre.Console.Cli;
+using D365FO.Core;
 
 namespace D365FO.Cli;
 
@@ -12,7 +13,7 @@ public static class OutputMode
     public static bool IsTty =>
         !Console.IsOutputRedirected
         && !Console.IsErrorRedirected
-        && Environment.GetEnvironmentVariable("D365FO_FORCE_JSON") != "1";
+        && !D365FoSettings.ResolveFlag("D365FO_FORCE_JSON");
 
     public enum Kind { Json, Table, Raw }
 

--- a/src/D365FO.Cli/RenderHelpers.cs
+++ b/src/D365FO.Cli/RenderHelpers.cs
@@ -97,8 +97,10 @@ public static class RenderHelpers
 
     private static IReadOnlyCollection<string> ResolveLanguages()
     {
-        var langs = D365FoSettings.FromEnvironment().LabelLanguages;
-        return langs.Count == 0 ? new[] { "en-us" } : langs;
+        var raw = D365FoSettings.Resolve("D365FO_LABEL_LANGUAGES");
+        return string.IsNullOrWhiteSpace(raw)
+            ? new[] { "en-us" }
+            : raw.Split(',', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries);
     }
 
     public static string Escape(string? s) => s is null ? string.Empty : Markup.Escape(s);

--- a/src/D365FO.Cli/RenderHelpers.cs
+++ b/src/D365FO.Cli/RenderHelpers.cs
@@ -97,12 +97,8 @@ public static class RenderHelpers
 
     private static IReadOnlyCollection<string> ResolveLanguages()
     {
-        var env = Environment.GetEnvironmentVariable("D365FO_LABEL_LANGUAGES");
-        if (string.IsNullOrWhiteSpace(env))
-        {
-            return new[] { "en-us" };
-        }
-        return env.Split(',', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries);
+        var langs = D365FoSettings.FromEnvironment().LabelLanguages;
+        return langs.Count == 0 ? new[] { "en-us" } : langs;
     }
 
     public static string Escape(string? s) => s is null ? string.Empty : Markup.Escape(s);

--- a/src/D365FO.Core/Bridge/BridgeClient.cs
+++ b/src/D365FO.Core/Bridge/BridgeClient.cs
@@ -34,6 +34,19 @@ public sealed record BridgeOptions
     public string? MetadataBinPath { get; init; }
 
     /// <summary>
+    /// PackagesLocalDirectory root. Forwarded to the bridge via
+    /// <c>D365FO_PACKAGES_PATH</c> so that a value configured only in
+    /// settings.json still reaches the child process.
+    /// </summary>
+    public string? PackagesPath { get; init; }
+
+    /// <summary>
+    /// DYNAMICSXREFDB connection string. Forwarded to the bridge via
+    /// <c>D365FO_XREF_CONNECTIONSTRING</c> when set.
+    /// </summary>
+    public string? XrefConnectionString { get; init; }
+
+    /// <summary>
     /// Per-request timeout. Defaults to 10 s to match upstream.
     /// </summary>
     public TimeSpan RequestTimeout { get; init; } = TimeSpan.FromSeconds(10);
@@ -55,7 +68,7 @@ public sealed record BridgeOptions
             return explicitPath;
         }
 
-        var env = Environment.GetEnvironmentVariable("D365FO_BRIDGE_PATH");
+        var env = D365FoSettings.Resolve("D365FO_BRIDGE_PATH");
         if (!string.IsNullOrWhiteSpace(env) && File.Exists(env))
         {
             return env;
@@ -265,6 +278,14 @@ public sealed class BridgeClient : IDisposable
             if (!string.IsNullOrWhiteSpace(options.MetadataBinPath))
             {
                 psi.Environment["D365FO_BIN_PATH"] = options.MetadataBinPath;
+            }
+            if (!string.IsNullOrWhiteSpace(options.PackagesPath))
+            {
+                psi.Environment["D365FO_PACKAGES_PATH"] = options.PackagesPath;
+            }
+            if (!string.IsNullOrWhiteSpace(options.XrefConnectionString))
+            {
+                psi.Environment["D365FO_XREF_CONNECTIONSTRING"] = options.XrefConnectionString;
             }
 
             process = Process.Start(psi);

--- a/src/D365FO.Core/D365FO.Core.csproj
+++ b/src/D365FO.Core/D365FO.Core.csproj
@@ -9,6 +9,12 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <AssemblyAttribute Include="System.Runtime.CompilerServices.InternalsVisibleTo">
+      <_Parameter1>D365FO.Core.Tests</_Parameter1>
+    </AssemblyAttribute>
+  </ItemGroup>
+
+  <ItemGroup>
     <EmbeddedResource Include="Index\Schema.sql" />
     <EmbeddedResource Include="Scaffolding\FormTemplates\*.template.xml" />
   </ItemGroup>

--- a/src/D365FO.Core/D365FoSettings.cs
+++ b/src/D365FO.Core/D365FoSettings.cs
@@ -31,12 +31,31 @@ public sealed record D365FoSettings(
 
     /// <summary>
     /// settings.json contents, loaded once per process and cached. Invalidated
-    /// by <see cref="SaveJsonConfig"/>.
+    /// by <see cref="SaveJsonConfig"/>. Protected by <see cref="_cacheLock"/>.
     /// </summary>
+    private static readonly object _cacheLock = new();
     private static Dictionary<string, string>? jsonConfigCache;
 
-    private static Dictionary<string, string> JsonConfig =>
-        jsonConfigCache ??= LoadJsonConfig();
+    /// <summary>
+    /// Override the config file path. For unit tests only — do not set in
+    /// production code. Reset to null and call <see cref="ClearCacheForTests"/>
+    /// between tests.
+    /// </summary>
+    internal static string? ConfigPathOverrideForTests;
+
+    /// <summary>Clear the in-process JSON config cache. For unit tests only.</summary>
+    internal static void ClearCacheForTests()
+    {
+        lock (_cacheLock) { jsonConfigCache = null; }
+    }
+
+    private static Dictionary<string, string> GetJsonConfig()
+    {
+        lock (_cacheLock)
+        {
+            return jsonConfigCache ??= LoadJsonConfig();
+        }
+    }
 
     /// <summary>
     /// Resolve a single configuration value using the standard precedence:
@@ -48,7 +67,8 @@ public sealed record D365FoSettings(
     {
         var env = Environment.GetEnvironmentVariable(key);
         if (!string.IsNullOrWhiteSpace(env)) return env;
-        return JsonConfig.TryGetValue(key, out var jv) && !string.IsNullOrWhiteSpace(jv)
+        var config = GetJsonConfig();
+        return config.TryGetValue(key, out var jv) && !string.IsNullOrWhiteSpace(jv)
             ? jv
             : null;
     }
@@ -107,14 +127,14 @@ public sealed record D365FoSettings(
         File.WriteAllText(path, JsonSerializer.Serialize(merged, D365Json.Pretty));
 
         // Keep the in-process cache consistent with what we just persisted.
-        jsonConfigCache = merged;
+        lock (_cacheLock) { jsonConfigCache = merged; }
     }
 
     // ---- private helpers -----------------------------------------------------
 
     private static Dictionary<string, string> LoadJsonConfig()
     {
-        var path = GetDefaultConfigPath();
+        var path = ConfigPathOverrideForTests ?? GetDefaultConfigPath();
         if (!File.Exists(path)) return new(StringComparer.OrdinalIgnoreCase);
         try
         {

--- a/src/D365FO.Core/D365FoSettings.cs
+++ b/src/D365FO.Core/D365FoSettings.cs
@@ -29,17 +29,46 @@ public sealed record D365FoSettings(
             Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData),
             "d365fo-cli", ConfigFileName);
 
+    /// <summary>
+    /// settings.json contents, loaded once per process and cached. Invalidated
+    /// by <see cref="SaveJsonConfig"/>.
+    /// </summary>
+    private static Dictionary<string, string>? jsonConfigCache;
+
+    private static Dictionary<string, string> JsonConfig =>
+        jsonConfigCache ??= LoadJsonConfig();
+
+    /// <summary>
+    /// Resolve a single configuration value using the standard precedence:
+    /// (1) process environment variable, (2) settings.json. Returns null when
+    /// the key is set in neither. This is the single entry point every call
+    /// site should use so that settings.json is honored consistently.
+    /// </summary>
+    public static string? Resolve(string key)
+    {
+        var env = Environment.GetEnvironmentVariable(key);
+        if (!string.IsNullOrWhiteSpace(env)) return env;
+        return JsonConfig.TryGetValue(key, out var jv) && !string.IsNullOrWhiteSpace(jv)
+            ? jv
+            : null;
+    }
+
+    /// <summary>
+    /// Resolve a boolean flag via <see cref="Resolve"/>. True when the resolved
+    /// value is <c>"1"</c> or <c>"true"</c> (case-insensitive); otherwise
+    /// <paramref name="defaultValue"/> when the key is unset.
+    /// </summary>
+    public static bool ResolveFlag(string key, bool defaultValue = false)
+    {
+        var v = Resolve(key);
+        if (v is null) return defaultValue;
+        return v == "1" || string.Equals(v, "true", StringComparison.OrdinalIgnoreCase);
+    }
+
     public static D365FoSettings FromEnvironment(string? databaseOverride = null)
     {
-        // Load JSON config file as fallback; env vars always take priority.
-        var jsonConfig = LoadJsonConfig();
-
-        string Env(string k)
-        {
-            var v = Environment.GetEnvironmentVariable(k);
-            if (!string.IsNullOrWhiteSpace(v)) return v;
-            return jsonConfig.TryGetValue(k, out var jv) ? jv ?? string.Empty : string.Empty;
-        }
+        // Env var first, then settings.json fallback — same chain as Resolve.
+        static string Env(string k) => Resolve(k) ?? string.Empty;
 
         var models = Split(Env("D365FO_CUSTOM_MODELS"));
         var langs = Split(Env("D365FO_LABEL_LANGUAGES"));
@@ -76,6 +105,9 @@ public sealed record D365FoSettings(
         foreach (var (k, v) in values) merged[k] = v;
 
         File.WriteAllText(path, JsonSerializer.Serialize(merged, D365Json.Pretty));
+
+        // Keep the in-process cache consistent with what we just persisted.
+        jsonConfigCache = merged;
     }
 
     // ---- private helpers -----------------------------------------------------
@@ -83,16 +115,18 @@ public sealed record D365FoSettings(
     private static Dictionary<string, string> LoadJsonConfig()
     {
         var path = GetDefaultConfigPath();
-        if (!File.Exists(path)) return new();
+        if (!File.Exists(path)) return new(StringComparer.OrdinalIgnoreCase);
         try
         {
             var json = File.ReadAllText(path);
-            return JsonSerializer.Deserialize<Dictionary<string, string>>(json, D365Json.Options)
-                   ?? new();
+            return new Dictionary<string, string>(
+                JsonSerializer.Deserialize<Dictionary<string, string>>(json, D365Json.Options)
+                    ?? new(),
+                StringComparer.OrdinalIgnoreCase);
         }
         catch
         {
-            return new();
+            return new(StringComparer.OrdinalIgnoreCase);
         }
     }
 

--- a/src/D365FO.Core/Guardrails/ProvenanceStore.cs
+++ b/src/D365FO.Core/Guardrails/ProvenanceStore.cs
@@ -35,14 +35,14 @@ public static class ProvenanceStore
     private static readonly TimeSpan Ttl = TimeSpan.FromMinutes(30);
 
     public static bool EnforcementEnabled =>
-        string.Equals(Environment.GetEnvironmentVariable(EnforceEnvVar), "true", StringComparison.OrdinalIgnoreCase);
+        string.Equals(D365FoSettings.Resolve(EnforceEnvVar), "true", StringComparison.OrdinalIgnoreCase);
 
     /// <summary>Storage directory; override via D365FO_HOME for tests.</summary>
     internal static string StoreDirectory
     {
         get
         {
-            var home = Environment.GetEnvironmentVariable("D365FO_HOME");
+            var home = D365FoSettings.Resolve("D365FO_HOME");
             var root = string.IsNullOrEmpty(home)
                 ? Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.UserProfile), ".d365fo")
                 : home;

--- a/src/D365FO.Core/Guardrails/ProvenanceStore.cs
+++ b/src/D365FO.Core/Guardrails/ProvenanceStore.cs
@@ -35,7 +35,7 @@ public static class ProvenanceStore
     private static readonly TimeSpan Ttl = TimeSpan.FromMinutes(30);
 
     public static bool EnforcementEnabled =>
-        string.Equals(D365FoSettings.Resolve(EnforceEnvVar), "true", StringComparison.OrdinalIgnoreCase);
+        D365FoSettings.ResolveFlag(EnforceEnvVar);
 
     /// <summary>Storage directory; override via D365FO_HOME for tests.</summary>
     internal static string StoreDirectory

--- a/src/D365FO.Mcp/ToolHandlers.cs
+++ b/src/D365FO.Mcp/ToolHandlers.cs
@@ -1019,7 +1019,7 @@ public sealed class ToolHandlers
     }
 
     private static bool FormPatternEnforced() =>
-        !string.Equals(Environment.GetEnvironmentVariable("D365FO_FORM_PATTERN_ENFORCE"), "false", StringComparison.OrdinalIgnoreCase);
+        !string.Equals(D365FoSettings.Resolve("D365FO_FORM_PATTERN_ENFORCE"), "false", StringComparison.OrdinalIgnoreCase);
 
     /// <summary>Up to 10 objects per call — parity with upstream <c>batch_get_info</c>.</summary>
     public ToolResult<object> BatchGetInfo(string[]? objects)

--- a/tests/D365FO.Core.Tests/D365FoSettingsResolveTests.cs
+++ b/tests/D365FO.Core.Tests/D365FoSettingsResolveTests.cs
@@ -76,4 +76,124 @@ public class D365FoSettingsResolveTests
             Environment.SetEnvironmentVariable(FlagKey, prev);
         }
     }
+
+    // ---- JSON fallback tests -------------------------------------------------
+
+    [Fact]
+    public void Resolve_falls_back_to_settings_json_when_env_not_set()
+    {
+        var tmp = Path.GetTempFileName();
+        try
+        {
+            File.WriteAllText(tmp, $"{{\"{Key}\": \"from-json\"}}");
+            D365FoSettings.ConfigPathOverrideForTests = tmp;
+            D365FoSettings.ClearCacheForTests();
+
+            // Env var must be absent so the JSON fallback is reached.
+            var prev = Environment.GetEnvironmentVariable(Key);
+            Environment.SetEnvironmentVariable(Key, null);
+            try
+            {
+                Assert.Equal("from-json", D365FoSettings.Resolve(Key));
+            }
+            finally
+            {
+                Environment.SetEnvironmentVariable(Key, prev);
+            }
+        }
+        finally
+        {
+            D365FoSettings.ConfigPathOverrideForTests = null;
+            D365FoSettings.ClearCacheForTests();
+            File.Delete(tmp);
+        }
+    }
+
+    [Fact]
+    public void Resolve_env_var_takes_priority_over_settings_json()
+    {
+        var tmp = Path.GetTempFileName();
+        try
+        {
+            File.WriteAllText(tmp, $"{{\"{Key}\": \"from-json\"}}");
+            D365FoSettings.ConfigPathOverrideForTests = tmp;
+            D365FoSettings.ClearCacheForTests();
+
+            var prev = Environment.GetEnvironmentVariable(Key);
+            Environment.SetEnvironmentVariable(Key, "from-env");
+            try
+            {
+                Assert.Equal("from-env", D365FoSettings.Resolve(Key));
+            }
+            finally
+            {
+                Environment.SetEnvironmentVariable(Key, prev);
+            }
+        }
+        finally
+        {
+            D365FoSettings.ConfigPathOverrideForTests = null;
+            D365FoSettings.ClearCacheForTests();
+            File.Delete(tmp);
+        }
+    }
+
+    [Fact]
+    public void Resolve_settings_json_keys_are_case_insensitive()
+    {
+        var tmp = Path.GetTempFileName();
+        try
+        {
+            // Store the key in lowercase; resolve with the canonical uppercase name.
+            File.WriteAllText(tmp, $"{{\"{Key.ToLowerInvariant()}\": \"case-ok\"}}");
+            D365FoSettings.ConfigPathOverrideForTests = tmp;
+            D365FoSettings.ClearCacheForTests();
+
+            var prev = Environment.GetEnvironmentVariable(Key);
+            Environment.SetEnvironmentVariable(Key, null);
+            try
+            {
+                Assert.Equal("case-ok", D365FoSettings.Resolve(Key));
+            }
+            finally
+            {
+                Environment.SetEnvironmentVariable(Key, prev);
+            }
+        }
+        finally
+        {
+            D365FoSettings.ConfigPathOverrideForTests = null;
+            D365FoSettings.ClearCacheForTests();
+            File.Delete(tmp);
+        }
+    }
+
+    [Fact]
+    public void ResolveFlag_reads_flag_from_settings_json()
+    {
+        var tmp = Path.GetTempFileName();
+        try
+        {
+            File.WriteAllText(tmp, $"{{\"{FlagKey}\": \"true\"}}");
+            D365FoSettings.ConfigPathOverrideForTests = tmp;
+            D365FoSettings.ClearCacheForTests();
+
+            var prev = Environment.GetEnvironmentVariable(FlagKey);
+            Environment.SetEnvironmentVariable(FlagKey, null);
+            try
+            {
+                Assert.True(D365FoSettings.ResolveFlag(FlagKey));
+            }
+            finally
+            {
+                Environment.SetEnvironmentVariable(FlagKey, prev);
+            }
+        }
+        finally
+        {
+            D365FoSettings.ConfigPathOverrideForTests = null;
+            D365FoSettings.ClearCacheForTests();
+            File.Delete(tmp);
+        }
+    }
 }

--- a/tests/D365FO.Core.Tests/D365FoSettingsResolveTests.cs
+++ b/tests/D365FO.Core.Tests/D365FoSettingsResolveTests.cs
@@ -1,0 +1,79 @@
+using Xunit;
+
+namespace D365FO.Core.Tests;
+
+public class D365FoSettingsResolveTests
+{
+    // Use unlikely key names so a real settings.json on the test host cannot
+    // collide with these deterministic env-var assertions.
+    private const string Key = "D365FO_TEST_RESOLVE_KEY_XYZ";
+    private const string FlagKey = "D365FO_TEST_RESOLVE_FLAG_XYZ";
+
+    [Fact]
+    public void Resolve_returns_env_value_when_set()
+    {
+        var prev = Environment.GetEnvironmentVariable(Key);
+        try
+        {
+            Environment.SetEnvironmentVariable(Key, "hello");
+            Assert.Equal("hello", D365FoSettings.Resolve(Key));
+        }
+        finally
+        {
+            Environment.SetEnvironmentVariable(Key, prev);
+        }
+    }
+
+    [Fact]
+    public void Resolve_returns_null_when_unset_in_env_and_json()
+    {
+        var prev = Environment.GetEnvironmentVariable(Key);
+        try
+        {
+            Environment.SetEnvironmentVariable(Key, null);
+            Assert.Null(D365FoSettings.Resolve(Key));
+        }
+        finally
+        {
+            Environment.SetEnvironmentVariable(Key, prev);
+        }
+    }
+
+    [Theory]
+    [InlineData("1", true)]
+    [InlineData("true", true)]
+    [InlineData("TRUE", true)]
+    [InlineData("0", false)]
+    [InlineData("false", false)]
+    [InlineData("yes", false)]
+    public void ResolveFlag_parses_truthy_values(string value, bool expected)
+    {
+        var prev = Environment.GetEnvironmentVariable(FlagKey);
+        try
+        {
+            Environment.SetEnvironmentVariable(FlagKey, value);
+            Assert.Equal(expected, D365FoSettings.ResolveFlag(FlagKey));
+        }
+        finally
+        {
+            Environment.SetEnvironmentVariable(FlagKey, prev);
+        }
+    }
+
+    [Theory]
+    [InlineData(false)]
+    [InlineData(true)]
+    public void ResolveFlag_returns_default_when_unset(bool defaultValue)
+    {
+        var prev = Environment.GetEnvironmentVariable(FlagKey);
+        try
+        {
+            Environment.SetEnvironmentVariable(FlagKey, null);
+            Assert.Equal(defaultValue, D365FoSettings.ResolveFlag(FlagKey, defaultValue));
+        }
+        finally
+        {
+            Environment.SetEnvironmentVariable(FlagKey, prev);
+        }
+    }
+}


### PR DESCRIPTION
This pull request enhances configuration management by ensuring that all configuration values can be consistently sourced from either environment variables or a `settings.json` file, with a unified resolution chain. It refactors the codebase to use new helper methods for configuration lookup, making settings more discoverable and robust. The bridge client and related commands now forward all relevant settings to child processes, and several commands have been updated to use the new resolution logic. Documentation is updated to clarify the new configuration precedence and available options.

fixes #75 

**Configuration management improvements:**

* Introduced `D365FoSettings.Resolve` and `D365FoSettings.ResolveFlag` methods to consistently resolve configuration values from environment variables or `settings.json`, with caching and case-insensitive keys. All major code paths now use these helpers instead of directly reading environment variables. [[1]](diffhunk://#diff-26a517875520f78d869f6ecff9e01e6067a255b63353d78237d77e3d0cfa7be2L32-R72) [[2]](diffhunk://#diff-26a517875520f78d869f6ecff9e01e6067a255b63353d78237d77e3d0cfa7be2R108-R129)
* Updated documentation to clarify that every configuration variable can be set in the JSON config file, and described the resolution precedence (CLI flag → environment variable → JSON config → default). New settings such as `D365FO_BRIDGE_ENABLED`, `D365FO_BRIDGE_PATH`, `D365FO_BIN_PATH`, `D365FO_FORCE_JSON`, and `D365FO_HOME` are documented. [[1]](diffhunk://#diff-58f184d7415a8c22e56e4908527cfd1c7c28ea1c5720cf4280b2d511b25f7409L22-R27) [[2]](diffhunk://#diff-58f184d7415a8c22e56e4908527cfd1c7c28ea1c5720cf4280b2d511b25f7409R63-R64)

**Bridge and process configuration:**

* Refactored bridge client and related commands to forward all relevant settings (`D365FO_BIN_PATH`, `D365FO_PACKAGES_PATH`, `D365FO_XREF_CONNECTIONSTRING`) to the bridge child process, ensuring values from `settings.json` are honored. [[1]](diffhunk://#diff-56c4deefe48e6773263cffec15258dc4b18d70ca4b01d1db09e1b3c35d37cd9aL15-R27) [[2]](diffhunk://#diff-56c4deefe48e6773263cffec15258dc4b18d70ca4b01d1db09e1b3c35d37cd9aL49-R51) [[3]](diffhunk://#diff-56c4deefe48e6773263cffec15258dc4b18d70ca4b01d1db09e1b3c35d37cd9aL91-R90) [[4]](diffhunk://#diff-56c4deefe48e6773263cffec15258dc4b18d70ca4b01d1db09e1b3c35d37cd9aL120-R116) [[5]](diffhunk://#diff-56c4deefe48e6773263cffec15258dc4b18d70ca4b01d1db09e1b3c35d37cd9aL147-R140) [[6]](diffhunk://#diff-7182c5f9187dfac4d988511b4bcdb1bb887b30377b5a00f6def8c4daa35aaf73R36-R48) [[7]](diffhunk://#diff-7182c5f9187dfac4d988511b4bcdb1bb887b30377b5a00f6def8c4daa35aaf73L58-R71) [[8]](diffhunk://#diff-7182c5f9187dfac4d988511b4bcdb1bb887b30377b5a00f6def8c4daa35aaf73R282-R289)
* Updated bridge diagnostics and doctor checks to use the unified configuration chain and to better explain the source of resolved paths. [[1]](diffhunk://#diff-d88bce2681f64268f6d598ac618197b9eea9458d91f17ec791cac05a88db6088L61-R63) [[2]](diffhunk://#diff-d88bce2681f64268f6d598ac618197b9eea9458d91f17ec791cac05a88db6088L74-R93)

**General command and output improvements:**

* Updated output mode and language resolution to use the new configuration helpers, ensuring consistent behavior for flags like `D365FO_FORCE_JSON` and `D365FO_LABEL_LANGUAGES`. [[1]](diffhunk://#diff-d475d5320c35e3615282a5120fd17b725222180d684d8da400bbde343d5cea35L15-R16) [[2]](diffhunk://#diff-f5dafdacd3803c907e2167d2a4138615e8e039e1aa25a7748739b5245bd65b37L100-R101)
* Refactored build commands to use the new configuration resolution and introduced a fallback mechanism for locating the packages root directory. [[1]](diffhunk://#diff-39dd2d6166f0ff0d8dda9846a43e689db20d091b99f81c79b5a001b3b0ecc23aL231-R232) [[2]](diffhunk://#diff-39dd2d6166f0ff0d8dda9846a43e689db20d091b99f81c79b5a001b3b0ecc23aR278-R296)

**Guardrails and enforcement:**

* Updated guardrails and enforcement checks (e.g., provenance store, form pattern enforcement) to use the new configuration resolution logic. [[1]](diffhunk://#diff-5f04fd2f8bae60c2f60416571246740773168f827db8482491d5fb09398845eeL38-R45) [[2]](diffhunk://#diff-2d6a76aa8053a8ba366549bd8b94840b42515018d59002d2389a5d2db6f5f484L1022-R1022)