### PR TITLE
Fix/issue 86 remove sysentry

### DIFF
--- a/docs/CAPABILITIES.md
+++ b/docs/CAPABILITIES.md
@@ -349,7 +349,7 @@ Exposes the same index and scaffolding surface as the CLI over the `ModelContext
 | `xpp-statement-and-type-rules` | Type system, container, enum usage |
 | `business-events-authoring` | `BusinessEventsBase`, contract class, payload |
 | `integration-patterns` | OData, custom services, Dual-write surface |
-| `custom-service-authoring` | JSON/SOAP services, `ServiceAttribute`, `SysEntryPointAttribute` |
+| `custom-service-authoring` | JSON/SOAP services |
 
 ---
 

--- a/docs/EXAMPLES.md
+++ b/docs/EXAMPLES.md
@@ -506,7 +506,7 @@ d365fo generate custom-service CustCustomService \
   --out-group c:/AOT/MyModel/AxServiceGroup/CustCustomServiceGroup.xml
 ```
 
-The service class method is decorated with `[SysEntryPointAttribute(true)]` for security. Use `d365fo search service <name>` to check for existing services before naming.
+Use `d365fo search service <name>` to check for existing services before naming.
 
 ### Migration script — data-fix runnable with batching
 

--- a/skills/_source/custom-service-authoring.md
+++ b/skills/_source/custom-service-authoring.md
@@ -6,7 +6,7 @@ applyTo:
   - "**/AxServiceGroup/**"
   - "**/*Service.xml"
   - "**/*ServiceGroup.xml"
-appliesWhen: User intent mentions custom service, service class, service group, JSON endpoint, SOAP endpoint, REST API from X++, [ServiceAttribute], [SysEntryPointAttribute], or AxServiceGroup.
+appliesWhen: User intent mentions custom service, service class, service group, JSON endpoint, SOAP endpoint, REST API from X++, [ServiceAttribute], or AxServiceGroup.
 ---
 
 > ⛔ **NEVER write X++ AOT XML files directly** via PowerShell, terminal file commands (`Set-Content`, `Out-File`, `New-Item`), editor write tools, or any raw text approach. The XML schema is proprietary. **ALWAYS use `d365fo generate …` commands** to produce correct AOT XML. If `d365fo` is unavailable in PATH, stop and ask the user to install it.
@@ -27,7 +27,6 @@ A D365FO custom service requires three artifacts:
 
 ```
 1. Service class  — decorated with [ServiceAttribute]
-   - Each exposed method decorated with [SysEntryPointAttribute(true)]
    - Parameters/return types use [DataContractAttribute] classes
 
 2. AxService XML  — declares the service class + operation bindings
@@ -73,8 +72,6 @@ This produces:
 [ServiceAttribute]
 public class VendorLookupService
 {
-    // Each public method exposed via the service must carry [SysEntryPointAttribute]
-    [SysEntryPointAttribute(true)]
     public VendorLookupResponse lookupVendor(VendorLookupRequest _request)
     {
         var response = new VendorLookupResponse();
@@ -176,8 +173,8 @@ Use Azure AD OAuth2:
 
 ## Hard rules
 
-- **`[SysEntryPointAttribute(true)]` is required on every method exposed via the service.** Without it, the method is not accessible and callers receive a `Method not found` error.
 - **Request/response types must be `[DataContractAttribute]` classes.** Primitive types (`str`, `int`) are also accepted for simple services.
+- **Public methods in a `[ServiceAttribute]`-decorated class are automatically exposed** and do not require `[SysEntryPointAttribute]`.
 - **`[DataMemberAttribute]` on every parmXxx accessor** — the JSON serializer uses member names from this attribute.
 - **Service group name determines the URL** — choose a stable, module-scoped name; renaming it breaks all callers.
 - **Never include `ttsbegin/ttscommit` in service methods** unless you own the full transaction scope. If the service calls a framework method that manages its own transaction, wrap at a higher level.

--- a/skills/_source/integration-patterns.md
+++ b/skills/_source/integration-patterns.md
@@ -80,7 +80,6 @@ d365fo generate entity <Name> --table <T> \
 AxServiceGroup
   └── AxService (ServiceGroup reference)
         └── Service class (X++)
-              └── Operations decorated with [SysEntryPointAttribute(true)]
 ```
 
 **REST endpoint:** `https://{env}.cloudax.dynamics.com/api/services/{ServiceGroupName}/{ServiceName}/{OperationName}`
@@ -109,7 +108,6 @@ d365fo generate custom-service <Name> \
 
 **Hard rules:**
 
