### PR TITLE
fix(scaffold): emit valid AxEnum XML (xmlns:i + boolean IsExtensible)

### DIFF
--- a/src/D365FO.Cli/Commands/Generate/GenerateEnumCommand.cs
+++ b/src/D365FO.Cli/Commands/Generate/GenerateEnumCommand.cs
@@ -18,7 +18,7 @@ public sealed class GenerateEnumCommand : Command<GenerateEnumCommand.Settings>
         public string[] Values { get; init; } = Array.Empty<string>();
 
         [CommandOption("--non-extensible")]
-        [System.ComponentModel.Description("Emit IsExtensible=No (default is Yes, the recommended D365FO setting).")]
+        [System.ComponentModel.Description("Emit IsExtensible=false (default is true, the recommended D365FO setting).")]
         public bool NonExtensible { get; init; }
 
         [CommandOption("--label <TEXT>")]

--- a/src/D365FO.Core/Scaffolding/XppScaffolder.cs
+++ b/src/D365FO.Core/Scaffolding/XppScaffolder.cs
@@ -723,11 +723,17 @@ public static class XppScaffolder
             return el;
         });
 
+        // D365FO's metadata reader requires the XMLSchema-instance namespace declaration on
+        // the root element (it is emitted by Visual Studio on every AxEnum file). IsExtensible
+        // is a CLR bool, so the DataContractSerializer expects "true"/"false" — the NoYes-style
+        // "Yes"/"No" written previously produced an invalid file VS refused to read.
+        XNamespace xsi = "http://www.w3.org/2001/XMLSchema-instance";
         return new XDocument(
             new XElement("AxEnum",
+                new XAttribute(XNamespace.Xmlns + "i", xsi.NamespaceName),
                 new XElement("Name", name),
                 string.IsNullOrEmpty(label) ? null : new XElement("Label", label),
-                new XElement("IsExtensible", isExtensible ? "Yes" : "No"),
+                new XElement("IsExtensible", isExtensible ? "true" : "false"),
                 enumVals.Count > 0 ? new XElement("EnumValues", valEls) : null));
     }
 

--- a/tests/D365FO.Cli.Tests/ScaffoldingSnapshotTests.cs
+++ b/tests/D365FO.Cli.Tests/ScaffoldingSnapshotTests.cs
@@ -95,7 +95,12 @@ public class ScaffoldingSnapshotTests
         var doc = XppScaffolder.Enum("MyEnum", vals, isExtensible: true);
         var root = doc.Root!;
         Assert.Equal("AxEnum", root.Name.LocalName);
-        Assert.Equal("Yes", root.Element("IsExtensible")!.Value);
+        // IsExtensible is a CLR bool → DataContractSerializer expects true/false, not Yes/No.
+        Assert.Equal("true", root.Element("IsExtensible")!.Value);
+        // VS emits the XMLSchema-instance namespace on every AxEnum root.
+        Assert.Equal(
+            "http://www.w3.org/2001/XMLSchema-instance",
+            root.GetNamespaceOfPrefix("i")!.NamespaceName);
         var items = root.Element("EnumValues")!.Elements().ToList();
         Assert.Equal(3, items.Count);
         Assert.Equal("0", items[0].Element("Value")!.Value);


### PR DESCRIPTION
Visual Studio refused to read scaffolded enums (issue #70). Two defects in XppScaffolder.Enum produced metadata the reader rejected:

- The root <AxEnum> was missing the xmlns:i="http://www.w3.org/2001/ XMLSchema-instance" namespace declaration that VS emits on every enum file.
- IsExtensible is a CLR bool, so the DataContractSerializer expects true/false; the scaffolder wrote NoYes-style Yes/No, which is invalid.

Generate enum now emits <AxEnum xmlns:i="..."> with <IsExtensible>true/false. Updated the snapshot test and the --non-extensible help text accordingly.