### PR TITLE
fix(bridge): resolve --install-to models in custom packages roots (#65)

### DIFF
--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -14,7 +14,7 @@
 | Variable | Purpose | Default |
 |---|---|---|
 | `D365FO_PACKAGES_PATH` | Primary `PackagesLocalDirectory` root | *(required for indexing)* |
-| `D365FO_CUSTOM_PACKAGES_PATH` | Additional `PackagesLocalDirectory` roots (semicolon/comma separated) | — |
+| `D365FO_CUSTOM_PACKAGES_PATH` | Additional `PackagesLocalDirectory` roots (semicolon/comma separated). Indexed for reads **and** forwarded to the bridge so `generate --install-to <Model>` can resolve custom models that live outside the primary packages path (UDE dual-folder setups). | — |
 | `D365FO_LABEL_LANGUAGES` | Label languages to extract, e.g. `en-us,cs,de` | `en-us` |
 | `D365FO_INDEX_DB` | Path to the SQLite index file | `%LOCALAPPDATA%\d365fo-cli\d365fo-index.sqlite` |
 | `D365FO_WORKSPACE_PATH` | Root of your X++ solution (enables scaffold output) | — |

--- a/src/D365FO.Bridge/MetadataBootstrap.cs
+++ b/src/D365FO.Bridge/MetadataBootstrap.cs
@@ -23,6 +23,7 @@ namespace D365FO.Bridge
         private static bool _resolverInstalled;
         private static string _binPath;
         private static string _packagesPath;
+        private static string[] _customPackagesPaths = new string[0];
 
         // Cached reflection artefacts per logical provider instance.
         private static object _provider; // IMetadataProvider
@@ -48,6 +49,7 @@ namespace D365FO.Bridge
                 _lastError = null;
 
                 _binPath = ResolveBinPath(out _packagesPath);
+                _customPackagesPaths = ResolveCustomPackagesPaths();
                 if (string.IsNullOrEmpty(_binPath) || !Directory.Exists(_binPath))
                 {
                     _lastError = "D365FO_BIN_PATH (or D365FO_PACKAGES_PATH\\bin) is not set or does not exist.";
@@ -98,6 +100,7 @@ namespace D365FO.Bridge
                 ["loaded"] = _provider != null,
                 ["binPath"] = _binPath ?? string.Empty,
                 ["packagesPath"] = _packagesPath ?? string.Empty,
+                ["customPackagesPaths"] = string.Join(";", _customPackagesPaths),
                 ["error"] = _lastError ?? string.Empty,
             };
         }
@@ -111,6 +114,48 @@ namespace D365FO.Bridge
                 bin = Path.Combine(packagesPath, "bin");
             }
             return bin;
+        }
+
+        /// <summary>
+        /// Additional custom-model roots forwarded by the CLI through
+        /// <c>D365FO_CUSTOM_PACKAGES_PATH</c> (comma/semicolon separated). On a
+        /// UDE these hold the user's custom models, which live outside the
+        /// platform PackagesLocalDirectory — without adding them to the provider
+        /// the model would be invisible to <c>--install-to</c>.
+        /// </summary>
+        private static string[] ResolveCustomPackagesPaths()
+        {
+            var raw = Environment.GetEnvironmentVariable("D365FO_CUSTOM_PACKAGES_PATH");
+            if (string.IsNullOrWhiteSpace(raw)) return new string[0];
+            var parts = raw.Split(new[] { ';', ',' }, StringSplitOptions.RemoveEmptyEntries);
+            var list = new System.Collections.Generic.List<string>(parts.Length);
+            foreach (var p in parts)
+            {
+                var trimmed = p.Trim();
+                if (trimmed.Length > 0) list.Add(trimmed);
+            }
+            return list.ToArray();
+        }
+
+        /// <summary>
+        /// All metadata roots to register with the provider, in priority order:
+        /// the primary <c>D365FO_PACKAGES_PATH</c> first, then each custom root.
+        /// Empty entries and case-insensitive duplicates are skipped.
+        /// </summary>
+        private static System.Collections.Generic.IEnumerable<string> EnumerateMetadataRoots()
+        {
+            var seen = new System.Collections.Generic.HashSet<string>(StringComparer.OrdinalIgnoreCase);
+            if (!string.IsNullOrEmpty(_packagesPath) && seen.Add(_packagesPath))
+            {
+                yield return _packagesPath;
+            }
+            foreach (var custom in _customPackagesPaths)
+            {
+                if (!string.IsNullOrEmpty(custom) && seen.Add(custom))
+                {
+                    yield return custom;
+                }
+            }
         }
 
         private static Assembly OnAssemblyResolve(object sender, ResolveEventArgs args)
@@ -153,24 +198,28 @@ namespace D365FO.Bridge
 
             var config = CreateConfig(configType);
 
