### PR TITLE
fix: review diff false positives on FieldGroups (#117)

### DIFF
--- a/src/D365FO.Cli/Commands/Review/ReviewDiffCommand.cs
+++ b/src/D365FO.Cli/Commands/Review/ReviewDiffCommand.cs
@@ -72,7 +72,7 @@ public sealed class ReviewDiffCommand : Command<ReviewDiffCommand.Settings>
         }));
     }
 
-    private static void InspectTableXml(string path, string text, List<object> bag)
+    internal static void InspectTableXml(string path, string text, List<object> bag)
     {
         XDocument doc;
         try { doc = XDocument.Parse(text); }
@@ -81,15 +81,26 @@ public sealed class ReviewDiffCommand : Command<ReviewDiffCommand.Settings>
             bag.Add(new { file = path, rule = "XML_PARSE", severity = "error", message = ex.Message });
             return;
         }
-        var fields = doc.Descendants().Where(e => e.Name.LocalName.StartsWith("AxTableField", StringComparison.Ordinal));
+        // Real field definitions live only under AxTable/Fields/AxTableField*.
+        // Never descend into <FieldGroups> — <AxTableFieldGroup> names and
+        // <AxTableFieldGroupField><DataField> references are not fields and
+        // must not be evaluated as such.
+        var fieldsContainer = doc.Root?.Elements().FirstOrDefault(e => e.Name.LocalName == "Fields");
+        var fields = fieldsContainer?.Elements().Where(e => e.Name.LocalName.StartsWith("AxTableField", StringComparison.Ordinal))
+            ?? Enumerable.Empty<XElement>();
         foreach (var f in fields)
         {
             var name = f.Elements().FirstOrDefault(e => e.Name.LocalName == "Name")?.Value ?? "?";
-            var hasEdt = f.Elements().Any(e => e.Name.LocalName == "ExtendedDataType");
+            var edtValue = f.Elements().FirstOrDefault(e => e.Name.LocalName == "ExtendedDataType")?.Value;
+            var enumValue = f.Elements().FirstOrDefault(e => e.Name.LocalName == "EnumType")?.Value;
+            // EnumType is an equivalent, valid type declaration for AxTableFieldEnum
+            // fields — either it or a non-empty ExtendedDataType satisfies the rule,
+            // and both also carry an inherited label from their type definition.
+            var hasTypeDeclaration = !string.IsNullOrWhiteSpace(edtValue) || !string.IsNullOrWhiteSpace(enumValue);
             var hasLabel = f.Elements().Any(e => e.Name.LocalName == "Label");
-            if (!hasEdt)
+            if (!hasTypeDeclaration)
                 bag.Add(new { file = path, rule = "FIELD_WITHOUT_EDT", severity = "warning", field = name, message = $"Field '{name}' has no ExtendedDataType; prefer typed EDTs over raw types." });
-            if (!hasLabel)
+            if (!hasLabel && !hasTypeDeclaration)
                 bag.Add(new { file = path, rule = "FIELD_WITHOUT_LABEL", severity = "info", field = name, message = $"Field '{name}' has no Label; required for user-facing fields." });
         }
     }

