### PR TITLE
fix(generate): route object creation through metadata API; fix invalid AxTable XML (#91)

### DIFF
--- a/src/D365FO.Bridge/Handlers.cs
+++ b/src/D365FO.Bridge/Handlers.cs
@@ -135,6 +135,7 @@ namespace D365FO.Bridge
             if (!string.IsNullOrEmpty(xml))
             {
                 string rootLocalName;
+                string rootXsiType = null;
                 try
                 {
                     using (var sr = new StringReader(xml))
@@ -142,6 +143,10 @@ namespace D365FO.Bridge
                     {
                         xr.MoveToContent();
                         rootLocalName = xr.NodeType == System.Xml.XmlNodeType.Element ? xr.LocalName : null;
+                        // Some scaffolds emit the abstract base element with the concrete
+                        // subtype pinned via xsi:type (e.g. <AxEdt i:type="AxEdtString">).
+                        // Capture it so the polymorphic root can still be constructed.
+                        rootXsiType = xr.GetAttribute("type", "http://www.w3.org/2001/XMLSchema-instance");
                     }
                 }
                 catch (Exception ex)
@@ -151,15 +156,22 @@ namespace D365FO.Bridge
                 if (string.IsNullOrEmpty(rootLocalName))
                     return Fail("XML_PARSE_FAILED", "Could not read root element of input xml.");
 
-                axType = MetadataBootstrap.GetMetaModelTypeByShortName(rootLocalName)
-                         ?? MetadataBootstrap.GetMetaModelType(kind);
-                if (axType == null) return Fail("TYPE_NOT_FOUND", "Could not resolve Ax type for root element '" + rootLocalName + "'.");
-                if (axType.IsAbstract)
-                    return Fail("ABSTRACT_TYPE", "Root element '" + rootLocalName + "' maps to abstract type '" + axType.FullName + "'. Use a concrete subtype root such as AxEdtString.");
+                // The XmlSerializer must be built on the type whose XML root matches the
+                // document's root ELEMENT name. For a concrete root (AxTable, AxClass,
+                // AxEnum, AxForm) that is the type itself. For a polymorphic root emitted
+                // as the abstract base with a pinned discriminator (e.g.
+                // <AxEdt i:type="AxEdtString">), the serializer is built on the abstract
+                // base — XmlInclude metadata lets xsi:type select the concrete subtype.
+                var serializerType = MetadataBootstrap.GetMetaModelTypeByShortName(rootLocalName)
+                                     ?? MetadataBootstrap.GetMetaModelType(kind);
+                if (serializerType == null)
+                    return Fail("TYPE_NOT_FOUND", "Could not resolve Ax type for root element '" + rootLocalName + "'.");
+                if (serializerType.IsAbstract && string.IsNullOrEmpty(rootXsiType))
+                    return Fail("ABSTRACT_TYPE", "Root element '" + rootLocalName + "' maps to abstract type '" + serializerType.FullName + "'. Pin a concrete subtype via xsi:type or use a concrete root such as AxEdtString.");
 
                 try
                 {
-                    var serializer = new XmlSerializer(axType);
+                    var serializer = new XmlSerializer(serializerType);
                     using (var reader = new StringReader(xml))
                     {
                         ax = serializer.Deserialize(reader);
@@ -170,6 +182,10 @@ namespace D365FO.Bridge
                     var inner = ex.InnerException?.Message;
                     return Fail("XML_DESERIALIZE_FAILED", ex.Message + (inner != null ? " / " + inner : string.Empty));
                 }
+
+                // Use the deserialized instance's runtime (concrete) type from here on —
+                // for a polymorphic root this is the xsi:type subtype, not the base.
+                axType = ax.GetType();
             }
             else
             {

--- a/src/D365FO.Cli/Commands/Generate/GenerateCommands.cs
+++ b/src/D365FO.Cli/Commands/Generate/GenerateCommands.cs
@@ -48,6 +48,146 @@ internal static class GenerateInstaller
         }
         return System.IO.Path.Combine(folder!, axSubfolder, name + ".xml");
     }
+
+    /// <summary>
+    /// Build an EDT → primitive-base-type resolver backed by the SQLite index.
+    /// Passed to <see cref="XppScaffolder.Table"/> so each field gets its
+    /// concrete <c>i:type="AxTableField{Suffix}"</c> discriminator (issue #91).
+    /// Returns null when the index is unavailable — the scaffolder then falls
+    /// back to a name heuristic.
+    /// </summary>
+    internal static Func<string, string?>? BuildEdtBaseTypeResolver()
+    {
+        try
+        {
+            var repo = RepoFactory.Create();
+            return edt =>
+            {
+                if (string.IsNullOrWhiteSpace(edt)) return null;
+                try { return repo.GetEdt(edt)?.BaseType; }
+                catch { return null; }
+            };
+        }
+        catch { return null; }
+    }
+
+    internal enum InstallOutcome { CreatedViaApi, WriteScaffold, Failed }
+
+    /// <summary>
+    /// Plan how to install a generated artefact into <paramref name="model"/>.
+    /// Prefers the live metadata provider (bridge <c>createObject</c>) so the
+    /// on-disk XML is provider-canonical and consistent with Visual Studio /
+    /// <c>d365fo-mcp-server</c>. When the provider is unavailable, falls back to
+    /// writing the (now valid) scaffold into the resolved model folder, with a
+    /// warning. When neither path is reachable, returns a rendered failure.
+    /// </summary>
+    internal static (InstallOutcome outcome, string? writePath, int? failure, List<string> warnings)
+        PlanInstall(OutputMode.Kind kind, string axKind, string axSubfolder, string name, string model, string xml)
+    {
+        var warnings = new List<string>();
+
+        // 1) Metadata-API path — canonical, consistent output.
+        var (ok, err) = BridgeGate.TrySaveObject(axKind, name, model, xml);
+        if (ok) return (InstallOutcome.CreatedViaApi, null, null, warnings);
+
+        // 2) Fallback — write the scaffold into the model folder if resolvable.
+        var folder = BridgeGate.TryGetModelFolder(model);
+        if (!string.IsNullOrEmpty(folder))
+        {
+            warnings.Add(
+                $"Metadata API unavailable or rejected the object ({err}); wrote the raw scaffold instead. " +
+                "The file is structurally valid but not provider-canonicalised — open it in Visual Studio to verify.");
+            return (InstallOutcome.WriteScaffold,
+                System.IO.Path.Combine(folder!, axSubfolder, name + ".xml"), null, warnings);
+        }
+
+        // 3) Neither path worked.
+        var failure = RenderHelpers.Render(kind, ToolResult<object>.Fail(
+            "INSTALL_FAILED",
+            $"Could not install '{name}' into model '{model}'. Metadata API: {err}. " +
+            "Could not resolve the model folder either — set D365FO_BRIDGE_ENABLED=1 and point " +
+            "D365FO_PACKAGES_PATH (and D365FO_CUSTOM_PACKAGES_PATH for custom-model roots) at the " +
+            "directories that contain the model, on a D365FO VM."));
+        return (InstallOutcome.Failed, null, failure, warnings);
+    }
+
+    /// <summary>Inputs handed to a command's payload factory after the artefact is written.</summary>
+    internal readonly record struct EmitResult(string Source, string? Path, long? Bytes, string? Backup);
+
+    /// <summary>
+    /// Emit a generated artefact (<see cref="System.Xml.Linq.XDocument"/> form),
+    /// preferring the live metadata provider for <c>--install-to</c> and falling
+    /// back to the scaffold. <paramref name="axKind"/> must be one of the bridge
+    /// collection kinds: <c>class | table | edt | enum | form</c>.
+    /// </summary>
+    internal static int Emit(
+        OutputMode.Kind kind, string axKind, string axSubfolder, string name,
+        string? installTo, string? outPath, bool overwrite,
+        System.Xml.Linq.XDocument doc,
+        Func<EmitResult, object> buildPayload,
+        List<string>? warnings = null)
+        => EmitCore(kind, axKind, axSubfolder, name, installTo, outPath, doc.ToString(),
+            path => ScaffoldFileWriter.Write(doc, path, overwrite), buildPayload, warnings);
+
+    /// <summary>String-rendered counterpart of <see cref="Emit"/> (used for forms).</summary>
+    internal static int EmitString(
+        OutputMode.Kind kind, string axKind, string axSubfolder, string name,
+        string? installTo, string? outPath, bool overwrite,
+        string xml,
+        Func<EmitResult, object> buildPayload,
+        List<string>? warnings = null)
+        => EmitCore(kind, axKind, axSubfolder, name, installTo, outPath, xml,
+            path => ScaffoldFileWriter.Write(xml, path, overwrite), buildPayload, warnings);
+
+    private static int EmitCore(
+        OutputMode.Kind kind, string axKind, string axSubfolder, string name,
+        string? installTo, string? outPath, string xml,
+        Func<string, ScaffoldFileWriter.WriteResult> write,
+        Func<EmitResult, object> buildPayload,
+        List<string>? warnings)
+    {
+        warnings ??= new List<string>();
+        var hasInstall = !string.IsNullOrWhiteSpace(installTo);
+        var hasOut     = !string.IsNullOrWhiteSpace(outPath);
+        if (!hasInstall && !hasOut)
+            return RenderHelpers.Render(kind, ToolResult<object>.Fail("BAD_INPUT", "--out or --install-to is required."));
+
+        if (hasInstall && !hasOut)
+        {
+            var plan = PlanInstall(kind, axKind, axSubfolder, name, installTo!, xml);
+            if (plan.failure.HasValue) return plan.failure.Value;
+            var all = warnings.Concat(plan.warnings).ToList();
+
+            if (plan.outcome == InstallOutcome.CreatedViaApi)
+                return RenderHelpers.Render(kind, ToolResult<object>.Success(
+                    buildPayload(new EmitResult("bridge", null, null, null)),
+                    all.Count > 0 ? all : null));
+
+            try
+            {
+                var res = write(plan.writePath!);
+                return RenderHelpers.Render(kind, ToolResult<object>.Success(
+                    buildPayload(new EmitResult("scaffold", res.Path, res.Bytes, res.BackupPath)),
+                    all.Count > 0 ? all : null));
+            }
+            catch (Exception ex)
+            {
+                return RenderHelpers.Render(kind, ToolResult<object>.Fail("WRITE_FAILED", ex.Message));
+            }
+        }
+
+        try
+        {
+            var res = write(outPath!);
+            return RenderHelpers.Render(kind, ToolResult<object>.Success(
+                buildPayload(new EmitResult("scaffold", res.Path, res.Bytes, res.BackupPath)),
+                warnings.Count > 0 ? warnings : null));
+        }
+        catch (Exception ex)
+        {
+            return RenderHelpers.Render(kind, ToolResult<object>.Fail("WRITE_FAILED", ex.Message));
+        }
+    }
 }
 
 public sealed class GenerateTableCommand : Command<GenerateTableCommand.Settings>
