### PR TITLE
feat(index): opt-in full-text index of X++ method bodies

### DIFF
--- a/docs/CAPABILITIES.md
+++ b/docs/CAPABILITIES.md
@@ -8,6 +8,8 @@ Full reference of what the tool provides. For setup see [SETUP.md](SETUP.md), fo
 
 The SQLite index (`$D365FO_INDEX_DB`) stores AOT metadata extracted from `PackagesLocalDirectory`. It covers 22 AOT object types and is populated by `d365fo index extract`.
 
+By default the index stores object/method *metadata* only — method bodies (the X++ source) are parsed for lint flags and then discarded; the canonical source stays in the AOT XML on disk. Pass `--index-source` to additionally full-text index method bodies into `MethodSourceFts` (see below).
+
 ### Index maintenance commands
 
 | Command | What it does |
@@ -15,6 +17,7 @@ The SQLite index (`$D365FO_INDEX_DB`) stores AOT metadata extracted from `Packag
 | `index build` | Create or migrate the schema in-place |
 | `index extract` | Full extraction of all packages |
 | `index extract --model <M>` | Scoped extraction of one model (seconds) |
+| `index extract --index-source` | Also full-text index X++ method bodies (opt-in; enlarges the DB, accelerates `find refs`). Also available on `index refresh`. |
 | `index refresh` | Re-extract only models whose content fingerprint changed |
 | `index refresh --force` | Re-extract all models regardless of fingerprint |
 | `index status` | Show per-model row counts and last-extracted timestamps |
@@ -83,6 +86,7 @@ find usages <needle> [--kind k,k,…]  — All references by kind
 find extensions <target>              — All object extensions
 find handlers <object>                — Event subscribers
 find relations <table>                — FK relations
+find refs <needle>                    — References inside method bodies (FTS5 when `--index-source` was used, else on-demand source scan)
 find refs --xref                      — Path/line/kind via DYNAMICSXREFDB
 find form-patterns [--pattern P]      — Form pattern histogram / filter
 find batch-jobs [--model M]           — RunBaseBatch subclasses

--- a/docs/EXAMPLES.md
+++ b/docs/EXAMPLES.md
@@ -33,6 +33,13 @@ d365fo find coc CustTable::validateWrite
 
 Also available: `find relations|usages|extensions|handlers`. `find refs --xref` queries `DYNAMICSXREFDB` for path/line/column/kind.
 
+`find refs <needle>` searches inside X++ method bodies. By default it scans the source on disk on demand; if you extracted with `--index-source` it answers from the `MethodSourceFts` full-text index instead (much faster, and the result carries `via: "fts"`):
+
+```sh
+d365fo index extract --index-source     # one-time: full-text index method bodies
+d365fo find refs CustPostInvoice        # now served from FTS
+```
+
 #### `find form-patterns`
 
 ```sh

--- a/docs/TROUBLESHOOTING.md
+++ b/docs/TROUBLESHOOTING.md
@@ -175,12 +175,19 @@ The migration is applied automatically on first connection and is always additiv
 
 - New columns are added via `ALTER TABLE … ADD COLUMN` with safe defaults (`NULL` or `0`).
 - New tables (e.g. `BusinessEvents`, `SecurityPolicies`, `ConfigurationKeys`, `Tiles`) are created empty.
+- New virtual tables (e.g. the `MethodSourceFts` method-body index) are created empty.
 - Lint flag columns (`HasInsertInLoop`, `HasNestedSelect`, etc.) default to `0` in existing rows.
 
 After migration, newly added columns are empty until you re-extract:
 
 ```sh
 d365fo index extract --force    # re-populate all models with new columns
+```
+
+The opt-in method-body index stays empty until you re-extract *with the flag* — a plain `--force` does not populate it:
+
+```sh
+d365fo index extract --force --index-source   # backfill MethodSourceFts too
 ```
 
 ### When to use `index build` vs `index extract`

--- a/src/D365FO.Cli/Commands/Find/FindCommands.cs
+++ b/src/D365FO.Cli/Commands/Find/FindCommands.cs
@@ -1,5 +1,4 @@
 using D365FO.Core;
-using D365FO.Core.Extract;
 using Spectre.Console.Cli;
 using D365FO.Cli.Commands.Get;
 
@@ -350,43 +349,26 @@ public sealed class FindRelatedCommand : Command<FindRelatedCommand.Settings>
 
     private static int RenderRefs(OutputMode.Kind output, D365FO.Core.Index.MetadataRepository repo, string name, string? kind, int limit)
     {
-        var sources = repo.EnumerateSourcePaths();
-        if (!string.IsNullOrWhiteSpace(kind))
-            sources = sources.Where(s => string.Equals(s.Kind, kind, StringComparison.OrdinalIgnoreCase)).ToList();
-
-        var rx = new System.Text.RegularExpressions.Regex(
-            $@"\b{System.Text.RegularExpressions.Regex.Escape(name)}\b",
-            System.Text.RegularExpressions.RegexOptions.IgnoreCase);
-        var hits = new List<object>();
-        var scanned = 0;
-
-        foreach (var row in sources)
+        // Shared with the MCP find_references tool. Uses the MethodSourceFts index
+        // when it's populated (index extract --index-source), else scans on disk.
+        var result = D365FO.Core.Index.MethodSourceSearch.Find(repo, name, kind, model: null, limit: limit);
+        var items = result.Hits.Select(h => new
         {
-            if (hits.Count >= limit) break;
-            scanned++;
-            var src = XppSourceReader.Read(row.SourcePath);
-            if (src is null) continue;
-            foreach (var method in src.Methods)
-            {
-                if (!rx.IsMatch(method.Body)) continue;
-                hits.Add(new
-                {
-                    kind = row.Kind,
-                    name = row.Name,
-                    model = row.Model,
-                    method = method.Name,
-                    path = row.SourcePath,
-                });
-                if (hits.Count >= limit) break;
-            }
-        }
-
+            kind = h.Kind,
+            name = h.Name,
+            model = h.Model,
+            method = h.Method,
+            path = h.Path,
+            matches = h.Matches.Select(l => new { line = l.Line, text = l.Text }),
+        });
         return RenderHelpers.Render(output, ToolResult<object>.Success(new
         {
-            needle = name,
-            filesScanned = scanned,
-            count = hits.Count,
-            items = hits,
+            needle = result.Needle,
+            via = result.Via,
+            filesScanned = result.FilesScanned,
+            count = result.Hits.Count,
+            truncated = result.Truncated,
+            items,
         }));
     }
 

