### PR TITLE
fix(scaffolding): document all XppScaffolder.Table params (CS1573)

### DIFF
--- a/src/D365FO.Core/Scaffolding/XppScaffolder.cs
+++ b/src/D365FO.Core/Scaffolding/XppScaffolder.cs
@@ -13,6 +13,23 @@ namespace D365FO.Core.Scaffolding;
 /// </summary>
 public static class XppScaffolder
 {
+    /// <summary>
+    /// Scaffolds an <c>AxTable</c> XML skeleton: fields (from <paramref name="fields"/>
+    /// or the <paramref name="pattern"/> preset), an alternate-key index, and the
+    /// table group/type implied by the pattern and storage.
+    /// </summary>
+    /// <param name="name">Table name (the AOT <c>&lt;Name&gt;</c> and file stem).</param>
+    /// <param name="label">Optional label; emitted as <c>&lt;Label&gt;</c> when set.</param>
+    /// <param name="fields">
+    /// Explicit field list. Wins over the pattern preset; when null/empty the preset
+    /// for <paramref name="pattern"/> is used.
+    /// </param>
+    /// <param name="pattern">Table pattern preset driving default fields and table group.</param>
+    /// <param name="storage">Storage kind; anything other than a regular table stamps <c>&lt;TableType&gt;</c>.</param>
+    /// <param name="primaryKeyFields">
+    /// Optional field names for the primary/alternate-key index. Names that don't match
+    /// an effective field are ignored; falls back to mandatory fields, then the first field.
+    /// </param>
     /// <param name="edtBaseTypeResolver">
     /// Optional callback resolving an EDT name to its primitive base type
     /// (<c>String</c>, <c>Int</c>, <c>Enum</c>, …) — typically backed by the


### PR DESCRIPTION
## What

`dotnet build d365fo-cli.slnx -c Release` produced 6 `CS1573` warnings in `XppScaffolder.cs` (reported by @soerenprintz in #65):

```
warning CS1573: Parameter 'name' has no matching param tag in the XML comment for 'XppScaffolder.Table(...)' (but other parameters do)
... (label, fields, pattern, storage, primaryKeyFields)
```

CS1573 fires when *some but not all* parameters of a method carry a `<param>` tag. `XppScaffolder.Table` only documented `edtBaseTypeResolver`, so the other six were flagged.

## Fix

Added a `<summary>` for the method and `<param>` tags for every parameter. No behavioural change — documentation only.

## Verification

```
dotnet build d365fo-cli.slnx -c Release
→ 0 upozornění / 0 warnings, 0 errors
```

Closes #65

🤖 Generated with [Claude Code](https://claude.com/claude-code)