-- **Every exposed method must have `[SysEntryPointAttribute(true)]`** — without it the service is unreachable from external callers (security gate).
 - Use `[DataContractAttribute]` + `[DataMemberAttribute]` on parameter/return contract classes — not `pack()`/`unpack()`.
 - Service class must NOT hold state between calls (it is instantiated per request).
 

--- a/skills/_source/sysoperation-batch-patterns.md
+++ b/skills/_source/sysoperation-batch-patterns.md
@@ -66,7 +66,6 @@ d365fo generate sysoperation FmInvoiceBatch \
 - The Contract class must NOT hold state between calls — it is a simple data transfer object.
 - Do NOT use `today()` anywhere in the service — use `DateTimeUtil::getToday(DateTimeUtil::getUserPreferredTimeZone())`.
 - Never call `ttsbegin` / `ttscommit` in the Contract or Controller — only in the Service's `process()`.
-- Add a `[SysEntryPointAttribute(true)]` on the Service entry method to control security access.
 
 ---
 

--- a/skills/_source/x++-class-authoring.md
+++ b/skills/_source/x++-class-authoring.md
@@ -61,10 +61,9 @@ Modern replacement for `RunBaseBatch`. **Always use SysOperation for new batch c
 
 1. Structure: **DataContract** (parameters) + **Service** (logic) + **Controller** (execution mode).
 2. DataContract: decorate `parmXxx()` methods with `[DataMemberAttribute]`. Never use `pack()`/`unpack()`.
-3. Service method MUST be marked `[SysEntryPointAttribute(true)]` for security.
-4. Controller sets execution mode: `Synchronous`, `Asynchronous`, or `ScheduledBatch`.
-5. For SSRS report data providers: extend `SRSReportDataProviderBase` instead of `SysOperationServiceBase`.
-6. Custom dialog: use `SysOperationAutomaticUIBuilder`; link via `[SysOperationContractProcessingAttribute(classStr(MyUIBuilder))]` on the DataContract.
+3. Controller sets execution mode: `Synchronous`, `Asynchronous`, or `ScheduledBatch`.
+4. For SSRS report data providers: extend `SRSReportDataProviderBase` instead of `SysOperationServiceBase`.
+5. Custom dialog: use `SysOperationAutomaticUIBuilder`; link via `[SysOperationContractProcessingAttribute(classStr(MyUIBuilder))]` on the DataContract.
 
 **Scaffold with the CLI** — generates the DataContract, Service, and Controller XML in one command:
 

--- a/skills/anthropic/custom-service-authoring/SKILL.md
+++ b/skills/anthropic/custom-service-authoring/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: custom-service-authoring
 description: Build or extend a D365FO custom service (JSON/SOAP REST endpoint) using the AxService + AxServiceGroup + SysOperation or plain class pattern. Invoke when the user asks to "create a custom service", "expose an X++ method as a REST endpoint", "build a service class", or "register a service group".
-applies_when: User intent mentions custom service, service class, service group, JSON endpoint, SOAP endpoint, REST API from X++, [ServiceAttribute], [SysEntryPointAttribute], or AxServiceGroup.
+applies_when: User intent mentions custom service, service class, service group, JSON endpoint, SOAP endpoint, REST API from X++, [ServiceAttribute], or AxServiceGroup.
 ---
 > ⛔ **NEVER write X++ AOT XML files directly** via PowerShell, terminal file commands (`Set-Content`, `Out-File`, `New-Item`), editor write tools, or any raw text approach. The XML schema is proprietary. **ALWAYS use `d365fo generate …` commands** to produce correct AOT XML. If `d365fo` is unavailable in PATH, stop and ask the user to install it.
 
