### PR TITLE
fix: emit UseEnumValue=No on extensible AxEnum XML (#116)

### DIFF
--- a/src/D365FO.Core/Scaffolding/XppScaffolder.cs
+++ b/src/D365FO.Core/Scaffolding/XppScaffolder.cs
@@ -970,6 +970,10 @@ public static class XppScaffolder
         // the root element (it is emitted by Visual Studio on every AxEnum file). IsExtensible
         // is a CLR bool, so the DataContractSerializer expects "true"/"false" — the NoYes-style
         // "Yes"/"No" written previously produced an invalid file VS refused to read.
+        // VS's build-time validation additionally rejects IsExtensible=true unless
+        // UseEnumValue is explicitly "No" ("UseEnumValue property must be set to 'No' when
+        // the IsExtensible property is 'True'."). UseEnumValue is itself a NoYes-style enum
+        // property (unlike IsExtensible), so it takes "Yes"/"No", not "true"/"false".
         XNamespace xsi = "http://www.w3.org/2001/XMLSchema-instance";
         return new XDocument(
             new XElement("AxEnum",
@@ -977,6 +981,7 @@ public static class XppScaffolder
                 new XElement("Name", name),
                 string.IsNullOrEmpty(label) ? null : new XElement("Label", label),
                 new XElement("IsExtensible", isExtensible ? "true" : "false"),
+                isExtensible ? new XElement("UseEnumValue", "No") : null,
                 enumVals.Count > 0 ? new XElement("EnumValues", valEls) : null));
     }
 

--- a/tests/D365FO.Cli.Tests/ScaffoldingSnapshotTests.cs
+++ b/tests/D365FO.Cli.Tests/ScaffoldingSnapshotTests.cs
@@ -337,6 +337,31 @@ public class ScaffoldingSnapshotTests
         Assert.Equal("1", items[1].Element("Value")!.Value);
     }
 
+    [Fact]
+    public void Enum_extensible_sets_UseEnumValue_No()
+    {
+        // VS build validation: "UseEnumValue property must be set to 'No' when the
+        // IsExtensible property is 'True'." UseEnumValue is a NoYes-style enum property
+        // (unlike the CLR-bool IsExtensible), so it takes "Yes"/"No", not "true"/"false".
+        var vals = new[] { new EnumValueSpec("Draft", 0), new EnumValueSpec("Validated", 1), new EnumValueSpec("Completed", 2) };
+        var doc = XppScaffolder.Enum("MyEnumStatusType", vals, isExtensible: true, label: "test status");
+        var root = doc.Root!;
+        Assert.Equal("true", root.Element("IsExtensible")!.Value);
+        Assert.Equal("No", root.Element("UseEnumValue")!.Value);
+    }
+
+    [Fact]
+    public void Enum_non_extensible_does_not_emit_UseEnumValue()
+    {
+        // UseEnumValue is only forced when IsExtensible=true; a non-extensible enum has no
+        // build-rule requiring it, so the element is omitted (VS defaults it to Yes).
+        var vals = new[] { new EnumValueSpec("None", 0) };
+        var doc = XppScaffolder.Enum("MyEnum", vals, isExtensible: false);
+        var root = doc.Root!;
+        Assert.Equal("false", root.Element("IsExtensible")!.Value);
+        Assert.Null(root.Element("UseEnumValue"));
+    }
+
     // ---- Query (Phase 2) ----
 
     [Fact]


### PR DESCRIPTION
## Summary
- `generate enum --extensible` produced XML that the AOT rejects as an invalid extensible enum: the `<UseEnumValue>` element was missing entirely when `IsExtensible=true`.
- `XppScaffolder.Enum()` now emits `<UseEnumValue>No</UseEnumValue>` immediately after `<IsExtensible>` for extensible enums, and omits the element for non-extensible ones (matching real AOT-authored enum XML).

Fixes #116.

## Test plan
- [x] New snapshot tests: `Enum_extensible_sets_UseEnumValue_No`, `Enum_non_extensible_does_not_emit_UseEnumValue`
- [x] `dotnet test d365fo-cli.slnx` — 479/479 passing

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>