### PR TITLE
Add precise field-level lookup (find fields / find_tables_by_field) — fixes #101

### DIFF
--- a/src/D365FO.Cli/Commands/Agent/SchemaCommand.cs
+++ b/src/D365FO.Cli/Commands/Agent/SchemaCommand.cs
@@ -173,6 +173,7 @@ public sealed class SchemaCommand : Command<SchemaCommand.Settings>
         C("find coc", "Find Chain-of-Command extensions.", ["<TARGET>"], ["--output"], ["extension_info (mode=coc)"]),
         C("find relations", "Find table relations.", ["<TABLE>"], ["--output"], ["get_object_info (objectType=table,relations)"]),
         C("find usages", "Find indexed entities whose names contain a substring.", ["<SYMBOL>"], ["--limit", "--output"], ["search (type=any)"]),
+        C("find fields", "Find tables that declare a field name or EDT (exact match) — precise field-level lookup, not relation/FK or source-code search.", ["<NAME>"], ["--model", "--limit", "--output"], ["find_tables_by_field"]),
         C("find extensions", "Find Table/Form/Edt/Enum extensions targeting an object.", ["<TARGET>"], ["--kind", "--output"], ["extension_info (mode=points)", "extension_info (mode=table-merge)"]),
         C("find handlers", "Find event subscribers.", ["<OBJECT>"], ["--kind", "--output"], ["extension_info (mode=events)"]),
         C("find event-handlers", "Alias of `find handlers`.", ["<OBJECT>"], ["--kind", "--output"], ["extension_info (mode=events)"]),

--- a/src/D365FO.Cli/Commands/Find/FindCommands.cs
+++ b/src/D365FO.Cli/Commands/Find/FindCommands.cs
@@ -80,6 +80,40 @@ public sealed class FindUsagesCommand : Command<FindUsagesCommand.Settings>
     }
 }
 
+/// <summary>
+/// Field-level lookup: "which tables contain field/EDT X". Exact match against
+/// TableFields.Name / TableFields.EdtName — NOT a relation or FK lookup, and
+/// NOT a source-code grep. Use this instead of `find refs --kind table` or
+/// `find relations` when the question is about a table's own field list.
+/// </summary>
+public sealed class FindFieldsCommand : Command<FindFieldsCommand.Settings>
+{
+    public sealed class Settings : D365OutputSettings
+    {
+        [CommandArgument(0, "<NAME>")]
+        [System.ComponentModel.Description("Field name or EDT name to match exactly (e.g. CustAccount).")]
+        public string Name { get; init; } = "";
+
+        [CommandOption("--model <NAME>")]
+        [System.ComponentModel.Description("Restrict to a single model.")]
+        public string? Model { get; init; }
+
+        [CommandOption("-l|--limit <N>")]
+        public int Limit { get; init; } = 200;
+    }
+
+    public override int Execute(CommandContext ctx, Settings settings)
+    {
+        var kind = OutputMode.Resolve(settings.Output);
+        if (string.IsNullOrWhiteSpace(settings.Name))
+            return RenderHelpers.Render(kind, ToolResult<object>.Fail("BAD_INPUT", "Name required."));
+        var repo = RepoFactory.Create();
+        var items = repo.FindTablesByField(settings.Name, settings.Model, settings.Limit);
+        return RenderHelpers.Render(kind,
+            ToolResult<object>.Success(new { count = items.Count, items }));
+    }
+}
+
 public sealed class FindExtensionsCommand : Command<FindExtensionsCommand.Settings>
 {
     public sealed class Settings : D365OutputSettings
@@ -181,10 +215,22 @@ public sealed class FindRefsCommand : Command<FindRefsCommand.Settings>
 
         // Regex scan over indexed X++ source — shared with the unified
         // `find_references` MCP tool (D365FO.Mcp.ToolHandlers.FindReferences).
-        var repo = RepoFactory.Create();
-        var result = new D365FO.Mcp.ToolHandlers(repo)
-            .FindReferences(settings.Name, settings.Kind, settings.Model, settings.Limit);
-        return RenderHelpers.Render(kind, result);
+        // Wrapped so an unexpected disk/index error surfaces as a clear
+        // ToolResult.Fail instead of an unhandled exception (issue #101).
+        try
+        {
+            var repo = RepoFactory.Create();
+            var result = new D365FO.Mcp.ToolHandlers(repo)
+                .FindReferences(settings.Name, settings.Kind, settings.Model, settings.Limit);
+            return RenderHelpers.Render(kind, result);
+        }
+        catch (Exception ex)
+        {
+            return RenderHelpers.Render(kind, ToolResult<object>.Fail(
+                "SCAN_FAILED",
+                $"find refs failed: {ex.Message}",
+                "Try narrowing --kind/--model, or run `d365fo doctor --output json` to confirm the index is healthy."));
+        }
     }
 }
 

