### PR TITLE
fix(edt): harden scaffolding, metadata shape, and enum-type resolution

### DIFF
--- a/src/D365FO.Cli/Commands/Generate/GenerateEdtCommand.cs
+++ b/src/D365FO.Cli/Commands/Generate/GenerateEdtCommand.cs
@@ -87,10 +87,10 @@ public sealed class GenerateEdtCommand : Command<GenerateEdtCommand.Settings>
         }
     }
 
-    private static string ResolveEnumTypeFromExtendsChain(string extendsName)
+    private static string? ResolveEnumTypeFromExtendsChain(string extendsName)
     {
         if (string.IsNullOrWhiteSpace(extendsName))
-            return string.Empty;
+            return null;
 
         try
         {
@@ -106,8 +106,8 @@ public sealed class GenerateEdtCommand : Command<GenerateEdtCommand.Settings>
                 var edt = repo.GetEdt(current);
                 if (edt is null)
                 {
-                    // If the name is not an EDT, keep legacy fallback semantics.
-                    return extendsName;
+                    // Defer to scaffolder inference (e.g. NoYesId -> NoYes) when chain lookup is unavailable.
+                    return null;
                 }
 
                 if (!string.IsNullOrWhiteSpace(edt.EnumType))
@@ -121,6 +121,6 @@ public sealed class GenerateEdtCommand : Command<GenerateEdtCommand.Settings>
             // Best-effort inference; fallback handled below.
         }
 
-        return extendsName;
+        return null;
     }
 }

--- a/src/D365FO.Cli/Commands/Generate/GenerateEdtCommand.cs
+++ b/src/D365FO.Cli/Commands/Generate/GenerateEdtCommand.cs
@@ -18,7 +18,7 @@ public sealed class GenerateEdtCommand : Command<GenerateEdtCommand.Settings>
         public string? Extends { get; init; }
 
         [CommandOption("--base-type <TYPE>")]
-        [System.ComponentModel.Description("Primitive type when no --extends is given. String (default) | Int | Int64 | Real | Date | UtcDateTime | Boolean. Infers a sensible standard parent EDT.")]
+        [System.ComponentModel.Description("Primitive type when no --extends is given. String (default) | Int | Int64 | Real | Date | UtcDateTime | Boolean | Time | Guid | Container | Enum. Infers a sensible standard parent EDT.")]
         public string? BaseType { get; init; }
 
         [CommandOption("--size <N>")]
@@ -28,6 +28,10 @@ public sealed class GenerateEdtCommand : Command<GenerateEdtCommand.Settings>
         [CommandOption("--label <TEXT>")]
         [System.ComponentModel.Description("Label text or @File:Key label reference.")]
         public string? Label { get; init; }
+
+        [CommandOption("--enum-type <XPPENUM>")]
+        [System.ComponentModel.Description("Backing X++ enum name for Enum-type EDTs (e.g. NoYes). If omitted, inferred from --extends; otherwise not emitted.")]
+        public string? EnumType { get; init; }
     }
 
     public override int Execute(CommandContext ctx, Settings settings)
@@ -49,7 +53,16 @@ public sealed class GenerateEdtCommand : Command<GenerateEdtCommand.Settings>
             if (fail.HasValue) return fail.Value;
         }
 
-        var doc = XppScaffolder.Edt(settings.Name, settings.Extends, settings.BaseType, settings.Size, settings.Label);
+        var effectiveEnumType = settings.EnumType;
+        if (string.IsNullOrWhiteSpace(effectiveEnumType) &&
+            string.Equals(settings.BaseType, "Enum", StringComparison.OrdinalIgnoreCase) &&
+            !string.IsNullOrWhiteSpace(settings.Extends))
+        {
+            // EnumType derivation from --extends is not always identity (e.g. AccessToSensitiveData -> NoYes).
+            effectiveEnumType = ResolveEnumTypeFromExtendsChain(settings.Extends!);
+        }
+
+        var doc = XppScaffolder.Edt(settings.Name, settings.Extends, settings.BaseType, settings.Size, settings.Label, effectiveEnumType);
         try
         {
             var res = ScaffoldFileWriter.Write(doc, outPath!, settings.Overwrite);
@@ -59,6 +72,7 @@ public sealed class GenerateEdtCommand : Command<GenerateEdtCommand.Settings>
                 name       = settings.Name,
                 extends    = settings.Extends,
                 baseType   = settings.BaseType,
+                enumType   = effectiveEnumType,
                 stringSize = settings.Size,
                 label      = settings.Label,
                 path       = res.Path,
@@ -71,5 +85,42 @@ public sealed class GenerateEdtCommand : Command<GenerateEdtCommand.Settings>
         {
             return RenderHelpers.Render(kind, ToolResult<object>.Fail(D365FoErrorCodes.WriteFailed, ex.Message));
         }
+    }
+
+    private static string ResolveEnumTypeFromExtendsChain(string extendsName)
+    {
+        if (string.IsNullOrWhiteSpace(extendsName))
+            return string.Empty;
+
+        try
+        {
+            var repo = RepoFactory.Create();
+            var current = extendsName;
+            var visited = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+
+            // Follow extends links defensively; break on cycles or unreasonable depth.
+            for (var depth = 0; depth < 16 && !string.IsNullOrWhiteSpace(current); depth++)
+            {
+                if (!visited.Add(current)) break;
+
+                var edt = repo.GetEdt(current);
+                if (edt is null)
+                {
+                    // If the name is not an EDT, keep legacy fallback semantics.
+                    return extendsName;
+                }
+
+                if (!string.IsNullOrWhiteSpace(edt.EnumType))
+                    return edt.EnumType!;
+
+                current = edt.Extends;
+            }
+        }
+        catch
+        {
+            // Best-effort inference; fallback handled below.
+        }
+
+        return extendsName;
     }
 }

