### PR TITLE
fix(scaffold): nest CoC <Methods> inside <SourceCode> so the AOT loads them (#65)

### DIFF
--- a/src/D365FO.Core/Scaffolding/XppScaffolder.cs
+++ b/src/D365FO.Core/Scaffolding/XppScaffolder.cs
@@ -129,13 +129,17 @@ public static class XppScaffolder
             new XElement("Source",
                 $"public void {m}()\n{{\n    next {m}();\n    // extension logic here\n}}\n")));
 
+        // <Methods> MUST be nested inside <SourceCode> (after <Declaration>) —
+        // this is the canonical AxClass shape the metadata deserializer expects.
+        // When emitted as a sibling of <SourceCode> the AOT/Visual Studio loads
+        // the class with no methods at all (it looks "empty"). See issue #65.
         return new XDocument(
             new XElement("AxClass",
                 new XElement("Name", name),
                 new XElement("SourceCode",
                     new XElement("Declaration",
-                        $"[ExtensionOf({intrinsic}({targetClass}))]\nfinal class {name}\n{{\n}}")),
-                new XElement("Methods", methodEls)));
+                        $"[ExtensionOf({intrinsic}({targetClass}))]\nfinal class {name}\n{{\n}}"),
+                    new XElement("Methods", methodEls))));
     }
 
     /// <summary>

--- a/tests/D365FO.Core.Tests/GoldenQualityGateTests.cs
+++ b/tests/D365FO.Core.Tests/GoldenQualityGateTests.cs
@@ -121,6 +121,24 @@ public class GoldenQualityGateTests : IDisposable
         AssertNoReferenceErrors(src, "generate coc (table)");
     }
 
+    // ── #65: <Methods> must be nested inside <SourceCode>, not a sibling.
+    // A misplaced <Methods> deserializes to a class with no methods at all —
+    // the AOT loads it "empty". Source()'s Descendants() walk can't catch this,
+    // so assert the structure explicitly.
+    [Fact]
+    public void Coc_methods_are_nested_inside_sourcecode()
+    {
+        var doc = XppScaffolder.CocExtension("CustTable", "table", "validateWrite");
+        var sourceCode = doc.Root!.Element("SourceCode");
+        Assert.NotNull(sourceCode);
+
+        // The method lives under SourceCode/Methods, and nowhere else.
+        var nestedMethod = sourceCode!.Element("Methods")?.Elements("Method")
+            .FirstOrDefault(m => (string?)m.Element("Name") == "validateWrite");
+        Assert.NotNull(nestedMethod);
+        Assert.Null(doc.Root!.Element("Methods")); // not a sibling of SourceCode
+    }
+
     [Fact]
     public void Class_scaffold_passes_xpp_gate()
     {


### PR DESCRIPTION
## Problem

Follow-up to #65 / #81. After the bridge custom-packages fix landed, `generate coc <Target> --method <m> --install-to <Model>` finally wrote the file to the right place — but the reporter found the generated class loaded **empty** in Visual Studio (no methods), even though the `.xml` on disk clearly contained the wrapper.

## Root cause

`XppScaffolder.CocExtension` emitted `<Methods>` as a **sibling** of `<SourceCode>` instead of nested **inside** it (after `<Declaration>`):

```xml
<!-- wrong (before) -->
<AxClass>
  <Name>CustTable_Extension</Name>
  <SourceCode>
    <Declaration>…</Declaration>
  </SourceCode>
  <Methods>…</Methods>   <!-- ignored by the metadata deserializer -->
</AxClass>
```

The canonical `AxClass` shape (see e.g. `tests/Samples/MiniAot/.../FmVehicleService.xml`, and every other scaffolder in this repo) nests `<Methods>` inside `<SourceCode>`. When it's a sibling, the metadata deserializer reads zero methods → the AOT loads the class "empty".

CoC was the lone scaffolder with this mistake; `RunBase`, `SysOperation`, `NumberSequence`, `Workflow`, etc. all already nest correctly.

## Fix

Move `<Methods>` inside `<SourceCode>`:

```xml
<!-- correct (after) -->
<SourceCode>
  <Declaration>…</Declaration>
  <Methods>
    <Method><Name>insert</Name><Source>…</Source></Method>
  </Methods>
</SourceCode>
```

Added a structural unit test asserting the nesting. The existing golden-gate tests could not catch this because their `Source()` helper walks `Descendants()`, which finds the method text regardless of placement.

## Tests

Full suite green (391 tests).