### PR TITLE
fix(config): honor deprecated D365FO_EXTRA_PACKAGES_PATH as fallback

### DIFF
--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -14,7 +14,7 @@
 | Variable | Purpose | Default |
 |---|---|---|
 | `D365FO_PACKAGES_PATH` | Primary `PackagesLocalDirectory` root | *(required for indexing)* |
-| `D365FO_CUSTOM_PACKAGES_PATH` | Additional `PackagesLocalDirectory` roots (semicolon/comma separated). Indexed for reads **and** forwarded to the bridge so `generate --install-to <Model>` can resolve custom models that live outside the primary packages path (UDE dual-folder setups). | — |
+| `D365FO_CUSTOM_PACKAGES_PATH` | Additional `PackagesLocalDirectory` roots (semicolon/comma separated). Indexed for reads **and** forwarded to the bridge so `generate --install-to <Model>` can resolve custom models that live outside the primary packages path (UDE dual-folder setups). Formerly named `D365FO_EXTRA_PACKAGES_PATH` — the old name is still honored as a fallback when the new one is unset, but is deprecated; `d365fo doctor` warns when it is in use. | — |
 | `D365FO_LABEL_LANGUAGES` | Label languages to extract, e.g. `en-us,cs,de` | `en-us` |
 | `D365FO_INDEX_DB` | Path to the SQLite index file | `%LOCALAPPDATA%\d365fo-cli\d365fo-index.sqlite` |
 | `D365FO_WORKSPACE_PATH` | Root of your X++ solution (enables scaffold output) | — |

--- a/src/D365FO.Bridge/MetadataBootstrap.cs
+++ b/src/D365FO.Bridge/MetadataBootstrap.cs
@@ -125,7 +125,11 @@ namespace D365FO.Bridge
         /// </summary>
         private static string[] ResolveCustomPackagesPaths()
         {
+            // D365FO_EXTRA_PACKAGES_PATH is the deprecated pre-rename name; honored
+            // as a fallback so a standalone bridge daemon still picks up custom roots.
             var raw = Environment.GetEnvironmentVariable("D365FO_CUSTOM_PACKAGES_PATH");
+            if (string.IsNullOrWhiteSpace(raw))
+                raw = Environment.GetEnvironmentVariable("D365FO_EXTRA_PACKAGES_PATH");
             if (string.IsNullOrWhiteSpace(raw)) return new string[0];
             var parts = raw.Split(new[] { ';', ',' }, StringSplitOptions.RemoveEmptyEntries);
             var list = new System.Collections.Generic.List<string>(parts.Length);

--- a/src/D365FO.Cli/Commands/Ops/OpsCommands.cs
+++ b/src/D365FO.Cli/Commands/Ops/OpsCommands.cs
@@ -42,6 +42,18 @@ public sealed class DoctorCommand : Command<DoctorCommand.Settings>
                 ? "not set (optional — set D365FO_CUSTOM_PACKAGES_PATH to your git repo for `generate --install-to`)."
                 : string.Join(", ", cfg.CustomPackagesPaths));
 
+        // Surface usage of the deprecated pre-rename env var so users migrate.
+        var legacyCustom = D365FoSettings.Resolve("D365FO_EXTRA_PACKAGES_PATH");
+        var newCustom = D365FoSettings.Resolve("D365FO_CUSTOM_PACKAGES_PATH");
+        if (!string.IsNullOrWhiteSpace(legacyCustom))
+        {
+            Add("config.customPackagesPaths (deprecated env var)",
+                DoctorSeverity.Warn,
+                string.IsNullOrWhiteSpace(newCustom)
+                    ? "D365FO_EXTRA_PACKAGES_PATH is deprecated; rename it to D365FO_CUSTOM_PACKAGES_PATH (still honored as a fallback for now)."
+                    : "D365FO_EXTRA_PACKAGES_PATH is set but ignored because D365FO_CUSTOM_PACKAGES_PATH takes precedence; remove the old variable.");
+        }
+
         Add("config.workspacePath",
             DoctorSeverity.Ok,
             cfg.WorkspacePath ?? "not set (optional — only needed for `generate --out <PATH>` outside Packages).");

--- a/src/D365FO.Core/D365FoSettings.cs
+++ b/src/D365FO.Core/D365FoSettings.cs
@@ -100,13 +100,21 @@ public sealed record D365FoSettings(
                         Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData),
                         "d365fo-cli", DefaultDatabaseFile);
 