--- a/src/D365FO.Cli/Program.cs
+++ b/src/D365FO.Cli/Program.cs
@@ -82,6 +82,7 @@ app.Configure(cfg =>
         b.AddCommand<FindCocCommand>("coc").WithDescription("Find Chain-of-Command extensions.");
         b.AddCommand<FindRelationsCommand>("relations").WithDescription("Find table relations.");
         b.AddCommand<FindUsagesCommand>("usages").WithDescription("Find index entities whose name contains a substring.");
+        b.AddCommand<FindFieldsCommand>("fields").WithDescription("Find tables that declare a field name or EDT (exact match) — precise field-level lookup, not a relation/FK or source-code search.");
         b.AddCommand<FindExtensionsCommand>("extensions").WithDescription("Find Table/Form/Edt/Enum extensions targeting an object.");
         b.AddCommand<FindHandlersCommand>("handlers").WithDescription("Find event handlers subscribed to a form/table/delegate.");
         b.AddCommand<FindRefsCommand>("refs").WithDescription("Regex scan of indexed X++ source for reverse references to a symbol.");

--- a/src/D365FO.Core/Index/MetadataRepository.cs
+++ b/src/D365FO.Core/Index/MetadataRepository.cs
@@ -1700,6 +1700,30 @@ public sealed partial class MetadataRepository
 
     // ---- additional read operations ----
 
+    /// <summary>
+    /// Tables that actually declare a field named <paramref name="name"/> (exact,
+    /// case-insensitive) or whose field uses an EDT named <paramref name="name"/>
+    /// (exact, case-insensitive, walking the EdtName column only — not relation
+    /// FK targets). This answers "which tables contain field X" precisely; use
+    /// this instead of <c>find refs</c> or relation lookups, which answer a
+    /// different question (source-code references / FK relation targets) and
+    /// silently inflate the result set with unrelated tables. See issue #101.
+    /// </summary>
+    public IReadOnlyList<TableFieldMatch> FindTablesByField(string name, string? model = null, int limit = 200)
+    {
+        using var conn = OpenReadOnly();
+        return conn.Query<TableFieldMatch>(@"
+            SELECT t.Name AS TableName, m.Name AS Model, f.Name AS FieldName,
+                   f.Type AS Type, f.EdtName AS EdtName, f.Mandatory AS Mandatory
+            FROM TableFields f
+            JOIN Tables t ON t.TableId = f.TableId
+            JOIN Models m ON m.ModelId = t.ModelId
+            WHERE (f.Name = @name COLLATE NOCASE OR f.EdtName = @name COLLATE NOCASE)
+              AND (@model IS NULL OR m.Name = @model)
+            ORDER BY t.Name
+            LIMIT @limit", new { name, model, limit }).ToList();
+    }
+
     public IReadOnlyList<TableInfo> SearchTables(string query, string? model = null, int limit = 50)
     {
         using var conn = OpenReadOnly();

--- a/src/D365FO.Core/Index/Models.cs
+++ b/src/D365FO.Core/Index/Models.cs
@@ -67,6 +67,19 @@ public sealed record TableFieldInfo(
     string? Label,
     bool Mandatory);
 
+/// <summary>
+/// A table that has a field whose name or EDT matches a lookup — used by
+/// <see cref="MetadataRepository.FindTablesByField"/> to answer "which tables
+/// contain field X" precisely (as opposed to relation-based heuristics).
+/// </summary>
+public sealed record TableFieldMatch(
+    string TableName,
+    string Model,
+    string FieldName,
+    string? Type,
+    string? EdtName,
+    bool Mandatory);
+
 public sealed record TableDetails(
     TableInfo Table,
     IReadOnlyList<TableFieldInfo> Fields,

--- a/src/D365FO.Mcp/ToolCatalog.cs
+++ b/src/D365FO.Mcp/ToolCatalog.cs
@@ -255,6 +255,14 @@ public static class ToolCatalog
             Schema(("name", "string", true), ("kind", "string", false), ("model", "string", false), ("limit", "integer", false)),
             (h, p) => h.FindReferences(Str(p, "name"), StrOrNull(p, "kind"), StrOrNull(p, "model"), Int(p, "limit", 200))),
 
+        new Descriptor("find_tables_by_field",
+            "Which tables declare a field named `name` (or whose field uses an EDT named `name`) — exact match. " +
+            "Use this for 'which tables contain field X' questions. Do NOT use find_references or relation lookups for " +
+            "this — those answer source-code usage / FK-relation targets, not a table's own field list, and will " +
+            "return an inflated, semantically-wrong result set.",
+            Schema(("name", "string", true), ("model", "string", false), ("limit", "integer", false)),
+            (h, p) => h.FindTablesByField(Str(p, "name"), StrOrNull(p, "model"), Int(p, "limit", 200))),
+
         new Descriptor("validate_object_naming",
             "Static naming-rule check (PascalCase, length, character set, extension suffix, optional publisher prefix). No index access required.",
             Schema(("kind", "string", true), ("name", "string", true), ("prefix", "string", false)),

--- a/src/D365FO.Mcp/ToolHandlers.cs
+++ b/src/D365FO.Mcp/ToolHandlers.cs
@@ -1519,4 +1519,19 @@ public sealed class ToolHandlers
             items,
         });
     }
+
+    /// <summary>
+    /// Field-level lookup shared with the CLI <c>find fields</c> command: which
+    /// tables declare a field (or use an EDT) with this exact name. Answers
+    /// "which tables contain field X" without the relation/FK false-positives
+    /// that <c>find_references</c> / relation lookups produce (issue #101).
+    /// </summary>
+    public ToolResult<object> FindTablesByField(string name, string? model, int limit = 200)
+    {
+        if (string.IsNullOrWhiteSpace(name))
+            return ToolResult<object>.Fail("BAD_INPUT", "name is required.");
+
+        var items = _repo.FindTablesByField(name, model, limit);
+        return ToolResult<object>.Success(new { count = items.Count, items });
+    }
 }