@@ -87,40 +227,36 @@ public sealed class GenerateTableCommand : Command<GenerateTableCommand.Settings
         if (!TablePatternNormalizer.TryNormalizeStorage(settings.TableType, out var storage, out var serr))
             return RenderHelpers.Render(kind, ToolResult<object>.Fail("BAD_INPUT", serr!));
 
-        var hasInstall = !string.IsNullOrWhiteSpace(settings.InstallTo);
-        var hasOut     = !string.IsNullOrWhiteSpace(settings.Out);
-        if (!hasInstall && !hasOut)
-            return RenderHelpers.Render(kind, ToolResult<object>.Fail("BAD_INPUT", "--out or --install-to is required."));
-        var outPath = settings.Out;
-        if (hasInstall && !hasOut)
-        {
-            outPath = GenerateInstaller.ResolveInstallPath(kind, "AxTable", settings.Name, settings.InstallTo!, out var fail);
-            if (fail.HasValue) return fail.Value;
-        }
-
         var fields2 = settings.Fields.Select(ParseField).ToList();
-        var doc = XppScaffolder.Table(settings.Name, settings.Label, fields2, pattern, storage, settings.PrimaryKey);
-        try
-        {
-            var res = ScaffoldFileWriter.Write(doc, outPath!, settings.Overwrite);
-            return RenderHelpers.Render(kind, ToolResult<object>.Success(new
+        // Resolve each field's EDT base type from the index so the scaffold
+        // stamps the concrete i:type discriminator on every <AxTableField>.
+        var edtResolver = GenerateInstaller.BuildEdtBaseTypeResolver();
+        var doc = XppScaffolder.Table(settings.Name, settings.Label, fields2, pattern, storage, settings.PrimaryKey, edtResolver);
+
+        var fieldCount = fields2.Count > 0 ? fields2.Count : TablePatternPresets.DefaultFieldsFor(pattern).Count;
+        var patternStr = pattern == TablePattern.None ? null : pattern.ToString();
+        var tableTypeStr = storage == TableStorage.RegularTable ? null : storage.ToString();
+        var usedDefaults = fields2.Count == 0 && pattern != TablePattern.None;
+
+        // Prefer the live metadata provider for --install-to (canonical output,
+        // consistent with VS / d365fo-mcp-server); fall back to the scaffold.
+        return GenerateInstaller.Emit(
+            kind, "table", "AxTable", settings.Name,
+            settings.InstallTo, settings.Out, settings.Overwrite, doc,
+            r => new
             {
                 kind = "AxTable",
                 name = settings.Name,
-                path = res.Path,
-                bytes = res.Bytes,
-                backup = res.BackupPath,
-                fieldCount = fields2.Count > 0 ? fields2.Count : TablePatternPresets.DefaultFieldsFor(pattern).Count,
-                pattern = pattern == TablePattern.None ? null : pattern.ToString(),
-                tableType = storage == TableStorage.RegularTable ? null : storage.ToString(),
-                usedPatternDefaults = fields2.Count == 0 && pattern != TablePattern.None,
+                source = r.Source,
+                path = r.Path,
+                bytes = r.Bytes,
+                backup = r.Backup,
+                fieldCount,
+                pattern = patternStr,
+                tableType = tableTypeStr,
+                usedPatternDefaults = usedDefaults,
                 model = settings.InstallTo,
-            }));
-        }
-        catch (Exception ex)
-        {
-            return RenderHelpers.Render(kind, ToolResult<object>.Fail("WRITE_FAILED", ex.Message));
-        }
+            });
     }
 
     private static TableFieldSpec ParseField(string raw)