--- a/src/D365FO.Cli/Commands/Index/IndexCommands.cs
+++ b/src/D365FO.Cli/Commands/Index/IndexCommands.cs
@@ -139,6 +139,10 @@ public sealed class IndexExtractCommand : Command<IndexExtractCommand.Settings>
         [CommandOption("--extra-packages <PATH>")]
         [System.ComponentModel.Description("Additional PackagesLocalDirectory root(s) to include alongside --packages. Repeatable. Also reads D365FO_CUSTOM_PACKAGES_PATH (semicolon/comma-separated). Supports UDE setups with two separate metadata folders.")]
         public string[]? ExtraPackagesPaths { get; init; }
+
+        [CommandOption("--index-source")]
+        [System.ComponentModel.Description("Also full-text index X++ method bodies into MethodSourceFts (opt-in; enlarges the DB). Speeds up `find refs` and enables source search.")]
+        public bool IndexSource { get; init; }
     }
 
     public override int Execute(CommandContext ctx, Settings settings)
@@ -152,7 +156,8 @@ public sealed class IndexExtractCommand : Command<IndexExtractCommand.Settings>
             settings.OnlyModel,
             settings.Since,
             extraPackagesPaths: extraPaths,
-            parallelism: settings.Parallelism);
+            parallelism: settings.Parallelism,
+            indexSource: settings.IndexSource);
     }
 
     internal static int ExtractCore(
@@ -163,7 +168,8 @@ public sealed class IndexExtractCommand : Command<IndexExtractCommand.Settings>
         string? sinceIso,
         IReadOnlyDictionary<string, string?>? fingerprintsByModel = null,
         int? parallelism = null,
-        IReadOnlyList<string>? extraPackagesPaths = null)
+        IReadOnlyList<string>? extraPackagesPaths = null,
+        bool indexSource = false)
     {
         var cfg = D365FoSettings.FromEnvironment(databaseOverride);
         var root = packagesOverride ?? cfg.PackagesPath;
@@ -181,7 +187,7 @@ public sealed class IndexExtractCommand : Command<IndexExtractCommand.Settings>
         }
 
         var repo = RepoFactory.Create(databaseOverride);
-        var extractor = new MetadataExtractor();
+        var extractor = new MetadataExtractor { CaptureMethodSource = indexSource };
         var matcher = new ModelMatcher(cfg.CustomModels);
         int modelCount = 0;
         int customCount = 0;
@@ -310,7 +316,7 @@ public sealed class IndexExtractCommand : Command<IndexExtractCommand.Settings>
                 {
                     onStart?.Invoke(batch.Model);
                     var writeSw = System.Diagnostics.Stopwatch.StartNew();
-                    repo.ApplyExtract(batch, fp);
+                    repo.ApplyExtract(batch, fp, indexSource);
                     writeSw.Stop();
                     var elapsedMs = parseMs + writeSw.ElapsedMilliseconds;
                     repo.RecordExtractionRun(batch.Model, startedUtc, elapsedMs,
@@ -548,6 +554,10 @@ public sealed class IndexRefreshCommand : Command<IndexRefreshCommand.Settings>
         [CommandOption("--extra-packages <PATH>")]
         [System.ComponentModel.Description("Additional PackagesLocalDirectory root(s). Repeatable. Also reads D365FO_CUSTOM_PACKAGES_PATH.")]
         public string[]? ExtraPackagesPaths { get; init; }
+
+        [CommandOption("--index-source")]
+        [System.ComponentModel.Description("Also full-text index X++ method bodies into MethodSourceFts (opt-in; enlarges the DB). Speeds up `find refs` and enables source search.")]
+        public bool IndexSource { get; init; }
     }
 
     public override int Execute(CommandContext ctx, Settings settings)
@@ -588,7 +598,8 @@ public sealed class IndexRefreshCommand : Command<IndexRefreshCommand.Settings>
             since,
             fingerprints,
             parallelism: settings.Parallelism,
-            extraPackagesPaths: extraPaths);
+            extraPackagesPaths: extraPaths,
+            indexSource: settings.IndexSource);
     }
 }
 

--- a/src/D365FO.Core/Extract/MetadataExtractor.cs
+++ b/src/D365FO.Core/Extract/MetadataExtractor.cs
@@ -26,6 +26,15 @@ public sealed class MetadataExtractor
 
     public MetadataExtractor(ILogger? log = null) => _log = log ?? NullLogger.Instance;
 