--- a/src/D365FO.Core/Scaffolding/XppScaffolder.cs
+++ b/src/D365FO.Core/Scaffolding/XppScaffolder.cs
@@ -1,4 +1,5 @@
 using System.Xml.Linq;
+using System.Xml;
 using D365FO.Core.Guardrails;
 
 namespace D365FO.Core.Scaffolding;
@@ -681,11 +682,10 @@ public static class XppScaffolder
             : InferConcreteTypeSuffixFromExtends(effectiveExtends);
 
         // D365FO's metadata reader requires the XMLSchema-instance namespace declaration on
-        // the root element (Visual Studio emits it on every AxEdt* file). Without it VS refuses
-        // to read the metadata. The i:type attribute specifies the concrete type (e.g. AxEdtString).
-        // Element order also matters: the DataContractSerializer serializes base-class members
-        // (AxEdt: Name/Extends/Label) before derived-class members (AxEdtString.StringSize), so
-        // StringSize must come *after* Label, not before it.
+        // the root element (Visual Studio emits it on every AxEdt* file). The i:type
+        // attribute specifies the concrete type (e.g. AxEdtString).
+        // Element order matters: Name/Extends/Label/StringSize first, then collection
+        // elements, then EnumType (when present) to match VS metadata shape.
         // For Enum-type EDTs the backing X++ enum name is required (<EnumType> element).
         // Resolve in this order:
         //   1) explicit --enum-type
@@ -694,9 +694,12 @@ public static class XppScaffolder
         var effectiveEnumType = concreteTypeSuffix == "Enum"
             ? (!string.IsNullOrEmpty(enumType)
                 ? enumType
-                : (string.IsNullOrEmpty(effectiveExtends)
-                    ? null
-                    : InferEnumTypeFromExtends(effectiveExtends)))
+                : (!string.IsNullOrEmpty(effectiveExtends)
+                    ? InferEnumTypeFromExtends(effectiveExtends)
+                    : (string.Equals(baseType, "Boolean", StringComparison.OrdinalIgnoreCase) ||
+                       string.Equals(baseType, "Bool", StringComparison.OrdinalIgnoreCase)
+                        ? "NoYes"
+                        : null)))
             : null;
 
         XNamespace xsi = "http://www.w3.org/2001/XMLSchema-instance";
@@ -707,30 +710,24 @@ public static class XppScaffolder
             string.IsNullOrEmpty(effectiveExtends) ? null : new XElement("Extends", effectiveExtends),
             string.IsNullOrEmpty(label) ? null : new XElement("Label", label),
             stringSize.HasValue ? new XElement("StringSize", stringSize.Value.ToString()) : null,
-            new XElement("ArrayElements"),
-            new XElement("Relations"),
-            new XElement("TableReferences"),
+            concreteTypeSuffix == "String" ? null : new XElement("ArrayElements"),
+            concreteTypeSuffix == "String" ? null : new XElement("Relations"),
+            concreteTypeSuffix == "String" ? null : new XElement("TableReferences"),
             string.IsNullOrEmpty(effectiveEnumType) ? null : new XElement("EnumType", effectiveEnumType));
-        // Set the default namespace (empty xmlns) as per VS-emitted metadata format
-        root.SetAttributeValue(XName.Get("xmlns"), "");
         return new XDocument(root);
     }
 
     /// <summary>
-    /// Infers the concrete <c>AxEdt*</c> type suffix from a well-known system EDT name.
-    /// Returns <c>"String"</c> as the safe default for unknown or custom parent EDTs.
-    /// </summary>
-    /// <summary>
     /// Infers the backing X++ enum name from a well-known system EDT name used as Extends.
-    /// For unknown names, returns the extends value as-is.
+    /// For unknown names, returns null to avoid guessing an invalid enum name.
     /// </summary>
