### PR TITLE
feat(labels): bulk create via labels:[…] array (port from d365fo-mcp-…

### DIFF
--- a/docs/MIGRATION_FROM_MCP.md
+++ b/docs/MIGRATION_FROM_MCP.md
@@ -76,7 +76,7 @@ renaming `form_pattern` → `object_patterns`.
 | `search` | `type`, `queries[]` (batch) | all per-type `search_*`, `search_any`, `batch_search`, `find_usages` |
 | `get_object_info` | `objectType` (+ `relations`/`methods`/`indexes`/`deleteActions` for tables) | all `get_*_details`, `get_form/query/view/...`, `get_table_*` |
 | `get_method` | `include` (signature/source/both) | reads X++ source (was CLI `read` only) |
-| `labels` | `action` (search/fts/info/resolve/create/rename/delete) | `search_labels(_fts)`, `get_label`, `resolve_label`, `create/rename/delete_label` |
+| `labels` | `action` (search/fts/info/resolve/create/rename/delete); `create` also accepts a bulk `labels:[{key,value}, …]` array with shared top-level fields | `search_labels(_fts)`, `get_label`, `resolve_label`, `create/rename/delete_label` |
 | `security_info` | `mode` (artifact/coverage) | `get_security_role/duty/privilege`, `get_security_coverage_for_object` |
 | `object_patterns` | `domain` (form) + `action` (spec/validate) | `get_form_pattern_spec`, `validate_form_pattern`, `form_pattern` |
 | `generate_object` | `objectType` — table/class/coc/form (writes to disk) **and** edt/enum/query/sysoperation/business-event/runbase/security-policy (XML only) | `generate_table/class/coc/form` + the XML-only scaffolders (was two tools `generate` + `generate_xml`) |

--- a/src/D365FO.Mcp/ToolCatalog.cs
+++ b/src/D365FO.Mcp/ToolCatalog.cs
@@ -167,12 +167,13 @@ public static class ToolCatalog
             "Unified label operations via `action`: " +
             "search (substring across label files) · fts (ranked FTS5; supports phrases, NEAR, Value: filters) · " +
             "info (all translations of a token like @SYS12345, or one entry by file+language+key) · " +
-            "resolve (alias of info) · create (write a key=value; needs file or installTo) · " +
+            "resolve (alias of info) · create (write a key=value; needs file or installTo; " +
+            "pass `labels:[{key,value}, …]` for a bulk create with shared top-level fields) · " +
             "rename (rename a key in place) · delete (remove a key). Values are sanitised unless raw=true.",
             Schema(("action", "string", true), ("query", "string", false), ("token", "string", false),
                    ("languages", "array", false), ("limit", "integer", false), ("raw", "boolean", false),
                    ("file", "string", false), ("language", "string", false), ("key", "string", false),
-                   ("value", "string", false), ("overwrite", "boolean", false),
+                   ("value", "string", false), ("overwrite", "boolean", false), ("labels", "array", false),
                    ("installTo", "string", false), ("lang", "string", false), ("labelFile", "string", false),
                    ("oldKey", "string", false), ("newKey", "string", false),
                    // create-input aliases tolerated for clients that guess the schema
@@ -188,7 +189,13 @@ public static class ToolCatalog
                 // text/label for value, model for installTo, language for lang,
                 // labelFileId for labelFile. Canonical names still win when both
                 // are present.
-                "create" => h.CreateLabel(StrOrNull(p, "file"),
+                // A `labels:[…]` array fans out as a bulk create (shared top-level
+                // file/installTo/lang/labelFile/overwrite); otherwise a single create.
+                "create" => LabelEntries(p) is { Count: > 0 } entries
+                            ? h.CreateLabels(entries, StrOrNull(p, "file"), Bool(p, "overwrite"),
+                                StrAliasOrNull(p, "installTo", "model"), StrAliasOrNull(p, "lang", "language"),
+                                StrAliasOrNull(p, "labelFile", "labelFileId"))
+                            : h.CreateLabel(StrOrNull(p, "file"),
                                 StrAlias(p, "key", "labelId"), StrAlias(p, "value", "text", "label"),
                                 Bool(p, "overwrite"),
                                 StrAliasOrNull(p, "installTo", "model"), StrAliasOrNull(p, "lang", "language"),
@@ -484,5 +491,25 @@ public static class ToolCatalog
         if (v.ValueKind != JsonValueKind.Array) return null;
         return v.EnumerateArray().Where(x => x.ValueKind == JsonValueKind.String)
                  .Select(x => x.GetString()!).ToArray();
+    }
+
+    /// <summary>
+    /// Read a bulk-create <c>labels:[{key,value}, …]</c> array. Each entry tolerates the
+    /// same key/value aliases as a single create (key|labelId, value|text|label). Entries
+    /// missing a key are skipped here; an empty result falls back to single-create.
+    /// </summary>
+    private static List<(string key, string value)> LabelEntries(JsonElement p)
+    {
+        var list = new List<(string, string)>();
+        if (p.ValueKind != JsonValueKind.Object || !p.TryGetProperty("labels", out var arr)
+            || arr.ValueKind != JsonValueKind.Array) return list;
+        foreach (var e in arr.EnumerateArray())
+        {
+            if (e.ValueKind != JsonValueKind.Object) continue;
+            var key = StrAlias(e, "key", "labelId");
+            if (string.IsNullOrEmpty(key)) continue;
+            list.Add((key, StrAlias(e, "value", "text", "label")));
+        }
+        return list;
     }
 }

--- a/src/D365FO.Mcp/ToolHandlers.cs
+++ b/src/D365FO.Mcp/ToolHandlers.cs
@@ -516,6 +516,39 @@ public sealed class ToolHandlers
         }
     }
 