+    /// <summary>
+    /// v15 opt-in: when true, each extracted method keeps its raw X++ body in
+    /// <see cref="ExtractedMethod.Body"/> so <c>ApplyExtract</c> can feed the
+    /// <c>MethodSourceFts</c> full-text index. Off by default — bodies are
+    /// discarded after deriving lint flags, keeping batches lean. Set once
+    /// before extraction; read concurrently by the per-model parse tasks.
+    /// </summary>
+    public bool CaptureMethodSource { get; init; }
+
     public IEnumerable<ExtractBatch> ExtractAll(
         string packagesRoot,
         IReadOnlyCollection<string>? labelLanguages = null,
@@ -358,7 +367,7 @@ public sealed class MetadataExtractor
         return withoutStrings;
     }
 
-    private static ExtractedTable? ParseTable(XDocument doc, string file)
+    private ExtractedTable? ParseTable(XDocument doc, string file)
     {
         var root = doc.Root;
         if (root is null) return null;
@@ -464,7 +473,7 @@ public sealed class MetadataExtractor
         @"^\s*public\s+\w[\w\s]*\s+\w+\s*;",
         System.Text.RegularExpressions.RegexOptions.Multiline | System.Text.RegularExpressions.RegexOptions.Compiled);
 
-    private static ExtractedClass? ParseClass(XDocument doc, string file)
+    private ExtractedClass? ParseClass(XDocument doc, string file)
     {
         var root = doc.Root;
         if (root is null) return null;
@@ -515,7 +524,7 @@ public sealed class MetadataExtractor
         };
     }
 
-    private static IReadOnlyList<ExtractedMethod> ExtractMethods(XElement root)
+    private IReadOnlyList<ExtractedMethod> ExtractMethods(XElement root)
     {
         var (methods, sources) = ExtractMethodsWithSources(root);
         // For table methods, apply the IsEmptyOverride flag based on body contents.
@@ -528,7 +537,7 @@ public sealed class MetadataExtractor
         return result;
     }
 
-    private static (IReadOnlyList<ExtractedMethod> Methods, List<(string Name, string Source)> Sources) ExtractMethodsWithSources(XElement root)
+    private (IReadOnlyList<ExtractedMethod> Methods, List<(string Name, string Source)> Sources) ExtractMethodsWithSources(XElement root)
     {
         var methods = new List<ExtractedMethod>();
         var sources = new List<(string, string)>();
@@ -573,7 +582,11 @@ public sealed class MetadataExtractor
                 hasDocComment, hasTodayCall, hasDoInsertUpdate,
                 hasInsertInLoop, hasNestedSelect, hasForceLiterals,
                 hasForUpdateWithoutUpdate, hasTryCatchInTts, hasEmptyLoop,
-                IsEmptyOverride: false));
+                IsEmptyOverride: false)
+            {
+                // v15: keep the body only when source indexing is requested.
+                Body = CaptureMethodSource ? source : null,
+            });
             sources.Add((mname!, source));
         }
         return (methods, sources);

--- a/src/D365FO.Core/Index/ExtractModels.cs
+++ b/src/D365FO.Core/Index/ExtractModels.cs
@@ -91,7 +91,16 @@ public sealed record ExtractedMethod(string Name, string? Signature, string? Ret
     bool HasInsertInLoop = false, bool HasNestedSelect = false, bool HasForceLiterals = false,
     bool HasForUpdateWithoutUpdate = false, bool HasTryCatchInTts = false, bool HasEmptyLoop = false,
     // v12 table-method-only flag
-    bool IsEmptyOverride = false);
+    bool IsEmptyOverride = false)
+{
+    /// <summary>
+    /// v15: Raw X++ source of the method body. Transient — only populated when
+    /// the extractor runs with source capture enabled (<c>index extract
+    /// --index-source</c>) and consumed by <c>ApplyExtract</c> to feed the
+    /// <c>MethodSourceFts</c> index. Never persisted as a column; null otherwise.
+    /// </summary>
+    public string? Body { get; init; }
+}
 public sealed record ExtractedClassAttribute(string? MethodName, string AttributeName, string RawArgs);
 public sealed record ExtractedEventSubscriber(
     string SubscriberClass,

--- a/src/D365FO.Core/Index/MetadataRepository.cs
+++ b/src/D365FO.Core/Index/MetadataRepository.cs
@@ -14,7 +14,7 @@ namespace D365FO.Core.Index;
 public sealed partial class MetadataRepository
 {
     /// <summary>Current schema version tracked in PRAGMA user_version.</summary>
-    public const int CurrentSchemaVersion = 14;
+    public const int CurrentSchemaVersion = 15;
 
     private static readonly Lazy<string> SchemaSql = new(LoadEmbeddedSchema);
 
@@ -450,6 +450,79 @@ public sealed partial class MetadataRepository
                     "FTS5 unavailable or invalid query syntax; results may be incomplete (fell back to LIKE)."));
             }
             return results;
