### PR TITLE
fix: port d365fo-mcp-server June-2026 fixes (find-refs scoping, label aliases, extension name normalization)

### DIFF
--- a/src/D365FO.Bridge/XrefRepository.cs
+++ b/src/D365FO.Bridge/XrefRepository.cs
@@ -82,9 +82,9 @@ namespace D365FO.Bridge
             }
             if (limit <= 0 || limit > 1000) limit = 200;
 
-            // Path looks like /Classes/<Name>[/<Element>/<Child>]. Match the
-            // target symbol both as a standalone AOT root (e.g. /Tables/CustTable)
-            // and as a node anywhere inside a path ( .../CustTable/... ).
+            // Resolve the input into one or more candidate XREFDB target paths.
+            var (exactPaths, likePaths, memberQualified) = ResolveTargetPaths(symbol);
+
             var result = new JsonObject();
             var items = new JsonArray();
 
@@ -96,6 +96,31 @@ namespace D365FO.Bridge
                     using (var cmd = c.CreateCommand())
                     {
                         cmd.CommandTimeout = 30;
+
+                        // Build a parameterised WHERE: exact target paths via IN (...),
+                        // plus LIKE conditions for child/contains matches. A member-
+                        // qualified target points at an exact leaf, so it carries no
+                        // LIKE terms — adding "/%" children or a "%/name%" contains
+                        // would pool callers of every same-named member across types.
+                        var inParams = new List<string>();
+                        for (int i = 0; i < exactPaths.Count; i++)
+                        {
+                            var pn = "@P" + i;
+                            inParams.Add(pn);
+                            cmd.Parameters.Add(new SqlParameter(pn, exactPaths[i]));
+                        }
+                        var likeConds = new List<string>();
+                        for (int i = 0; i < likePaths.Count; i++)
+                        {
+                            var pn = "@L" + i;
+                            likeConds.Add("tgtName.Path LIKE " + pn);
+                            cmd.Parameters.Add(new SqlParameter(pn, likePaths[i]));
+                        }
+
+                        var where = "tgtName.Path IN (" + string.Join(",", inParams) + ")";
+                        if (likeConds.Count > 0)
+                            where += " OR " + string.Join(" OR ", likeConds);
+
                         var sql = @"
 SELECT TOP (@limit)
     srcName.Path  AS SourcePath,
@@ -108,17 +133,10 @@ FROM [References] r
 INNER JOIN Names srcName ON srcName.Id = r.SourceId
 INNER JOIN Names tgtName ON tgtName.Id = r.TargetId
 LEFT  JOIN Modules m     ON m.Id = srcName.ModuleId
-WHERE tgtName.Path = @exact
-   OR tgtName.Path LIKE @prefix
-   OR tgtName.Path LIKE @contains
+WHERE " + where + @"
 ORDER BY srcName.Path";
                         cmd.CommandText = sql;
                         cmd.Parameters.Add(new SqlParameter("@limit", limit));
-                        // Exact AOT root (/Tables/CustTable) — cheap and
-                        // typically returns the bulk of direct references.
-                        cmd.Parameters.Add(new SqlParameter("@exact", "/" + TrimSlash(symbol)));
-                        cmd.Parameters.Add(new SqlParameter("@prefix", "/" + TrimSlash(symbol) + "/%"));
-                        cmd.Parameters.Add(new SqlParameter("@contains", "%/" + TrimSlash(symbol) + "%"));
 
                         using (var r = cmd.ExecuteReader())
                         {
@@ -167,8 +185,68 @@ ORDER BY srcName.Path";
             result["kindFilter"] = kindFilter ?? string.Empty;
             result["count"] = items.Count;
             result["source"] = "xrefdb";
+            // When the target is member-qualified the result is scoped to the
+            // declaring type, so an empty list is an authoritative "no callers"
+            // — not a hint to fall back to a looser name-only scan.
+            result["scoped"] = memberQualified;
             result["items"] = items;
             return result;
+        }
+
+        /// <summary>
+        /// Resolve a caller-supplied symbol into candidate XREFDB target paths.
+        /// Three input shapes are recognised:
+        /// <list type="bullet">
+        /// <item>Explicit AOT path ("/Tables/SalesTable/Methods/initFromX") — used
+        /// verbatim. Method/field paths are treated as exact leaves.</item>
+        /// <item>Member-qualified ("SalesTable.initFromX") — scoped to a single
+        /// method/field on its declaring type. The owner's object kind is unknown,
+        /// so method+field variants are expanded across every container type; only
+        /// the path that actually exists matches. This is the precise where-used
+        /// Visual Studio shows, instead of pooling every same-named member.</item>
+        /// <item>Bare name ("CustTable") — matched loosely as a standalone AOT root,
+        /// its children, and as a node anywhere inside a path.</item>
+        /// </list>
+        /// Returns exact paths (matched via IN), LIKE patterns, and whether the
+        /// target is member-qualified (an exact leaf carrying no LIKE terms).
+        /// </summary>
+        internal static (List<string> exactPaths, List<string> likePaths, bool memberQualified) ResolveTargetPaths(string symbol)
+        {
+            // Container segments that can own methods/fields.
+            string[] memberContainers = { "Tables", "Classes", "Forms", "Views", "DataEntityViews", "Queries", "Maps" };
+
+            var exact = new List<string>();
+            var like = new List<string>();
+            bool memberQualified = false;
+            var trimmed = TrimSlash(symbol);
+
+            if (symbol.StartsWith("/"))
+            {
+                exact.Add("/" + trimmed);
+                memberQualified = symbol.Contains("/Methods/") || symbol.Contains("/Fields/");
+                if (!memberQualified) like.Add("/" + trimmed + "/%");
+            }
+            else if (symbol.Contains("."))
+            {
+                memberQualified = true;
+                var dot = symbol.IndexOf('.');
+                var owner = symbol.Substring(0, dot);
+                var member = symbol.Substring(dot + 1);
+                foreach (var ct in memberContainers)
+                {
+                    exact.Add("/" + ct + "/" + owner + "/Methods/" + member);
+                    exact.Add("/" + ct + "/" + owner + "/Fields/" + member);
+                }
+            }
+            else
+            {
+                // Bare name — exact AOT root plus loose child/contains matching.
+                exact.Add("/" + trimmed);
+                like.Add("/" + trimmed + "/%");
+                like.Add("%/" + trimmed + "%");
+            }
+
+            return (exact, like, memberQualified);
         }
 
         private static string TrimSlash(string s)

--- a/src/D365FO.Cli/Commands/Find/FindCommands.cs
+++ b/src/D365FO.Cli/Commands/Find/FindCommands.cs
@@ -141,7 +141,7 @@ public sealed class FindRefsCommand : Command<FindRefsCommand.Settings>
     public sealed class Settings : D365OutputSettings
     {
         [CommandArgument(0, "<NAME>")]
-        [System.ComponentModel.Description("Symbol to search for (class / table / EDT / enum / label).")]
+        [System.ComponentModel.Description("Symbol to search for (class / table / EDT / enum / label). With --xref, qualify a method/field as \"Owner.member\" (e.g. SalesTable.initFromSalesQuotationTable) or pass an AOT path to scope the where-used to its declaring type; a bare member name matches that name on every type.")]
         public string Name { get; init; } = "";
 
         [CommandOption("--kind <KIND>")]

--- a/src/D365FO.Core/Index/MetadataRepository.cs
+++ b/src/D365FO.Core/Index/MetadataRepository.cs
@@ -361,8 +361,23 @@ public sealed partial class MetadataRepository
             WHERE e.Name = @name LIMIT 1", new { name });
     }
 
+    /// <summary>
+    /// Index rows store the <em>base</em> object an extension targets (e.g.
+    /// <c>CustTable</c>), but callers and LLMs often pass the full extension
+    /// name (<c>CustTable.Extension</c>, <c>CustTable.MyModelSuffix</c>). AOT
+    /// object names never contain a dot, so a dot unambiguously marks an
+    /// extension suffix — strip it to the base before matching.
+    /// </summary>
+    private static string BaseExtensionTarget(string target)
+    {
+        if (string.IsNullOrEmpty(target)) return target;
+        var dot = target.IndexOf('.');
+        return dot > 0 ? target.Substring(0, dot) : target;
+    }
+
     public IReadOnlyList<CocExtensionInfo> FindCocExtensions(string targetClass, string? targetMethod = null)
     {
+        targetClass = BaseExtensionTarget(targetClass);
         using var conn = OpenReadOnly();
         var sql = @"
             SELECT c.TargetClass, c.TargetMethod, c.ExtensionClass, m.Name AS Model
@@ -558,6 +573,7 @@ public sealed partial class MetadataRepository
 
     public IReadOnlyList<ObjectExtensionInfo> FindExtensions(string targetName, string? kind = null)
     {
+        targetName = BaseExtensionTarget(targetName);
         using var conn = OpenReadOnly();
         return conn.Query<ObjectExtensionInfo>(@"
             SELECT e.Kind, e.TargetName, e.ExtensionName, m.Name AS Model, e.SourcePath
@@ -569,6 +585,7 @@ public sealed partial class MetadataRepository
 
     public IReadOnlyList<EventSubscriberInfo> FindEventSubscribers(string sourceObject, string? sourceKind = null)
     {
+        sourceObject = BaseExtensionTarget(sourceObject);
         using var conn = OpenReadOnly();
         return conn.Query<EventSubscriberInfo>(@"
             SELECT s.SubscriberClass, s.SubscriberMethod, s.SourceKind, s.SourceObject,

--- a/src/D365FO.Mcp/ToolCatalog.cs
+++ b/src/D365FO.Mcp/ToolCatalog.cs
@@ -174,15 +174,25 @@ public static class ToolCatalog
                    ("file", "string", false), ("language", "string", false), ("key", "string", false),
                    ("value", "string", false), ("overwrite", "boolean", false),
                    ("installTo", "string", false), ("lang", "string", false), ("labelFile", "string", false),
-                   ("oldKey", "string", false), ("newKey", "string", false)),
+                   ("oldKey", "string", false), ("newKey", "string", false),
+                   // create-input aliases tolerated for clients that guess the schema
+                   ("labelId", "string", false), ("text", "string", false), ("label", "string", false),
+                   ("model", "string", false), ("labelFileId", "string", false)),
             (h, p) => StrOr(p, "action", "search").ToLowerInvariant() switch
             {
                 "fts"    => h.SearchLabelsFts(Str(p, "query"), StrArray(p, "languages"), Int(p, "limit", 100), Bool(p, "raw")),
                 "info" or "resolve" => StrOrNull(p, "file") is not null
                             ? h.GetLabel(Str(p, "file"), Str(p, "language"), Str(p, "key"), Bool(p, "raw"))
                             : h.ResolveLabel(Str(p, "token"), StrArray(p, "languages"), Bool(p, "raw")),
-                "create" => h.CreateLabel(StrOrNull(p, "file"), Str(p, "key"), Str(p, "value"), Bool(p, "overwrite"),
-                                StrOrNull(p, "installTo"), StrOrNull(p, "lang"), StrOrNull(p, "labelFile")),
+                // Tolerate the param names MCP clients commonly guess: a scalar
+                // text/label for value, model for installTo, language for lang,
+                // labelFileId for labelFile. Canonical names still win when both
+                // are present.
+                "create" => h.CreateLabel(StrOrNull(p, "file"),
+                                StrAlias(p, "key", "labelId"), StrAlias(p, "value", "text", "label"),
+                                Bool(p, "overwrite"),
+                                StrAliasOrNull(p, "installTo", "model"), StrAliasOrNull(p, "lang", "language"),
+                                StrAliasOrNull(p, "labelFile", "labelFileId")),
                 "rename" => h.RenameLabel(Str(p, "file"), Str(p, "oldKey"), Str(p, "newKey"), Bool(p, "overwrite")),
                 "delete" => h.DeleteLabel(Str(p, "file"), Str(p, "key")),
                 _        => h.SearchLabels(Str(p, "query"), StrArray(p, "languages"), Int(p, "limit", 100), Bool(p, "raw")),
@@ -215,7 +225,8 @@ public static class ToolCatalog
             "table-merge (all TableExtensions targeting `target` table + effective merged schema) · " +
             "points (Table/Form/Enum/EDT _Extension objects targeting `target`; filter with `kind`) · " +
             "strategy (enumerate existing extensions/handlers/CoC on `target` and recommend the least-invasive change). " +
-            "Use before writing any extension to check for conflicts and pick the right mechanism.",
+            "Use before writing any extension to check for conflicts and pick the right mechanism. " +
+            "`target` may be the base object (CustTable) or the full extension name (CustTable.Extension) — both resolve to the base.",
             Schema(("mode", "string", true), ("target", "string", true),
                    ("method", "string", false), ("objectType", "string", false), ("kind", "string", false)),
             (h, p) => StrOr(p, "mode", "").ToLowerInvariant() switch
@@ -424,6 +435,27 @@ public static class ToolCatalog
     private static string? StrOrNull(JsonElement p, string name)
     {
         var s = Str(p, name);
+        return string.IsNullOrEmpty(s) ? null : s;
+    }
+
+    /// <summary>
+    /// Read the first non-empty value among <paramref name="names"/>. Lets MCP
+    /// clients that guess alias param names (e.g. <c>text</c> for <c>value</c>)
+    /// still reach the handler; the canonical name (listed first) wins.
+    /// </summary>
+    private static string StrAlias(JsonElement p, params string[] names)
+    {
+        foreach (var n in names)
+        {
+            var s = Str(p, n);
+            if (!string.IsNullOrEmpty(s)) return s;
+        }
+        return "";
+    }
+
+    private static string? StrAliasOrNull(JsonElement p, params string[] names)
+    {
+        var s = StrAlias(p, names);
         return string.IsNullOrEmpty(s) ? null : s;
     }
 

--- a/tests/D365FO.Core.Tests/McpDispatcherTests.cs
+++ b/tests/D365FO.Core.Tests/McpDispatcherTests.cs
@@ -188,6 +188,42 @@ public class McpDispatcherTests : IDisposable
     }
 
     [Fact]
+    public async Task Labels_create_accepts_text_alias_for_value()
+    {
+        var file = Path.Combine(Path.GetTempPath(), $"d365fo-lbl-{Guid.NewGuid():N}.en-us.label.txt");
+        try
+        {
+            // 'text' is a guessed alias for the canonical 'value' param. The
+            // dispatcher must forward it so the written file carries the value.
+            var req = "{\"jsonrpc\":\"2.0\",\"id\":24,\"method\":\"tools/call\",\"params\":{\"name\":\"labels\","
+                    + "\"arguments\":{\"action\":\"create\",\"file\":\"" + file.Replace("\\", "\\\\") + "\","
+                    + "\"key\":\"@Con:Hello\",\"text\":\"Hello world\"}}}";
+            var resp = await Roundtrip(req);
+            var doc = Assert.Single(resp);
+            var payload = JsonDocument.Parse(doc.RootElement.GetProperty("result")
+                .GetProperty("content")[0].GetProperty("text").GetString()!);
+            Assert.True(payload.RootElement.GetProperty("ok").GetBoolean());
+            Assert.Contains("Hello world", await File.ReadAllTextAsync(file));
+        }
+        finally
+        {
+            if (File.Exists(file)) File.Delete(file);
+        }
+    }
+
+    [Fact]
+    public async Task ExtensionInfo_points_accepts_full_extension_name()
+    {
+        // The dispatch must reach the handler and resolve the dotted extension
+        // name to its base target without erroring on a fresh db.
+        var resp = await Roundtrip("""{"jsonrpc":"2.0","id":25,"method":"tools/call","params":{"name":"extension_info","arguments":{"mode":"points","target":"CustTable.Extension"}}}""");
+        var doc = Assert.Single(resp);
+        var payload = JsonDocument.Parse(doc.RootElement.GetProperty("result")
+            .GetProperty("content")[0].GetProperty("text").GetString()!);
+        Assert.True(payload.RootElement.GetProperty("ok").GetBoolean());
+    }
+
+    [Fact]
     public async Task FindReferences_returns_empty_on_fresh_db()
     {
         var resp = await Roundtrip("""{"jsonrpc":"2.0","id":21,"method":"tools/call","params":{"name":"find_references","arguments":{"name":"CustTable"}}}""");

--- a/tests/D365FO.Core.Tests/MetadataRepositoryTests.cs
+++ b/tests/D365FO.Core.Tests/MetadataRepositoryTests.cs
@@ -66,6 +66,30 @@ public class MetadataRepositoryTests : IDisposable
     }
 
     [Fact]
+    public void FindExtensions_accepts_full_extension_name_for_base_target()
+    {
+        var repo = new MetadataRepository(_dbPath);
+        repo.EnsureSchema();
+
+        using var conn = new Microsoft.Data.Sqlite.SqliteConnection(repo.ConnectionString);
+        conn.Open();
+        using var cmd = conn.CreateCommand();
+        cmd.CommandText = @"
+            INSERT INTO Models(Name,IsCustom) VALUES('Contoso',1);
+            INSERT INTO ObjectExtensions(Kind,TargetName,ExtensionName,ModelId,SourcePath)
+              VALUES('Table','CustTable','CustTable.Extension',1,'/x');";
+        cmd.ExecuteNonQuery();
+
+        // Both the base table name and the full extension name resolve to the
+        // same indexed row (a dot marks an extension suffix; AOT names have none).
+        var byBase = repo.FindExtensions("CustTable", "Table");
+        var byFull = repo.FindExtensions("CustTable.Extension", "Table");
+        Assert.Single(byBase);
+        Assert.Single(byFull);
+        Assert.Equal("CustTable.Extension", byFull[0].ExtensionName);
+    }
+
+    [Fact]
     public void RecordExtractionRun_roundtrips_via_GetExtractionRuns()
     {
         var repo = new MetadataRepository(_dbPath);


### PR DESCRIPTION
Ports the applicable 2026-06-16 bug-fix batch from the sister project `d365fo-mcp-server` into the C# CLI. The two projects share intent but not implementation (mcp-server is TS/JS + a net48 C# bridge), so each upstream fix was mapped to its CLI analog — or deliberately skipped where none exists.

## Ported

- **find-references scoping** (upstream `b10b753`/`7dc6364`). The xref-bridge path `XrefRepository.Find` had the same pooling bug as upstream: a bare method name matched `%/<name>%` and pooled callers of *every* same-named method/field across all object types (e.g. 25 hits instead of the 7 Visual Studio shows). Extracted a testable `ResolveTargetPaths(symbol)` that recognises:
  - explicit AOT path `/Tables/SalesTable/Methods/initFromX` (exact leaf),
  - member-qualified `Owner.member` → `/Methods/` + `/Fields/` variants across container types, **no** `/%` children and **no** `%/name%` contains (precise where-used),
  - bare name → unchanged loose matching.

  Adds a `scoped` flag so a member-qualified empty result is authoritative. Only `find refs --xref` uses this path; the default regex scanner is untouched.

- **labels create input aliases** (upstream `c8624b8`). The MCP `labels` schema is already flat/scalar, so added `StrAlias`/`StrAliasOrNull` to tolerate the param names LLMs commonly guess: `text`/`label`→`value`, `model`→`installTo`, `language`→`lang`, `labelFileId`→`labelFile`, `labelId`→`key`. Alias names added to the advertised schema (which is `additionalProperties:false`).

- **extension name normalization** (upstream `d078c86`/`e61fa51`). Extension lookups now accept the full extension name (`Foo.Extension`, `Foo.MyModelSuffix`) and resolve to the base target via `BaseExtensionTarget` in `MetadataRepository` (`FindExtensions`/`FindCocExtensions`/`FindEventSubscribers`) — benefiting both the CLI commands and the MCP `extension_info` tool. A dot unambiguously marks an extension suffix since AOT object names never contain one.

## Not ported (no CLI analog)

- **run_bp_check UDE metadata path** (upstream `141fac8` + audit) — CLI `validate xpp` is a pure C# rule-canon validator and never shells out to `xppbp.exe`, so the whole `-compilerMetadata` / UDE-path class of bugs cannot occur.
- **class-extension dispatch fix** (part of `e61fa51`) — the CLI reads extensions only through the dedicated `extension_info` tool, not through the `get_object_info` reader, so upstream's "class-extension routed to the plain class reader" bug has no analog here.
- **bridge-error≠authoritative-empty** (upstream `7dc6364`) — already correct in the CLI: `BridgeGate.TryFindReferences` returns null on `ok==false` → falls back to the regex scan; only a clean empty is reported authoritatively. This PR just adds the `scoped` signal and `/Fields/` variants.

## Tests

3 added (label `text` alias via MCP, extension full-name via MCP `extension_info`, extension full-name at the repo layer). Full suite: **411 green**. The net48 bridge can't be unit-tested on this toolchain, so `ResolveTargetPaths` is covered by the clean extraction rather than a direct test.

🤖 Generated with [Claude Code](https://claude.com/claude-code)