@@ -21,7 +21,6 @@ A D365FO custom service requires three artifacts:
 
 ```
 1. Service class  — decorated with [ServiceAttribute]
-   - Each exposed method decorated with [SysEntryPointAttribute(true)]
    - Parameters/return types use [DataContractAttribute] classes
 
 2. AxService XML  — declares the service class + operation bindings
@@ -67,8 +66,6 @@ This produces:
 [ServiceAttribute]
 public class VendorLookupService
 {
-    // Each public method exposed via the service must carry [SysEntryPointAttribute]
-    [SysEntryPointAttribute(true)]
     public VendorLookupResponse lookupVendor(VendorLookupRequest _request)
     {
         var response = new VendorLookupResponse();
@@ -170,8 +167,8 @@ Use Azure AD OAuth2:
 
 ## Hard rules
 
-- **`[SysEntryPointAttribute(true)]` is required on every method exposed via the service.** Without it, the method is not accessible and callers receive a `Method not found` error.
 - **Request/response types must be `[DataContractAttribute]` classes.** Primitive types (`str`, `int`) are also accepted for simple services.
+- **Public methods in a `[ServiceAttribute]`-decorated class are automatically exposed** and do not require `[SysEntryPointAttribute]`.
 - **`[DataMemberAttribute]` on every parmXxx accessor** — the JSON serializer uses member names from this attribute.
 - **Service group name determines the URL** — choose a stable, module-scoped name; renaming it breaks all callers.
 - **Never include `ttsbegin/ttscommit` in service methods** unless you own the full transaction scope. If the service calls a framework method that manages its own transaction, wrap at a higher level.

--- a/skills/anthropic/integration-patterns/SKILL.md
+++ b/skills/anthropic/integration-patterns/SKILL.md
@@ -73,7 +73,6 @@ d365fo generate entity <Name> --table <T> \
 AxServiceGroup
   └── AxService (ServiceGroup reference)
         └── Service class (X++)
-              └── Operations decorated with [SysEntryPointAttribute(true)]
 ```
 
 **REST endpoint:** `https://{env}.cloudax.dynamics.com/api/services/{ServiceGroupName}/{ServiceName}/{OperationName}`
@@ -102,7 +101,6 @@ d365fo generate custom-service <Name> \
 
 **Hard rules:**
 
-- **Every exposed method must have `[SysEntryPointAttribute(true)]`** — without it the service is unreachable from external callers (security gate).
 - Use `[DataContractAttribute]` + `[DataMemberAttribute]` on parameter/return contract classes — not `pack()`/`unpack()`.
 - Service class must NOT hold state between calls (it is instantiated per request).
 

--- a/skills/anthropic/sysoperation-batch-patterns/SKILL.md
+++ b/skills/anthropic/sysoperation-batch-patterns/SKILL.md
@@ -58,7 +58,6 @@ d365fo generate sysoperation FmInvoiceBatch \
 - The Contract class must NOT hold state between calls — it is a simple data transfer object.
 - Do NOT use `today()` anywhere in the service — use `DateTimeUtil::getToday(DateTimeUtil::getUserPreferredTimeZone())`.
 - Never call `ttsbegin` / `ttscommit` in the Contract or Controller — only in the Service's `process()`.
-- Add a `[SysEntryPointAttribute(true)]` on the Service entry method to control security access.
 
 ---
 

--- a/skills/anthropic/x++-class-authoring/SKILL.md
+++ b/skills/anthropic/x++-class-authoring/SKILL.md
@@ -56,10 +56,9 @@ Modern replacement for `RunBaseBatch`. **Always use SysOperation for new batch c
 
 1. Structure: **DataContract** (parameters) + **Service** (logic) + **Controller** (execution mode).
 2. DataContract: decorate `parmXxx()` methods with `[DataMemberAttribute]`. Never use `pack()`/`unpack()`.
-3. Service method MUST be marked `[SysEntryPointAttribute(true)]` for security.
-4. Controller sets execution mode: `Synchronous`, `Asynchronous`, or `ScheduledBatch`.
-5. For SSRS report data providers: extend `SRSReportDataProviderBase` instead of `SysOperationServiceBase`.
-6. Custom dialog: use `SysOperationAutomaticUIBuilder`; link via `[SysOperationContractProcessingAttribute(classStr(MyUIBuilder))]` on the DataContract.
+3. Controller sets execution mode: `Synchronous`, `Asynchronous`, or `ScheduledBatch`.
+4. For SSRS report data providers: extend `SRSReportDataProviderBase` instead of `SysOperationServiceBase`.
+5. Custom dialog: use `SysOperationAutomaticUIBuilder`; link via `[SysOperationContractProcessingAttribute(classStr(MyUIBuilder))]` on the DataContract.
 
 **Scaffold with the CLI** — generates the DataContract, Service, and Controller XML in one command:
 