+        }
+    }
+
+    /// <summary>
+    /// Number of method bodies currently in the opt-in <c>MethodSourceFts</c>
+    /// index, optionally restricted to one model. Returns 0 when source indexing
+    /// was never run or the host SQLite build lacks FTS5. Callers use this to
+    /// decide between the fast FTS path and the on-demand disk scan.
+    /// </summary>
+    public long CountMethodSource(string? model = null)
+    {
+        using var conn = OpenReadOnly();
+        try
+        {
+            return string.IsNullOrEmpty(model)
+                ? conn.ExecuteScalar<long>("SELECT count(*) FROM MethodSourceFts")
+                : conn.ExecuteScalar<long>("SELECT count(*) FROM MethodSourceFts WHERE Model=@m", new { m = model });
+        }
+        catch (Microsoft.Data.Sqlite.SqliteException)
+        {
+            return 0;
+        }
+    }
+
+    /// <summary>
+    /// FTS5-backed search over X++ method bodies (the opt-in v15
+    /// <c>MethodSourceFts</c> index, populated via <c>index extract --index-source</c>).
+    /// Supports standard FTS5 query syntax. Returns an empty list when the index
+    /// is empty or the host SQLite build lacks FTS5 — callers that need a result
+    /// regardless should fall back to scanning source on disk. The
+    /// <see cref="MethodSourceMatch.Snippet"/> highlights the matched region.
+    /// </summary>
+    public IReadOnlyList<MethodSourceMatch> SearchMethodSource(string query, int limit = 100, string? model = null, string? kind = null)
+    {
+        using var conn = OpenReadOnly();
+        try
+        {
+            // FTS5 columns are typeless; Dapper infers byte[] (especially for an
+            // empty result set) and fails to bind the string record. Read with a
+            // raw reader and GetString instead, which coerces regardless of type.
+            // Model/Kind are UNINDEXED but still stored, so filtering them next to
+            // the MATCH is cheap and keeps the LIMIT semantics correct.
+            using var cmd = conn.CreateCommand();
+            cmd.CommandText = @"
+                SELECT Kind, ObjectName, MethodName, Model, SourcePath,
+                       snippet(MethodSourceFts, 0, '«', '»', ' … ', 12) AS Snippet
+                FROM MethodSourceFts
+                WHERE MethodSourceFts MATCH $q
+                  AND ($model IS NULL OR Model = $model)
+                  AND ($kind  IS NULL OR Kind  = $kind)
+                ORDER BY rank
+                LIMIT $limit";
+            cmd.Parameters.AddWithValue("$q", query);
+            cmd.Parameters.AddWithValue("$limit", limit);
+            cmd.Parameters.AddWithValue("$model", (object?)model ?? DBNull.Value);
+            cmd.Parameters.AddWithValue("$kind", (object?)kind ?? DBNull.Value);
+            using var reader = cmd.ExecuteReader();
+            var results = new List<MethodSourceMatch>();
+            while (reader.Read())
+            {
+                results.Add(new MethodSourceMatch(
+                    reader.GetString(0),
+                    reader.GetString(1),
+                    reader.GetString(2),
+                    reader.GetString(3),
+                    reader.IsDBNull(4) ? null : reader.GetString(4),
+                    reader.IsDBNull(5) ? null : reader.GetString(5)));
+            }
+            return results;
+        }
+        catch (Microsoft.Data.Sqlite.SqliteException)
+        {
+            return Array.Empty<MethodSourceMatch>();
         }
     }
 
@@ -1916,8 +1989,14 @@ public sealed partial class MetadataRepository
     /// <summary>
     /// Apply a batch of extracted records atomically, stamping the model's
     /// <c>LastExtractedUtc</c> and (when provided) <c>SourceFingerprint</c>.
+    /// When <paramref name="indexMethodSource"/> is true and the extracted
+    /// methods carry their <see cref="ExtractedMethod.Body"/> (opt-in via
+    /// <c>index extract --index-source</c>), method bodies are also written to
+    /// the <c>MethodSourceFts</c> full-text index. The model's existing FTS rows
+    /// are always cleared first, so re-extracting without the flag cleans up
+    /// stale source previously indexed for that model.
     /// </summary>