@@ -152,30 +288,16 @@ public sealed class GenerateClassCommand : Command<GenerateClassCommand.Settings
         var kind = OutputMode.Resolve(settings.Output);
         if (string.IsNullOrWhiteSpace(settings.Name))
             return RenderHelpers.Render(kind, ToolResult<object>.Fail("BAD_INPUT", "Class name required."));
-        var hasInstall = !string.IsNullOrWhiteSpace(settings.InstallTo);
-        var hasOut     = !string.IsNullOrWhiteSpace(settings.Out);
-        if (!hasInstall && !hasOut)
-            return RenderHelpers.Render(kind, ToolResult<object>.Fail("BAD_INPUT", "--out or --install-to is required."));
-        var outPath = settings.Out;
-        if (hasInstall && !hasOut)
-        {
-            outPath = GenerateInstaller.ResolveInstallPath(kind, "AxClass", settings.Name, settings.InstallTo!, out var fail);
-            if (fail.HasValue) return fail.Value;
-        }
 
         var doc = XppScaffolder.Class(settings.Name, settings.Extends, !settings.NonFinal);
-        try
-        {
-            var res = ScaffoldFileWriter.Write(doc, outPath!, settings.Overwrite);
-            return RenderHelpers.Render(kind, ToolResult<object>.Success(new
+        return GenerateInstaller.Emit(
+            kind, "class", "AxClass", settings.Name,
+            settings.InstallTo, settings.Out, settings.Overwrite, doc,
+            r => new
             {
-                kind = "AxClass", name = settings.Name, path = res.Path, bytes = res.Bytes, backup = res.BackupPath, model = settings.InstallTo,
-            }));
-        }
-        catch (Exception ex)
-        {
-            return RenderHelpers.Render(kind, ToolResult<object>.Fail("WRITE_FAILED", ex.Message));
-        }
+                kind = "AxClass", name = settings.Name, source = r.Source,
+                path = r.Path, bytes = r.Bytes, backup = r.Backup, model = settings.InstallTo,
+            });
     }
 }
 