--- a/skills/copilot/custom-service-authoring.instructions.md
+++ b/skills/copilot/custom-service-authoring.instructions.md
@@ -20,7 +20,6 @@ A D365FO custom service requires three artifacts:
 
 ```
 1. Service class  — decorated with [ServiceAttribute]
-   - Each exposed method decorated with [SysEntryPointAttribute(true)]
    - Parameters/return types use [DataContractAttribute] classes
 
 2. AxService XML  — declares the service class + operation bindings
@@ -66,8 +65,6 @@ This produces:
 [ServiceAttribute]
 public class VendorLookupService
 {
-    // Each public method exposed via the service must carry [SysEntryPointAttribute]
-    [SysEntryPointAttribute(true)]
     public VendorLookupResponse lookupVendor(VendorLookupRequest _request)
     {
         var response = new VendorLookupResponse();
@@ -169,8 +166,8 @@ Use Azure AD OAuth2:
 
 ## Hard rules
 
-- **`[SysEntryPointAttribute(true)]` is required on every method exposed via the service.** Without it, the method is not accessible and callers receive a `Method not found` error.
 - **Request/response types must be `[DataContractAttribute]` classes.** Primitive types (`str`, `int`) are also accepted for simple services.
+- **Public methods in a `[ServiceAttribute]`-decorated class are automatically exposed** and do not require `[SysEntryPointAttribute]`.
 - **`[DataMemberAttribute]` on every parmXxx accessor** — the JSON serializer uses member names from this attribute.
 - **Service group name determines the URL** — choose a stable, module-scoped name; renaming it breaks all callers.
 - **Never include `ttsbegin/ttscommit` in service methods** unless you own the full transaction scope. If the service calls a framework method that manages its own transaction, wrap at a higher level.

--- a/skills/copilot/integration-patterns.instructions.md
+++ b/skills/copilot/integration-patterns.instructions.md
@@ -72,7 +72,6 @@ d365fo generate entity <Name> --table <T> \
 AxServiceGroup
   └── AxService (ServiceGroup reference)
         └── Service class (X++)
-              └── Operations decorated with [SysEntryPointAttribute(true)]
 ```
 
 **REST endpoint:** `https://{env}.cloudax.dynamics.com/api/services/{ServiceGroupName}/{ServiceName}/{OperationName}`
@@ -101,7 +100,6 @@ d365fo generate custom-service <Name> \
 
 **Hard rules:**
 
-- **Every exposed method must have `[SysEntryPointAttribute(true)]`** — without it the service is unreachable from external callers (security gate).
 - Use `[DataContractAttribute]` + `[DataMemberAttribute]` on parameter/return contract classes — not `pack()`/`unpack()`.
 - Service class must NOT hold state between calls (it is instantiated per request).
 

--- a/skills/copilot/sysoperation-batch-patterns.instructions.md
+++ b/skills/copilot/sysoperation-batch-patterns.instructions.md
@@ -57,7 +57,6 @@ d365fo generate sysoperation FmInvoiceBatch \
 - The Contract class must NOT hold state between calls — it is a simple data transfer object.
 - Do NOT use `today()` anywhere in the service — use `DateTimeUtil::getToday(DateTimeUtil::getUserPreferredTimeZone())`.
 - Never call `ttsbegin` / `ttscommit` in the Contract or Controller — only in the Service's `process()`.
-- Add a `[SysEntryPointAttribute(true)]` on the Service entry method to control security access.
 
 ---
 

--- a/skills/copilot/x++-class-authoring.instructions.md
+++ b/skills/copilot/x++-class-authoring.instructions.md
@@ -55,10 +55,9 @@ Modern replacement for `RunBaseBatch`. **Always use SysOperation for new batch c
 
 1. Structure: **DataContract** (parameters) + **Service** (logic) + **Controller** (execution mode).
 2. DataContract: decorate `parmXxx()` methods with `[DataMemberAttribute]`. Never use `pack()`/`unpack()`.
-3. Service method MUST be marked `[SysEntryPointAttribute(true)]` for security.
-4. Controller sets execution mode: `Synchronous`, `Asynchronous`, or `ScheduledBatch`.
-5. For SSRS report data providers: extend `SRSReportDataProviderBase` instead of `SysOperationServiceBase`.
-6. Custom dialog: use `SysOperationAutomaticUIBuilder`; link via `[SysOperationContractProcessingAttribute(classStr(MyUIBuilder))]` on the DataContract.
+3. Controller sets execution mode: `Synchronous`, `Asynchronous`, or `ScheduledBatch`.
+4. For SSRS report data providers: extend `SRSReportDataProviderBase` instead of `SysOperationServiceBase`.
+5. Custom dialog: use `SysOperationAutomaticUIBuilder`; link via `[SysOperationContractProcessingAttribute(classStr(MyUIBuilder))]` on the DataContract.
 
 **Scaffold with the CLI** — generates the DataContract, Service, and Controller XML in one command:
 

--- a/src/D365FO.Core/Scaffolding/CustomServiceScaffolder.cs
+++ b/src/D365FO.Core/Scaffolding/CustomServiceScaffolder.cs
@@ -46,7 +46,6 @@ public static class CustomServiceScaffolder
             };
 
             var src =