-            // Add package roots. Prefer AddMetadataPath (returns void), fall
-            // back to MetadataPaths collection Add.
-            if (!string.IsNullOrEmpty(_packagesPath))
+            // Add every package root: the primary PackagesLocalDirectory plus
+            // any custom-model roots (UDE dual-folder setups). All of them must
+            // be registered with the provider, otherwise models that live only
+            // under a custom root cannot be resolved by `--install-to`.
+            var addMethod = configType.GetMethod("AddMetadataPath", new[] { typeof(string) });
+            object metadataPathsList = null;
+            if (addMethod == null)
             {
-                var add = configType.GetMethod("AddMetadataPath", new[] { typeof(string) });
-                if (add != null)
+                var prop = configType.GetProperty("MetadataPaths");
+                metadataPathsList = prop != null ? prop.GetValue(config) : null;
+            }
+
+            foreach (var root in EnumerateMetadataRoots())
+            {
+                if (addMethod != null)
                 {
-                    add.Invoke(config, new object[] { _packagesPath });
+                    addMethod.Invoke(config, new object[] { root });
                 }
-                else
+                else if (metadataPathsList != null)
                 {
-                    var prop = configType.GetProperty("MetadataPaths");
-                    var list = prop != null ? prop.GetValue(config) : null;
-                    if (list != null)
-                    {
-                        var addItem = list.GetType().GetMethod("Add", new[] { typeof(string) });
-                        if (addItem != null) addItem.Invoke(list, new object[] { _packagesPath });
-                    }
+                    var addItem = metadataPathsList.GetType().GetMethod("Add", new[] { typeof(string) });
+                    if (addItem != null) addItem.Invoke(metadataPathsList, new object[] { root });
                 }
             }
 

--- a/src/D365FO.Cli/Commands/Generate/GenerateCommands.cs
+++ b/src/D365FO.Cli/Commands/Generate/GenerateCommands.cs
@@ -43,7 +43,7 @@ internal static class GenerateInstaller
         {
             failure = RenderHelpers.Render(kind, ToolResult<object>.Fail(
                 "INSTALL_FAILED",
-                $"Could not resolve folder for model '{model}'. Set D365FO_BRIDGE_ENABLED=1 and D365FO_PACKAGES_PATH on a D365FO VM, and make sure the model exists."));
+                $"Could not resolve folder for model '{model}'. Ensure the bridge can see the model: set D365FO_BRIDGE_ENABLED=1 and point D365FO_PACKAGES_PATH (and D365FO_CUSTOM_PACKAGES_PATH for custom-model roots) at the directories that contain the model, on a D365FO VM."));
             return null;
         }
         return System.IO.Path.Combine(folder!, axSubfolder, name + ".xml");

--- a/src/D365FO.Cli/Commands/Get/BridgeGate.cs
+++ b/src/D365FO.Cli/Commands/Get/BridgeGate.cs
@@ -23,6 +23,7 @@ internal static class BridgeGate
     {
         MetadataBinPath = D365FoSettings.Resolve("D365FO_BIN_PATH"),
         PackagesPath = D365FoSettings.Resolve("D365FO_PACKAGES_PATH"),
+        CustomPackagesPaths = D365FoSettings.FromEnvironment().CustomPackagesPaths,
         XrefConnectionString = D365FoSettings.Resolve("D365FO_XREF_CONNECTIONSTRING"),
     };
 

--- a/src/D365FO.Core/Bridge/BridgeClient.cs
+++ b/src/D365FO.Core/Bridge/BridgeClient.cs
@@ -41,6 +41,14 @@ public sealed record BridgeOptions
     public string? PackagesPath { get; init; }
 
     /// <summary>
+    /// Additional custom-model roots (e.g. a git repo of custom models on a
+    /// UDE setup). Forwarded to the bridge via <c>D365FO_CUSTOM_PACKAGES_PATH</c>
+    /// so the metadata provider indexes them too — without this, models that
+    /// live only under a custom root are invisible to <c>--install-to</c>.
+    /// </summary>
+    public IReadOnlyList<string> CustomPackagesPaths { get; init; } = Array.Empty<string>();
+
+    /// <summary>
     /// DYNAMICSXREFDB connection string. Forwarded to the bridge via
     /// <c>D365FO_XREF_CONNECTIONSTRING</c> when set.
     /// </summary>
@@ -231,6 +239,27 @@ public sealed class BridgeClient : IDisposable
         return response["result"] as JsonObject;
     }
 