-    private static string InferEnumTypeFromExtends(string? extends) =>
+    private static string? InferEnumTypeFromExtends(string? extends) =>
         extends?.ToLowerInvariant() switch
         {
             "noyesid" or "noyes"   => "NoYes",
             "boolean"              => "NoYes",
-            _                      => extends!,
-        } ?? string.Empty;
+            _                      => null,
+        };
 
     private static string InferConcreteTypeSuffixFromExtends(string? extends) =>
         extends?.ToLowerInvariant() switch
@@ -879,8 +876,6 @@ public static class ScaffoldFileWriter
     // Writing one of these as the document root makes VS metadata reader throw
     // "Cannot create an abstract class" when the file is opened — callers must use the
     // concrete subtype (AxEdtString, AxEdtInt, AxEdtStringExtension, …).
-    // Note: AxEdt is no longer in this list as the scaffolder now emits AxEdt with an i:type
-    // attribute specifying the concrete type (e.g. i:type="AxEdtString"), which is not abstract.
     private static readonly HashSet<string> _abstractAxRoots = new(StringComparer.Ordinal)
     {
         "AxEdtExtension",
@@ -941,7 +936,14 @@ public static class ScaffoldFileWriter
     {
         try
         {
-            return XDocument.Parse(xml, LoadOptions.PreserveWhitespace).Root;
+            var settings = new XmlReaderSettings
+            {
+                DtdProcessing = DtdProcessing.Prohibit,
+                XmlResolver = null,
+            };
+            using var sr = new StringReader(xml);
+            using var xr = XmlReader.Create(sr, settings);
+            return XDocument.Load(xr, LoadOptions.PreserveWhitespace).Root;
         }
         catch
         {

--- a/src/D365FO.Core/Scaffolding/XppScaffolder.cs
+++ b/src/D365FO.Core/Scaffolding/XppScaffolder.cs
@@ -639,34 +639,30 @@ public static class XppScaffolder
     /// clause, which is valid for root EDTs. When <paramref name="baseType"/> is
     /// supplied without <paramref name="extends"/>, a sensible standard parent is
     /// inferred (e.g. <c>String → Name</c>, <c>Int → Integer</c>).
+    /// For Enum-type EDTs, supply <paramref name="enumType"/> with the backing X++ enum
+    /// name (e.g. <c>NoYes</c>). When omitted, the value is inferred from
+    /// <paramref name="extends"/> (e.g. <c>NoYesId -> NoYes</c>). If neither
+    /// <paramref name="enumType"/> nor <paramref name="extends"/> is supplied,
+    /// no <c>EnumType</c> element is emitted.
     /// </summary>
     public static XDocument Edt(
         string name,
         string? extends = null,
         string? baseType = null,
         int? stringSize = null,
-        string? label = null)
+        string? label = null,
+        string? enumType = null)
     {
         var effectiveExtends = extends;
         if (string.IsNullOrEmpty(effectiveExtends) && !string.IsNullOrEmpty(baseType))
         {
-            effectiveExtends = baseType.ToLowerInvariant() switch
-            {
-                "int" or "integer"          => "Integer",
-                "int64"                     => "Int64",
-                "real"                      => "Amount",
-                "date"                      => "Date",
-                "utcdatetime" or "datetime" => "TransDate",
-                "boolean" or "bool"         => "NoYesId",
-                _                           => "Name",
-            };
+            effectiveExtends = null; // Root EDTs stay root-level unless --extends is explicit.
         }
 
-        // D365FO's DataContractSerializer requires the root element to be the concrete
-        // subtype name (e.g. AxEdtString) — not the abstract base AxEdt.  Without the
-        // concrete root element the metadata parser throws "Cannot create an abstract class".
-        // Derive the concrete type suffix from --base-type; when only --extends is given,
-        // apply a heuristic over well-known system EDTs so common cases work without flags.
+        // D365FO's DataContractSerializer uses the i:type attribute to indicate the concrete
+        // type (e.g. AxEdtString). Derive the concrete type suffix from --base-type; when only
+        // --extends is given, apply a heuristic over well-known system EDTs so common cases
+        // work without flags.
         var concreteTypeSuffix = !string.IsNullOrEmpty(baseType)
             ? baseType.ToLowerInvariant() switch
             {
@@ -674,32 +670,68 @@ public static class XppScaffolder
                 "int64"                     => "Int64",
                 "real"                      => "Real",
                 "date"                      => "Date",
-                "utcdatetime" or "datetime" => "DateTime",
-                "boolean" or "bool"         => "Boolean",
+                "utcdatetime" or "datetime" => "UtcDateTime",
+                "boolean" or "bool"         => "Enum",
+                "time"                      => "Time",
+                "guid"                      => "Guid",
+                "container"                 => "Container",
+                "enum"                      => "Enum",
                 _                           => "String",
             }
             : InferConcreteTypeSuffixFromExtends(effectiveExtends);
 
         // D365FO's metadata reader requires the XMLSchema-instance namespace declaration on
         // the root element (Visual Studio emits it on every AxEdt* file). Without it VS refuses
-        // to read the metadata — the same defect previously fixed for AxEnum.
+        // to read the metadata. The i:type attribute specifies the concrete type (e.g. AxEdtString).
         // Element order also matters: the DataContractSerializer serializes base-class members
         // (AxEdt: Name/Extends/Label) before derived-class members (AxEdtString.StringSize), so
         // StringSize must come *after* Label, not before it.
+        // For Enum-type EDTs the backing X++ enum name is required (<EnumType> element).
+        // Resolve in this order:
+        //   1) explicit --enum-type
+        //   2) infer from --extends (NoYesId -> NoYes, otherwise use extends as enum name)
+        //   3) no value when neither is supplied
+        var effectiveEnumType = concreteTypeSuffix == "Enum"
+            ? (!string.IsNullOrEmpty(enumType)
+                ? enumType
+                : (string.IsNullOrEmpty(effectiveExtends)
+                    ? null
+                    : InferEnumTypeFromExtends(effectiveExtends)))
+            : null;
+
         XNamespace xsi = "http://www.w3.org/2001/XMLSchema-instance";
-        return new XDocument(
-            new XElement($"AxEdt{concreteTypeSuffix}",
-                new XAttribute(XNamespace.Xmlns + "i", xsi.NamespaceName),
-                new XElement("Name", name),
-                string.IsNullOrEmpty(effectiveExtends) ? null : new XElement("Extends", effectiveExtends),
-                string.IsNullOrEmpty(label) ? null : new XElement("Label", label),
-                stringSize.HasValue ? new XElement("StringSize", stringSize.Value.ToString()) : null));
+        var root = new XElement("AxEdt",
+            new XAttribute(XNamespace.Xmlns + "i", xsi.NamespaceName),
+            new XAttribute(XName.Get("type", xsi.NamespaceName), $"AxEdt{concreteTypeSuffix}"),
+            new XElement("Name", name),
+            string.IsNullOrEmpty(effectiveExtends) ? null : new XElement("Extends", effectiveExtends),
+            string.IsNullOrEmpty(label) ? null : new XElement("Label", label),
+            stringSize.HasValue ? new XElement("StringSize", stringSize.Value.ToString()) : null,
+            new XElement("ArrayElements"),
+            new XElement("Relations"),
+            new XElement("TableReferences"),
+            string.IsNullOrEmpty(effectiveEnumType) ? null : new XElement("EnumType", effectiveEnumType));
+        // Set the default namespace (empty xmlns) as per VS-emitted metadata format
+        root.SetAttributeValue(XName.Get("xmlns"), "");
+        return new XDocument(root);
     }
 
     /// <summary>
     /// Infers the concrete <c>AxEdt*</c> type suffix from a well-known system EDT name.
     /// Returns <c>"String"</c> as the safe default for unknown or custom parent EDTs.
     /// </summary>
+    /// <summary>
+    /// Infers the backing X++ enum name from a well-known system EDT name used as Extends.
+    /// For unknown names, returns the extends value as-is.
+    /// </summary>
+    private static string InferEnumTypeFromExtends(string? extends) =>
+        extends?.ToLowerInvariant() switch
+        {
+            "noyesid" or "noyes"   => "NoYes",
+            "boolean"              => "NoYes",
+            _                      => extends!,
+        } ?? string.Empty;
+
     private static string InferConcreteTypeSuffixFromExtends(string? extends) =>
         extends?.ToLowerInvariant() switch
         {
@@ -707,8 +739,11 @@ public static class XppScaffolder
             "int64" or "recid"                                      => "Int64",
             "amount" or "amountmst" or "qty" or "weight" or "real"  => "Real",
             "date" or "transdate"                                   => "Date",
-            "utcdatetime"                                           => "DateTime",
-            "noyes" or "noyesid" or "boolean"                      => "Boolean",
+            "utcdatetime" or "transdatetime"                        => "UtcDateTime",
+            "noyes" or "noyesid" or "boolean"                      => "Enum",
+            "timeofday" or "time"                                   => "Time",
+            "guid"                                                   => "Guid",
+            "container"                                              => "Container",
             _                                                       => "String",
         } ?? "String";
 
@@ -844,9 +879,10 @@ public static class ScaffoldFileWriter
     // Writing one of these as the document root makes VS metadata reader throw
     // "Cannot create an abstract class" when the file is opened — callers must use the
     // concrete subtype (AxEdtString, AxEdtInt, AxEdtStringExtension, …).
+    // Note: AxEdt is no longer in this list as the scaffolder now emits AxEdt with an i:type
+    // attribute specifying the concrete type (e.g. i:type="AxEdtString"), which is not abstract.
     private static readonly HashSet<string> _abstractAxRoots = new(StringComparer.Ordinal)
     {
-        "AxEdt",
         "AxEdtExtension",
     };
 
@@ -854,6 +890,7 @@ public static class ScaffoldFileWriter
     {
         ArgumentNullException.ThrowIfNull(doc);
         EnsureConcreteAxRoot(doc.Root?.Name.LocalName);
+        EnsureValidEdtRoot(doc.Root);
         return WriteCore(doc.ToString(SaveOptions.None), path, overwrite, declarationOnSaveFromXDoc: true, doc);
     }
 
@@ -865,7 +902,9 @@ public static class ScaffoldFileWriter
     public static WriteResult Write(string xml, string path, bool overwrite = false)
     {
         ArgumentException.ThrowIfNullOrEmpty(xml);
-        EnsureConcreteAxRoot(SniffRootLocalName(xml));
+        var root = ParseRootElement(xml);
+        EnsureConcreteAxRoot(root?.Name.LocalName);
+        EnsureValidEdtRoot(root);
         return WriteCore(xml, path, overwrite, declarationOnSaveFromXDoc: false, null);
     }
 
@@ -875,18 +914,34 @@ public static class ScaffoldFileWriter
             throw new InvalidOperationException(
                 $"Refusing to write AOT XML with abstract root element <{rootLocalName}>. " +
                 "Use the concrete subtype (e.g. AxEdtString, AxEdtInt, AxEdtReal, AxEdtDate, " +
-                "AxEdtDateTime, AxEdtBoolean). Visual Studio's metadata reader throws " +
+                "AxEdtUtcDateTime, AxEdtTime, AxEdtGuid, AxEdtContainer, AxEdtEnum). Visual Studio's metadata reader throws " +
                 "\"Cannot create an abstract class\" on this root.");
     }
 
-    private static string? SniffRootLocalName(string xml)
+    private static void EnsureValidEdtRoot(XElement? root)
+    {
+        if (root?.Name.LocalName != "AxEdt")
+            return;
+
+        XNamespace xsi = "http://www.w3.org/2001/XMLSchema-instance";
+        var typeValue = root.Attribute(XName.Get("type", xsi.NamespaceName))?.Value;
+        if (string.IsNullOrWhiteSpace(typeValue) ||
+            string.Equals(typeValue, "AxEdt", StringComparison.Ordinal) ||
+            !typeValue.StartsWith("AxEdt", StringComparison.Ordinal))
+        {
+            throw new InvalidOperationException(
+                "Refusing to write <AxEdt> without a concrete XMLSchema-instance type. " +
+                "Set i:type to a concrete subtype (e.g. AxEdtString, AxEdtInt, AxEdtReal, " +
+                "AxEdtDate, AxEdtUtcDateTime, AxEdtTime, AxEdtGuid, AxEdtContainer, AxEdtEnum). Visual Studio's metadata reader " +
+                "throws \"Cannot create an abstract class\" when type metadata is missing.");
+        }
+    }
+
+    private static XElement? ParseRootElement(string xml)
     {
         try
         {
-            using var sr = new StringReader(xml);
-            using var xr = System.Xml.XmlReader.Create(sr, new System.Xml.XmlReaderSettings { DtdProcessing = System.Xml.DtdProcessing.Prohibit });
-            xr.MoveToContent();
-            return xr.NodeType == System.Xml.XmlNodeType.Element ? xr.LocalName : null;
+            return XDocument.Parse(xml, LoadOptions.PreserveWhitespace).Root;
         }
         catch
         {

--- a/tests/D365FO.Cli.Tests/ScaffoldingSnapshotTests.cs
+++ b/tests/D365FO.Cli.Tests/ScaffoldingSnapshotTests.cs
@@ -53,9 +53,177 @@ public class ScaffoldingSnapshotTests
     {
         var doc = XppScaffolder.Edt("MyEdt", "Name");
         var root = doc.Root!;
-        Assert.Equal("AxEdtString", root.Name.LocalName);
+        Assert.Equal("AxEdt", root.Name.LocalName);
+        Assert.Equal("AxEdtString", root.Attribute(XName.Get("type", "http://www.w3.org/2001/XMLSchema-instance"))!.Value);
         Assert.Equal("MyEdt", root.Element("Name")!.Value);
         Assert.Equal("Name", root.Element("Extends")!.Value);
+    }
+
+    [Theory]
+    [InlineData("String", "AxEdtString")]
+    [InlineData("Int", "AxEdtInt")]
+    [InlineData("Int64", "AxEdtInt64")]
+    [InlineData("Real", "AxEdtReal")]
+    [InlineData("Date", "AxEdtDate")]
+    [InlineData("UtcDateTime", "AxEdtUtcDateTime")]
+    [InlineData("Boolean", "AxEdtEnum")]
+    [InlineData("Time", "AxEdtTime")]
+    [InlineData("Guid", "AxEdtGuid")]
+    [InlineData("Container", "AxEdtContainer")]
+    [InlineData("Enum", "AxEdtEnum")]
+    public void Edt_base_type_emits_matching_concrete_i_type(string baseType, string expectedType)
+    {
+        var doc = XppScaffolder.Edt("MyEdt", null, baseType);
+        Assert.Equal(
+            expectedType,
+            doc.Root!.Attribute(XName.Get("type", "http://www.w3.org/2001/XMLSchema-instance"))!.Value);
+    }
+
+    [Fact]
+    public void Edt_enum_type_emits_EnumType_element_after_TableReferences()
+    {
+        // Enum-type EDTs require <EnumType> (the backing X++ enum name) after <TableReferences>.
+        // Without it VS metadata reader cannot bind the EDT to the enum. (issue #70)
+        var doc = XppScaffolder.Edt("MyEnumEdt", "NoYesId", "Enum", null, null, "NoYes");
+        var names = doc.Root!.Elements().Select(e => e.Name.LocalName).ToList();
+        Assert.Contains("EnumType", names);
+        Assert.True(names.IndexOf("EnumType") > names.IndexOf("TableReferences"),
+            "<EnumType> must appear after <TableReferences>");
+        Assert.Equal("NoYes", doc.Root.Element("EnumType")!.Value);
+    }
+
+    [Fact]
+    public void Edt_enum_type_defaults_to_NoYes_when_extends_NoYesId()
+    {
+        // When --enum-type is omitted and extends is NoYesId, NoYes is inferred.
+        var doc = XppScaffolder.Edt("MyEnumEdt", "NoYesId", "Enum");
+        Assert.Equal("NoYes", doc.Root!.Element("EnumType")!.Value);
+    }
+
+    [Fact]
+    public void Edt_enum_type_without_extends_and_without_enum_type_does_not_emit_EnumType()
+    {
+        var doc = XppScaffolder.Edt("MyEnumEdt", null, "Enum");
+        Assert.Null(doc.Root!.Element("EnumType"));
+    }
+
+    [Fact]
+    public void Edt_enum_type_infers_EnumType_from_custom_extends()
+    {
+        var doc = XppScaffolder.Edt("MyEnumEdt", "ABCModelType", "Enum");
+        Assert.Equal("ABCModelType", doc.Root!.Element("EnumType")!.Value);
+    }
+
+    [Fact]
+    public void Edt_non_enum_type_does_not_emit_EnumType_element()
+    {
+        // Non-enum EDTs must not get a spurious <EnumType> element.
+        var doc = XppScaffolder.Edt("MyStringEdt", null, "String");
+        Assert.Null(doc.Root!.Element("EnumType"));
+    }
+
+    [Fact]
+    public void Edt_base_type_Date_has_no_default_extends()
+    {
+        var doc = XppScaffolder.Edt("MyDateEdt", null, "Date");
+        Assert.Null(doc.Root!.Element("Extends"));
+    }
+
+    [Fact]
+    public void Edt_base_type_Int64_has_no_default_extends()
+    {
+        var doc = XppScaffolder.Edt("MyInt64Edt", null, "Int64");
+        Assert.Null(doc.Root!.Element("Extends"));
+    }
+
+    [Fact]
+    public void Edt_base_type_String_has_no_default_extends()
+    {
+        var doc = XppScaffolder.Edt("MyStringEdt", null, "String");
+        Assert.Null(doc.Root!.Element("Extends"));
+    }
+
+    [Fact]
+    public void Edt_base_type_Int_has_no_default_extends()
+    {
+        var doc = XppScaffolder.Edt("MyIntEdt", null, "Int");
+        Assert.Null(doc.Root!.Element("Extends"));
+    }
+
+    [Fact]
+    public void Edt_base_type_Real_has_no_default_extends()
+    {
+        var doc = XppScaffolder.Edt("MyRealEdt", null, "Real");
+        Assert.Null(doc.Root!.Element("Extends"));
+    }
+
+    [Fact]
+    public void Edt_base_type_Time_has_no_default_extends()
+    {
+        var doc = XppScaffolder.Edt("MyTimeEdt", null, "Time");
+        Assert.Null(doc.Root!.Element("Extends"));
+    }
+
+    [Fact]
+    public void Edt_base_type_UtcDateTime_has_no_default_extends()
+    {
+        var doc = XppScaffolder.Edt("MyDateTimeEdt", null, "UtcDateTime");
+        Assert.Null(doc.Root!.Element("Extends"));
+    }
+
+    [Fact]
+    public void Edt_base_type_Boolean_has_no_default_extends()
+    {
+        var doc = XppScaffolder.Edt("MyBoolEdt", null, "Boolean");
+        Assert.Null(doc.Root!.Element("Extends"));
+    }
+
+    [Fact]
+    public void Edt_base_type_Boolean_without_extends_does_not_emit_EnumType()
+    {
+        var doc = XppScaffolder.Edt("MyBoolEdt", null, "Boolean");
+        Assert.Null(doc.Root!.Element("EnumType"));
+    }
+
+    [Fact]
+    public void Edt_base_type_Enum_has_no_default_extends()
+    {
+        var doc = XppScaffolder.Edt("MyEnumEdt", null, "Enum");
+        Assert.Null(doc.Root!.Element("Extends"));
+    }
+
+    [Fact]
+    public void Edt_base_type_Guid_has_no_default_extends()
+    {
+        var doc = XppScaffolder.Edt("MyGuidEdt", null, "Guid");
+        Assert.Null(doc.Root!.Element("Extends"));
+    }
+
+    [Fact]
+    public void Edt_base_type_Container_has_no_default_extends()
+    {
+        var doc = XppScaffolder.Edt("MyContainerEdt", null, "Container");
+        Assert.Null(doc.Root!.Element("Extends"));
+    }
+
+    [Theory]
+    [InlineData("Integer", "AxEdtInt")]
+    [InlineData("Int64", "AxEdtInt64")]
+    [InlineData("Amount", "AxEdtReal")]
+    [InlineData("Date", "AxEdtDate")]
+    [InlineData("TransDate", "AxEdtDate")]
+    [InlineData("UtcDateTime", "AxEdtUtcDateTime")]
+    [InlineData("TransDateTime", "AxEdtUtcDateTime")]
+    [InlineData("NoYesId", "AxEdtEnum")]
+    [InlineData("TimeOfDay", "AxEdtTime")]
+    [InlineData("Guid", "AxEdtGuid")]
+    [InlineData("Container", "AxEdtContainer")]
+    public void Edt_extends_infers_non_string_i_type(string extends, string expectedType)
+    {
+        var doc = XppScaffolder.Edt("MyEdt", extends);
+        Assert.Equal(
+            expectedType,
+            doc.Root!.Attribute(XName.Get("type", "http://www.w3.org/2001/XMLSchema-instance"))!.Value);
     }
 
     [Fact]
@@ -84,7 +252,7 @@ public class ScaffoldingSnapshotTests
         // before derived members (AxEdtString.StringSize): Label must precede StringSize.
         var doc = XppScaffolder.Edt("MyEdt", "Name", null, 10, "My label");
         var names = doc.Root!.Elements().Select(e => e.Name.LocalName).ToList();
-        Assert.Equal(new[] { "Name", "Extends", "Label", "StringSize" }, names);
+        Assert.Equal(new[] { "Name", "Extends", "Label", "StringSize", "ArrayElements", "Relations", "TableReferences" }, names);
     }
 
     [Fact]
@@ -92,6 +260,7 @@ public class ScaffoldingSnapshotTests
     {
         var doc = new XDocument(new XElement("AxEdt", new XElement("Name", "Bad")));
         var tmp = System.IO.Path.Combine(System.IO.Path.GetTempPath(), "d365fo-cli-test-abstract-edt.xml");
+        if (System.IO.File.Exists(tmp)) System.IO.File.Delete(tmp);
         var ex = Assert.Throws<System.InvalidOperationException>(() => ScaffoldFileWriter.Write(doc, tmp, overwrite: true));
         Assert.Contains("AxEdt", ex.Message);
         Assert.False(System.IO.File.Exists(tmp));
@@ -102,6 +271,7 @@ public class ScaffoldingSnapshotTests
     {
         var raw = "<?xml version=\"1.0\" encoding=\"utf-8\"?><AxEdtExtension><Name>Bad.Extension</Name></AxEdtExtension>";
         var tmp = System.IO.Path.Combine(System.IO.Path.GetTempPath(), "d365fo-cli-test-abstract-edt-ext.xml");
+        if (System.IO.File.Exists(tmp)) System.IO.File.Delete(tmp);
         var ex = Assert.Throws<System.InvalidOperationException>(() => ScaffoldFileWriter.Write(raw, tmp, overwrite: true));
         Assert.Contains("AxEdtExtension", ex.Message);
         Assert.False(System.IO.File.Exists(tmp));

--- a/tests/D365FO.Cli.Tests/ScaffoldingSnapshotTests.cs
+++ b/tests/D365FO.Cli.Tests/ScaffoldingSnapshotTests.cs
@@ -1,4 +1,5 @@
 using D365FO.Core.Scaffolding;
+using D365FO.Cli.Commands.Generate;
 using System.Xml.Linq;
 using Xunit;
 
@@ -108,10 +109,10 @@ public class ScaffoldingSnapshotTests
     }
 
     [Fact]
-    public void Edt_enum_type_infers_EnumType_from_custom_extends()
+    public void Edt_enum_type_with_custom_extends_does_not_guess_EnumType()
     {
         var doc = XppScaffolder.Edt("MyEnumEdt", "ABCModelType", "Enum");
-        Assert.Equal("ABCModelType", doc.Root!.Element("EnumType")!.Value);
+        Assert.Null(doc.Root!.Element("EnumType"));
     }
 
     [Fact]
@@ -179,10 +180,10 @@ public class ScaffoldingSnapshotTests
     }
 
     [Fact]
-    public void Edt_base_type_Boolean_without_extends_does_not_emit_EnumType()
+    public void Edt_base_type_Boolean_without_extends_defaults_EnumType_to_NoYes()
     {
         var doc = XppScaffolder.Edt("MyBoolEdt", null, "Boolean");
-        Assert.Null(doc.Root!.Element("EnumType"));
+        Assert.Equal("NoYes", doc.Root!.Element("EnumType")!.Value);
     }
 
     [Fact]
@@ -237,8 +238,6 @@ public class ScaffoldingSnapshotTests
     [Fact]
     public void Edt_root_has_XMLSchema_instance_namespace()
     {
-        // VS emits the XMLSchema-instance namespace on every AxEdt* root; without it the
-        // metadata reader refuses the file. (issue #70)
         var doc = XppScaffolder.Edt("MyEdt", "Name", null, 10, "My label");
         Assert.Equal(
             "http://www.w3.org/2001/XMLSchema-instance",
@@ -252,7 +251,7 @@ public class ScaffoldingSnapshotTests
         // before derived members (AxEdtString.StringSize): Label must precede StringSize.
         var doc = XppScaffolder.Edt("MyEdt", "Name", null, 10, "My label");
         var names = doc.Root!.Elements().Select(e => e.Name.LocalName).ToList();
-        Assert.Equal(new[] { "Name", "Extends", "Label", "StringSize", "ArrayElements", "Relations", "TableReferences" }, names);
+        Assert.Equal(new[] { "Name", "Extends", "Label", "StringSize" }, names);
     }
 
     [Fact]
@@ -275,6 +274,45 @@ public class ScaffoldingSnapshotTests
         var ex = Assert.Throws<System.InvalidOperationException>(() => ScaffoldFileWriter.Write(raw, tmp, overwrite: true));
         Assert.Contains("AxEdtExtension", ex.Message);
         Assert.False(System.IO.File.Exists(tmp));
+    }
+
+    [Fact]
+    public void GenerateEdtCommand_without_index_still_infers_NoYes_from_NoYesId()
+    {
+        var outPath = System.IO.Path.Combine(System.IO.Path.GetTempPath(), $"d365fo-cli-test-edt-{System.Guid.NewGuid():N}.xml");
+        if (System.IO.File.Exists(outPath)) System.IO.File.Delete(outPath);
+
+        var cmd = new GenerateEdtCommand();
+        var settings = new GenerateEdtCommand.Settings
+        {
+            Name = "MyEnumEdt",
+            Extends = "NoYesId",
+            BaseType = "Enum",
+            Out = outPath,
+            Overwrite = true,
+            EnumType = null,
+        };
+
+        var oldDb = System.Environment.GetEnvironmentVariable("D365FO_INDEX_DB");
+        var forcedMissingDb = System.IO.Path.Combine(System.IO.Path.GetTempPath(), $"d365fo-cli-missing-{System.Guid.NewGuid():N}.sqlite");
+        if (System.IO.File.Exists(forcedMissingDb)) System.IO.File.Delete(forcedMissingDb);
+
+        try
+        {
+            System.Environment.SetEnvironmentVariable("D365FO_INDEX_DB", forcedMissingDb);
+            var exit = cmd.Execute(null!, settings);
+            Assert.Equal(0, exit);
+
+            var doc = XDocument.Load(outPath);
+            Assert.Equal("AxEdt", doc.Root!.Name.LocalName);
+            Assert.Equal("AxEdtEnum", doc.Root!.Attribute(XName.Get("type", "http://www.w3.org/2001/XMLSchema-instance"))!.Value);
+            Assert.Equal("NoYes", doc.Root.Element("EnumType")!.Value);
+        }
+        finally
+        {
+            System.Environment.SetEnvironmentVariable("D365FO_INDEX_DB", oldDb);
+            if (System.IO.File.Exists(outPath)) System.IO.File.Delete(outPath);
+        }
     }
 
     // ---- Enum (Phase 2) ----


### PR DESCRIPTION
Thanks for your time reviewing this.
I’m happy to chat through the changes and follow your guidance on any refinements.

## Summary
This PR fixes Issue 70 by improving Enum EDT scaffolding in the d365fo generator and tightening metadata validation behavior.

## What Changed
- Improved EDT scaffolding logic for Enum scenarios
- Corrected `EnumType` resolution when using `--base-type Enum` with `--extends`
- Hardened EDT XML generation to align with expected D365FO metadata shape
- Added/updated snapshot and validation-focused tests to prevent regressions

## Why
Generating EDTs with Enum base type could produce inconsistent or invalid metadata in certain paths.  
These changes make generation deterministic and compatible with expected D365FO metadata requirements.

## Verification
- Ran relevant unit/snapshot tests
- Manually verified generator behavior for Enum EDT scenarios

## Issue Reference
Closes #70