### PR TITLE
fix(find): include extension-added fields in `find fields`

### DIFF
--- a/src/D365FO.Core/Index/MetadataRepository.cs
+++ b/src/D365FO.Core/Index/MetadataRepository.cs
@@ -1724,6 +1724,7 @@ public sealed partial class MetadataRepository
             JOIN Models m ON m.ModelId = t.ModelId
             WHERE (f.Name = @name COLLATE NOCASE OR f.EdtName = @name COLLATE NOCASE)
               AND (@model IS NULL OR m.Name = @model)
+            ORDER BY t.Name
             LIMIT @limit", new { name, model, limit }))
         {
             results.Add(new TableFieldMatch(
@@ -1746,6 +1747,7 @@ public sealed partial class MetadataRepository
             JOIN Models m ON m.ModelId = ef.ModelId
             WHERE (ef.Name = @name COLLATE NOCASE OR ef.EdtName = @name COLLATE NOCASE)
               AND (@model IS NULL OR m.Name = @model)
+            ORDER BY ef.TargetTable
             LIMIT @limit", new { name, model, limit }))
         {
             results.Add(new TableFieldMatch(

--- a/src/D365FO.Core/Index/MetadataRepository.cs
+++ b/src/D365FO.Core/Index/MetadataRepository.cs
@@ -1712,7 +1712,11 @@ public sealed partial class MetadataRepository
     public IReadOnlyList<TableFieldMatch> FindTablesByField(string name, string? model = null, int limit = 200)
     {
         using var conn = OpenReadOnly();
-        return conn.Query<TableFieldMatch>(@"
+
+        // Base-table fields (TableFields). Queried as real columns so the SQLite
+        // provider reports column types correctly; provenance is stamped in C#.
+        var results = new List<TableFieldMatch>();
+        foreach (var r in conn.Query(@"
             SELECT t.Name AS TableName, m.Name AS Model, f.Name AS FieldName,
                    f.Type AS Type, f.EdtName AS EdtName, f.Mandatory AS Mandatory
             FROM TableFields f
@@ -1720,8 +1724,41 @@ public sealed partial class MetadataRepository
             JOIN Models m ON m.ModelId = t.ModelId
             WHERE (f.Name = @name COLLATE NOCASE OR f.EdtName = @name COLLATE NOCASE)
               AND (@model IS NULL OR m.Name = @model)
-            ORDER BY t.Name
-            LIMIT @limit", new { name, model, limit }).ToList();
+            LIMIT @limit", new { name, model, limit }))
+        {
+            results.Add(new TableFieldMatch(
+                (string)r.TableName, (string)r.Model, (string)r.FieldName,
+                (string?)r.Type, (string?)r.EdtName,
+                r.Mandatory is not null && Convert.ToBoolean(r.Mandatory),
+                Source: "base"));
+        }
+
+        // Extension-added fields (ExtensionFields). An AxTableExtension field
+        // materialises as a real column on the target table's physical SQL table,
+        // so omitting these made `find fields` under-report versus a direct
+        // database column query (e.g. CustAccount added to ContactPerson via
+        // ContactPerson.<Ext>). The @model filter matches the extension's owning
+        // model here (vs the base table's model above).
+        foreach (var r in conn.Query(@"
+            SELECT ef.TargetTable AS TableName, m.Name AS Model, ef.Name AS FieldName,
+                   ef.Type AS Type, ef.EdtName AS EdtName, ef.ExtensionName AS ExtensionName
+            FROM ExtensionFields ef
+            JOIN Models m ON m.ModelId = ef.ModelId
+            WHERE (ef.Name = @name COLLATE NOCASE OR ef.EdtName = @name COLLATE NOCASE)
+              AND (@model IS NULL OR m.Name = @model)
+            LIMIT @limit", new { name, model, limit }))
+        {
+            results.Add(new TableFieldMatch(
+                (string)r.TableName, (string)r.Model, (string)r.FieldName,
+                (string?)r.Type, (string?)r.EdtName, Mandatory: false,
+                Source: "extension", ExtensionName: (string?)r.ExtensionName));
+        }
+
+        return results
+            .OrderBy(x => x.TableName, StringComparer.Ordinal)
+            .ThenBy(x => x.Source, StringComparer.Ordinal)
+            .Take(limit)
+            .ToList();
     }
 
     public IReadOnlyList<TableInfo> SearchTables(string query, string? model = null, int limit = 50)

--- a/src/D365FO.Core/Index/Models.cs
+++ b/src/D365FO.Core/Index/Models.cs
@@ -71,6 +71,14 @@ public sealed record TableFieldInfo(
 /// A table that has a field whose name or EDT matches a lookup — used by
 /// <see cref="MetadataRepository.FindTablesByField"/> to answer "which tables
 /// contain field X" precisely (as opposed to relation-based heuristics).
+/// <para>
+/// <see cref="Source"/> is <c>"base"</c> when the field is declared on the base
+/// table (<c>TableFields</c>) and <c>"extension"</c> when it is added by an
+/// <c>AxTableExtension</c> (<c>ExtensionFields</c>). Extension-added fields land
+/// on the same physical SQL column as base fields, so both must be returned to
+/// reconcile with a direct database column query. <see cref="ExtensionName"/>
+/// names the owning extension for <c>"extension"</c> rows and is null otherwise.
+/// </para>
 /// </summary>
 public sealed record TableFieldMatch(
     string TableName,
@@ -78,7 +86,9 @@ public sealed record TableFieldMatch(
     string FieldName,
     string? Type,
     string? EdtName,
-    bool Mandatory);
+    bool Mandatory,
+    string Source = "base",
+    string? ExtensionName = null);
 
 public sealed record TableDetails(
     TableInfo Table,

--- a/tests/D365FO.Core.Tests/ExtractPipelineTests.cs
+++ b/tests/D365FO.Core.Tests/ExtractPipelineTests.cs
@@ -108,6 +108,65 @@ public class ExtractPipelineTests : IDisposable
     }
 
     [Fact]
+    public void FindTablesByField_limit_returns_deterministic_alphabetical_order_across_base_and_extension()
+    {
+        var repo = new MetadataRepository(_dbPath);
+        repo.EnsureSchema();
+
+        // Base tables declaring "SharedField" directly, inserted in REVERSE
+        // alphabetical order so the two alphabetically-earliest names (AlphaTable,
+        // BravoTable) are the LAST rows written. Without an ORDER BY before the
+        // SQL-side LIMIT, SQLite's unordered scan returns rows in insertion order,
+        // so a naive `LIMIT @limit` would truncate away exactly the earliest names
+        // before the final in-memory sort ever sees them.
+        var baseTableNames = new[]
+        {
+            "GolfTable", "FoxtrotTable", "EchoTable", "DeltaTable", "CharlieTable", "BravoTable", "AlphaTable",
+        };
+        var tables = baseTableNames.Select(n => new ExtractedTable(n, null, $"/x/{n}.xml",
+            new[] { new ExtractedTableField("SharedField", "String", null, null, false) })).ToArray();
+
+        // Extension-added "SharedField" on further tables, sorting well after the
+        // base tables above but also inserted in reverse order, to exercise the
+        // same truncation risk on the ExtensionFields query.
+        var extTableNames = new[]
+        {
+            "NovemberTable", "MikeTable", "LimaTable", "KiloTable", "JulietTable", "IndiaTable", "HotelTable",
+        };
+        var extensions = extTableNames.Select(n => new ExtractedObjectExtension(
+            "Table", n, $"{n}.SharedExt", $"/x/{n}.SharedExt.xml")
+        {
+            AddedFields = new[] { new ExtractedTableField("SharedField", "String", null, null, false) },
+        }).ToArray();
+
+        var batch = new ExtractBatch(
+            Model: "Shared",
+            Publisher: "Contoso",
+            Layer: "usr",
+            IsCustom: true,
+            Tables: tables,
+            Classes: Array.Empty<ExtractedClass>(),
+            Edts: Array.Empty<ExtractedEdt>(),
+            Enums: Array.Empty<ExtractedEnum>(),
+            MenuItems: Array.Empty<ExtractedMenuItem>(),
+            CocExtensions: Array.Empty<ExtractedCoc>(),
+            Labels: Array.Empty<ExtractedLabel>())
+        {
+            Extensions = extensions,
+        };
+
+        repo.ApplyExtract(batch);
+
+        // 14 total matches (7 base + 7 extension); ask for far fewer so the
+        // per-source SQL-side LIMIT actually kicks in on both queries.
+        var results = repo.FindTablesByField("SharedField", limit: 5);
+
+        Assert.Equal(
+            new[] { "AlphaTable", "BravoTable", "CharlieTable", "DeltaTable", "EchoTable" },
+            results.Select(r => r.TableName).ToArray());
+    }
+
+    [Fact]
     public void MetadataExtractor_reads_a_synthetic_model()
     {
         var model = Path.Combine(_workRoot, "Contoso", "Contoso");

--- a/tests/D365FO.Core.Tests/ExtractPipelineTests.cs
+++ b/tests/D365FO.Core.Tests/ExtractPipelineTests.cs
@@ -41,7 +41,23 @@ public class ExtractPipelineTests : IDisposable
             Enums: new[] { new ExtractedEnum("FleetKind", "Kind", new[] { new ExtractedEnumValue("Car", 0, "Car") }) },
             MenuItems: new[] { new ExtractedMenuItem("FleetForm", "Display", "FleetVehicleForm", "Form", null) },
             CocExtensions: new[] { new ExtractedCoc("CustTable", "update", "CustTable_Extension") },
-            Labels: new[] { new ExtractedLabel("FleetLabels", "en-us", "VIN", "Vehicle Identification Number") });
+            Labels: new[] { new ExtractedLabel("FleetLabels", "en-us", "VIN", "Vehicle Identification Number") })
+        {
+            // Extension that adds a field to a DIFFERENT table (CustTable) using the
+            // same EDT as the base FleetVehicle.Vin field. Exercises the base +
+            // extension union in FindTablesByField (find-fields gap fix).
+            Extensions = new[]
+            {
+                new ExtractedObjectExtension("Table", "CustTable", "CustTable.FleetExtension",
+                    "/x/CustTable.FleetExtension.xml")
+                {
+                    AddedFields = new[]
+                    {
+                        new ExtractedTableField("FleetVin", "ExtendedDataType", "VinEdt", "Fleet VIN", false),
+                    },
+                },
+            },
+        };
 
         repo.ApplyExtract(batch);
         var counts1 = repo.CountAll();
@@ -70,10 +86,23 @@ public class ExtractPipelineTests : IDisposable
         var hit = Assert.Single(byFieldName);
         Assert.Equal("FleetVehicle", hit.TableName);
         Assert.Equal("VinEdt", hit.EdtName);
+        Assert.Equal("base", hit.Source);
 
+        // EDT lookup now spans base-table fields AND extension-added fields, so it
+        // reconciles with a direct SQL column query (find-fields gap fix).
         var byEdtName = repo.FindTablesByField("VinEdt");
-        Assert.Single(byEdtName);
-        Assert.Equal("FleetVehicle", byEdtName[0].TableName);
+        Assert.Equal(2, byEdtName.Count);
+        Assert.Contains(byEdtName, r => r.TableName == "FleetVehicle" && r.Source == "base");
+        var extByEdt = Assert.Single(byEdtName, r => r.Source == "extension");
+        Assert.Equal("CustTable", extByEdt.TableName);
+        Assert.Equal("CustTable.FleetExtension", extByEdt.ExtensionName);
+
+        // The extension-added field also resolves by its own name and carries provenance.
+        var byExtField = repo.FindTablesByField("FleetVin");
+        var extHit = Assert.Single(byExtField);
+        Assert.Equal("CustTable", extHit.TableName);
+        Assert.Equal("extension", extHit.Source);
+        Assert.Equal("CustTable.FleetExtension", extHit.ExtensionName);
 
         Assert.Empty(repo.FindTablesByField("NoSuchFieldOrEdt"));
     }


### PR DESCRIPTION
## Problem

`find fields` (`MetadataRepository.FindTablesByField`) only queried the base-table `TableFields`. Fields added via an **`AxTableExtension`** were never returned — even though such a field materialises as a **real column** on the target table's physical SQL table.

This surfaced while reconciling `find fields CustAccount` against a **direct SQL column query** (`SELECT ... WHERE column = 'CUSTACCOUNT'`) over a full `PackagesLocalDirectory`:

| | Before |
|---|---|
| Tables in SQL, missing from index | **4** |

Two of the four (`ContactPerson`, `PersonSearchCriteriaKnownId`) get their `CustAccount` column from a table extension and were silently absent. (The other two — `AgreementHeader`/`AgreementHeaderHistory` — are table-inheritance cases whose field is correctly indexed under the derived `SalesAgreementHeader`; not a bug.)

## Fix

- **Include `ExtensionFields` in `FindTablesByField`.** Assembled in C# from two real-column queries rather than a `UNION` subquery — a compound/subquery strips column `decltype`s, after which Microsoft.Data.Sqlite mis-reports the computed `Mandatory`/`Source` columns as `byte[]` and Dapper fails to materialise the record.
- **Add provenance to `TableFieldMatch`:** `Source` (`"base"` | `"extension"`) and `ExtensionName` (owning extension for extension rows, `null` for base). Backward-compatible — new params default, existing fields unchanged.
- **Test:** `ExtractPipelineTests` now covers an extension-added field, asserting both name/EDT lookup and `Source`/`ExtensionName`.

## Verification (live index)

```
find fields CustAccount  →  734 matches (724 base + 10 extension)
  ContactPerson                → source=extension via ContactPerson.ApplicationSuiteExtension
  PersonSearchCriteriaKnownId  → source=extension via PersonSearchCriteriaKnownId.ExtensionAppSuite

SQL-vs-index reconciliation delta: 4 → 2
  (remaining 2 are table-inheritance, correctly indexed under the derived table)
```

`dotnet test` — `ExtractPipelineTests` all green; no new failures introduced.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0151gWZSfi9gCTPM9BLwr2ry