+    /// <summary>
+    /// Build the set of environment variables forwarded to the bridge child
+    /// process from <paramref name="options"/>. Only non-empty values are
+    /// emitted; <c>CustomPackagesPaths</c> is joined with <c>;</c> so the bridge
+    /// can re-split it. Exposed internally so tests can assert the contract
+    /// without spawning a real process.
+    /// </summary>
+    internal static IReadOnlyList<KeyValuePair<string, string>> BuildProcessEnvironment(BridgeOptions options)
+    {
+        var env = new List<KeyValuePair<string, string>>();
+        if (!string.IsNullOrWhiteSpace(options.MetadataBinPath))
+            env.Add(new("D365FO_BIN_PATH", options.MetadataBinPath!));
+        if (!string.IsNullOrWhiteSpace(options.PackagesPath))
+            env.Add(new("D365FO_PACKAGES_PATH", options.PackagesPath!));
+        if (options.CustomPackagesPaths.Count > 0)
+            env.Add(new("D365FO_CUSTOM_PACKAGES_PATH", string.Join(";", options.CustomPackagesPaths)));
+        if (!string.IsNullOrWhiteSpace(options.XrefConnectionString))
+            env.Add(new("D365FO_XREF_CONNECTIONSTRING", options.XrefConnectionString!));
+        return env;
+    }
+
     private void EnsureStarted()
     {
         if (disposed)
@@ -275,17 +304,9 @@ public sealed class BridgeClient : IDisposable
                 StandardInputEncoding = new UTF8Encoding(false),
                 StandardOutputEncoding = new UTF8Encoding(false),
             };
-            if (!string.IsNullOrWhiteSpace(options.MetadataBinPath))
+            foreach (var (key, value) in BuildProcessEnvironment(options))
             {
-                psi.Environment["D365FO_BIN_PATH"] = options.MetadataBinPath;
-            }
-            if (!string.IsNullOrWhiteSpace(options.PackagesPath))
-            {
-                psi.Environment["D365FO_PACKAGES_PATH"] = options.PackagesPath;
-            }
-            if (!string.IsNullOrWhiteSpace(options.XrefConnectionString))
-            {
-                psi.Environment["D365FO_XREF_CONNECTIONSTRING"] = options.XrefConnectionString;
+                psi.Environment[key] = value;
             }
 
             process = Process.Start(psi);

--- a/tests/D365FO.Core.Tests/BridgeClientTests.cs
+++ b/tests/D365FO.Core.Tests/BridgeClientTests.cs
@@ -1,4 +1,5 @@
 using System.IO;
+using System.Linq;
 using System.Text.Json.Nodes;
 using System.Threading.Tasks;
 using D365FO.Core.Bridge;
@@ -66,6 +67,35 @@ public sealed class BridgeClientTests
         var ex = await Assert.ThrowsAsync<BridgeException>(
             async () => await harness.Client.SendAsync("ping", new JsonObject()));
         Assert.Contains("closed", ex.Message);
+    }
+
+    [Fact]
+    public void BuildProcessEnvironment_forwards_custom_packages_paths_joined()
+    {
+        var options = new BridgeOptions
+        {
+            MetadataBinPath = @"C:\bin",
+            PackagesPath = @"C:\Packages",
+            CustomPackagesPaths = new[] { @"C:\D365FO_Metadata", @"D:\More" },
+        };
+
+        var env = BridgeClient.BuildProcessEnvironment(options)
+            .ToDictionary(kv => kv.Key, kv => kv.Value);
+
+        Assert.Equal(@"C:\bin", env["D365FO_BIN_PATH"]);
+        Assert.Equal(@"C:\Packages", env["D365FO_PACKAGES_PATH"]);
+        Assert.Equal(@"C:\D365FO_Metadata;D:\More", env["D365FO_CUSTOM_PACKAGES_PATH"]);
+    }
+
+    [Fact]
+    public void BuildProcessEnvironment_omits_custom_packages_when_none()
+    {
+        var options = new BridgeOptions { PackagesPath = @"C:\Packages" };
+
+        var env = BridgeClient.BuildProcessEnvironment(options)
+            .ToDictionary(kv => kv.Key, kv => kv.Value);
+
+        Assert.False(env.ContainsKey("D365FO_CUSTOM_PACKAGES_PATH"));
     }
 
     /// <summary>


### PR DESCRIPTION
generate --install-to <Model> resolved the on-disk model folder through the bridge's IMetadataProvider, but that provider was only ever built from D365FO_PACKAGES_PATH. On a UDE dual-folder setup the custom models live under D365FO_CUSTOM_PACKAGES_PATH (e.g. C:\D365FO_Metadata), which was never forwarded to the bridge nor registered with the provider — so ModelManifest.Read() returned null and the CLI failed with "Could not resolve folder for model '<name>'", even though `doctor` reported all checks passing.

Plumb the custom packages roots end to end:
- BridgeOptions gains CustomPackagesPaths; BridgeGate.DefaultOptions fills it from D365FoSettings.
- BridgeClient forwards them to the child process via D365FO_CUSTOM_PACKAGES_PATH (extracted BuildProcessEnvironment helper, now unit-tested).
- MetadataBootstrap reads that var and registers every root (primary + custom, deduped) with DiskProviderConfiguration, and surfaces them in ping diagnostics.
- Clearer INSTALL_FAILED hint and CONFIGURATION.md note.