-    public void ApplyExtract(ExtractBatch batch, string? sourceFingerprint)
+    public void ApplyExtract(ExtractBatch batch, string? sourceFingerprint, bool indexMethodSource = false)
     {
         ArgumentNullException.ThrowIfNull(batch);
         using var conn = Open();
@@ -1997,6 +2076,12 @@ public sealed partial class MetadataRepository
         conn.Execute("DELETE FROM Tiles WHERE ModelId=@m", new { m = modelId }, tx);
         conn.Execute("DELETE FROM Workspaces WHERE ModelId=@m", new { m = modelId }, tx);
         conn.Execute("DELETE FROM ModelDependencies WHERE ModelId=@m", new { m = modelId }, tx);
+        // Method-body FTS (v15) is keyed by Model name. Always clear this model's
+        // rows up front so that re-extracting it — with or without --index-source —
+        // never leaves stale source behind. Guarded: a SQLite build lacking FTS5
+        // (and thus the MethodSourceFts table) degrades to a no-op.
+        try { conn.Execute("DELETE FROM MethodSourceFts WHERE Model=@n", new { n = batch.Model }, tx); }
+        catch (Microsoft.Data.Sqlite.SqliteException) { indexMethodSource = false; }
         // Labels are keyed by file+lang, not model; we delete by file instead.
         foreach (var file in batch.Labels.Select(l => l.File).Distinct(StringComparer.OrdinalIgnoreCase))
             conn.Execute("DELETE FROM Labels WHERE LabelFile=@f", new { f = file }, tx);
@@ -2051,6 +2136,39 @@ public sealed partial class MetadataRepository
         var tmIsEmptyOvr  = tableMtdCmd.Parameters.Add("$ieo", Microsoft.Data.Sqlite.SqliteType.Integer);
         tableMtdCmd.Prepare();
 
+        // v15: opt-in method-body FTS. Prepared once, reused for both table and
+        // class methods. Only created when indexing is requested so the no-flag
+        // path pays nothing.
+        Microsoft.Data.Sqlite.SqliteCommand? ftsCmd = null;
+        Microsoft.Data.Sqlite.SqliteParameter? ftsBody = null, ftsKind = null, ftsObj = null, ftsMethod = null, ftsModel = null, ftsPath = null;
+        if (indexMethodSource)
+        {
+            ftsCmd = conn.CreateCommand();
+            ftsCmd.Transaction = (Microsoft.Data.Sqlite.SqliteTransaction)tx;
+            ftsCmd.CommandText = "INSERT INTO MethodSourceFts(Body, Kind, ObjectName, MethodName, Model, SourcePath) VALUES($b, $k, $o, $mn, $md, $p)";
+            ftsBody   = ftsCmd.Parameters.Add("$b",  Microsoft.Data.Sqlite.SqliteType.Text);
+            ftsKind   = ftsCmd.Parameters.Add("$k",  Microsoft.Data.Sqlite.SqliteType.Text);
+            ftsObj    = ftsCmd.Parameters.Add("$o",  Microsoft.Data.Sqlite.SqliteType.Text);
+            ftsMethod = ftsCmd.Parameters.Add("$mn", Microsoft.Data.Sqlite.SqliteType.Text);
+            ftsModel  = ftsCmd.Parameters.Add("$md", Microsoft.Data.Sqlite.SqliteType.Text);
+            ftsPath   = ftsCmd.Parameters.Add("$p",  Microsoft.Data.Sqlite.SqliteType.Text);
+            ftsCmd.Prepare();
+        }
+
+        // Local helper: index one method body if it carries source text. No-op
+        // when indexing is off or the method has no captured body.
+        void IndexBody(string kind, string objectName, string? sourcePath, string method, string? body)
+        {
+            if (ftsCmd is null || string.IsNullOrEmpty(body)) return;
+            ftsBody!.Value   = body;
+            ftsKind!.Value   = kind;
+            ftsObj!.Value    = objectName;
+            ftsMethod!.Value = method;
+            ftsModel!.Value  = batch.Model;
+            ftsPath!.Value   = (object?)sourcePath ?? DBNull.Value;
+            ftsCmd.ExecuteNonQuery();
+        }
+
         foreach (var t in batch.Tables)
         {
             tblName.Value    = t.Name;
@@ -2090,6 +2208,7 @@ public sealed partial class MetadataRepository
                 tmHasDoInsert.Value = mtd.HasDoInsertOrUpdate ? 1 : 0;
                 tmIsEmptyOvr.Value  = mtd.IsEmptyOverride ? 1 : 0;
                 tableMtdCmd.ExecuteNonQuery();
+                IndexBody("Table", t.Name, t.SourcePath, mtd.Name, mtd.Body);
             }
             foreach (var ix in t.Indexes)
             {
@@ -2188,6 +2307,7 @@ public sealed partial class MetadataRepository
                 mtdTtsTry.Value      = mtd.HasTryCatchInTts ? 1 : 0;
                 mtdEmptyLoop.Value   = mtd.HasEmptyLoop ? 1 : 0;
                 methodCmd.ExecuteNonQuery();
+                IndexBody("Class", c.Name, c.SourcePath, mtd.Name, mtd.Body);
             }
             attrCid.Value = classId;
             foreach (var a in c.Attributes)
@@ -2445,6 +2565,8 @@ public sealed partial class MetadataRepository
         }
 
         MinePropertyStats(conn, tx, batch);
+
+        ftsCmd?.Dispose();
 
         tx.Commit();
 