--- a/tests/D365FO.Core.Tests/ExtractPipelineTests.cs
+++ b/tests/D365FO.Core.Tests/ExtractPipelineTests.cs
@@ -62,6 +62,20 @@ public class ExtractPipelineTests : IDisposable
 
         var usages = repo.FindUsages("Fleet");
         Assert.NotEmpty(usages);
+
+        // Field-level lookup: exact field name and exact EDT name should both
+        // resolve to the same table (issue #101 — relation-based results were
+        // being confused with actual field membership).
+        var byFieldName = repo.FindTablesByField("Vin");
+        var hit = Assert.Single(byFieldName);
+        Assert.Equal("FleetVehicle", hit.TableName);
+        Assert.Equal("VinEdt", hit.EdtName);
+
+        var byEdtName = repo.FindTablesByField("VinEdt");
+        Assert.Single(byEdtName);
+        Assert.Equal("FleetVehicle", byEdtName[0].TableName);
+
+        Assert.Empty(repo.FindTablesByField("NoSuchFieldOrEdt"));
     }
 
     [Fact]


### PR DESCRIPTION
## Summary

Closes #101.

The root cause of the reported CLI/MCP divergence was that neither surface had
an actual field-level lookup. \`find refs --kind table\` scans X++ **method
bodies** for a symbol, and \`find relations\` walks foreign-key relations —
neither answers "which tables contain a field named X", so agents fell back to
a relation-based heuristic that returned 100+ unrelated tables (anything with a
FK relation to CustTable via the CustAccount EDT).

## Changes

- **`MetadataRepository.FindTablesByField(name, model, limit)`** — exact
  (case-insensitive) match against `TableFields.Name` / `TableFields.EdtName`.
  This is the precise query for "which tables declare field X or use EDT X".
- **CLI**: new `d365fo find fields <NAME> [--model] [--limit] --output json`.
- **MCP**: new `find_tables_by_field` tool for CLI/MCP parity, with a
  description that explicitly warns agents off `find_references`/relation
  lookups for this question.
- **`d365fo schema`**: added an entry for `find fields` so agents discover it.
- **Hardening**: `FindRefsCommand.Execute` now wraps the scan in try/catch and
  returns a clear `SCAN_FAILED` error instead of failing silently, per the
  issue's acceptance criteria (point 1). I could not reproduce the actual
  `find refs --kind table` failure — same as the issue reporter, I don't have
  a live D365FO metadata index to test against — but this ensures any future
  failure is surfaced instead of silently degrading to a wrong heuristic.
- Unit test added covering field-name and EDT-name lookups
  (`ExtractPipelineTests.ApplyExtract_is_idempotent_and_counts_match`).

## Testing

- `dotnet build` (whole solution) — 0 warnings, 0 errors.
- `dotnet test` — 423 passed, 0 failed.

## Acceptance criteria from #101

- [x] CLI now has a command that answers "which tables contain field X" with
      the same precise scoping (exact field/EDT match) rather than a
      relation-based heuristic — closing the CLI/MCP parity gap.
- [x] `find refs --kind table` no longer fails silently; any error now returns
      a clear `SCAN_FAILED` result.