@@ -199,16 +321,6 @@ public sealed class GenerateCocCommand : Command<GenerateCocCommand.Settings>
             return RenderHelpers.Render(kind, ToolResult<object>.Fail("BAD_INPUT", "Target class required."));
         if (settings.Methods.Length == 0)
             return RenderHelpers.Render(kind, ToolResult<object>.Fail("BAD_INPUT", "At least one --method required."));
-        var hasInstall = !string.IsNullOrWhiteSpace(settings.InstallTo);
-        var hasOut     = !string.IsNullOrWhiteSpace(settings.Out);
-        if (!hasInstall && !hasOut)
-            return RenderHelpers.Render(kind, ToolResult<object>.Fail("BAD_INPUT", "--out or --install-to is required."));
-        var outPath = settings.Out;
-        if (hasInstall && !hasOut)
-        {
-            outPath = GenerateInstaller.ResolveInstallPath(kind, "AxClass", settings.Target + "_Extension", settings.InstallTo!, out var fail);
-            if (fail.HasValue) return fail.Value;
-        }
 
         // Guardrail: warn if the target already has CoC wrappers, and resolve
         // the target's AOT kind so [ExtensionOf] uses the right intrinsic
@@ -238,25 +350,22 @@ public sealed class GenerateCocCommand : Command<GenerateCocCommand.Settings>
         if (gate.Failure is not null) return RenderHelpers.Render(kind, gate.Failure);
         warnings.AddRange(gate.Warnings);
 
-        try
-        {
-            var res = ScaffoldFileWriter.Write(doc, outPath!, settings.Overwrite);
-            return RenderHelpers.Render(kind, ToolResult<object>.Success(new
+        return GenerateInstaller.Emit(
+            kind, "class", "AxClass", settings.Target + "_Extension",
+            settings.InstallTo, settings.Out, settings.Overwrite, doc,
+            r => new
             {
                 kind = "AxClass",
                 name = settings.Target + "_Extension",
-                path = res.Path,
-                bytes = res.Bytes,
-                backup = res.BackupPath,
+                source = r.Source,
+                path = r.Path,
+                bytes = r.Bytes,
+                backup = r.Backup,
                 methodCount = settings.Methods.Length,
                 model = settings.InstallTo,
                 grounding = gate.Grounding,
-            }, warnings: warnings));
-        }
-        catch (Exception ex)
-        {
-            return RenderHelpers.Render(kind, ToolResult<object>.Fail("WRITE_FAILED", ex.Message));
-        }
+            },
+            warnings);
     }
 }
 
@@ -374,12 +483,6 @@ internal static class GenerateFormImpl
         if (!hasInstall && !hasOut)
             return RenderHelpers.Render(kind, ToolResult<object>.Fail("BAD_INPUT", "--out or --install-to is required."));
 
-        if (hasInstall && !hasOut)
-        {
-            outPath = GenerateInstaller.ResolveInstallPath(kind, "AxForm", formName, installTo!, out var fail);
-            if (fail.HasValue) return fail.Value;
-        }
-
         var sectionSpecs = ParseSections(sections);
 
         string xml;
@@ -418,17 +521,18 @@ internal static class GenerateFormImpl
                 "or set D365FO_FORM_PATTERN_ENFORCE=false to bypass the gate."));
         }
 
-        try
-        {
-            var res = ScaffoldFileWriter.Write(xml, outPath!, overwrite);
-            return RenderHelpers.Render(kind, ToolResult<object>.Success(new
+        return GenerateInstaller.EmitString(
+            kind, "form", "AxForm", formName,
+            installTo, outPath, overwrite, xml,
+            r => new
             {
                 kind         = "AxForm",
                 name         = formName,
                 pattern      = pattern.ToString(),
-                path         = res.Path,
-                bytes        = res.Bytes,
-                backup       = res.BackupPath,
+                source       = r.Source,
+                path         = r.Path,
+                bytes        = r.Bytes,
+                backup       = r.Backup,
                 model        = installTo,
                 fieldCount   = fields.Count,
                 sectionCount = sectionSpecs.Count,
@@ -438,12 +542,8 @@ internal static class GenerateFormImpl
                     errors   = patternReport.ErrorCount,
                     warnings = patternReport.WarningCount,
                 },
-            }, patternWarnings.Count > 0 ? patternWarnings : null));
-        }
-        catch (Exception ex)
-        {
-            return RenderHelpers.Render(kind, ToolResult<object>.Fail("WRITE_FAILED", ex.Message));
-        }
+            },
+            patternWarnings.Count > 0 ? patternWarnings : null);
     }
 
     private static IReadOnlyList<FormSectionSpec> ParseSections(IReadOnlyList<string> raw)

--- a/src/D365FO.Cli/Commands/Generate/GenerateEdtCommand.cs
+++ b/src/D365FO.Cli/Commands/Generate/GenerateEdtCommand.cs
@@ -41,18 +41,6 @@ public sealed class GenerateEdtCommand : Command<GenerateEdtCommand.Settings>
         if (string.IsNullOrWhiteSpace(settings.Name))
             return RenderHelpers.Render(kind, ToolResult<object>.Fail(D365FoErrorCodes.BadInput, "EDT name required."));
 