--- a/src/D365FO.Core/Index/MethodSourceSearch.cs
+++ b/src/D365FO.Core/Index/MethodSourceSearch.cs
@@ -1,0 +1,143 @@
+using System.Text.RegularExpressions;
+using D365FO.Core.Extract;
+
+namespace D365FO.Core.Index;
+
+/// <summary>One matching line inside a method body.</summary>
+public sealed record SourceRefMatchLine(int Line, string Text);
+
+/// <summary>A method that references the searched symbol.</summary>
+public sealed record SourceRefHit(
+    string Kind,
+    string Name,
+    string Model,
+    string Method,
+    string? Path,
+    IReadOnlyList<SourceRefMatchLine> Matches);
+
+/// <summary>Result of a reverse-reference search over X++ method bodies.</summary>
+public sealed record SourceRefResult(
+    string Needle,
+    string Via,           // "fts" when served from MethodSourceFts, else "scan"
+    int FilesScanned,
+    bool Truncated,
+    IReadOnlyList<SourceRefHit> Hits);
+
+/// <summary>
+/// Shared reverse-reference search over X++ method bodies, used by both
+/// <c>find refs</c> (CLI) and the <c>find_references</c> MCP tool so the two
+/// surfaces stay in parity.
+///
+/// When the opt-in <c>MethodSourceFts</c> index is populated
+/// (<c>index extract --index-source</c>) the bulk of the work — class and table
+/// methods — is answered by a single FTS5 <c>MATCH</c> instead of opening every
+/// source XML on disk. Form method bodies are not extracted into the index, so
+/// forms are always covered by an on-demand disk scan of just the form subset.
+/// With no FTS index the whole corpus falls back to a disk scan, preserving the
+/// previous behaviour.
+/// </summary>
+public static class MethodSourceSearch
+{
+    public static SourceRefResult Find(
+        MetadataRepository repo,
+        string needle,
+        string? kind,
+        string? model,
+        int limit,
+        int sampleLinesPerHit = 3)
+    {
+        var normKind = NormalizeKind(kind);
+        var rx = new Regex($@"\b{Regex.Escape(needle)}\b", RegexOptions.IgnoreCase);
+        var hits = new List<SourceRefHit>();
+        int scanned = 0;
+        bool truncated = false;
+
+        if (repo.CountMethodSource() > 0)
+        {
+            // Class + Table methods: answered from the FTS index.
+            if (normKind is null or "Class" or "Table")
+            {
+                var ftsKind = normKind is "Class" or "Table" ? normKind : null;
+                // Quote the needle so identifiers with FTS-special characters can't
+                // break MATCH syntax; unicode61 tokenization makes this an
+                // identifier-token match, close to the \bword\b disk scan.
+                var quoted = "\"" + needle.Replace("\"", "\"\"") + "\"";
+                foreach (var mm in repo.SearchMethodSource(quoted, limit, model, ftsKind))
+                {
+                    if (hits.Count >= limit) { truncated = true; break; }
+                    hits.Add(new SourceRefHit(
+                        mm.Kind, mm.ObjectName, mm.Model, mm.MethodName, mm.SourcePath,
+                        SampleLines(mm.SourcePath, mm.MethodName, rx, sampleLinesPerHit)));
+                }
+            }
+
+            // Forms are not in the FTS index — scan just the (small) form subset.
+            if (normKind is null or "Form")
+                ScanSources(repo.EnumerateSourcePaths(model).Where(s => s.Kind == "Form"),
+                            rx, limit, sampleLinesPerHit, hits, ref scanned, ref truncated);
+
+            return new SourceRefResult(needle, "fts", scanned, truncated, hits);
+        }
+
+        // No FTS index: scan the whole corpus on disk.
+        var sources = repo.EnumerateSourcePaths(model);
+        if (normKind is not null)
+            sources = sources.Where(s => string.Equals(s.Kind, normKind, StringComparison.OrdinalIgnoreCase)).ToList();
+        ScanSources(sources, rx, limit, sampleLinesPerHit, hits, ref scanned, ref truncated);
+        return new SourceRefResult(needle, "scan", scanned, truncated, hits);
+    }
+
+    private static void ScanSources(
+        IEnumerable<(string Kind, string Name, string Model, string SourcePath)> sources,
+        Regex rx, int limit, int sampleLinesPerHit,
+        List<SourceRefHit> hits, ref int scanned, ref bool truncated)
+    {
+        foreach (var row in sources)
+        {
+            if (hits.Count >= limit) { truncated = true; break; }
+            scanned++;
+            var src = XppSourceReader.Read(row.SourcePath);
+            if (src is null) continue;
+            foreach (var m in src.Methods)
+            {
+                if (!rx.IsMatch(m.Body)) continue;
+                if (hits.Count >= limit) { truncated = true; break; }
+                hits.Add(new SourceRefHit(
+                    row.Kind, row.Name, row.Model, m.Name, row.SourcePath,
+                    SampleLinesFromBody(m.Body, rx, sampleLinesPerHit)));
+            }
+        }
+    }
+
+    private static IReadOnlyList<SourceRefMatchLine> SampleLines(string? path, string method, Regex rx, int max)
+    {
+        if (string.IsNullOrEmpty(path) || max <= 0) return Array.Empty<SourceRefMatchLine>();
+        var src = XppSourceReader.Read(path);
+        var block = src is null ? null : XppSourceReader.FindMethod(src, method);
+        return block is null ? Array.Empty<SourceRefMatchLine>() : SampleLinesFromBody(block.Body, rx, max);
+    }
+
+    private static IReadOnlyList<SourceRefMatchLine> SampleLinesFromBody(string body, Regex rx, int max)
+    {
+        var res = new List<SourceRefMatchLine>();
+        if (max <= 0) return res;
+        var lines = body.Replace("\r\n", "\n").Split('\n');
+        for (int i = 0; i < lines.Length && res.Count < max; i++)
+            if (rx.IsMatch(lines[i]))
+                res.Add(new SourceRefMatchLine(i + 1, lines[i].Trim()));
+        return res;
+    }
+
+    /// <summary>Map a free-form kind filter to a stored source kind (Class/Table/Form), or null.</summary>
+    private static string? NormalizeKind(string? kind)
+    {
+        if (string.IsNullOrWhiteSpace(kind)) return null;
+        return kind.Trim().ToLowerInvariant() switch
+        {
+            "class" => "Class",
+            "table" => "Table",
+            "form"  => "Form",
+            _       => kind, // pass through unknown values; they simply match nothing
+        };
+    }
+}

