### PR TITLE
fix: return empty list instead of throwing on zero-result label FTS search (#115)

### DIFF
--- a/src/D365FO.Core/Index/MetadataRepository.cs
+++ b/src/D365FO.Core/Index/MetadataRepository.cs
@@ -438,7 +438,7 @@ public sealed partial class MetadataRepository
                 WHERE LabelFts MATCH @q
                 ORDER BY rank
                 LIMIT @limit";
-                return conn.Query<LabelMatch>(sql, new { q = query, limit }).ToList();
+                return ReadLabelMatches(conn.Query(sql, new { q = query, limit }));
             }
             else
             {
@@ -449,7 +449,7 @@ public sealed partial class MetadataRepository
                   AND LOWER(Language) IN @langs
                 ORDER BY rank
                 LIMIT @limit";
-                return conn.Query<LabelMatch>(sql, new { q = query, langs = langsLower, limit }).ToList();
+                return ReadLabelMatches(conn.Query(sql, new { q = query, langs = langsLower, limit }));
             }
         }
         catch (Microsoft.Data.Sqlite.SqliteException)
@@ -467,6 +467,22 @@ public sealed partial class MetadataRepository
             return results;
         }
     }
+
+    /// <summary>
+    /// Maps rows from the <c>LabelFts</c> virtual table into <see cref="LabelMatch"/>.
+    /// FTS5 columns carry no declared SQLite type, so on a zero-row result set
+    /// Dapper's strongly-typed <c>Query&lt;LabelMatch&gt;</c> infers every column as
+    /// <c>byte[]</c> and fails to find a matching constructor (see issue #115).
+    /// Querying as <c>dynamic</c> and converting by hand sidesteps that
+    /// materialization entirely, for both the empty and non-empty cases.
+    /// </summary>
+    private static List<LabelMatch> ReadLabelMatches(IEnumerable<dynamic> rows) =>
+        rows.Select(row => new LabelMatch(
+                (string)Convert.ChangeType(row.File, typeof(string)),
+                (string)Convert.ChangeType(row.Language, typeof(string)),
+                (string)Convert.ChangeType(row.Key, typeof(string)),
+                row.Value is null ? null : (string)Convert.ChangeType(row.Value, typeof(string))))
+            .ToList();
 
     /// <summary>
     /// Number of method bodies currently in the opt-in <c>MethodSourceFts</c>

--- a/tests/D365FO.Core.Tests/LabelFtsTests.cs
+++ b/tests/D365FO.Core.Tests/LabelFtsTests.cs
@@ -57,6 +57,33 @@ public class LabelFtsTests
         }
     }
 
+    [Fact]
+    public void Fts_search_with_zero_results_returns_empty_list()
+    {
+        var db = Path.Combine(Path.GetTempPath(), $"d365fo-fts-{Guid.NewGuid():N}.sqlite");
+        try
+        {
+            var repo = new MetadataRepository(db);
+            repo.EnsureSchema();
+            repo.UpsertModel("Fleet", "Contoso", "usr", true);
+            // Only index an English label; searching for a term that only
+            // exists in a non-indexed language (or nowhere) must yield zero
+            // matches from the FTS5 MATCH query, not throw during
+            // materialization (see issue #115).
+            Insert(db, 1, "Vehicle fleet operations", "en-us", "VehicleFleet", "Vehicles.en-us");
+
+            var hits = repo.SearchLabelsFts("zzzznonexistentterm", new[] { "en-us" }, 10);
+            Assert.Empty(hits);
+
+            var likeHits = repo.SearchLabels("zzzznonexistentterm", new[] { "en-us" }, 10);
+            Assert.Empty(likeHits);
+        }
+        finally
+        {
+            try { File.Delete(db); } catch { }
+        }
+    }
+
     private static void Insert(string db, long labelId, string value, string lang, string key, string file)
     {
         using var conn = new Microsoft.Data.Sqlite.SqliteConnection($"Data Source={db}");


### PR DESCRIPTION
## Summary
- `label search` crashed when a query matched zero rows in the `LabelFts` FTS5 virtual table: Dapper's typed `Query<LabelMatch>` infers column types (incl. byte[] blobs) from the result set, and with zero rows it has nothing to infer from, throwing instead of returning an empty list.
- `SearchLabelsFts()` now queries the FTS5 table untyped (`conn.Query(sql, ...)` returning dynamic rows) and manually maps rows to `LabelMatch` via a new `ReadLabelMatches` helper, sidestepping Dapper's zero-row inference failure.

Fixes #115.

## Test plan
- [x] New test `Fts_search_with_zero_results_returns_empty_list` in `LabelFtsTests.cs`
- [x] `dotnet test d365fo-cli.slnx` — 479/479 passing

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>