-        var hasInstall = !string.IsNullOrWhiteSpace(settings.InstallTo);
-        var hasOut     = !string.IsNullOrWhiteSpace(settings.Out);
-        if (!hasInstall && !hasOut)
-            return RenderHelpers.Render(kind, ToolResult<object>.Fail(D365FoErrorCodes.BadInput, "--out or --install-to is required."));
-
-        var outPath = settings.Out;
-        if (hasInstall && !hasOut)
-        {
-            outPath = GenerateInstaller.ResolveInstallPath(kind, "AxEdt", settings.Name, settings.InstallTo!, out var fail);
-            if (fail.HasValue) return fail.Value;
-        }
-
         var effectiveEnumType = settings.EnumType;
         if (string.IsNullOrWhiteSpace(effectiveEnumType) &&
             string.Equals(settings.BaseType, "Enum", StringComparison.OrdinalIgnoreCase) &&
@@ -63,10 +51,10 @@ public sealed class GenerateEdtCommand : Command<GenerateEdtCommand.Settings>
         }
 
         var doc = XppScaffolder.Edt(settings.Name, settings.Extends, settings.BaseType, settings.Size, settings.Label, effectiveEnumType);
-        try
-        {
-            var res = ScaffoldFileWriter.Write(doc, outPath!, settings.Overwrite);
-            return RenderHelpers.Render(kind, ToolResult<object>.Success(new
+        return GenerateInstaller.Emit(
+            kind, "edt", "AxEdt", settings.Name,
+            settings.InstallTo, settings.Out, settings.Overwrite, doc,
+            r => new
             {
                 kind       = "AxEdt",
                 name       = settings.Name,
@@ -75,16 +63,12 @@ public sealed class GenerateEdtCommand : Command<GenerateEdtCommand.Settings>
                 enumType   = effectiveEnumType,
                 stringSize = settings.Size,
                 label      = settings.Label,
-                path       = res.Path,
-                bytes      = res.Bytes,
-                backup     = res.BackupPath,
+                source     = r.Source,
+                path       = r.Path,
+                bytes      = r.Bytes,
+                backup     = r.Backup,
                 model      = settings.InstallTo,
-            }));
-        }
-        catch (Exception ex)
-        {
-            return RenderHelpers.Render(kind, ToolResult<object>.Fail(D365FoErrorCodes.WriteFailed, ex.Message));
-        }
+            });
     }
 
     private static string? ResolveEnumTypeFromExtendsChain(string extendsName)

--- a/src/D365FO.Cli/Commands/Generate/GenerateEnumCommand.cs
+++ b/src/D365FO.Cli/Commands/Generate/GenerateEnumCommand.cs
@@ -33,25 +33,13 @@ public sealed class GenerateEnumCommand : Command<GenerateEnumCommand.Settings>
         if (string.IsNullOrWhiteSpace(settings.Name))
             return RenderHelpers.Render(kind, ToolResult<object>.Fail(D365FoErrorCodes.BadInput, "Enum name required."));
 
-        var hasInstall = !string.IsNullOrWhiteSpace(settings.InstallTo);
-        var hasOut     = !string.IsNullOrWhiteSpace(settings.Out);
-        if (!hasInstall && !hasOut)
-            return RenderHelpers.Render(kind, ToolResult<object>.Fail(D365FoErrorCodes.BadInput, "--out or --install-to is required."));
-
-        var outPath = settings.Out;
-        if (hasInstall && !hasOut)
-        {
-            outPath = GenerateInstaller.ResolveInstallPath(kind, "AxEnum", settings.Name, settings.InstallTo!, out var fail);
-            if (fail.HasValue) return fail.Value;
-        }
-
         var values = settings.Values.Select(ParseValue).ToList();
         var doc = XppScaffolder.Enum(settings.Name, values, !settings.NonExtensible, settings.Label);
 
-        try
-        {
-            var res = ScaffoldFileWriter.Write(doc, outPath!, settings.Overwrite);
-            return RenderHelpers.Render(kind, ToolResult<object>.Success(new
+        return GenerateInstaller.Emit(
+            kind, "enum", "AxEnum", settings.Name,
+            settings.InstallTo, settings.Out, settings.Overwrite, doc,
+            r => new
             {
                 kind         = "AxEnum",
                 name         = settings.Name,
@@ -59,16 +47,12 @@ public sealed class GenerateEnumCommand : Command<GenerateEnumCommand.Settings>
                 label        = settings.Label,
                 valueCount   = values.Count,
                 values       = values.Select(v => new { v.Name, v.IntValue, v.Label }).ToList(),
-                path         = res.Path,
-                bytes        = res.Bytes,
-                backup       = res.BackupPath,
+                source       = r.Source,
+                path         = r.Path,
+                bytes        = r.Bytes,
+                backup       = r.Backup,
                 model        = settings.InstallTo,
-            }));
-        }
-        catch (Exception ex)
-        {
-            return RenderHelpers.Render(kind, ToolResult<object>.Fail(D365FoErrorCodes.WriteFailed, ex.Message));
-        }
+            });
     }
 
     private static EnumValueSpec ParseValue(string raw)

--- a/src/D365FO.Cli/Commands/Generate/GenerateMoreCommands.cs
+++ b/src/D365FO.Cli/Commands/Generate/GenerateMoreCommands.cs
@@ -209,16 +209,6 @@ public sealed class GenerateEventHandlerCommand : Command<GenerateEventHandlerCo
             return RenderHelpers.Render(kind, ToolResult<object>.Fail(D365FoErrorCodes.BadInput, "Class name required."));
         if (string.IsNullOrWhiteSpace(settings.SourceObject))
             return RenderHelpers.Render(kind, ToolResult<object>.Fail(D365FoErrorCodes.BadInput, "--source-object required."));