--- a/tests/D365FO.Cli.Tests/ReviewDiffInspectTableXmlTests.cs
+++ b/tests/D365FO.Cli.Tests/ReviewDiffInspectTableXmlTests.cs
@@ -1,0 +1,135 @@
+using D365FO.Cli.Commands.Review;
+
+namespace D365FO.Cli.Tests;
+
+/// <summary>
+/// Repro for GitHub issue #117: FIELD_WITHOUT_EDT / FIELD_WITHOUT_LABEL must
+/// only evaluate real field definitions under AxTable/Fields/AxTableField*,
+/// never &lt;FieldGroups&gt; contents, and must treat &lt;EnumType&gt; as an
+/// equivalent, label-bearing type declaration alongside &lt;ExtendedDataType&gt;.
+/// </summary>
+public class ReviewDiffInspectTableXmlTests
+{
+    // Minimal repro from the issue: 3 well-typed fields (two via ExtendedDataType,
+    // one enum field via EnumType) plus 6 field groups (the standard auto-groups
+    // and one custom group) referencing those fields by <DataField>.
+    private const string MinimalReproXml = """
+        <?xml version="1.0" encoding="utf-8"?>
+        <AxTable xmlns:i="http://www.w3.org/2001/XMLSchema-instance">
+          <Name>MyTable</Name>
+          <FieldGroups>
+            <AxTableFieldGroup>
+              <Name>AutoReport</Name>
+              <Fields>
+                <AxTableFieldGroupField><DataField>FieldA</DataField></AxTableFieldGroupField>
+                <AxTableFieldGroupField><DataField>FieldB</DataField></AxTableFieldGroupField>
+                <AxTableFieldGroupField><DataField>FieldC</DataField></AxTableFieldGroupField>
+              </Fields>
+            </AxTableFieldGroup>
+            <AxTableFieldGroup>
+              <Name>AutoLookup</Name>
+              <Fields>
+                <AxTableFieldGroupField><DataField>FieldA</DataField></AxTableFieldGroupField>
+                <AxTableFieldGroupField><DataField>FieldB</DataField></AxTableFieldGroupField>
+              </Fields>
+            </AxTableFieldGroup>
+            <AxTableFieldGroup>
+              <Name>AutoSummary</Name>
+              <Fields>
+                <AxTableFieldGroupField><DataField>FieldA</DataField></AxTableFieldGroupField>
+              </Fields>
+            </AxTableFieldGroup>
+            <AxTableFieldGroup>
+              <Name>AutoIdentification</Name>
+              <AutoPopulate>Yes</AutoPopulate>
+              <Fields>
+                <AxTableFieldGroupField><DataField>FieldA</DataField></AxTableFieldGroupField>
+                <AxTableFieldGroupField><DataField>FieldB</DataField></AxTableFieldGroupField>
+              </Fields>
+            </AxTableFieldGroup>
+            <AxTableFieldGroup>
+              <Name>AutoBrowse</Name>
+              <Fields />
+            </AxTableFieldGroup>
+            <AxTableFieldGroup>
+              <Name>Overview</Name>
+              <Label>@MyModel:MyTableLabel</Label>
+              <Fields>
+                <AxTableFieldGroupField><DataField>FieldA</DataField></AxTableFieldGroupField>
+                <AxTableFieldGroupField><DataField>FieldB</DataField></AxTableFieldGroupField>
+                <AxTableFieldGroupField><DataField>FieldC</DataField></AxTableFieldGroupField>
+              </Fields>
+            </AxTableFieldGroup>
+          </FieldGroups>
+          <Fields>
+            <AxTableField xmlns="" i:type="AxTableFieldString">
+              <Name>FieldA</Name>
+              <ExtendedDataType>MyStringEdtA</ExtendedDataType>
+              <Mandatory>Yes</Mandatory>
+            </AxTableField>
+            <AxTableField xmlns="" i:type="AxTableFieldEnum">
+              <Name>FieldB</Name>
+              <EnumType>MyEnumType</EnumType>
+            </AxTableField>
+            <AxTableField xmlns="" i:type="AxTableFieldString">
+              <Name>FieldC</Name>
+              <ExtendedDataType>MyStringEdtB</ExtendedDataType>
+              <Mandatory>Yes</Mandatory>
+            </AxTableField>
+          </Fields>
+        </AxTable>
+        """;
+
+    [Fact]
+    public void FieldGroups_and_typed_fields_produce_zero_violations()
+    {
+        var violations = new List<object>();
+
+        ReviewDiffCommand.InspectTableXml("Metadata/MyModel/AxTable/MyTable.xml", MinimalReproXml, violations);
+
+        Assert.Empty(violations);
+    }
+
+    [Fact]
+    public void FieldGroup_names_are_not_treated_as_fields()
+    {
+        var violations = new List<object>();
+
+        ReviewDiffCommand.InspectTableXml("t.xml", MinimalReproXml, violations);
+
+        var fieldNames = violations
+            .Select(v => v.GetType().GetProperty("field")!.GetValue(v) as string)
+            .ToList();
+
+        Assert.DoesNotContain("AutoReport", fieldNames);
+        Assert.DoesNotContain("AutoLookup", fieldNames);
+        Assert.DoesNotContain("AutoSummary", fieldNames);
+        Assert.DoesNotContain("AutoIdentification", fieldNames);
+        Assert.DoesNotContain("AutoBrowse", fieldNames);
+        Assert.DoesNotContain("Overview", fieldNames);
+        Assert.DoesNotContain("?", fieldNames);
+    }
+
+    [Fact]
+    public void Field_with_raw_type_and_no_label_still_flagged()
+    {
+        const string xml = """
+            <?xml version="1.0" encoding="utf-8"?>
+            <AxTable xmlns:i="http://www.w3.org/2001/XMLSchema-instance">
+              <Name>MyTable</Name>
+              <Fields>
+                <AxTableField xmlns="" i:type="AxTableFieldString">
+                  <Name>RawField</Name>
+                </AxTableField>
+              </Fields>
+            </AxTable>
+            """;
+        var violations = new List<object>();
+
+        ReviewDiffCommand.InspectTableXml("t.xml", xml, violations);
+
+        var rules = violations.Select(v => v.GetType().GetProperty("rule")!.GetValue(v) as string).ToList();
+        Assert.Contains("FIELD_WITHOUT_EDT", rules);
+        Assert.Contains("FIELD_WITHOUT_LABEL", rules);
+    }
+}


### PR DESCRIPTION
## Summary
- `InspectTableXml` field discovery was matching any descendant element starting with `AxTableField`, which incorrectly picked up field references inside `<FieldGroups>` definitions and flagged them as real table fields missing an EDT/label.
- Field discovery is now restricted to direct children of `doc.Root.Elements("Fields")`, and `<EnumType>` is now treated as equivalent to `<ExtendedDataType>` for the FIELD_WITHOUT_EDT rule (enum-typed fields don't need a separate EDT), with FIELD_WITHOUT_LABEL suppressed whenever either is present.

Fixes #117.

## Test plan
- [x] New unit tests in `ReviewDiffInspectTableXmlTests.cs` covering FieldGroup exclusion, EnumType-as-EDT equivalence, and label suppression
- [x] `dotnet test d365fo-cli.slnx` — 479/479 passing

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>