+    /// <summary>
+    /// Bulk variant of <see cref="CreateLabel"/>: each entry (key + value) fans out
+    /// through the normal single-label path with shared top-level fields. A failed
+    /// entry is recorded but does not abort the batch — the report aggregates per-entry
+    /// outcomes so a partial success is still actionable.
+    /// </summary>
+    public ToolResult<object> CreateLabels(
+        IReadOnlyList<(string key, string value)> entries,
+        string? file, bool overwrite = false,
+        string? installTo = null, string? lang = null, string? labelFile = null)
+    {
+        if (entries is null || entries.Count == 0)
+            return ToolResult<object>.Fail(D365FoErrorCodes.BadInput,
+                "labels array is empty.",
+                "Provide labels:[{key,value}, …], or use a single create with key+value.");
+
+        var results = new List<object>(entries.Count);
+        int created = 0, failed = 0;
+        foreach (var (key, value) in entries)
+        {
+            var r = CreateLabel(file, key, value, overwrite, installTo, lang, labelFile);
+            if (r.Ok) created++; else failed++;
+            results.Add(new
+            {
+                key,
+                ok = r.Ok,
+                error = r.Error?.Code,
+                message = r.Error?.Message,
+            });
+        }
+        return ToolResult<object>.Success(new { total = entries.Count, created, failed, results });
+    }
+
     public ToolResult<object> RenameLabel(string file, string oldKey, string newKey, bool overwrite = false)
     {
         if (string.IsNullOrWhiteSpace(file)) return ToolResult<object>.Fail(D365FoErrorCodes.BadInput, "file required");

--- a/tests/D365FO.Core.Tests/McpDispatcherTests.cs
+++ b/tests/D365FO.Core.Tests/McpDispatcherTests.cs
@@ -212,6 +212,37 @@ public class McpDispatcherTests : IDisposable
     }
 
     [Fact]
+    public async Task Labels_create_fans_out_bulk_array()
+    {
+        var file = Path.Combine(Path.GetTempPath(), $"d365fo-lbl-{Guid.NewGuid():N}.en-us.label.txt");
+        try
+        {
+            // A `labels:[…]` array writes every entry through the single-create path
+            // with the shared top-level file; the report aggregates per-entry results.
+            var req = "{\"jsonrpc\":\"2.0\",\"id\":26,\"method\":\"tools/call\",\"params\":{\"name\":\"labels\","
+                    + "\"arguments\":{\"action\":\"create\",\"file\":\"" + file.Replace("\\", "\\\\") + "\","
+                    + "\"labels\":[{\"key\":\"@Con:One\",\"value\":\"First\"},"
+                    + "{\"labelId\":\"@Con:Two\",\"text\":\"Second\"}]}}}";
+            var resp = await Roundtrip(req);
+            var doc = Assert.Single(resp);
+            var payload = JsonDocument.Parse(doc.RootElement.GetProperty("result")
+                .GetProperty("content")[0].GetProperty("text").GetString()!);
+            Assert.True(payload.RootElement.GetProperty("ok").GetBoolean());
+            var data = payload.RootElement.GetProperty("data");
+            Assert.Equal(2, data.GetProperty("total").GetInt32());
+            Assert.Equal(2, data.GetProperty("created").GetInt32());
+            Assert.Equal(0, data.GetProperty("failed").GetInt32());
+            var written = await File.ReadAllTextAsync(file);
+            Assert.Contains("First", written);
+            Assert.Contains("Second", written);
+        }
+        finally
+        {
+            if (File.Exists(file)) File.Delete(file);
+        }
+    }
+
+    [Fact]
     public async Task ExtensionInfo_points_accepts_full_extension_name()
     {
         // The dispatch must reach the handler and resolve the dotted extension


### PR DESCRIPTION
…server)

Mirrors the upstream d365fo-mcp-server bulk-labels feature (2026-06 wave). The MCP `labels` tool's `create` action now accepts a `labels:[{key,value}, …]` array with shared top-level fields (file/installTo/lang/labelFile/overwrite).

Each entry fans out through the existing single-create path (validation/write unchanged); a failed entry is recorded but does not abort the batch. The report aggregates per-entry outcomes (total/created/failed/results[]). Entry keys tolerate key|labelId and values value|text|label, matching the single-create aliases. Absent a `labels` array, behaviour is unchanged (single create).

The post-2026-06-16 upstream wave was otherwise reviewed and found non-portable: TS/Node-runtime robustness has no C# analog (StdioDispatcher is sequential, so in-flight dedup is moot), and the write/modify/smart-scaffold fixes target a surface this adapter does not expose (no CDATA bridge writes, no EDT inference).

Test: McpDispatcherTests.Labels_create_fans_out_bulk_array.