-        var hasInstall = !string.IsNullOrWhiteSpace(settings.InstallTo);
-        var hasOut = !string.IsNullOrWhiteSpace(settings.Out);
-        if (!hasInstall && !hasOut)
-            return RenderHelpers.Render(kind, ToolResult<object>.Fail(D365FoErrorCodes.BadInput, "--out or --install-to is required."));
-        var outPath = settings.Out;
-        if (hasInstall && !hasOut)
-        {
-            outPath = GenerateInstaller.ResolveInstallPath(kind, "AxClass", settings.ClassName, settings.InstallTo!, out var fail);
-            if (fail.HasValue) return fail.Value;
-        }
 
         var doc = XppScaffolder.EventHandler(settings.ClassName, settings.SourceKind, settings.SourceObject!, settings.Event, settings.HandlerMethod);
 
@@ -228,10 +218,10 @@ public sealed class GenerateEventHandlerCommand : Command<GenerateEventHandlerCo
             requiredSymbols: new[] { settings.SourceObject! });
         if (gate.Failure is not null) return RenderHelpers.Render(kind, gate.Failure);
 
-        try
-        {
-            var res = ScaffoldFileWriter.Write(doc, outPath!, settings.Overwrite);
-            return RenderHelpers.Render(kind, ToolResult<object>.Success(new
+        return GenerateInstaller.Emit(
+            kind, "class", "AxClass", settings.ClassName,
+            settings.InstallTo, settings.Out, settings.Overwrite, doc,
+            r => new
             {
                 kind = "AxClass",
                 role = "EventHandler",
@@ -240,17 +230,14 @@ public sealed class GenerateEventHandlerCommand : Command<GenerateEventHandlerCo
                 sourceObject = settings.SourceObject,
                 @event = settings.Event,
                 method = settings.HandlerMethod,
-                path = res.Path,
-                bytes = res.Bytes,
-                backup = res.BackupPath,
+                source = r.Source,
+                path = r.Path,
+                bytes = r.Bytes,
+                backup = r.Backup,
                 model = settings.InstallTo,
                 grounding = gate.Grounding,
-            }, warnings: gate.Warnings.Count > 0 ? gate.Warnings : null));
-        }
-        catch (Exception ex)
-        {
-            return RenderHelpers.Render(kind, ToolResult<object>.Fail(D365FoErrorCodes.WriteFailed, ex.Message));
-        }
+            },
+            gate.Warnings.Count > 0 ? gate.Warnings.ToList() : null);
     }
 }
 

