### PR TITLE
fix: port upstream d365fo-mcp-server fixes (2026-07 wave)

### DIFF
--- a/docs/CAPABILITIES.md
+++ b/docs/CAPABILITIES.md
@@ -170,10 +170,10 @@ All scaffolders write atomically (`.tmp` + move, `.bak` on overwrite). Pass `--i
 | `generate form` | `AxForm` XML (9 patterns: SimpleList, DetailsMaster, Workspace …) |
 | `generate datasource-method` | Add/override a method on a form datasource (form-level `SourceCode`); `--list` shows overridable methods |
 | `generate control-method` | Add/override a method on a form control (form-level `SourceCode`); `--list` shows overridable methods |
-| `generate entity` | `AxDataEntityView` |
-| `generate extension` | `AxTableExtension` / `AxFormExtension` / `AxEdtExtension` / `AxEnumExtension` |
+| `generate entity` | `AxDataEntityView` (`DataManagementEnabled=No` by default; opt in via `--data-management`) |
+| `generate extension` | `AxTableExtension` / `AxFormExtension` / `AxEdtExtension` / `AxEnumExtension` / `AxSecurityDutyExtension` / `AxSecurityRoleExtension` |
 | `generate event-handler` | X++ event subscriber class with correct attribute |
-| `generate privilege` | `AxSecurityPrivilege` |
+| `generate privilege` | `AxSecurityPrivilege` (entry point and/or `--data-entity` OData/DMF grant) |
 | `generate duty` | `AxSecurityDuty` |
 | `generate role` | `AxSecurityRole` (new or merge into existing) |
 | `generate menu-item` | `AxMenuItemDisplay` / `AxMenuItemAction` / `AxMenuItemOutput` |

--- a/docs/followups/upstream-port-2026-07.md
+++ b/docs/followups/upstream-port-2026-07.md
@@ -1,0 +1,51 @@
+# Follow-up: upstream d365fo-mcp-server changes NOT ported in the 2026-07 wave
+
+The 2026-07 port wave (branch `claude/d365fo-mcp-port-plan-joqtl0`) synced the
+CLI with upstream `d365fo-mcp-server` up to PR #671 (2026-07-09) for bug fixes
+to functionality the CLI already has. The items below were deliberately
+deferred — each is either a whole missing subsystem (a feature decision, not a
+bug fix) or targets a surface this CLI does not expose.
+
+## Deferred — candidate future features
+
+- **Modify operations on existing objects** (upstream `b81ae94` modify-enum-value
+  rename, `922d262` add-control, `03d698f` modify-property false-success,
+  `4b772f1`/`3b14715` modify param aliases, `f045b6c` CDATA source guard).
+  The CLI mutates existing objects only via `generate datasource-method` /
+  `control-method` and `generate role --add-to`; there is no
+  modify-property/add-field/add-control/replace-code surface. Porting this is a
+  new command family (`d365fo modify …`) plus bridge verbs — the CLI bridge
+  (`src/D365FO.Bridge`) only exposes generic Save/Update/Delete of whole
+  artifacts.
+- **Knowledge base + build-error hint scoring** (upstream `bf4ed28` error-hint
+  scoring false positives, `31b9ced` Excel/CSV + parallel-batch + direct-SQL
+  X++ topics, `9183f63` AxMenuElementSubMenu doc). The CLI has no
+  `get_knowledge`/error-help subsystem; only the form-pattern catalog was ever
+  ported (`src/D365FO.Core/FormPatterns`).
+- **View / Map creation** (upstream `a36f4ac` map `edt` alias + property docs,
+  `dac1413` view datasource docs). The CLI only reads/indexes views and maps;
+  there is no `ViewScaffolder`/`MapScaffolder`. The upstream alias fixes become
+  relevant only once creation exists.
+- **TRUDUtils-style generators + form auto-repair** (upstream `17ac6e2`
+  deterministic form control expander, find-methods, relation-xpp; `7c8a210`
+  form repair + Create Table Relation). Partial overlap exists
+  (`FormMethodScaffolder`, `FormPatternValidator`), but the control
+  expander/repair pipeline is a feature port of its own.
+- **Bulk multi-key label creation** (upstream `2cfaf38` `labels:[{labelId,…}]`
+  with per-item error isolation). The CLI's `label create` fans out one key to
+  multiple locales; multi-key batches would extend
+  `src/D365FO.Cli/Commands/Label/LabelWriteCommands.cs`.
+
+## Not applicable to this codebase (permanently)
+
+- Upstream bridge verbs the CLI bridge does not expose: per-property setters
+  (`Set<Type>Property`), `CreateFormControl`, `AddMenuItemToMenu`,
+  `add-data-source` (upstream `7d4314c`, `111949a` bridge parts). The CLI
+  bridge persists caller-built XML via `MetadataBootstrap.SaveArtifact`;
+  `BuildModelSaveInfo` already resolves runtime `ModelInfo` incl. `Name`,
+  `Id`, `SequenceId` — verified equivalent to upstream `111949a`.
+- `createSmartTable` routing (`817bd4c`): the CLI's `generate table` already
+  emits smart defaults (field groups, PrimaryIdx, ClusteredIndex) directly.
+- MCP-server infrastructure: eval framework/oracle/corpus, tool-schema token
+  diet, stdio crash handling, in-flight dedup, Node interactive management
+  CLI, startup UX.

--- a/src/D365FO.Bridge/Handlers.cs
+++ b/src/D365FO.Bridge/Handlers.cs
@@ -37,8 +37,38 @@ namespace D365FO.Bridge
         internal JsonObject ReadClass(JsonObject args) { return ReadArtifact(args, "Classes", "class"); }
         internal JsonObject ReadTable(JsonObject args) { return ReadArtifact(args, "Tables", "table"); }
         internal JsonObject ReadEdt(JsonObject args) { return ReadArtifact(args, "Edts", "edt"); }
-        internal JsonObject ReadEnum(JsonObject args) { return ReadArtifact(args, "Enums", "enum"); }
+        internal JsonObject ReadEnum(JsonObject args)
+        {
+            var result = ReadArtifact(args, "Enums", "enum");
+            FixPositionalEnumValues(result);
+            return result;
+        }
+
         internal JsonObject ReadForm(JsonObject args) { return ReadArtifact(args, "Forms", "form"); }
+
+        /// <summary>
+        /// UseEnumValue=No (required for extensible enums) omits the &lt;Value&gt;
+        /// element from the XML entirely, so AxEnumValue.Value deserialises to its
+        /// int default (0) for every member — no exception, no fallback. The value
+        /// that actually gets compiled is position-based (0,1,2,… by declaration
+        /// order), so only trust the serialised Value when UseEnumValue=Yes and
+        /// substitute the declaration-order index otherwise.
+        /// </summary>
+        private static void FixPositionalEnumValues(JsonObject result)
+        {
+            if (result == null || !(result["ok"] is JsonNode okNode) || !string.Equals(okNode.ToString(), "true", StringComparison.OrdinalIgnoreCase)) return;
+            if (!(result["data"] is JsonObject data)) return;
+            var useEnumValue = data["UseEnumValue"] != null ? data["UseEnumValue"].ToString() : null;
+            if (string.Equals(useEnumValue, "Yes", StringComparison.OrdinalIgnoreCase)) return;
+            if (!(data["EnumValues"] is JsonArray values)) return;
+            for (int i = 0; i < values.Count; i++)
+            {
+                if (values[i] is JsonObject v && v["Value"] != null)
+                {
+                    v["Value"] = JsonValue.Create(i.ToString(System.Globalization.CultureInfo.InvariantCulture));
+                }
+            }
+        }
 
         // --- write path -----------------------------------------------------
 

--- a/src/D365FO.Cli/Commands/Generate/GenerateCommands.cs
+++ b/src/D365FO.Cli/Commands/Generate/GenerateCommands.cs
@@ -485,6 +485,50 @@ internal static class GenerateFormImpl
 
         var sectionSpecs = ParseSections(sections);
 
+        // Caption resolution: explicit --caption wins; otherwise reuse the bound
+        // table's Label from the index (a raw-text caption trips
+        // BPErrorLabelIsText, the table's label is already translated). Falls
+        // back to no <Caption> element when neither is available.
+        var effectiveCaption = caption;
+        var preflightWarnings = new List<string>();
+        if (!string.IsNullOrWhiteSpace(table))
+        {
+            try
+            {
+                var t = RepoFactory.Create().GetTableDetails(table!)?.Table;
+                if (t is not null)
+                {
+                    if (string.IsNullOrWhiteSpace(effectiveCaption) && !string.IsNullOrWhiteSpace(t.Label))
+                        effectiveCaption = t.Label;
+
+                    // The index is a cache that is never invalidated on delete or
+                    // rollback — verify the table's XML still exists before
+                    // trusting the hit, so a form is not bound to a phantom table.
+                    if (!string.IsNullOrEmpty(t.SourcePath) && !File.Exists(t.SourcePath))
+                    {
+                        preflightWarnings.Add(
+                            $"Table '{table}' is in the index but its XML no longer exists on disk ({t.SourcePath}) — " +
+                            "it may have been deleted or rolled back. Run `d365fo index refresh` and verify the table before using this form.");
+                    }
+                    else if (!string.IsNullOrEmpty(t.SourcePath))
+                    {
+                        // SimpleList/SimpleListDetails/DetailsMaster/DetailsTransaction
+                        // controls reference the table's Overview (and sometimes
+                        // General) field group via <DataGroup>; a missing group
+                        // renders an empty grid and flags BP on build.
+                        foreach (var group in RequiredFieldGroups(pattern))
+                        {
+                            if (!TableDefinesFieldGroup(t.SourcePath!, group))
+                                preflightWarnings.Add(
+                                    $"Form pattern {pattern} references field group '{group}' but table '{table}' does not define it " +
+                                    "(extension-added groups are not checked). Add the field group to the table, or the bound controls will render empty.");
+                        }
+                    }
+                }
+            }
+            catch { /* index may be empty; not fatal */ }
+        }
+
         string xml;
         try
         {
@@ -492,7 +536,7 @@ internal static class GenerateFormImpl
                 formName:        formName,
                 dataSourceTable: table,
                 pattern:         pattern,
-                caption:         caption,
+                caption:         effectiveCaption,
                 gridFields:      fields,
                 sections:        sectionSpecs,
                 linesTable:      linesTable);
@@ -506,8 +550,9 @@ internal static class GenerateFormImpl
         // block the write while D365FO_FORM_PATTERN_ENFORCE=true (the default),
         // mirroring the upstream MCP form-pattern write gate.
         var patternReport = D365FO.Core.FormPatterns.FormPatternValidator.ValidateXml(xml);
-        var patternWarnings = patternReport.Violations
-            .Select(v => $"form-pattern {v.Rule} [{v.Severity}] {v.Path}: {v.Excerpt}")
+        var patternWarnings = preflightWarnings
+            .Concat(patternReport.Violations
+                .Select(v => $"form-pattern {v.Rule} [{v.Severity}] {v.Path}: {v.Excerpt}"))
             .ToList();
         if (patternReport.HasErrors && FormPatternGate.EnforcementEnabled)
         {
@@ -544,6 +589,31 @@ internal static class GenerateFormImpl
                 },
             },
             patternWarnings.Count > 0 ? patternWarnings : null);
+    }
+
+    /// <summary>Field groups a pattern's controls reference via &lt;DataGroup&gt; (see FormTemplates/*.template.xml).</summary>
+    internal static IReadOnlyList<string> RequiredFieldGroups(FormPattern pattern) => pattern switch
+    {
+        FormPattern.SimpleList or FormPattern.DetailsTransaction => new[] { "Overview" },
+        FormPattern.SimpleListDetails or FormPattern.DetailsMaster => new[] { "Overview", "General" },
+        _ => Array.Empty<string>(),
+    };
+
+    internal static bool TableDefinesFieldGroup(string tableXmlPath, string groupName)
+    {
+        try
+        {
+            var doc = System.Xml.Linq.XDocument.Load(tableXmlPath);
+            return doc.Root?
+                .Element("FieldGroups")?
+                .Elements("AxTableFieldGroup")
+                .Any(g => string.Equals(g.Element("Name")?.Value, groupName, StringComparison.OrdinalIgnoreCase)) == true;
+        }
+        catch
+        {
+            // Unreadable XML must not block form generation — skip the warning.
+            return true;
+        }
     }
 
     private static IReadOnlyList<FormSectionSpec> ParseSections(IReadOnlyList<string> raw)

--- a/src/D365FO.Cli/Commands/Generate/GenerateMoreCommands.cs
+++ b/src/D365FO.Cli/Commands/Generate/GenerateMoreCommands.cs
@@ -29,6 +29,14 @@ public sealed class GenerateEntityCommand : Command<GenerateEntityCommand.Settin
         [CommandOption("--all-fields")]
         [System.ComponentModel.Description("Populate <Fields /> from the source table's columns. Requires the table to be indexed.")]
         public bool AllFields { get; init; }
+
+        [CommandOption("--data-management")]
+        [System.ComponentModel.Description("Emit DataManagementEnabled=Yes. Off by default: the staging table is NOT generated, so enabling this without an existing <ENTITY>Staging table fails the next build.")]
+        public bool DataManagement { get; init; }
+
+        [CommandOption("--staging-table <TABLE>")]
+        [System.ComponentModel.Description("Staging table name when --data-management is set (default: <ENTITY>Staging).")]
+        public string? StagingTable { get; init; }
     }
 
     public override int Execute(CommandContext ctx, Settings settings)
@@ -64,7 +72,8 @@ public sealed class GenerateEntityCommand : Command<GenerateEntityCommand.Settin
             autoFromTable = true;
         }
         var doc = XppScaffolder.DataEntity(
-            settings.EntityName, settings.Table!, settings.PublicEntity, settings.PublicCollection, fields);
+            settings.EntityName, settings.Table!, settings.PublicEntity, settings.PublicCollection, fields,
+            settings.DataManagement, settings.StagingTable);
         try
         {
             var res = ScaffoldFileWriter.Write(doc, outPath!, settings.Overwrite);
@@ -103,7 +112,7 @@ public sealed class GenerateExtensionCommand : Command<GenerateExtensionCommand.
     public sealed class Settings : GenerateSettings
     {
         [CommandArgument(0, "<KIND>")]
-        [System.ComponentModel.Description("Extension kind: Table, Form, Edt, Enum.")]
+        [System.ComponentModel.Description("Extension kind: Table, Form, Edt, Enum, SecurityDuty, SecurityRole.")]
         public string Kind { get; init; } = "";
 
         [CommandArgument(1, "<TARGET>")]
@@ -112,6 +121,14 @@ public sealed class GenerateExtensionCommand : Command<GenerateExtensionCommand.
         [CommandOption("--suffix <SUFFIX>")]
         [System.ComponentModel.Description("Extension suffix. Defaults to the InstallTo model name or 'Extension'.")]
         public string? Suffix { get; init; }
+
+        [CommandOption("--privilege <NAME>")]
+        [System.ComponentModel.Description("Repeatable; SecurityDuty/SecurityRole only: privilege reference to add to the base duty/role.")]
+        public string[] Privileges { get; init; } = Array.Empty<string>();
+
+        [CommandOption("--duty <NAME>")]
+        [System.ComponentModel.Description("Repeatable; SecurityRole only: duty reference to add to the base role.")]
+        public string[] Duties { get; init; } = Array.Empty<string>();
     }
 
     public override int Execute(CommandContext ctx, Settings settings)
@@ -128,17 +145,20 @@ public sealed class GenerateExtensionCommand : Command<GenerateExtensionCommand.
 
         var suffix = settings.Suffix
             ?? (hasInstall ? settings.InstallTo! : "Extension");
-        var axFolder = settings.Kind switch
+        var normalizedKind = settings.Kind.Replace("-", "").Replace("_", "");
+        var axFolder = normalizedKind.ToLowerInvariant() switch
         {
-            "Table" => "AxTableExtension",
-            "Form" => "AxFormExtension",
-            "Edt" => "AxEdtExtension",
-            "Enum" => "AxEnumExtension",
+            "table" => "AxTableExtension",
+            "form" => "AxFormExtension",
+            "edt" => "AxEdtExtension",
+            "enum" => "AxEnumExtension",
+            "securityduty" => "AxSecurityDutyExtension",
+            "securityrole" => "AxSecurityRoleExtension",
             _ => null,
         };
         if (axFolder is null)
             return RenderHelpers.Render(kind, ToolResult<object>.Fail(D365FoErrorCodes.BadInput,
-                $"Unsupported extension kind: {settings.Kind}. Expected Table|Form|Edt|Enum."));
+                $"Unsupported extension kind: {settings.Kind}. Expected Table|Form|Edt|Enum|SecurityDuty|SecurityRole."));
 
         var fullName = $"{settings.Target}.{suffix}";
         var outPath = settings.Out;
@@ -148,7 +168,12 @@ public sealed class GenerateExtensionCommand : Command<GenerateExtensionCommand.
             if (fail.HasValue) return fail.Value;
         }
 
-        var doc = XppScaffolder.Extension(settings.Kind, settings.Target, suffix);
+        var doc = axFolder switch
+        {
+            "AxSecurityDutyExtension" => XppScaffolder.SecurityDutyExtension(settings.Target, suffix, settings.Privileges),
+            "AxSecurityRoleExtension" => XppScaffolder.SecurityRoleExtension(settings.Target, suffix, settings.Duties, settings.Privileges),
+            _ => XppScaffolder.Extension(axFolder["Ax".Length..^"Extension".Length], settings.Target, suffix),
+        };
 
         // Grounding gate: the target object must exist in the index; fail
         // closed under D365FO_GROUNDING_ENFORCE=true.
@@ -267,6 +292,14 @@ public sealed class GeneratePrivilegeCommand : Command<GeneratePrivilegeCommand.
         [CommandOption("--label <TEXT>")]
         public string? Label { get; init; }
 
+        [CommandOption("--data-entity <NAME>")]
+        [System.ComponentModel.Description("Grant OData/DMF permissions on this data entity (emits <DataEntityPermissions>).")]
+        public string? DataEntity { get; init; }
+
+        [CommandOption("--data-entity-access <LEVEL>")]
+        [System.ComponentModel.Description("view (Read only, default) | maintain (Correct/Create/Delete/Read/Update).")]
+        public string DataEntityAccess { get; init; } = "view";
+
         [CommandOption("--into-role <PATH>")]
         [System.ComponentModel.Description("Path to an existing AxSecurityRole XML; after scaffolding, merge this privilege's Name into the role's <Privileges>.")]
         public string? IntoRole { get; init; }
@@ -277,8 +310,11 @@ public sealed class GeneratePrivilegeCommand : Command<GeneratePrivilegeCommand.
         var kind = OutputMode.Resolve(settings.Output);
         if (string.IsNullOrWhiteSpace(settings.Name))
             return RenderHelpers.Render(kind, ToolResult<object>.Fail(D365FoErrorCodes.BadInput, "Privilege name required."));
-        if (string.IsNullOrWhiteSpace(settings.EntryPoint))
-            return RenderHelpers.Render(kind, ToolResult<object>.Fail(D365FoErrorCodes.BadInput, "--entry-point required."));
+        if (string.IsNullOrWhiteSpace(settings.EntryPoint) && string.IsNullOrWhiteSpace(settings.DataEntity))
+            return RenderHelpers.Render(kind, ToolResult<object>.Fail(D365FoErrorCodes.BadInput, "--entry-point or --data-entity required."));
+        if (!string.Equals(settings.DataEntityAccess, "view", StringComparison.OrdinalIgnoreCase)
+            && !string.Equals(settings.DataEntityAccess, "maintain", StringComparison.OrdinalIgnoreCase))
+            return RenderHelpers.Render(kind, ToolResult<object>.Fail(D365FoErrorCodes.BadInput, "--data-entity-access must be view or maintain."));
         var hasInstall = !string.IsNullOrWhiteSpace(settings.InstallTo);
         var hasOut = !string.IsNullOrWhiteSpace(settings.Out);
         if (!hasInstall && !hasOut)
@@ -290,7 +326,8 @@ public sealed class GeneratePrivilegeCommand : Command<GeneratePrivilegeCommand.
             if (fail.HasValue) return fail.Value;
         }
 
-        var doc = XppScaffolder.Privilege(settings.Name, settings.EntryPoint!, settings.EntryKind, settings.EntryObject, settings.Access, settings.Label);
+        var doc = XppScaffolder.Privilege(settings.Name, settings.EntryPoint, settings.EntryKind, settings.EntryObject, settings.Access, settings.Label,
+            settings.DataEntity, settings.DataEntityAccess);
         try
         {
             var res = ScaffoldFileWriter.Write(doc, outPath!, settings.Overwrite);
@@ -313,6 +350,8 @@ public sealed class GeneratePrivilegeCommand : Command<GeneratePrivilegeCommand.
                 entryPoint = settings.EntryPoint,
                 entryKind = settings.EntryKind,
                 access = settings.Access,
+                dataEntity = settings.DataEntity,
+                dataEntityAccess = settings.DataEntity is null ? null : settings.DataEntityAccess,
                 path = res.Path,
                 bytes = res.Bytes,
                 backup = res.BackupPath,

--- a/src/D365FO.Cli/Commands/Label/LabelWriteCommands.cs
+++ b/src/D365FO.Cli/Commands/Label/LabelWriteCommands.cs
@@ -37,6 +37,10 @@ public sealed class LabelCreateCommand : Command<LabelCreateCommand.Settings>
         [CommandOption("--overwrite")]
         [System.ComponentModel.Description("Replace an existing value. Default: fail with KEY_EXISTS.")]
         public bool Overwrite { get; init; }
+
+        [CommandOption("--allow-extension-label-file")]
+        [System.ComponentModel.Description("Permit writing into a label file EXTENSION (…_Extension…). Off by default: new labels belong in the model's original label file.")]
+        public bool AllowExtensionLabelFile { get; init; }
     }
 
     public override int Execute(CommandContext ctx, Settings settings)
@@ -81,6 +85,16 @@ public sealed class LabelCreateCommand : Command<LabelCreateCommand.Settings>
                 var diskLang = ResolveOnDiskCasing(resourcesDir, lang);
                 resolvedFiles.Add(System.IO.Path.Combine(resourcesDir, diskLang, $"{lf}.{diskLang}.label.txt"));
             }
+        }
+
+        if (!settings.AllowExtensionLabelFile)
+        {
+            var extFile = resolvedFiles.FirstOrDefault(LabelFileWriter.IsExtensionLabelFile);
+            if (extFile is not null)
+                return RenderHelpers.Render(kind, ToolResult<object>.Fail(
+                    "EXTENSION_LABEL_FILE",
+                    $"'{System.IO.Path.GetFileName(extFile)}' is a label file EXTENSION — it only extends a base label file owned by another model. New labels belong in the model's ORIGINAL label file.",
+                    hint: "Target the model's own label file (e.g. --label-file <MODEL>), or pass --allow-extension-label-file to override."));
         }
 
         try
@@ -151,6 +165,10 @@ public sealed class LabelRenameCommand : Command<LabelRenameCommand.Settings>
 
         [CommandOption("--overwrite")]
         public bool Overwrite { get; init; }
+
+        [CommandOption("--allow-extension-label-file")]
+        [System.ComponentModel.Description("Permit renaming inside a label file EXTENSION (…_Extension…). Off by default.")]
+        public bool AllowExtensionLabelFile { get; init; }
     }
 
     public override int Execute(CommandContext ctx, Settings settings)
@@ -160,6 +178,11 @@ public sealed class LabelRenameCommand : Command<LabelRenameCommand.Settings>
             return RenderHelpers.Render(kind, ToolResult<object>.Fail(D365FoErrorCodes.BadInput, "Both <OLD> and <NEW> label keys required."));
         if (string.IsNullOrWhiteSpace(settings.File))
             return RenderHelpers.Render(kind, ToolResult<object>.Fail(D365FoErrorCodes.BadInput, "--file <PATH> required."));
+        if (!settings.AllowExtensionLabelFile && LabelFileWriter.IsExtensionLabelFile(settings.File!))
+            return RenderHelpers.Render(kind, ToolResult<object>.Fail(
+                "EXTENSION_LABEL_FILE",
+                $"'{System.IO.Path.GetFileName(settings.File)}' is a label file EXTENSION — it only extends a base label file owned by another model.",
+                hint: "Rename the label in the model's ORIGINAL label file, or pass --allow-extension-label-file to override."));
 
         try
         {

--- a/src/D365FO.Core/Extract/MetadataExtractor.cs
+++ b/src/D365FO.Core/Extract/MetadataExtractor.cs
@@ -708,6 +708,9 @@ public sealed class MetadataExtractor
         if (root is null) return null;
         var name = Local(root, "Name") ?? Path.GetFileNameWithoutExtension(file);
         var label = Local(root, "Label");
+        // Extensible enums carry UseEnumValue=No and omit <Value>; each
+        // member's runtime value is then its declaration order, not 0/unknown.
+        var explicitValues = !string.Equals(Local(root, "UseEnumValue"), "No", StringComparison.OrdinalIgnoreCase);
         var values = new List<ExtractedEnumValue>();
         var container = root.Descendants().FirstOrDefault(x => x.Name.LocalName == "EnumValues");
         if (container is not null)
@@ -716,7 +719,9 @@ public sealed class MetadataExtractor
             {
                 var vname = Local(v, "Name");
                 if (string.IsNullOrEmpty(vname)) continue;
-                int? val = int.TryParse(Local(v, "Value"), out var i) ? i : null;
+                int? val = explicitValues
+                    ? (int.TryParse(Local(v, "Value"), out var i) ? i : null)
+                    : values.Count;
                 values.Add(new ExtractedEnumValue(vname!, val, Local(v, "Label")));
             }
         }

--- a/src/D365FO.Core/FormPatterns/FormPatternCatalog.cs
+++ b/src/D365FO.Core/FormPatterns/FormPatternCatalog.cs
@@ -1192,6 +1192,10 @@ public static class FormPatternCatalog
         (s => s.Contains("dialog"), "Dialog"),
         (s => s.Contains("tableofcontents") || s.Contains("toc") || s.Contains("parameter"), "TableOfContents"),
         (s => s.Contains("lookup"), "Lookup"),
+        // Bare "FactBox" resolves to the grid variant — the common case; the
+        // card variant stays an explicit ask ("FactBoxCard" hits the exact
+        // alias map before this fallback runs).
+        (s => s.Contains("factbox"), "FormPartFactboxGrid"),
         (s => s.Contains("operational"), "WorkspaceOperational"),
         (s => s.Contains("workspace") || s.Contains("panorama"), "Workspace"),
         (s => s.Contains("master"), "DetailsMaster"),

--- a/src/D365FO.Core/Index/MetadataRepository.cs
+++ b/src/D365FO.Core/Index/MetadataRepository.cs
@@ -1816,6 +1816,10 @@ public sealed partial class MetadataRepository
             SELECT Name, Value, Label
             FROM EnumValues WHERE EnumId = @id
             ORDER BY COALESCE(Value, EnumValueId)", new { id = en.EnumId }).ToList();
+        // Rows extracted before UseEnumValue=No synthesis store NULL — the
+        // runtime value of such members is their declaration order.
+        for (var i = 0; i < values.Count; i++)
+            if (values[i].Value is null) values[i] = values[i] with { Value = i };
         return new EnumDetails(new EnumInfo(en.Name, en.Model, en.Label), values);
     }
 

--- a/src/D365FO.Core/Labels/LabelFileWriter.cs
+++ b/src/D365FO.Core/Labels/LabelFileWriter.cs
@@ -117,6 +117,26 @@ public static class LabelFileWriter
         return new WriteResult(path, WriteOutcome.Renamed, newKey, source.existingValue, source.existingValue);
     }
 
+    /// <summary>
+    /// True when a label file ID (or a <c>*.label.txt</c> path) refers to a
+    /// label file EXTENSION rather than an original (base) label file owned by
+    /// the model. D365FO names label file extensions with an <c>_Extension</c>
+    /// marker, optionally followed by a model prefix — e.g.
+    /// <c>Base_Extension</c> or <c>Base_ExtensionContoso</c>. New labels must
+    /// always go into the model's own ORIGINAL label file: an extension only
+    /// extends a base file owned by another model, and writing there is what
+    /// leads clients to wrongly prefix label IDs.
+    /// </summary>
+    public static bool IsExtensionLabelFile(string labelFileIdOrPath)
+    {
+        if (string.IsNullOrWhiteSpace(labelFileIdOrPath)) return false;
+        var name = Path.GetFileName(labelFileIdOrPath);
+        // Strip the `.<lang>.label.txt` tail when a physical path was given.
+        var dot = name.IndexOf('.');
+        var fileId = dot > 0 ? name[..dot] : name;
+        return fileId.Contains("_Extension", StringComparison.OrdinalIgnoreCase);
+    }
+
     /// <summary>Delete a key. Returns <see cref="WriteOutcome.KeyMissing"/> when absent.</summary>
     public static WriteResult Delete(string path, string key)
     {

--- a/src/D365FO.Core/Scaffolding/XppScaffolder.cs
+++ b/src/D365FO.Core/Scaffolding/XppScaffolder.cs
@@ -257,13 +257,22 @@ public static class XppScaffolder
     /// Scaffolds a minimal <c>AxDataEntityView</c> — data entity with a
     /// single table datasource and public OData names derived from the table
     /// by convention (<c>&lt;Table&gt;Entity</c>, collection plural).
+    /// <para>
+    /// <c>DataManagementEnabled</c> defaults to <c>No</c>: nothing here creates
+    /// the DIXF staging table, and <c>Yes</c> with a non-existent
+    /// <c>&lt;Name&gt;Staging</c> table fails the very next build. Opting in via
+    /// <paramref name="dataManagementEnabled"/> makes the caller responsible for
+    /// the staging table existing (create it as its own table).
+    /// </para>
     /// </summary>
     public static XDocument DataEntity(
         string entityName,
         string table,
         string? publicEntityName = null,
         string? publicCollectionName = null,
-        IEnumerable<EntityFieldSpec>? fields = null)
+        IEnumerable<EntityFieldSpec>? fields = null,
+        bool dataManagementEnabled = false,
+        string? dataManagementStagingTable = null)
     {
         var pubEntity = string.IsNullOrEmpty(publicEntityName) ? entityName : publicEntityName;
         var pubColl = string.IsNullOrEmpty(publicCollectionName) ? pubEntity + "s" : publicCollectionName;
@@ -275,12 +284,18 @@ public static class XppScaffolder
                 new XElement("DataSource", table),
                 f.IsMandatory ? new XElement("IsMandatory", "Yes") : null));
 
+        var stagingTable = dataManagementEnabled
+            ? new XElement("DataManagementStagingTable",
+                string.IsNullOrEmpty(dataManagementStagingTable) ? entityName + "Staging" : dataManagementStagingTable)
+            : new XElement("DataManagementStagingTable");
+
         return new XDocument(
             new XElement("AxDataEntityView",
                 new XElement("Name", entityName),
                 new XElement("PublicEntityName", pubEntity),
                 new XElement("PublicCollectionName", pubColl),
-                new XElement("DataManagementEnabled", "Yes"),
+                new XElement("DataManagementEnabled", dataManagementEnabled ? "Yes" : "No"),
+                stagingTable,
                 new XElement("IsPublic", "Yes"),
                 new XElement("DataSources",
                     new XElement("AxQuerySimpleRootDataSource",
@@ -307,6 +322,49 @@ public static class XppScaffolder
         return new XDocument(
             new XElement(elementName,
                 new XElement("Name", $"{targetName}.{suffix}")));
+    }
+
+    /// <summary>
+    /// Scaffolds an <c>AxSecurityDutyExtension</c> — adds privileges to an
+    /// EXISTING (often Microsoft-owned) duty without overlaying it. Name follows
+    /// the dot-notation convention <c>&lt;BaseDuty&gt;.&lt;Suffix&gt;</c>, same
+    /// as table/menu extensions.
+    /// </summary>
+    public static XDocument SecurityDutyExtension(
+        string targetDuty, string suffix, IEnumerable<string>? privileges = null)
+    {
+        return new XDocument(
+            new XElement("AxSecurityDutyExtension",
+                new XElement("Name", $"{targetDuty}.{suffix}"),
+                new XElement("Privileges",
+                    (privileges ?? Enumerable.Empty<string>())
+                        .Where(p => !string.IsNullOrWhiteSpace(p))
+                        .Select(p => new XElement("AxSecurityPrivilegeReference", new XElement("Name", p)))),
+                new XElement("PropertyModifications")));
+    }
+
+    /// <summary>
+    /// Scaffolds an <c>AxSecurityRoleExtension</c> — adds duties and/or
+    /// privileges to an EXISTING (often Microsoft-owned) role without
+    /// overlaying it. Name follows <c>&lt;BaseRole&gt;.&lt;Suffix&gt;</c>.
+    /// </summary>
+    public static XDocument SecurityRoleExtension(
+        string targetRole, string suffix,
+        IEnumerable<string>? duties = null, IEnumerable<string>? privileges = null)
+    {
+        return new XDocument(
+            new XElement("AxSecurityRoleExtension",
+                new XElement("Name", $"{targetRole}.{suffix}"),
+                new XElement("DirectAccessPermissions"),
+                new XElement("Duties",
+                    (duties ?? Enumerable.Empty<string>())
+                        .Where(d => !string.IsNullOrWhiteSpace(d))
+                        .Select(d => new XElement("AxSecurityDutyReference", new XElement("Name", d)))),
+                new XElement("Privileges",
+                    (privileges ?? Enumerable.Empty<string>())
+                        .Where(p => !string.IsNullOrWhiteSpace(p))
+                        .Select(p => new XElement("AxSecurityPrivilegeReference", new XElement("Name", p)))),
+                new XElement("PropertyModifications")));
     }
 
     /// <summary>
@@ -343,20 +401,57 @@ public static class XppScaffolder
                     new XElement("Declaration", src))));
     }
 
-    /// <summary>Scaffolds an <c>AxSecurityPrivilege</c> with a single entry point.</summary>
+    /// <summary>
+    /// Scaffolds an <c>AxSecurityPrivilege</c> with an optional entry point and
+    /// an optional data-entity permission (for OData/DMF access).
+    /// <para>
+    /// <c>AxSecurityDataEntityPermission</c> child order matches the Microsoft
+    /// metadata serializer (verified against shipped ApplicationCommon
+    /// privileges <c>AgentFeedEntityMaintain/View</c>): <c>Grant</c> FIRST,
+    /// then <c>Name</c>, <c>Fields</c>, <c>Methods</c> — unlike
+    /// <c>AxSecurityEntryPointReference</c>, which is Name-first. The
+    /// <c>&lt;Grant&gt;</c> CRUD elements are alphabetical (Correct, Create,
+    /// Delete, Read, Update). Non-canonical order re-sorts noisily on first
+    /// save in Visual Studio.
+    /// </para>
+    /// </summary>
     public static XDocument Privilege(
-        string name, string entryPointName, string entryPointKind,
-        string? entryPointObject = null, string? access = "Read", string? label = null)
+        string name, string? entryPointName, string? entryPointKind,
+        string? entryPointObject = null, string? access = "Read", string? label = null,
+        string? dataEntity = null, string? dataEntityAccess = "view")
     {
+        XElement? dataEntityPermissions = null;
+        if (!string.IsNullOrEmpty(dataEntity))
+        {
+            var maintain = string.Equals(dataEntityAccess, "maintain", StringComparison.OrdinalIgnoreCase);
+            var grant = maintain
+                ? new XElement("Grant",
+                    new XElement("Correct", "Allow"),
+                    new XElement("Create", "Allow"),
+                    new XElement("Delete", "Allow"),
+                    new XElement("Read", "Allow"),
+                    new XElement("Update", "Allow"))
+                : new XElement("Grant",
+                    new XElement("Read", "Allow"));
+            dataEntityPermissions = new XElement("DataEntityPermissions",
+                new XElement("AxSecurityDataEntityPermission",
+                    grant,
+                    new XElement("Name", dataEntity),
+                    new XElement("Fields"),
+                    new XElement("Methods")));
+        }
+
         return new XDocument(
             new XElement("AxSecurityPrivilege",
                 new XElement("Name", name),
                 string.IsNullOrEmpty(label) ? null : new XElement("Label", label),
+                dataEntityPermissions,
                 new XElement("EntryPoints",
+                    string.IsNullOrEmpty(entryPointName) ? null :
                     new XElement("AxSecurityEntryPointReference",
                         new XElement("Name", entryPointName),
                         new XElement("ObjectName", entryPointObject ?? entryPointName),
-                        new XElement("ObjectType", entryPointKind),
+                        new XElement("ObjectType", entryPointKind ?? "MenuItemDisplay"),
                         new XElement("AccessLevel", access ?? "Read")))));
     }
 
@@ -826,20 +921,31 @@ public static class XppScaffolder
                 _                     => null,
             };
 
-    private static string InferConcreteTypeSuffixFromExtends(string? extends) =>
-        extends?.ToLowerInvariant() switch
+    private static string InferConcreteTypeSuffixFromExtends(string? extends)
+    {
+        var e = extends?.ToLowerInvariant();
+        if (string.IsNullOrEmpty(e)) return "String";
+        var exact = e switch
         {
             "integer" or "int"                                      => "Int",
             "int64" or "recid"                                      => "Int64",
             "amount" or "amountmst" or "qty" or "weight" or "real"  => "Real",
             "date" or "transdate"                                   => "Date",
             "utcdatetime" or "transdatetime"                        => "UtcDateTime",
-            "noyes" or "noyesid" or "boolean"                      => "Enum",
+            "noyes" or "noyesid" or "boolean"                       => "Enum",
             "timeofday" or "time"                                   => "Time",
             "guid"                                                   => "Guid",
             "container"                                              => "Container",
-            _                                                       => "String",
-        } ?? "String";
+            _                                                        => null,
+        };
+        if (exact is not null) return exact;
+        // Name-shape fallback for unindexed custom EDTs. Any *DateTime* name is
+        // a utcDateTime EDT — an exclusion-based variant of this check upstream
+        // mistyped exactly "TransDateTime" (contains both markers) as String.
+        if (e.Contains("datetime")) return "UtcDateTime";
+        if (e.EndsWith("date")) return "Date";
+        return "String";
+    }
 
     /// <summary>Scaffolds an <c>AxEnum</c> with optional values.</summary>
     public static XDocument Enum(

--- a/src/D365FO.Core/Validation/XppValidator.cs
+++ b/src/D365FO.Core/Validation/XppValidator.cs
@@ -175,21 +175,42 @@ public static class XppValidator
     private static void CheckFunctionInWhere(string code, List<XppViolation> v)
     {
         var lines = code.Split('\n');
+        // inWhere carries an open where-clause across wrapped lines. It must be
+        // closed at the clause's actual boundary — the statement terminator `;`
+        // or a block-open `{` — otherwise every function call in the rest of
+        // the file (including unrelated later methods) gets misattributed to
+        // "inside where clause".
         bool inWhere = false;
         for (int i = 0; i < lines.Length; i++)
         {
             var rawLine = lines[i];
             var line = rawLine.TrimStart();
             if (line.StartsWith("//") || line.StartsWith('*')) continue;
-            if (Regex.IsMatch(rawLine, @"\bwhere\b", RegexOptions.IgnoreCase)) inWhere = true;
-            if (inWhere && rawLine.Contains('{')) inWhere = false;
-            if (!inWhere) continue;
 
-            foreach (Match m in Regex.Matches(rawLine, @"\b([a-zA-Z_]\w*)\s*\("))
+            // Scanning starts right after the `where` keyword when a new clause
+            // opens on this line (so a count(...) in the select list before the
+            // `where` is never in scope), or at the top of the line when a
+            // clause opened on an earlier line is still open.
+            int scanStart = 0;
+            if (!inWhere)
+            {
+                var whereMatch = Regex.Match(rawLine, @"\bwhere\b", RegexOptions.IgnoreCase);
+                if (!whereMatch.Success) continue;
+                inWhere = true;
+                scanStart = whereMatch.Index + whereMatch.Length;
+            }
+
+            // The clause ends at the first `;` or `{` at/after scanStart — only
+            // scan the segment before that terminator.
+            var rest = rawLine[scanStart..];
+            int endIdx = rest.IndexOfAny([';', '{']);
+            var scanSegment = endIdx >= 0 ? rest[..endIdx] : rest;
+
+            foreach (Match m in Regex.Matches(scanSegment, @"\b([a-zA-Z_]\w*)\s*\("))
             {
                 var fnName = m.Groups[1].Value;
                 if (IntrinsicFunctions.Contains(fnName)) continue;
-                if (fnName.ToLowerInvariant() is "if" or "while" or "for" or "switch" or "catch" or "str" or "int" or "new") continue;
+                if (fnName.ToLowerInvariant() is "if" or "while" or "for" or "switch" or "catch" or "str" or "int" or "new" or "where") continue;
                 v.Add(new XppViolation("SEL005", "warning", i + 1,
                     $"{fnName}(...) inside where clause",
                     $"Assign the result of {fnName}() to a local variable BEFORE the select statement, " +
@@ -197,6 +218,8 @@ public static class XppValidator
                     "Function calls in where clauses prevent index usage and may cause unexpected results."));
                 break; // one violation per line is enough
             }
+
+            if (endIdx >= 0) inWhere = false;
         }
     }
 

--- a/tests/D365FO.Cli.Tests/FormPatternScaffoldingTests.cs
+++ b/tests/D365FO.Cli.Tests/FormPatternScaffoldingTests.cs
@@ -143,4 +143,35 @@ public class FormPatternScaffoldingTests
     {
         Assert.Equal(expected, FormPatternNormalizer.Normalize(raw));
     }
+
+    [Theory]
+    [InlineData(FormPattern.SimpleList, new[] { "Overview" })]
+    [InlineData(FormPattern.DetailsTransaction, new[] { "Overview" })]
+    [InlineData(FormPattern.SimpleListDetails, new[] { "Overview", "General" })]
+    [InlineData(FormPattern.DetailsMaster, new[] { "Overview", "General" })]
+    [InlineData(FormPattern.Dialog, new string[0])]
+    public void RequiredFieldGroups_lists_datagroups_referenced_by_templates(FormPattern pattern, string[] expected)
+    {
+        Assert.Equal(expected, D365FO.Cli.Commands.Generate.GenerateFormImpl.RequiredFieldGroups(pattern));
+    }
+
+    [Fact]
+    public void TableDefinesFieldGroup_reads_table_xml()
+    {
+        var path = Path.Combine(Path.GetTempPath(), Path.GetRandomFileName() + ".xml");
+        File.WriteAllText(path, """
+            <AxTable>
+              <Name>FmVehicle</Name>
+              <FieldGroups>
+                <AxTableFieldGroup><Name>Overview</Name></AxTableFieldGroup>
+              </FieldGroups>
+            </AxTable>
+            """);
+        try
+        {
+            Assert.True(D365FO.Cli.Commands.Generate.GenerateFormImpl.TableDefinesFieldGroup(path, "Overview"));
+            Assert.False(D365FO.Cli.Commands.Generate.GenerateFormImpl.TableDefinesFieldGroup(path, "General"));
+        }
+        finally { File.Delete(path); }
+    }
 }

--- a/tests/D365FO.Cli.Tests/ScaffoldingSmokeTests.cs
+++ b/tests/D365FO.Cli.Tests/ScaffoldingSmokeTests.cs
@@ -21,6 +21,28 @@ public class ScaffoldingSmokeTests
     }
 
     [Fact]
+    public void DataEntity_defaults_data_management_off_with_empty_staging_table()
+    {
+        var doc = XppScaffolder.DataEntity("CustEntity", "CustTable");
+        var root = doc.Root!;
+        Assert.Equal("No", root.Element("DataManagementEnabled")!.Value);
+        Assert.Equal("", root.Element("DataManagementStagingTable")!.Value);
+    }
+
+    [Fact]
+    public void DataEntity_opt_in_data_management_names_staging_table()
+    {
+        var doc = XppScaffolder.DataEntity("CustEntity", "CustTable", dataManagementEnabled: true);
+        var root = doc.Root!;
+        Assert.Equal("Yes", root.Element("DataManagementEnabled")!.Value);
+        Assert.Equal("CustEntityStaging", root.Element("DataManagementStagingTable")!.Value);
+
+        var custom = XppScaffolder.DataEntity("CustEntity", "CustTable",
+            dataManagementEnabled: true, dataManagementStagingTable: "MyStaging");
+        Assert.Equal("MyStaging", custom.Root!.Element("DataManagementStagingTable")!.Value);
+    }
+
+    [Fact]
     public void Extension_produces_dotted_name_for_target_and_suffix()
     {
         var doc = XppScaffolder.Extension("Table", "CustTable", "Contoso");
@@ -45,6 +67,81 @@ public class ScaffoldingSmokeTests
         Assert.Equal("PurchTable", ep.Element("ObjectName")!.Value);
         Assert.Equal("MenuItemDisplay", ep.Element("ObjectType")!.Value);
         Assert.Equal("Read", ep.Element("AccessLevel")!.Value);
+    }
+
+    [Fact]
+    public void Privilege_data_entity_view_emits_canonical_permission_order()
+    {
+        var doc = XppScaffolder.Privilege("CustEntityViewPriv", null, null,
+            dataEntity: "CustCustomerEntity", dataEntityAccess: "view");
+        var perm = doc.Root!.Element("DataEntityPermissions")!
+            .Element("AxSecurityDataEntityPermission")!;
+        // Serializer-canonical child order: Grant FIRST, then Name, Fields, Methods.
+        Assert.Equal(new[] { "Grant", "Name", "Fields", "Methods" },
+            perm.Elements().Select(e => e.Name.LocalName).ToArray());
+        Assert.Equal("CustCustomerEntity", perm.Element("Name")!.Value);
+        var grant = perm.Element("Grant")!.Elements().Select(e => e.Name.LocalName).ToArray();
+        Assert.Equal(new[] { "Read" }, grant);
+    }
+
+    [Fact]
+    public void Privilege_data_entity_maintain_emits_alphabetical_crud_grant()
+    {
+        var doc = XppScaffolder.Privilege("CustEntityMaintainPriv", null, null,
+            dataEntity: "CustCustomerEntity", dataEntityAccess: "maintain");
+        var grant = doc.Root!.Element("DataEntityPermissions")!
+            .Element("AxSecurityDataEntityPermission")!
+            .Element("Grant")!.Elements().Select(e => e.Name.LocalName).ToArray();
+        // CRUD elements alphabetical, matching the Microsoft serializer.
+        Assert.Equal(new[] { "Correct", "Create", "Delete", "Read", "Update" }, grant);
+        Assert.All(doc.Root.Element("DataEntityPermissions")!
+            .Element("AxSecurityDataEntityPermission")!
+            .Element("Grant")!.Elements(), e => Assert.Equal("Allow", e.Value));
+    }
+
+    [Fact]
+    public void Privilege_without_data_entity_omits_permissions_block()
+    {
+        var doc = XppScaffolder.Privilege("PurchOrderReadPriv", "PurchTableForm", "MenuItemDisplay");
+        Assert.Null(doc.Root!.Element("DataEntityPermissions"));
+    }
+
+    [Fact]
+    public void SecurityDutyExtension_adds_privileges_to_base_duty()
+    {
+        var doc = XppScaffolder.SecurityDutyExtension("BatchJobMaintain", "Contoso", new[] { "MyPriv" });
+        var root = doc.Root!;
+        Assert.Equal("AxSecurityDutyExtension", root.Name.LocalName);
+        Assert.Equal("BatchJobMaintain.Contoso", root.Element("Name")!.Value);
+        var priv = root.Element("Privileges")!.Elements("AxSecurityPrivilegeReference").Single();
+        Assert.Equal("MyPriv", priv.Element("Name")!.Value);
+        Assert.NotNull(root.Element("PropertyModifications"));
+    }
+
+    [Fact]
+    public void SecurityRoleExtension_adds_duties_and_privileges_to_base_role()
+    {
+        var doc = XppScaffolder.SecurityRoleExtension("SystemUser", "Contoso",
+            duties: new[] { "MyDuty" }, privileges: new[] { "MyPriv" });
+        var root = doc.Root!;
+        Assert.Equal("AxSecurityRoleExtension", root.Name.LocalName);
+        Assert.Equal("SystemUser.Contoso", root.Element("Name")!.Value);
+        Assert.Equal("MyDuty", root.Element("Duties")!.Elements().Single().Element("Name")!.Value);
+        Assert.Equal("MyPriv", root.Element("Privileges")!.Elements().Single().Element("Name")!.Value);
+        Assert.NotNull(root.Element("DirectAccessPermissions"));
+    }
+
+    [Theory]
+    [InlineData("TransDateTime", "AxTableFieldUtcDateTime")]
+    [InlineData("EventDateTime", "AxTableFieldUtcDateTime")]
+    [InlineData("StartDate", "AxTableFieldDate")]
+    [InlineData("SomethingElse", "AxTableFieldString")]
+    public void Table_field_discriminator_infers_datetime_edts_without_index(string edt, string expectedType)
+    {
+        var doc = XppScaffolder.Table("MyTable", null, new[] { new TableFieldSpec("F1", edt, null, false) });
+        XNamespace xsi = "http://www.w3.org/2001/XMLSchema-instance";
+        var field = doc.Root!.Element("Fields")!.Elements("AxTableField").Single();
+        Assert.Equal(expectedType, field.Attribute(xsi + "type")!.Value);
     }
 
     [Fact]

--- a/tests/D365FO.Core.Tests/ExtractPipelineTests.cs
+++ b/tests/D365FO.Core.Tests/ExtractPipelineTests.cs
@@ -210,6 +210,50 @@ public class ExtractPipelineTests : IDisposable
     }
 
     [Fact]
+    public void MetadataExtractor_synthesizes_positional_values_for_UseEnumValue_No()
+    {
+        var model = Path.Combine(_workRoot, "Contoso", "Contoso");
+        Directory.CreateDirectory(Path.Combine(model, "AxEnum"));
+        File.WriteAllText(Path.Combine(model, "AxEnum", "TierEnum.xml"), """
+            <AxEnum>
+              <Name>TierEnum</Name>
+              <UseEnumValue>No</UseEnumValue>
+              <IsExtensible>true</IsExtensible>
+              <EnumValues>
+                <AxEnumValue><Name>Standard</Name></AxEnumValue>
+                <AxEnumValue><Name>Silver</Name></AxEnumValue>
+                <AxEnumValue><Name>Gold</Name></AxEnumValue>
+              </EnumValues>
+            </AxEnum>
+            """);
+
+        var batches = new MetadataExtractor().ExtractAll(_workRoot).ToList();
+        var en = Assert.Single(Assert.Single(batches).Enums);
+        // UseEnumValue=No omits <Value>; the compiled value is positional.
+        Assert.Equal(new int?[] { 0, 1, 2 }, en.Values.Select(v => v.Value).ToArray());
+    }
+
+    [Fact]
+    public void MetadataExtractor_keeps_explicit_values_for_UseEnumValue_Yes()
+    {
+        var model = Path.Combine(_workRoot, "Contoso", "Contoso");
+        Directory.CreateDirectory(Path.Combine(model, "AxEnum"));
+        File.WriteAllText(Path.Combine(model, "AxEnum", "GapEnum.xml"), """
+            <AxEnum>
+              <Name>GapEnum</Name>
+              <EnumValues>
+                <AxEnumValue><Name>A</Name><Value>10</Value></AxEnumValue>
+                <AxEnumValue><Name>B</Name><Value>20</Value></AxEnumValue>
+              </EnumValues>
+            </AxEnum>
+            """);
+
+        var batches = new MetadataExtractor().ExtractAll(_workRoot).ToList();
+        var en = Assert.Single(Assert.Single(batches).Enums);
+        Assert.Equal(new int?[] { 10, 20 }, en.Values.Select(v => v.Value).ToArray());
+    }
+
+    [Fact]
     public void MetadataExtractor_marks_models_matching_custom_pattern()
     {
         foreach (var name in new[] { "AslCore", "AslFinance", "MsExtensions" })

--- a/tests/D365FO.Core.Tests/FormPatternValidatorTests.cs
+++ b/tests/D365FO.Core.Tests/FormPatternValidatorTests.cs
@@ -57,6 +57,16 @@ public class FormPatternValidatorTests
     }
 
     [Fact]
+    public void Resolve_maps_bare_factbox_to_grid_variant()
+    {
+        // Bare "FactBox" must not silently degrade; grid is the common variant.
+        Assert.Equal("FormPartFactboxGrid", FormPatternCatalog.Resolve("FactBox")!.Id);
+        Assert.Equal("FormPartFactboxGrid", FormPatternCatalog.Resolve("fact box")!.Id);
+        // The card variant stays an explicit ask via its exact alias.
+        Assert.Equal("FormPartFactboxCard", FormPatternCatalog.Resolve("FactBoxCard")!.Id);
+    }
+
+    [Fact]
     public void ResolveExact_rejects_fuzzy_names_the_validator_must_not_accept()
     {
         Assert.NotNull(FormPatternCatalog.ResolveExact("SimpleList"));

--- a/tests/D365FO.Core.Tests/LabelFileWriterTests.cs
+++ b/tests/D365FO.Core.Tests/LabelFileWriterTests.cs
@@ -164,6 +164,20 @@ public class LabelFileWriterTests
         finally { SafeDelete(path); }
     }
 
+    [Theory]
+    [InlineData("Base_Extension", true)]
+    [InlineData("Base_ExtensionContoso", true)]
+    [InlineData("base_extension", true)]
+    [InlineData(@"C:\Pkg\M\M\AxLabelFile\LabelResources\en-us\Foo_Extension.en-us.label.txt", true)]
+    [InlineData("Contoso", false)]
+    [InlineData("ExtensionPoints", false)]
+    [InlineData("/pkg/M/M/AxLabelFile/LabelResources/en-us/Contoso.en-us.label.txt", false)]
+    [InlineData("", false)]
+    public void IsExtensionLabelFile_detects_extension_marker(string input, bool expected)
+    {
+        Assert.Equal(expected, LabelFileWriter.IsExtensionLabelFile(input));
+    }
+
     private static void SafeDelete(string path)
     {
         try { if (File.Exists(path)) File.Delete(path); } catch { }

--- a/tests/D365FO.Core.Tests/XppValidatorTests.cs
+++ b/tests/D365FO.Core.Tests/XppValidatorTests.cs
@@ -80,6 +80,58 @@ public class XppValidatorTests
         Assert.DoesNotContain(v, x => x.Rule == "SEL005" && x.Excerpt.Contains("fieldNum"));
     }
 
+    [Fact]
+    public void Sel005_clause_closes_at_statement_terminator()
+    {
+        var code = """
+            int certCount = (select count(RecId) from certTable
+                where certTable.Status == status).RecId;
+            info(strFmt("Found %1 certificates", certCount));
+            """;
+        var v = Run(code);
+        Assert.DoesNotContain(v, x => x.Rule == "SEL005" && x.Excerpt.Contains("info"));
+        Assert.DoesNotContain(v, x => x.Rule == "SEL005" && x.Excerpt.Contains("strFmt"));
+    }
+
+    [Fact]
+    public void Sel005_state_does_not_leak_into_later_methods()
+    {
+        var code = """
+            public void run1()
+            {
+                select custTable where custTable.Blocked == blockedStatus;
+            }
+
+            public void run2()
+            {
+                this.doWork(someArg);
+            }
+            """;
+        var v = Run(code);
+        Assert.DoesNotContain(v, x => x.Rule == "SEL005" && x.Excerpt.Contains("doWork"));
+        Assert.DoesNotContain(v, x => x.Rule == "SEL005" && x.Excerpt.Contains("run2"));
+    }
+
+    [Fact]
+    public void Sel005_ignores_calls_before_where_on_same_line()
+    {
+        var v = Run("select count(RecId) from certTable where certTable.Status == status;");
+        Assert.DoesNotContain(v, x => x.Rule == "SEL005");
+    }
+
+    [Fact]
+    public void Sel005_still_flags_call_in_multiline_where()
+    {
+        var code = """
+            select custTable
+                where custTable.AccountNum == getCurrentAccount()
+            {
+            }
+            """;
+        var v = Run(code);
+        Assert.Contains(v, x => x.Rule == "SEL005" && x.Excerpt.Contains("getCurrentAccount"));
+    }
+
     // ── COC rules ────────────────────────────────────────────────────────────
 
     [Fact]


### PR DESCRIPTION
## Summary

Ports bug-fix wave from upstream \d365fo-mcp-server\ (up to 2026-07-09).

### Changes

**SEL005 validator** — where-clause scanner state now closes at \;\ or \{\; fixes false positives on code after \select … where …;\.

**Data entity** — \DataManagementEnabled\ defaults to \No\; opt in via \--data-management\ / \--staging-table\.

**Extension scaffolding** — \generate extension\ now accepts \SecurityDuty\ and \SecurityRole\ kinds.

**Privilege scaffolding** — \--data-entity\ / \--data-entity-access\ (view|maintain); \--entry-point\ optional when \--data-entity\ is given; canonical \AxSecurityDataEntityPermission\ child order.

**Enum extractor / repository / bridge** — \UseEnumValue=No\ synthesizes positional values; legacy NULL rows fall back to declaration order; Bridge \ReadEnum\ fixed.

**Label create/rename** — guards against \_Extension\ label files (\EXTENSION_LABEL_FILE\ error + \--allow-extension-label-file\ escape hatch).

**Form generation** — caption from table label, field-group pre-flight warnings, phantom-table detection, bare \FactBox\ → \FormPartFactboxGrid\.

**EDT heuristic** — \*DateTime*\ → UtcDateTime, \*Date\ → Date (fixes TransDateTime mistyped as String).

### Tests

460 tests pass (176 CLI + 284 Core), 0 failures.