-                "[SysEntryPointAttribute(true)]\n" +
                 $"public {op.ReturnType} {op.Name}({contractParam})\n" +
                 "{\n" +
                 "    // TODO: implement" +

--- a/src/D365FO.Core/Scaffolding/SysOperationScaffolder.cs
+++ b/src/D365FO.Core/Scaffolding/SysOperationScaffolder.cs
@@ -72,7 +72,6 @@ public static class SysOperationScaffolder
             : "";
 
         var methodSrc =
-            $"[SysEntryPointAttribute(true)]\n" +
             $"public void {serviceMethod}({contractName} _contract)\n" +
             "{\n" +
             contractUnpack +

--- a/tests/D365FO.Cli.Tests/ScaffoldingSnapshotTests.cs
+++ b/tests/D365FO.Cli.Tests/ScaffoldingSnapshotTests.cs
@@ -25,15 +25,15 @@ public class ScaffoldingSnapshotTests
     }
 
     [Fact]
-    public void SysOperation_service_has_SysEntryPoint_and_correct_extends()
+    public void SysOperation_service_has_single_process_method_and_correct_extends()
     {
         var doc = SysOperationScaffolder.Service("MyService", "MyContract", "process");
         var root = doc.Root!;
         Assert.Equal("AxClass", root.Name.LocalName);
         Assert.Equal("SysOperationServiceBase", root.Element("Extends")!.Value);
         var methods = root.Element("SourceCode")!.Element("Methods")!.Elements("Method").ToList();
-        Assert.Equal(1, methods.Count);
-        Assert.Equal("process", methods[0].Element("Name")!.Value);
+        var method = Assert.Single(methods);
+        Assert.Equal("process", method.Element("Name")!.Value);
     }
 
     [Fact]

--- a/tests/D365FO.Cli.Tests/ScaffoldingSnapshotTests.cs
+++ b/tests/D365FO.Cli.Tests/ScaffoldingSnapshotTests.cs
@@ -32,7 +32,8 @@ public class ScaffoldingSnapshotTests
         Assert.Equal("AxClass", root.Name.LocalName);
         Assert.Equal("SysOperationServiceBase", root.Element("Extends")!.Value);
         var methods = root.Element("SourceCode")!.Element("Methods")!.Elements("Method").ToList();
-        Assert.Contains(methods, m => m.Element("Source")!.Value.Contains("[SysEntryPointAttribute"));
+        Assert.Equal(1, methods.Count);
+        Assert.Equal("process", methods[0].Element("Name")!.Value);
     }
 
     [Fact]
@@ -218,7 +219,7 @@ public class ScaffoldingSnapshotTests
     // ---- CustomService (Phase 6) ----
 
     [Fact]
-    public void CustomService_class_has_ServiceAttribute_and_SysEntryPoint()
+    public void CustomService_class_has_ServiceAttribute()
     {
         var doc = CustomServiceScaffolder.ServiceClass("VendorService",
             new[] { new OperationSpec("lookupVendor", "void") });
@@ -229,6 +230,6 @@ public class ScaffoldingSnapshotTests
         var methods = root.Element("SourceCode")!.Element("Methods")!.Elements("Method").ToList();
         Assert.Contains(methods, m => m.Element("Name")!.Value == "lookupVendor");
         var lookupSrc = methods.First(m => m.Element("Name")!.Value == "lookupVendor").Element("Source")!.Value;
-        Assert.Contains("[SysEntryPointAttribute(true)]", lookupSrc);
+        Assert.DoesNotContain("[SysEntryPointAttribute", lookupSrc);
     }
 }


### PR DESCRIPTION
## Summary
This PR fixes incorrect guidance around SysEntryPointAttribute in the repository.

Previously, documentation, skills, and scaffolded output suggested that SysEntryPointAttribute(true) is required for service methods.  
That requirement is misleading for the scenarios covered here and has been removed to align generated output and guidance with intended usage.

## What changed
1. Updated documentation to remove the hard requirement for SysEntryPointAttribute(true).
2. Updated skill source content to remove the same requirement from generated guidance.
3. Updated scaffolding code so generated methods no longer include SysEntryPointAttribute(true) by default.
4. Updated snapshot tests to reflect the new scaffolding behavior.

## Why
The previous wording/behavior could lead developers to add unnecessary attributes and created inconsistency between guidance and practical implementation.  
This change makes the docs, skills, scaffolding, and tests consistent.

## Validation
1. Snapshot tests adjusted to match expected output.
2. No API surface expansion introduced by this change.
3. Changes are focused on guidance/scaffolding defaults and related test expectations.

## Linked issue
Closes #86