--- a/src/D365FO.Core/Index/Models.cs
+++ b/src/D365FO.Core/Index/Models.cs
@@ -112,6 +112,15 @@ public sealed record EnumDetails(EnumInfo Enum, IReadOnlyList<EnumValueInfo> Val
 
 public sealed record LabelMatch(string File, string Language, string Key, string? Value);
 
+/// <summary>A method-body full-text hit from the opt-in <c>MethodSourceFts</c> index.</summary>
+public sealed record MethodSourceMatch(
+    string Kind,
+    string ObjectName,
+    string MethodName,
+    string Model,
+    string? SourcePath,
+    string? Snippet);
+
 public sealed record MenuItemInfo(
     string Name,
     string Kind,

--- a/src/D365FO.Core/Index/Schema.sql
+++ b/src/D365FO.Core/Index/Schema.sql
@@ -673,3 +673,22 @@ CREATE TABLE IF NOT EXISTS PropertyStats (
 );
 CREATE INDEX IF NOT EXISTS IX_PropStats_NodeProp ON PropertyStats(NodeType, Property);
 
+-- v15: Full-text search over X++ method bodies. OPT-IN — only populated when
+-- `index extract --index-source` is passed; an empty table is the default so
+-- the DB stays lean for users who don't need code search. This is a *standalone*
+-- FTS5 table (not content-linked like LabelFts) because method bodies are not
+-- stored in any base table — the canonical source remains the XML on disk and
+-- `read`/`find refs` still read bodies from there. The Kind/ObjectName/
+-- MethodName/Model/SourcePath columns are UNINDEXED locator metadata so a MATCH
+-- on Body can point callers straight at the method without a tokenize cost.
+-- Populated/cleared per model inside ApplyExtract.
+CREATE VIRTUAL TABLE IF NOT EXISTS MethodSourceFts USING fts5(
+    Body,
+    Kind        UNINDEXED,
+    ObjectName  UNINDEXED,
+    MethodName  UNINDEXED,
+    Model       UNINDEXED,
+    SourcePath  UNINDEXED,
+    tokenize = 'unicode61'
+);
+

--- a/src/D365FO.Mcp/ToolHandlers.cs
+++ b/src/D365FO.Mcp/ToolHandlers.cs
@@ -1444,8 +1444,11 @@ public sealed class ToolHandlers
     // ---- find_references (reverse references in indexed X++ source) ----
 
     /// <summary>
-    /// Regex scan of indexed X++ source for reverse references to a symbol.
-    /// Backs the unified <c>find_references</c> MCP tool. (The bridge-backed
+    /// Reverse-reference search over indexed X++ source for a symbol. Backs the
+    /// unified <c>find_references</c> MCP tool and shares its implementation
+    /// (<see cref="MethodSourceSearch"/>) with the CLI <c>find refs</c> command,
+    /// so both surfaces use the MethodSourceFts index when it's populated and
+    /// fall back to the same disk scan otherwise. (The bridge-backed
     /// DYNAMICSXREFDB path stays CLI-only via <c>find refs --xref</c>.)
     /// </summary>
     public ToolResult<object> FindReferences(string name, string? kind, string? model, int limit = 200)
@@ -1453,51 +1456,24 @@ public sealed class ToolHandlers
         if (string.IsNullOrWhiteSpace(name))
             return ToolResult<object>.Fail("BAD_INPUT", "name is required.");
 
-        var sources = _repo.EnumerateSourcePaths(model);
-        if (!string.IsNullOrWhiteSpace(kind))
-            sources = sources.Where(s => string.Equals(s.Kind, kind, StringComparison.OrdinalIgnoreCase)).ToList();
+        var result = MethodSourceSearch.Find(_repo, name, kind, model, limit);
+        var items = result.Hits.Select(h => new
+        {
+            kind = h.Kind,
+            name = h.Name,
+            model = h.Model,
+            method = h.Method,
+            matches = h.Matches.Select(l => new { line = l.Line, text = l.Text }),
+            path = h.Path,
+        }).ToList();
 
-        var rx = new System.Text.RegularExpressions.Regex(
-            $@"\b{System.Text.RegularExpressions.Regex.Escape(name)}\b",
-            System.Text.RegularExpressions.RegexOptions.IgnoreCase);
-
-        var hits = new System.Collections.Concurrent.ConcurrentBag<object>();
-        int scanned = 0;
-
-        System.Threading.Tasks.Parallel.ForEach(sources,
-            new System.Threading.Tasks.ParallelOptions { MaxDegreeOfParallelism = Environment.ProcessorCount },
-            row =>
-            {
-                System.Threading.Interlocked.Increment(ref scanned);
-                var src = XppSourceReader.Read(row.SourcePath);
-                if (src is null) return;
-                foreach (var m in src.Methods)
-                {
-                    if (!rx.IsMatch(m.Body)) continue;
-                    var lines = m.Body.Replace("\r\n", "\n").Split('\n');
-                    var sampleLines = new List<object>();
-                    for (int i = 0; i < lines.Length && sampleLines.Count < 3; i++)
-                        if (rx.IsMatch(lines[i]))
-                            sampleLines.Add(new { line = i + 1, text = lines[i].Trim() });
-                    hits.Add(new
-                    {
-                        kind = row.Kind,
-                        name = row.Name,
-                        model = row.Model,
-                        method = m.Name,
-                        matches = sampleLines,
-                        path = row.SourcePath,
-                    });
-                }
-            });
-
-        var items = hits.Take(limit).ToList();
         return ToolResult<object>.Success(new
         {
-            needle = name,
-            filesScanned = scanned,
+            needle = result.Needle,
+            via = result.Via,
+            filesScanned = result.FilesScanned,
             count = items.Count,
-            truncated = hits.Count > limit,
+            truncated = result.Truncated,
             items,
         });
     }

--- a/tests/D365FO.Core.Tests/MethodSourceFtsTests.cs
+++ b/tests/D365FO.Core.Tests/MethodSourceFtsTests.cs
@@ -1,0 +1,125 @@
+using D365FO.Core.Extract;
+using D365FO.Core.Index;
+using Xunit;
+
+namespace D365FO.Core.Tests;
+
+/// <summary>
+/// Covers the opt-in v15 method-body full-text index (MethodSourceFts):
+/// capture is off by default, on when requested, and cleaned up when a model
+/// is re-extracted without the flag.
+/// </summary>
+public class MethodSourceFtsTests : IDisposable
+{
+    private static readonly string SamplesDir =
+        Path.GetFullPath(Path.Combine(AppContext.BaseDirectory, "Samples", "MiniAot"));
+
+    private readonly string _dbPath = Path.Combine(
+        Path.GetTempPath(), $"d365fo-mfts-{Guid.NewGuid():N}.sqlite");
+
+    private readonly MetadataRepository _repo;
+
+    public MethodSourceFtsTests()
+    {
+        _repo = new MetadataRepository(_dbPath);
+        _repo.EnsureSchema();
+    }
+
+    public void Dispose()
+    {
+        Microsoft.Data.Sqlite.SqliteConnection.ClearAllPools();
+        foreach (var ext in new[] { "", "-wal", "-shm" })
+        {
+            var p = _dbPath + ext;
+            if (File.Exists(p)) File.Delete(p);
+        }
+    }
+
+    private void Ingest(bool indexSource)
+    {
+        var ex = new MetadataExtractor { CaptureMethodSource = indexSource };
+        foreach (var batch in ex.ExtractAll(SamplesDir))
+            _repo.ApplyExtract(batch, sourceFingerprint: null, indexMethodSource: indexSource);
+    }
+
+    [Fact]
+    public void Default_extract_does_not_populate_method_source_fts()
+    {
+        Ingest(indexSource: false);
+        Assert.Equal(0, _repo.CountMethodSource());
+        Assert.Empty(_repo.SearchMethodSource("strFmt"));
+    }
+
+    [Fact]
+    public void IndexSource_extract_makes_method_bodies_searchable()
+    {
+        Ingest(indexSource: true);
+
+        Assert.True(_repo.CountMethodSource() > 0);
+
+        // 'strFmt' appears only inside FmVehicleService.run's body.
+        var hits = _repo.SearchMethodSource("strFmt");
+        var hit = Assert.Single(hits);
+        Assert.Equal("Class", hit.Kind);
+        Assert.Equal("FmVehicleService", hit.ObjectName);
+        Assert.Equal("run", hit.MethodName);
+        Assert.Equal("TestModel", hit.Model);
+        Assert.NotNull(hit.SourcePath);
+    }
+
+    [Fact]
+    public void Reextract_without_flag_clears_stale_source_rows()
+    {
+        Ingest(indexSource: true);
+        Assert.True(_repo.CountMethodSource() > 0);
+
+        // Re-extracting the same model without --index-source must drop its FTS rows.
+        Ingest(indexSource: false);
+        Assert.Equal(0, _repo.CountMethodSource());
+    }
+
+    // ─── Shared search helper (backs CLI find refs + MCP find_references) ────
+
+    [Fact]
+    public void Find_uses_fts_and_returns_line_numbers_when_indexed()
+    {
+        Ingest(indexSource: true);
+
+        var result = MethodSourceSearch.Find(_repo, "strFmt", kind: null, model: null, limit: 50);
+
+        Assert.Equal("fts", result.Via);
+        var hit = Assert.Single(result.Hits);
+        Assert.Equal("FmVehicleService", hit.Name);
+        Assert.Equal("run", hit.Method);
+        // 'strFmt' is on one line of run()'s body — the helper resolves the actual
+        // line number by reading the source file the FTS row points at.
+        var line = Assert.Single(hit.Matches);
+        Assert.Contains("strFmt", line.Text);
+    }
+
+    [Fact]
+    public void Find_falls_back_to_disk_scan_when_not_indexed()
+    {
+        Ingest(indexSource: false);
+
+        var result = MethodSourceSearch.Find(_repo, "strFmt", kind: null, model: null, limit: 50);
+
+        Assert.Equal("scan", result.Via);
+        var hit = Assert.Single(result.Hits);
+        Assert.Equal("FmVehicleService", hit.Name);
+        Assert.Equal("run", hit.Method);
+    }
+
+    [Fact]
+    public void Find_honours_kind_filter_on_fts_path()
+    {
+        Ingest(indexSource: true);
+
+        // strFmt lives in a class method; filtering to tables yields nothing.
+        var asTable = MethodSourceSearch.Find(_repo, "strFmt", kind: "Table", model: null, limit: 50);
+        Assert.Empty(asTable.Hits);
+
+        var asClass = MethodSourceSearch.Find(_repo, "strFmt", kind: "Class", model: null, limit: 50);
+        Assert.Single(asClass.Hits);
+    }
+}


### PR DESCRIPTION
Method bodies were parsed for lint flags and then discarded — the index held only symbol/metadata, so `find refs` scanned every source XML on disk on each call. Add an opt-in FTS5 index over method bodies that both `find refs` (CLI) and `find_references` (MCP) can use.

- Schema v15: standalone MethodSourceFts(Body, Kind, ObjectName, MethodName, Model, SourcePath) FTS5 table; locator columns UNINDEXED. Created idempotently on migration; bodies stay canonical on disk.
- Extractor: opt-in MetadataExtractor.CaptureMethodSource attaches the transient ExtractedMethod.Body; off by default so batches stay lean.
- Repository: ApplyExtract(.., indexMethodSource) populates/clears FTS per model; SearchMethodSource + CountMethodSource queries.
- CLI: `index extract|refresh --index-source` threads the flag through ExtractCore. Daemon/init unchanged (default off).
- Shared MethodSourceSearch helper backs both CLI find refs and the MCP find_references tool for parity: FTS for class/table methods, on-demand disk scan for forms (not indexed) and as full fallback when FTS empty.
- Docs: CAPABILITIES / EXAMPLES / TROUBLESHOOTING updated.
- Tests: round-trip, stale-row cleanup, FTS vs scan parity, kind filter.