### PR TITLE
docs: disambiguate D365FO_WORKSPACE_PATH from IDE workspace for Copilot instruction discovery

### DIFF
--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -19,6 +19,8 @@
 | `D365FO_INDEX_DB` | Path to the SQLite index file | `%LOCALAPPDATA%\d365fo-cli\d365fo-index.sqlite` |
 | `D365FO_WORKSPACE_PATH` | Root of your X++ solution (enables scaffold output) | — |
 | `D365FO_CUSTOM_MODELS` | Comma-separated list of custom model names | — |
+
+> ⚠️ **`D365FO_WORKSPACE_PATH` is not the same thing as your editor's "workspace".** This variable only tells the `d365fo` CLI where scaffolded X++ output should be written. It has **no effect** on where Visual Studio or VS Code loads GitHub Copilot instruction files from — that is determined purely by the folder/`.sln` you have open in the editor (see [SETUP.md — Connect your AI agent](SETUP.md#step-5--connect-your-ai-agent)). Setting `D365FO_WORKSPACE_PATH` does **not** make Copilot pick up `.github/copilot-instructions.md` from that path.
 | `D365FO_BRIDGE_ENABLED` | `1`/`true` enables the metadata bridge (required for `generate --install-to` and `find refs --xref`) | `false` |
 | `D365FO_BRIDGE_PATH` | Path to `D365FO.Bridge.exe` (auto-detected next to `d365fo.exe` when unset) | *(auto)* |
 | `D365FO_BIN_PATH` | Folder containing `Microsoft.Dynamics.AX.Metadata.*.dll` (usually `<PackagesLocalDirectory>\bin`) | — |

--- a/docs/SETUP.md
+++ b/docs/SETUP.md
@@ -168,6 +168,15 @@ flowchart LR
 
 > ⚠️ **Never** use `@workspace` or built-in code search on AOT XML. It always fails. Copilot must use `d365fo` exclusively for codebase queries; the Skills enforce this.
 
+> ⚠️ **"Workspace" means two unrelated things here — don't conflate them.**
+>
+> | Term | What it controls | Set via |
+> |---|---|---|
+> | `D365FO_WORKSPACE_PATH` (CLI env var) | Where `d365fo generate` writes scaffolded X++ files | `d365fo init` / `settings.json` / env var |
+> | Editor "workspace" (VS solution root / VS Code opened folder) | Where Copilot looks for `.github/copilot-instructions.md` and `.github/instructions/*.instructions.md` | Which folder/`.sln` you open in the IDE |
+>
+> Setting `D365FO_WORKSPACE_PATH` (or any `D365FO_*` env var) has **zero effect** on Copilot's instruction discovery. If Copilot isn't finding your instructions, the fix is always about **which folder is open in the editor**, never about CLI configuration — re-run `Install-D365FoCopilotSkills.ps1` against the actual parent folder you open, not against `D365FO_WORKSPACE_PATH`.
+
 ### Claude Code (CLI or VS Code extension)
 
 ```sh

--- a/docs/TROUBLESHOOTING.md
+++ b/docs/TROUBLESHOOTING.md
@@ -230,6 +230,31 @@ and report it so the catalog's version list can be updated.
 
 ---
 
+## Copilot isn't finding the instruction files
+
+### "I set `D365FO_WORKSPACE_PATH` / `D365FO_CUSTOM_PACKAGES_PATH` but Copilot still doesn't use the Skills"
+
+These are two completely unrelated concepts that happen to share the word "workspace":
+
+| Term | What it controls |
+|---|---|
+| `D365FO_WORKSPACE_PATH`, `D365FO_PACKAGES_PATH`, `D365FO_CUSTOM_PACKAGES_PATH` (CLI env vars) | Where the `d365fo` CLI indexes metadata from / writes scaffolded output to |
+| The folder/`.sln` open in Visual Studio or VS Code ("workspace" in the IDE sense) | Where Copilot looks for `.github/copilot-instructions.md` and `.github/instructions/*.instructions.md` |
+
+No `D365FO_*` environment variable or `settings.json` entry has any effect on Copilot's instruction discovery. Copilot (both in Visual Studio and VS Code) only walks **upward from the folder/solution you actually opened in the editor** looking for a `.github/` folder — it never reads CLI configuration.
+
+Fix, in order:
+
+1. Confirm which folder is actually open in the editor (Visual Studio: the `.sln`'s folder; VS Code: File → Open Folder).
+2. Re-run `Install-D365FoCopilotSkills.ps1` targeting that exact folder (or a parent of it) as `-XppRepo`, not the `D365FO_WORKSPACE_PATH` / `D365FO_CUSTOM_PACKAGES_PATH` value.
+3. Visual Studio only: enable **Tools → Options → GitHub → Copilot → Copilot Chat → "Enable custom instructions to be loaded from .github/copilot-instructions.md files and added to requests."**
+4. No shared parent solution/`.sln` above your projects? Use the global fallback instead of per-project copies:
+   - Visual Studio: concatenate `skills/copilot/*.instructions.md` into `%USERPROFILE%\copilot-instructions.md` (applies to every solution, but loses `applyTo` scoping).
+   - VS Code: point `chat.instructionsFilesLocations` at one shared folder containing the `*.instructions.md` files (keeps `applyTo` scoping).
+5. Verify: after Copilot answers, expand **References / "Used N references"** in the reply — loaded instruction files are listed there. If your file isn't listed, it wasn't discovered.
+
+---
+
 ## MCP tool count and token budget
 
 ### How many tools are exposed


### PR DESCRIPTION
## Why

Follow-up to #88. The root cause of the confusion was a naming collision:

- `D365FO_WORKSPACE_PATH` (CLI env var) only controls where scaffolded X++ output is written.
- The "workspace" Copilot / Visual Studio use to discover `.github/copilot-instructions.md` and `.github/instructions/*.instructions.md` is purely the folder/`.sln` open in the editor — it has nothing to do with any `D365FO_*` env var or `settings.json` entry.

soerenprintz's config never set `D365FO_WORKSPACE_PATH` at all in the second box, yet still assumed CLI config controlled Copilot discovery — confirming the docs didn't make this distinction clear anywhere.

## What changed

- `docs/CONFIGURATION.md` — callout under the `D365FO_WORKSPACE_PATH` row disambiguating it from the IDE workspace concept.
- `docs/SETUP.md` — callout in the \"Connect your AI agent\" section with a two-row table contrasting the CLI env var vs. the editor's opened folder/solution.
- `docs/TROUBLESHOOTING.md` — new \"Copilot isn't finding the instruction files\" section with a step-by-step fix (confirm open folder → re-run the install script against that folder → enable the VS toggle → use the global fallback if there's no shared parent solution → verify via the References list).

Closes #88.