### PR TITLE
honor output mode table in index extract command

### DIFF
--- a/src/D365FO.Cli/Commands/Index/IndexCommands.cs
+++ b/src/D365FO.Cli/Commands/Index/IndexCommands.cs
@@ -377,7 +377,7 @@ public sealed class IndexExtractCommand : Command<IndexExtractCommand.Settings>
 
         runSw.Stop();
         var totals = repo.CountAll();
-        return RenderHelpers.Render(kind, ToolResult<object>.Success(new
+        var result = ToolResult<object>.Success(new
         {
             packagesRoot = root,
             extraPackagesRoots = validExtraRoots.Count > 0 ? validExtraRoots : null,
@@ -389,7 +389,26 @@ public sealed class IndexExtractCommand : Command<IndexExtractCommand.Settings>
             elapsedMs = runSw.ElapsedMilliseconds,
             perModel = per,
             totals,
-        }));
+        });
+
+        return RenderHelpers.Render(kind, result, _ =>
+        {
+            AnsiConsole.MarkupLine("[green]OK[/] index extract completed");
+            AnsiConsole.MarkupLine($"models processed: [bold]{modelCount}[/], skipped: [bold]{skippedCount}[/], custom: [bold]{customCount}[/]");
+            AnsiConsole.MarkupLine($"elapsed: [bold]{runSw.ElapsedMilliseconds}[/] ms");
+
+            var table = new Table().Border(TableBorder.Rounded).Title("[bold]Index Totals[/]");
+            table.AddColumn("Artifact");
+            table.AddColumn(new TableColumn("Count").RightAligned());
+            table.AddRow("Tables", totals.Tables.ToString());
+            table.AddRow("Classes", totals.Classes.ToString());
+            table.AddRow("EDTs", totals.Edts.ToString());
+            table.AddRow("Enums", totals.Enums.ToString());
+            table.AddRow("Menu Items", totals.MenuItems.ToString());
+            table.AddRow("CoC Extensions", totals.Coc.ToString());
+            table.AddRow("Labels", totals.Labels.ToString());
+            AnsiConsole.Write(table);
+        });
     }
 
     private static DateTime? NewestMtime(string dir)

--- a/tests/D365FO.Cli.Tests/IndexExtractOutputModeTests.cs
+++ b/tests/D365FO.Cli.Tests/IndexExtractOutputModeTests.cs
@@ -1,0 +1,101 @@
+using D365FO.Cli;
+using D365FO.Cli.Commands.Index;
+
+namespace D365FO.Cli.Tests;
+
+[CollectionDefinition("Console output", DisableParallelization = true)]
+public sealed class ConsoleOutputCollectionDefinition { }
+
+[Collection("Console output")]
+public sealed class IndexExtractOutputModeTests : IDisposable
+{
+    private readonly string _root = Path.Combine(Path.GetTempPath(), $"d365fo-extract-{Guid.NewGuid():N}");
+    private readonly string _packages;
+    private readonly string _db;
+
+    public IndexExtractOutputModeTests()
+    {
+        _packages = Path.Combine(_root, "PackagesLocalDirectory");
+        _db = Path.Combine(_root, "index.sqlite");
+
+        // Minimal model directory shape expected by EnumerateModelDirs.
+        Directory.CreateDirectory(Path.Combine(_packages, "PkgA", "ISMModel", "AxClass"));
+    }
+
+    public void Dispose()
+    {
+        try { Directory.Delete(_root, recursive: true); } catch { }
+    }
+
+    [Fact]
+    public void ExtractCore_json_mode_emits_json_envelope()
+    {
+        var output = Capture(() =>
+        {
+            var code = IndexExtractCommand.ExtractCore(
+                OutputMode.Kind.Json,
+                packagesOverride: _packages,
+                databaseOverride: _db,
+                onlyModel: "ISMModel",
+                sinceIso: null);
+            Assert.Equal(0, code);
+        });
+
+        Assert.Contains("\"ok\":true", output, StringComparison.OrdinalIgnoreCase);
+        Assert.Contains("\"modelsProcessed\"", output, StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact]
+    public void ExtractCore_table_mode_emits_human_summary_not_json_dump()
+    {
+        var output = Capture(() =>
+        {
+            var code = IndexExtractCommand.ExtractCore(
+                OutputMode.Kind.Table,
+                packagesOverride: _packages,
+                databaseOverride: _db,
+                onlyModel: "ISMModel",
+                sinceIso: null);
+            Assert.Equal(0, code);
+        });
+
+        Assert.Contains("index extract completed", output, StringComparison.OrdinalIgnoreCase);
+        Assert.Contains("Index Totals", output, StringComparison.OrdinalIgnoreCase);
+        Assert.DoesNotContain("\"ok\"", output, StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact]
+    public void ExtractCore_raw_mode_uses_standard_json_envelope()
+    {
+        var output = Capture(() =>
+        {
+            var code = IndexExtractCommand.ExtractCore(
+                OutputMode.Kind.Raw,
+                packagesOverride: _packages,
+                databaseOverride: _db,
+                onlyModel: "ISMModel",
+                sinceIso: null);
+            Assert.Equal(0, code);
+        });
+
+        Assert.Contains("\"ok\":true", output, StringComparison.OrdinalIgnoreCase);
+        Assert.Contains("\"modelsProcessed\"", output, StringComparison.OrdinalIgnoreCase);
+    }
+
+    private static string Capture(Action action)
+    {
+        var originalOut = Console.Out;
+        var writer = new StringWriter();
+        try
+        {
+            Console.SetOut(writer);
+            action();
+            return writer.ToString();
+        }
+        finally
+        {
+            Console.SetOut(originalOut);
+            writer.Dispose();
+        }
+    }
+}


### PR DESCRIPTION
While testing #83 (nice feature btw), I noticed that the index extract command always outputs a json (which is rather long if the full application is extracted, which can cause a cut off in terminals).

This pull request enhances the output handling of the index extraction command and introduces new tests to ensure correct output formatting for different output modes. The key changes include improved human-readable summaries for table output mode and comprehensive test coverage for output modes.

**Improvements to output formatting:**

* Added a detailed human-readable summary, including a totals table and additional status messages, when running the index extraction in table output mode in `IndexCommands.cs` [[1]](diffhunk://#diff-561ba1924a195ef53258569d1ca58321dda26c81274928095cd81cdb30ae506fL392-R411) [[2]](diffhunk://#diff-561ba1924a195ef53258569d1ca58321dda26c81274928095cd81cdb30ae506fL380-R380).

**Test coverage enhancements:**

* Introduced `IndexExtractOutputModeTests` to verify that the index extraction command produces the correct output format for JSON, table, and raw output modes, ensuring that human-readable and machine-readable outputs are distinct and correct (`IndexExtractOutputModeTests.cs`).

<img width="857" height="519" alt="image" src="https://github.com/user-attachments/assets/3ae648b2-52fa-4342-b38b-b293c74d7b14" />