+        // D365FO_CUSTOM_PACKAGES_PATH was previously named D365FO_EXTRA_PACKAGES_PATH.
+        // Honor the old name as a deprecated alias so existing UDE configs keep
+        // working after the rename — without it, custom-model roots would silently
+        // drop out of the index. The new name wins when both are set.
+        var customPackages = Env("D365FO_CUSTOM_PACKAGES_PATH");
+        if (string.IsNullOrWhiteSpace(customPackages))
+            customPackages = Env("D365FO_EXTRA_PACKAGES_PATH");
+
         return new D365FoSettings(
             PackagesPath: NullIfEmpty(Env("D365FO_PACKAGES_PATH")),
             WorkspacePath: NullIfEmpty(Env("D365FO_WORKSPACE_PATH")),
             DatabasePath: db,
             CustomModels: models,
             LabelLanguages: langs,
-            CustomPackagesPaths: Split(Env("D365FO_CUSTOM_PACKAGES_PATH")));
+            CustomPackagesPaths: Split(customPackages));
     }
 
     /// <summary>

--- a/tests/D365FO.Core.Tests/D365FoSettingsResolveTests.cs
+++ b/tests/D365FO.Core.Tests/D365FoSettingsResolveTests.cs
@@ -168,6 +168,55 @@ public class D365FoSettingsResolveTests
         }
     }
 
+    // ---- D365FO_CUSTOM_PACKAGES_PATH / deprecated-alias fallback -------------
+
+    [Fact]
+    public void FromEnvironment_reads_custom_packages_from_new_var()
+    {
+        WithCustomPackagesEnv(custom: @"C:\Custom", extra: null, () =>
+        {
+            var cfg = D365FoSettings.FromEnvironment();
+            Assert.Equal(new[] { @"C:\Custom" }, cfg.CustomPackagesPaths);
+        });
+    }
+
+    [Fact]
+    public void FromEnvironment_falls_back_to_deprecated_extra_var()
+    {
+        WithCustomPackagesEnv(custom: null, extra: @"C:\Legacy", () =>
+        {
+            var cfg = D365FoSettings.FromEnvironment();
+            Assert.Equal(new[] { @"C:\Legacy" }, cfg.CustomPackagesPaths);
+        });
+    }
+
+    [Fact]
+    public void FromEnvironment_new_var_wins_over_deprecated_extra_var()
+    {
+        WithCustomPackagesEnv(custom: @"C:\Custom", extra: @"C:\Legacy", () =>
+        {
+            var cfg = D365FoSettings.FromEnvironment();
+            Assert.Equal(new[] { @"C:\Custom" }, cfg.CustomPackagesPaths);
+        });
+    }
+
+    private static void WithCustomPackagesEnv(string? custom, string? extra, Action body)
+    {
+        var prevCustom = Environment.GetEnvironmentVariable("D365FO_CUSTOM_PACKAGES_PATH");
+        var prevExtra = Environment.GetEnvironmentVariable("D365FO_EXTRA_PACKAGES_PATH");
+        try
+        {
+            Environment.SetEnvironmentVariable("D365FO_CUSTOM_PACKAGES_PATH", custom);
+            Environment.SetEnvironmentVariable("D365FO_EXTRA_PACKAGES_PATH", extra);
+            body();
+        }
+        finally
+        {
+            Environment.SetEnvironmentVariable("D365FO_CUSTOM_PACKAGES_PATH", prevCustom);
+            Environment.SetEnvironmentVariable("D365FO_EXTRA_PACKAGES_PATH", prevExtra);
+        }
+    }
+
     [Fact]
     public void ResolveFlag_reads_flag_from_settings_json()
     {


### PR DESCRIPTION
Fixes #49

## Problem

`D365FO_EXTRA_PACKAGES_PATH` was renamed to `D365FO_CUSTOM_PACKAGES_PATH` in `2a432be` **without a backwards-compatible fallback**. Anyone who had set the old variable (env or `settings.json`) silently lost their custom-model roots from the index — no error, the customizations just disappeared from `search`/`get`/`find` and from `generate --install-to` resolution.

This is what @soerenprintz flagged in [the issue thread](https://github.com/dynamics365ninja/d365fo-cli/issues/49#issuecomment-4729741630) ("I don't know if the old setup still works"). The `--extra-packages` **flag** was never affected (so @jeroeneikmans's command kept working) — only the env var broke.

## Fix

- **`D365FoSettings.FromEnvironment`** now reads `D365FO_CUSTOM_PACKAGES_PATH` and falls back to `D365FO_EXTRA_PACKAGES_PATH` when the new name is unset (new name wins when both are set). Single source of truth, so it covers both the CLI and the MCP server via `cfg.CustomPackagesPaths`.
- **`MetadataBootstrap`** applies the same fallback for a standalone bridge daemon.
- **`d365fo doctor`** now emits a `Warn` when the deprecated variable is in use, telling users to rename it (and notes when it is being ignored because the new one takes precedence).
- **Docs** (`CONFIGURATION.md`) document the deprecated alias.

## Tests

Added coverage in `D365FoSettingsResolveTests`: new var, legacy fallback, and precedence. Full suite green — **394 tests pass**, 0 build warnings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)