### PR TITLE
fix(scaffold): emit valid AxEdt XML (xmlns:i + base-before-derived or…

### DIFF
--- a/src/D365FO.Core/Scaffolding/XppScaffolder.cs
+++ b/src/D365FO.Core/Scaffolding/XppScaffolder.cs
@@ -680,12 +680,20 @@ public static class XppScaffolder
             }
             : InferConcreteTypeSuffixFromExtends(effectiveExtends);
 
+        // D365FO's metadata reader requires the XMLSchema-instance namespace declaration on
+        // the root element (Visual Studio emits it on every AxEdt* file). Without it VS refuses
+        // to read the metadata — the same defect previously fixed for AxEnum.
+        // Element order also matters: the DataContractSerializer serializes base-class members
+        // (AxEdt: Name/Extends/Label) before derived-class members (AxEdtString.StringSize), so
+        // StringSize must come *after* Label, not before it.
+        XNamespace xsi = "http://www.w3.org/2001/XMLSchema-instance";
         return new XDocument(
             new XElement($"AxEdt{concreteTypeSuffix}",
+                new XAttribute(XNamespace.Xmlns + "i", xsi.NamespaceName),
                 new XElement("Name", name),
                 string.IsNullOrEmpty(effectiveExtends) ? null : new XElement("Extends", effectiveExtends),
-                stringSize.HasValue ? new XElement("StringSize", stringSize.Value.ToString()) : null,
-                string.IsNullOrEmpty(label) ? null : new XElement("Label", label)));
+                string.IsNullOrEmpty(label) ? null : new XElement("Label", label),
+                stringSize.HasValue ? new XElement("StringSize", stringSize.Value.ToString()) : null));
     }
 
     /// <summary>

--- a/tests/D365FO.Cli.Tests/ScaffoldingSnapshotTests.cs
+++ b/tests/D365FO.Cli.Tests/ScaffoldingSnapshotTests.cs
@@ -67,6 +67,27 @@ public class ScaffoldingSnapshotTests
     }
 
     [Fact]
+    public void Edt_root_has_XMLSchema_instance_namespace()
+    {
+        // VS emits the XMLSchema-instance namespace on every AxEdt* root; without it the
+        // metadata reader refuses the file. (issue #70)
+        var doc = XppScaffolder.Edt("MyEdt", "Name", null, 10, "My label");
+        Assert.Equal(
+            "http://www.w3.org/2001/XMLSchema-instance",
+            doc.Root!.GetNamespaceOfPrefix("i")!.NamespaceName);
+    }
+
+    [Fact]
+    public void Edt_emits_base_members_before_derived_StringSize()
+    {
+        // DataContractSerializer serializes base-class members (AxEdt: Name/Extends/Label)
+        // before derived members (AxEdtString.StringSize): Label must precede StringSize.
+        var doc = XppScaffolder.Edt("MyEdt", "Name", null, 10, "My label");
+        var names = doc.Root!.Elements().Select(e => e.Name.LocalName).ToList();
+        Assert.Equal(new[] { "Name", "Extends", "Label", "StringSize" }, names);
+    }
+
+    [Fact]
     public void ScaffoldFileWriter_rejects_abstract_AxEdt_root()
     {
         var doc = new XDocument(new XElement("AxEdt", new XElement("Name", "Bad")));


### PR DESCRIPTION
…der)

The EDT scaffolder had the same two defects fixed for AxEnum in PR #78 but never applied to the EDT path (issue #70):

- Missing xmlns:i="http://www.w3.org/2001/XMLSchema-instance" on the root, which the VS metadata reader requires on every AxEdt* file.
- StringSize (derived AxEdtString member) was emitted before Label (base AxEdt member). DataContractSerializer serializes base members before derived ones, so order must be Name -> Extends -> Label -> StringSize.

Adds two snapshot tests covering the namespace and element order.