### PR TITLE
fix(help): escape markup in generate option descriptions so --help renders

### DIFF
--- a/src/D365FO.Cli/Commands/Generate/GenerateCommands.cs
+++ b/src/D365FO.Cli/Commands/Generate/GenerateCommands.cs
@@ -201,7 +201,7 @@ public sealed class GenerateTableCommand : Command<GenerateTableCommand.Settings
         public string? Label { get; init; }
 
         [CommandOption("--field <SPEC>")]
-        [System.ComponentModel.Description("Repeatable: <name>:<edt>[:mandatory]. Example: --field AccountNum:CustAccount:mandatory")]
+        [System.ComponentModel.Description("Repeatable: <name>:<edt>[[:mandatory]]. Example: --field AccountNum:CustAccount:mandatory")]
         public string[] Fields { get; init; } = Array.Empty<string>();
 
         [CommandOption("--pattern <PATTERN>")]

--- a/src/D365FO.Cli/Commands/Generate/GenerateEnumCommand.cs
+++ b/src/D365FO.Cli/Commands/Generate/GenerateEnumCommand.cs
@@ -14,7 +14,7 @@ public sealed class GenerateEnumCommand : Command<GenerateEnumCommand.Settings>
         public string Name { get; init; } = "";
 
         [CommandOption("--value <SPEC>")]
-        [System.ComponentModel.Description("Repeatable: <name>:<intValue>[:<label>]. Example: --value None:0 --value Active:1:'Active record'")]
+        [System.ComponentModel.Description("Repeatable: <name>:<intValue>[[:<label>]]. Example: --value None:0 --value Active:1:'Active record'")]
         public string[] Values { get; init; } = Array.Empty<string>();
 
         [CommandOption("--non-extensible")]

--- a/src/D365FO.Cli/Commands/Generate/GenerateMoreCommands.cs
+++ b/src/D365FO.Cli/Commands/Generate/GenerateMoreCommands.cs
@@ -23,7 +23,7 @@ public sealed class GenerateEntityCommand : Command<GenerateEntityCommand.Settin
         public string? PublicCollection { get; init; }
 
         [CommandOption("--field <SPEC>")]
-        [System.ComponentModel.Description("Repeatable: <name>[:<dataField>[:mandatory]].")]
+        [System.ComponentModel.Description("Repeatable: <name>[[:<dataField>[[:mandatory]]]].")]
         public string[] Fields { get; init; } = Array.Empty<string>();
 
         [CommandOption("--all-fields")]


### PR DESCRIPTION
## Summary
`d365fo generate table --help` (and `generate enum` / `generate entity`) crash instead of printing help:

```
{"ok":false,"error":{"code":"UNHANDLED","message":"Could not find color or style ':mandatory'.","hint":"System.InvalidOperationException"}}
```

## Root cause
Spectre.Console.Cli renders `CommandOption` descriptions as markup. The descriptions use literal optional-arg notation like `<name>:<edt>[:mandatory]`, `<name>:<intValue>[:<label>]`, and `<name>[:<dataField>[:mandatory]]`. Spectre parses the bracketed `[:mandatory]` / `[:<label>]` as a style tag, finds no such style, and throws `InvalidOperationException` — aborting the whole `--help` render.

## Fix
Escape the square brackets by doubling them (`[[` / `]]`) in the three affected `[Description(...)]` attributes. Spectre un-doubles on render, so the displayed help still shows the standard `[optional]` notation — it just no longer parses it as markup.

Files:
- `src/D365FO.Cli/Commands/Generate/GenerateCommands.cs` — `generate table --field`
- `src/D365FO.Cli/Commands/Generate/GenerateEnumCommand.cs` — `generate enum --value`
- `src/D365FO.Cli/Commands/Generate/GenerateMoreCommands.cs` — `generate entity --field`

No behavior change to the commands themselves; only their `--help` rendering.

## Test plan
- [x] `dotnet build d365fo-cli.slnx -c Release` — clean
- [x] `dotnet run --project src/D365FO.Cli -- generate table --help` — renders (was crashing)
- [x] `... generate enum --help` and `... generate entity --help` — render
- [x] Existing test suite passes (no tests assert the unescaped strings)