--- a/src/D365FO.Core/Scaffolding/XppScaffolder.cs
+++ b/src/D365FO.Core/Scaffolding/XppScaffolder.cs
@@ -13,13 +13,26 @@ namespace D365FO.Core.Scaffolding;
 /// </summary>
 public static class XppScaffolder
 {
+    /// <param name="edtBaseTypeResolver">
+    /// Optional callback resolving an EDT name to its primitive base type
+    /// (<c>String</c>, <c>Int</c>, <c>Enum</c>, …) — typically backed by the
+    /// SQLite index (<c>MetadataRepository.GetEdt(name)?.BaseType</c>). Used to
+    /// stamp each <c>&lt;AxTableField&gt;</c> with the concrete
+    /// <c>i:type="AxTableField{Suffix}"</c> discriminator. <c>AxTableField</c>
+    /// is an abstract base in <c>Microsoft.Dynamics.AX.Metadata.MetaModel</c>;
+    /// without the discriminator the metadata reader throws "Cannot create an
+    /// abstract class" and the table is invalid (issue #91). When the resolver
+    /// is null or returns null, a heuristic over well-known system EDTs is used,
+    /// defaulting to <c>AxTableFieldString</c>.
+    /// </param>
     public static XDocument Table(
         string name,
         string? label = null,
         IEnumerable<TableFieldSpec>? fields = null,
         TablePattern pattern = TablePattern.None,
         TableStorage storage = TableStorage.RegularTable,
-        IEnumerable<string>? primaryKeyFields = null)
+        IEnumerable<string>? primaryKeyFields = null,
+        Func<string, string?>? edtBaseTypeResolver = null)
     {
         // Resolve effective field list: caller-supplied wins; otherwise use the
         // pattern preset (if any). When neither is supplied, emit nothing —
@@ -30,11 +43,18 @@ public static class XppScaffolder
             ? supplied
             : TablePatternPresets.DefaultFieldsFor(pattern).ToList();
 
+        // Microsoft's metadata reader requires the XMLSchema-instance namespace
+        // and a concrete i:type on every polymorphic AxTableField (abstract base).
+        XNamespace xsi = "http://www.w3.org/2001/XMLSchema-instance";
+
         var fieldEls = effectiveFields.Select(f =>
         {
+            var edtName = f.Edt ?? "Name";
+            var suffix  = TableFieldConcreteSuffix(edtName, edtBaseTypeResolver);
             var el = new XElement("AxTableField",
+                new XAttribute(XName.Get("type", xsi.NamespaceName), $"AxTableField{suffix}"),
                 new XElement("Name", f.Name),
-                new XElement("ExtendedDataType", f.Edt ?? "Name"));
+                new XElement("ExtendedDataType", edtName));
             if (!string.IsNullOrEmpty(f.Label)) el.Add(new XElement("Label", f.Label));
             if (f.Mandatory) el.Add(new XElement("Mandatory", "Yes"));
             return el;
@@ -78,6 +98,9 @@ public static class XppScaffolder
 
         return new XDocument(
             new XElement("AxTable",
+                // Declare the i: prefix once on the root so every field's
+                // i:type discriminator resolves without re-declaring per element.
+                new XAttribute(XNamespace.Xmlns + "i", xsi.NamespaceName),
                 new XElement("Name", name),
                 string.IsNullOrEmpty(label) ? null : new XElement("Label", label),
                 tableGroup is null ? null : new XElement("TableGroup", tableGroup),
@@ -732,6 +755,43 @@ public static class XppScaffolder
             "boolean"              => "NoYes",
             _                      => null,
         };
+
+    /// <summary>
+    /// Resolve the concrete <c>AxTableField{Suffix}</c> discriminator for a
+    /// field's EDT. Prefers the index-backed base type; falls back to a
+    /// heuristic over well-known system EDTs (defaulting to <c>String</c>).
+    /// </summary>
+    private static string TableFieldConcreteSuffix(string edtName, Func<string, string?>? resolver)
+    {
+        var baseType = resolver?.Invoke(edtName);
+        var fromIndex = SuffixFromBaseType(baseType);
+        if (fromIndex is not null) return fromIndex;
+        return InferConcreteTypeSuffixFromExtends(edtName);
+    }
+
+    /// <summary>
+    /// Map an EDT primitive base type (as stored in the index — the concrete
+    /// <c>AxEdt*</c> root element name minus the prefix) to the matching
+    /// <c>AxTableField</c> subtype suffix. Returns null for unknown/empty input
+    /// so the caller can fall back to the name heuristic.
+    /// </summary>
+    private static string? SuffixFromBaseType(string? baseType) =>
+        string.IsNullOrWhiteSpace(baseType)
+            ? null
+            : baseType.ToLowerInvariant() switch
+            {
+                "string"              => "String",
+                "int" or "integer"    => "Int",
+                "int64"               => "Int64",
+                "real"                => "Real",
+                "date"                => "Date",
+                "time"                => "Time",
+                "utcdatetime"         => "UtcDateTime",
+                "enum"                => "Enum",
+                "guid"                => "Guid",
+                "container"           => "Container",
+                _                     => null,
+            };
 
     private static string InferConcreteTypeSuffixFromExtends(string? extends) =>
         extends?.ToLowerInvariant() switch

--- a/src/D365FO.Mcp/ToolHandlers.cs
+++ b/src/D365FO.Mcp/ToolHandlers.cs
@@ -933,8 +933,17 @@ public sealed class ToolHandlers
         }
         catch { /* index may not contain the table — not fatal */ }
 
+        // Resolve each field's EDT base type from the index so the scaffold
+        // stamps the concrete i:type discriminator on every <AxTableField>
+        // (AxTableField is abstract — without it the table is invalid). See issue #91.
+        Func<string, string?> edtResolver = edt =>
+        {
+            if (string.IsNullOrWhiteSpace(edt)) return null;
+            try { return _repo.GetEdt(edt)?.BaseType; }
+            catch { return null; }
+        };
         var doc = D365FO.Core.Scaffolding.XppScaffolder.Table(name, label, fieldSpecs, pat,
-            D365FO.Core.Scaffolding.TableStorage.RegularTable, null);
+            D365FO.Core.Scaffolding.TableStorage.RegularTable, null, edtResolver);
         var extra = new { fieldCount = fieldSpecs.Count > 0 ? fieldSpecs.Count : (int?)null, pattern = pat == D365FO.Core.Scaffolding.TablePattern.None ? null : pat.ToString() };
         return WriteScaffold(doc, name, "AxTable", "AxTable", installTo, outPath, overwrite, extra);
     }

--- a/tests/D365FO.Cli.Tests/TablePatternScaffoldingTests.cs
+++ b/tests/D365FO.Cli.Tests/TablePatternScaffoldingTests.cs
@@ -164,4 +164,82 @@ public class TablePatternScaffoldingTests
         var doc = XppScaffolder.Table("FmEmpty");
         Assert.Null(doc.Root!.Element("Indexes"));
     }
