### PR TITLE
docs: clarify when to run MCP + CLI side by side (#95)

### DIFF
--- a/docs/MIGRATION_FROM_MCP.md
+++ b/docs/MIGRATION_FROM_MCP.md
@@ -23,17 +23,25 @@ Both tools share an **identical purpose** — give GitHub Copilot access to real
 | Agent without a shell tool (Claude.ai web, ChatGPT web) | MCP |
 | Want both — Copilot picks the cheaper one per task | Side by side (Path A below) |
 
+### When to run both side by side
+
+Run them side by side only when a single index must serve agents with **mixed shell-tool support** (e.g. Copilot in VS Code alongside Claude.ai web), or during a **migration grace period** before you confirm the CLI path covers everything.
+
+Be aware of the cost: keeping MCP registered injects its full schema overhead (~1,800 tok/turn — see [TOKEN_ECONOMICS.md](TOKEN_ECONOMICS.md)) on **every** turn, including turns where only the CLI is called. The "Copilot picks the cheaper one" benefit applies per *call*, not per *turn*, so for a single agent with a working shell tool, prefer **CLI only (Path B)** — it is both cheaper and simpler.
+
 ---
 
 ## Migration
 
-### Path A — side-by-side operation (recommended)
+### Path A — side-by-side operation (mixed environments / migration)
 
 The existing `.mcp.json` and `copilot-instructions.md` stay unchanged. The CLI is added alongside:
 
 1. Build and deploy the CLI — see [SETUP.md](SETUP.md).
 2. Copy `skills/copilot/*.instructions.md` to `.github/instructions/` in your X++ project.
 3. Copilot automatically uses the shell tool for CLI commands and MCP for tool calls — both from the same index.
+
+> **Heads-up — `copilot-instructions.md` collision.** The per-topic skills in `.github/instructions/*.instructions.md` have unique filenames and coexist fine. But both the CLI and `d365fo-mcp-server` ship a top-level `.github/copilot-instructions.md` and install it with `Copy-Item -Force`, so it's last-installer-wins, not a merge — re-running the other installer clobbers it again. Keep **one** canon file: the CLI's, which is the schema-v5 superset and already documents the shell-first flow plus a no-shell fallback. You don't need the MCP server's instruction file for its tools to work — MCP tools are registered via `.mcp.json` and their schemas are self-describing; the instruction file only guides behaviour, it doesn't enable the tools.
 
 ### Path B — CLI only
 

--- a/docs/TOKEN_ECONOMICS.md
+++ b/docs/TOKEN_ECONOMICS.md
@@ -55,6 +55,8 @@ Figures use the post-consolidation MCP baseline (~1,800 tok/turn). Real workflow
 | Single one-off lookup per session | Either — an MCP warm connection has no per-turn startup cost |
 | Agent needs the full generated XML back in context | Avoid both — `d365fo generate` always writes to `--out` and returns a JSON summary only |
 
+> **Running CLI + MCP side by side?** Keeping MCP registered pays the full ~1,800 tok/turn schema overhead on *every* turn, even ones that only call the CLI — the per-call savings don't offset a per-turn cost. Side by side is worth it only for mixed shell-tool environments or a migration grace period; for a single agent with a working shell tool, prefer CLI only. See [MIGRATION_FROM_MCP.md](MIGRATION_FROM_MCP.md#when-to-run-both-side-by-side).
+
 ---
 
 ## Sources


### PR DESCRIPTION
Closes the documentation gap raised in #95: the docs explained *how* to run the MCP server and CLI side by side, but not *why* you would — or what trips you up when you do.

## Changes

**`docs/MIGRATION_FROM_MCP.md`**
- New **"When to run both side by side"** section — side by side is worth it only for mixed shell-tool environments (e.g. Copilot + Claude.ai web) or a migration grace period; for a single agent with a working shell tool, prefer CLI only.
- Renamed Path A from *"(recommended)"* to *"(mixed environments / migration)"* so it no longer reads as the universal default.
- Documented the **`.github/copilot-instructions.md` collision**: both installers `Copy-Item -Force` the same top-level file (last-installer-wins, not a merge), while the per-topic `.github/instructions/*.instructions.md` skills coexist fine. MCP tools are registered via `.mcp.json` and self-describing, so you only need one canon instructions file (the CLI's superset).

**`docs/TOKEN_ECONOMICS.md`**
- Note that keeping MCP registered pays its full ~1,800 tok/turn schema overhead on *every* turn — even turns where only the CLI is called — so the per-call "pick the cheaper one" benefit doesn't offset a per-turn cost.

## Why

Two users in #95 hit exactly these two questions (when does side-by-side make sense, and why do the instruction files keep overriding each other). This makes the answer discoverable in the docs instead of only in the issue thread.

🤖 Generated with [Claude Code](https://claude.com/claude-code)