### PR TITLE
fix(generate): populate Overview/General table field groups (#91)

### DIFF
--- a/src/D365FO.Core/Scaffolding/XppScaffolder.cs
+++ b/src/D365FO.Core/Scaffolding/XppScaffolder.cs
@@ -126,11 +126,27 @@ public static class XppScaffolder
                 // predictable physical ordering (validate xpp XML005).
                 indexesEl is null ? null : new XElement("ClusteredIndex", "PrimaryIdx"),
                 new XElement("Fields", fieldEls),
+                // "Overview" and "General" are referenced by <DataGroup> in every
+                // generated form pattern (SimpleList, SimpleListDetails,
+                // DetailsMaster, DetailsTransaction) — the metadata reader
+                // rejects the form with "Field group 'Overview' does not exist"
+                // when the underlying table lacks them (issue #91 follow-up).
+                // AutoReport is the standard AX lookup/report group. All three
+                // are populated with every effective field so any pattern's
+                // grid/group controls resolve.
                 new XElement("FieldGroups",
-                    new XElement("AxTableFieldGroup",
-                        new XElement("Name", "AutoReport"))),
+                    BuildFieldGroup("AutoReport", effectiveFields),
+                    BuildFieldGroup("Overview", effectiveFields),
+                    BuildFieldGroup("General", effectiveFields)),
                 indexesEl));
     }
+
+    private static XElement BuildFieldGroup(string name, IReadOnlyList<TableFieldSpec> fields) =>
+        new XElement("AxTableFieldGroup",
+            new XElement("Name", name),
+            new XElement("Fields",
+                fields.Select(f => new XElement("AxTableFieldGroupField",
+                    new XElement("DataField", f.Name)))));
 
     public static XDocument Class(string name, string? extends = null, bool isFinal = true)
     {


### PR DESCRIPTION
## Problem

Follow-up to #91: after the metadata-API fix landed, newly generated tables and forms "look better", but forms fail with:

```
Path: [AxForm/.../Design/Controls/Grid/DataGroup]: Field group 'Overview' does not exist.
```

Newly scaffolded tables only emitted an `AutoReport` field group. Every generated form pattern (`SimpleList`, `SimpleListDetails`, `DetailsMaster`, `DetailsTransaction`) references `<DataGroup>Overview</DataGroup>` and/or `<DataGroup>General</DataGroup>` on its grid/group controls, so form generation against a freshly scaffolded table failed metadata validation — and the CLI silently dropped the data group from the grid/controls as a workaround, losing the field-group layout.

## Fix

`XppScaffolder.Table` now emits `Overview` and `General` field groups (in addition to `AutoReport`), each populated with every effective field, so any form pattern's grid/group `DataGroup` reference resolves against the newly created table.

## Testing

- `dotnet build src/D365FO.Core` — clean
- `dotnet test tests/D365FO.Core.Tests` — 268/268 passing

Closes #91