+
+    // --- issue #91: AxTableField is abstract — every field needs a concrete
+    //     i:type discriminator or the metadata reader rejects the whole table.
+
+    private static readonly System.Xml.Linq.XNamespace Xsi =
+        "http://www.w3.org/2001/XMLSchema-instance";
+
+    [Fact]
+    public void Root_declares_the_XMLSchema_instance_namespace()
+    {
+        var doc = XppScaffolder.Table("FmThing", pattern: TablePattern.Main);
+        var decl = doc.Root!.Attribute(System.Xml.Linq.XNamespace.Xmlns + "i");
+        Assert.NotNull(decl);
+        Assert.Equal(Xsi.NamespaceName, decl!.Value);
+    }
+
+    [Fact]
+    public void Every_field_carries_a_concrete_AxTableField_itype()
+    {
+        var doc = XppScaffolder.Table("FmThing", pattern: TablePattern.Main);
+        var fields = doc.Root!.Element("Fields")!.Elements("AxTableField").ToList();
+        Assert.NotEmpty(fields);
+        foreach (var f in fields)
+        {
+            var t = f.Attribute(Xsi + "type")?.Value;
+            Assert.False(string.IsNullOrEmpty(t), "field missing i:type");
+            Assert.StartsWith("AxTableField", t);
+            Assert.NotEqual("AxTableField", t); // never the abstract base
+        }
+    }
+
+    [Theory]
+    [InlineData("String",      "AxTableFieldString")]
+    [InlineData("Int",         "AxTableFieldInt")]
+    [InlineData("Int64",       "AxTableFieldInt64")]
+    [InlineData("Real",        "AxTableFieldReal")]
+    [InlineData("Enum",        "AxTableFieldEnum")]
+    [InlineData("Date",        "AxTableFieldDate")]
+    [InlineData("UtcDateTime", "AxTableFieldUtcDateTime")]
+    [InlineData("Guid",        "AxTableFieldGuid")]
+    [InlineData("Container",   "AxTableFieldContainer")]
+    public void Resolver_base_type_maps_to_concrete_field_subtype(string baseType, string expected)
+    {
+        var custom = new[] { new TableFieldSpec("Foo", "SomeEdt", null, false) };
+        var doc = XppScaffolder.Table("FmThing", fields: custom, edtBaseTypeResolver: _ => baseType);
+        var field = doc.Root!.Element("Fields")!.Element("AxTableField")!;
+        Assert.Equal(expected, field.Attribute(Xsi + "type")!.Value);
+    }
+
+    [Fact]
+    public void Unknown_edt_without_resolver_falls_back_to_string()
+    {
+        var custom = new[] { new TableFieldSpec("Foo", "TotallyUnknownEdtXyz", null, false) };
+        var doc = XppScaffolder.Table("FmThing", fields: custom);
+        var field = doc.Root!.Element("Fields")!.Element("AxTableField")!;
+        Assert.Equal("AxTableFieldString", field.Attribute(Xsi + "type")!.Value);
+    }
+
+    [Fact]
+    public void Well_known_edt_name_heuristic_applies_without_resolver()
+    {
+        // AmountMST is a real-typed system EDT — the name heuristic should pick Real.
+        var custom = new[] { new TableFieldSpec("Amount", "AmountMST", null, false) };
+        var doc = XppScaffolder.Table("FmThing", fields: custom);
+        var field = doc.Root!.Element("Fields")!.Element("AxTableField")!;
+        Assert.Equal("AxTableFieldReal", field.Attribute(Xsi + "type")!.Value);
+    }
+
+    [Fact]
+    public void Resolver_null_return_falls_back_to_name_heuristic()
+    {
+        // Resolver present but returns null (EDT not in index) → heuristic over
+        // the EDT name still applies (TransDate → Date).
+        var custom = new[] { new TableFieldSpec("Posted", "TransDate", null, false) };
+        var doc = XppScaffolder.Table("FmThing", fields: custom, edtBaseTypeResolver: _ => null);
+        var field = doc.Root!.Element("Fields")!.Element("AxTableField")!;
+        Assert.Equal("AxTableFieldDate", field.Attribute(Xsi + "type")!.Value);
+    }
 }


### PR DESCRIPTION
Fixes #91.

## Problem
Newly created tables produced invalid XML: every `<AxTableField>` was emitted as the bare abstract element with no concrete `i:type` discriminator. `AxTableField` is an abstract base in `Microsoft.Dynamics.AX.Metadata.MetaModel`, so the metadata reader rejected the whole table (*"Cannot create an abstract class"*), and opening a form over the table failed as a knock-on effect.

The sibling [`d365fo-mcp-server`](https://github.com/dynamics365ninja/d365fo-mcp-server) doesn't hit this because it materialises objects through the **Microsoft metadata API** instead of hand-writing XML. This PR brings the CLI to parity, with the scaffold as a fallback.

## Changes
- **Scaffold fix** — `XppScaffolder.Table` stamps each field with `i:type="AxTableField{Suffix}"`, resolving the concrete subtype from the field EDT's base type via an index-backed resolver (`MetadataRepository.GetEdt(name).BaseType`), with a name heuristic fallback (defaults to `String`). Root declares `xmlns:i` once.
- **Metadata-API routing** — `generate {table,class,coc,event-handler,edt,enum,form} --install-to <MODEL>` now create the object through the live `IMetadataProvider` (bridge `createObject`) for provider-canonical output, consistent with Visual Studio / mcp-server. When the provider is unavailable, it falls back to writing the (now valid) scaffold into the model folder with a warning. Shared via `GenerateInstaller.Emit` / `EmitString`. Results carry `source: "bridge" | "scaffold"`.
- **Bridge** — build the `XmlSerializer` on the type matching the **root element name** and honour a pinned `xsi:type`, so a polymorphic root (`<AxEdt i:type="AxEdtString">`) deserialises into its concrete subtype; subsequent work uses the instance's runtime type.
- **MCP** — `generate_table` passes the same EDT resolver so its output is valid too.

Kinds the metadata API does not expose (`entity`, `extension`, `privilege`, `duty`, `role`, `report`) remain scaffold-only.

## Before / after (issue repro `ElfAnnex`)
```xml
<AxTable xmlns:i="http://www.w3.org/2001/XMLSchema-instance">
  ...
  <AxTableField i:type="AxTableFieldString">
    <Name>Annex</Name>
    <ExtendedDataType>ElfAnnexId</ExtendedDataType>
    <Mandatory>Yes</Mandatory>
```

## Testing
- `dotnet build` clean for CLI, MCP, and the net48 Bridge.
- **408/408** tests pass (+8 new scaffolder tests covering the `i:type` discriminator and base-type → subtype mapping).
- Smoke-tested `--out` for class/enum/edt/form; `--install-to` without a bridge degrades with a clear `INSTALL_FAILED` message.

## Needs verification on a D365FO VM
The bridge is Windows-only, so the metadata-API path couldn't be integration-tested here. Two spots carry real-but-gracefully-handled risk (failures fall back to the valid scaffold with a warning):
1. **EDT** relies on `AxEdt` carrying `[XmlInclude]` for its subtypes so `XmlSerializer` honours `xsi:type`.
2. **Form** round-trips a complex template through `XmlSerializer` into `AxForm`; worth diffing the first `generate form --install-to` output against VS.

🤖 Generated with [Claude Code](https://claude.com/claude-code)