### PR TITLE
fix(menu-item): emit Symbol image to avoid BPErrorMissingOrUnsupportedImage

### DIFF
--- a/skills/_source/form-pattern-scaffolding.md
+++ b/skills/_source/form-pattern-scaffolding.md
@@ -207,3 +207,4 @@ d365fo generate menu-item FmOrdersReportMenuItem \
 - One menu item per AOT type (`AxMenuItemDisplay`, `AxMenuItemAction`, `AxMenuItemOutput`) — naming convention `<ObjectName>MenuItem` or `<ObjectName>Action`.
 - Do not create an `Action` menu item pointing to a form — use `Display`.
 - After creating a menu item, it must be added to a menu or a security privilege to be reachable.
+- Generated menu items always include `<Image><ImageType>Symbol</ImageType></Image>` — this avoids `BPErrorMissingOrUnsupportedImage` (an omitted or `File`-typed image fails best-practice checks; `Symbol` inherits the icon from the target object and is always valid).

--- a/skills/anthropic/form-pattern-scaffolding/SKILL.md
+++ b/skills/anthropic/form-pattern-scaffolding/SKILL.md
@@ -200,3 +200,4 @@ d365fo generate menu-item FmOrdersReportMenuItem \
 - One menu item per AOT type (`AxMenuItemDisplay`, `AxMenuItemAction`, `AxMenuItemOutput`) — naming convention `<ObjectName>MenuItem` or `<ObjectName>Action`.
 - Do not create an `Action` menu item pointing to a form — use `Display`.
 - After creating a menu item, it must be added to a menu or a security privilege to be reachable.
+- Generated menu items always include `<Image><ImageType>Symbol</ImageType></Image>` — this avoids `BPErrorMissingOrUnsupportedImage` (an omitted or `File`-typed image fails best-practice checks; `Symbol` inherits the icon from the target object and is always valid).

--- a/skills/copilot/form-pattern-scaffolding.instructions.md
+++ b/skills/copilot/form-pattern-scaffolding.instructions.md
@@ -199,3 +199,4 @@ d365fo generate menu-item FmOrdersReportMenuItem \
 - One menu item per AOT type (`AxMenuItemDisplay`, `AxMenuItemAction`, `AxMenuItemOutput`) — naming convention `<ObjectName>MenuItem` or `<ObjectName>Action`.
 - Do not create an `Action` menu item pointing to a form — use `Display`.
 - After creating a menu item, it must be added to a menu or a security privilege to be reachable.
+- Generated menu items always include `<Image><ImageType>Symbol</ImageType></Image>` — this avoids `BPErrorMissingOrUnsupportedImage` (an omitted or `File`-typed image fails best-practice checks; `Symbol` inherits the icon from the target object and is always valid).

--- a/src/D365FO.Core/Scaffolding/MenuItemScaffolder.cs
+++ b/src/D365FO.Core/Scaffolding/MenuItemScaffolder.cs
@@ -38,6 +38,11 @@ public static class MenuItemScaffolder
             new XElement(rootElement,
                 new XElement("Name", name),
                 string.IsNullOrEmpty(label) ? null : new XElement("Label", label),
+                // Explicit Symbol image avoids BPErrorMissingOrUnsupportedImage:
+                // an omitted <Image> still resolves to the unsupported "File" type
+                // during best-practice checks, so state Symbol (inherit icon) up front.
+                new XElement("Image",
+                    new XElement("ImageType", "Symbol")),
                 new XElement("Object", objectName),
                 new XElement("ObjectType", objTypeStr)));
     }

--- a/tests/D365FO.Cli.Tests/ScaffoldingSnapshotTests.cs
+++ b/tests/D365FO.Cli.Tests/ScaffoldingSnapshotTests.cs
@@ -440,4 +440,30 @@ public class ScaffoldingSnapshotTests
         var lookupSrc = methods.First(m => m.Element("Name")!.Value == "lookupVendor").Element("Source")!.Value;
         Assert.DoesNotContain("[SysEntryPointAttribute", lookupSrc);
     }
+
+    // ---- MenuItem (issue #102) ----
+
+    [Fact]
+    public void MenuItem_emits_Symbol_image_to_avoid_BPErrorMissingOrUnsupportedImage()
+    {
+        // Omitting <Image> (or leaving it defaulted to File) trips
+        // BPErrorMissingOrUnsupportedImage during best-practice checks.
+        // Symbol tells the compiler to inherit the icon, which is always valid.
+        var doc = MenuItemScaffolder.MenuItem(MenuItemKind.Display, "MyMenuItem", "MyForm");
+        var root = doc.Root!;
+        Assert.Equal("AxMenuItemDisplay", root.Name.LocalName);
+        Assert.Equal("Symbol", root.Element("Image")!.Element("ImageType")!.Value);
+    }
+
+    [Theory]
+    [InlineData(MenuItemKind.Display, "AxMenuItemDisplay")]
+    [InlineData(MenuItemKind.Action, "AxMenuItemAction")]
+    [InlineData(MenuItemKind.Output, "AxMenuItemOutput")]
+    public void MenuItem_all_kinds_emit_Symbol_image(MenuItemKind kind, string expectedRoot)
+    {
+        var doc = MenuItemScaffolder.MenuItem(kind, "MyMenuItem", "MyObject");
+        var root = doc.Root!;
+        Assert.Equal(expectedRoot, root.Name.LocalName);
+        Assert.Equal("Symbol", root.Element("Image")!.Element("ImageType")!.Value);
+    }
 }


### PR DESCRIPTION
## Summary

Fixes #102.

`d365fo generate menu-item` never emitted an `<Image>` element for
`AxMenuItemDisplay` / `AxMenuItemAction` / `AxMenuItemOutput`. During best
practice checks, an omitted image resolves to the unsupported `File` type
and triggers:

```
BPErrorMissingOrUnsupportedImage: A missing or unsupported image is being
used by 'MenuItem' in form ''.
```

## Fix

`MenuItemScaffolder` now always emits:

```xml
<Image>
  <ImageType>Symbol</ImageType>
</Image>
```

`Symbol` tells the compiler to inherit the icon from the target object,
which is always valid and resolves the BP error out of the box — no new
CLI flags needed.

## Changes

- `src/D365FO.Core/Scaffolding/MenuItemScaffolder.cs` — emit the `Image`/`ImageType=Symbol` element for all three menu item kinds.
- `tests/D365FO.Cli.Tests/ScaffoldingSnapshotTests.cs` — snapshot tests covering Display/Action/Output.
- `skills/_source/form-pattern-scaffolding.md` (+ regenerated `skills/copilot/` and `skills/anthropic/` variants) — document the default.

## Testing

- `dotnet test` on `ScaffoldingSnapshotTests` and `ScaffoldingSmokeTests` — 70 passed.