### PR TITLE
fix: emit default AOT field groups on generated tables (#110)

### DIFF
--- a/src/D365FO.Core/Scaffolding/XppScaffolder.cs
+++ b/src/D365FO.Core/Scaffolding/XppScaffolder.cs
@@ -126,20 +126,48 @@ public static class XppScaffolder
                 // predictable physical ordering (validate xpp XML005).
                 indexesEl is null ? null : new XElement("ClusteredIndex", "PrimaryIdx"),
                 new XElement("Fields", fieldEls),
-                // "Overview" and "General" are referenced by <DataGroup> in every
-                // generated form pattern (SimpleList, SimpleListDetails,
-                // DetailsMaster, DetailsTransaction) — the metadata reader
+                // Visual Studio / the AOT stamps every new table with five default
+                // field groups, all initially empty (issue #110). Ground-truthed
+                // against shipped standard-model tables on a real AOS
+                // (e.g. ApplicationCommon\AgentFeedUserPreference.xml,
+                // ApplicationSuite\Foundation\AssetAddition.xml): VS does NOT
+                // auto-populate AutoReport (or any of the five) with fields, even
+                // once the table has real fields — the developer assigns them
+                // later in the AOT designer. AutoIdentification is the only one
+                // that carries a property, <AutoPopulate>Yes</AutoPopulate>. We
+                // match that shape exactly instead of pre-populating AutoReport.
+                //
+                // "Overview" and "General" are NOT part of the AOT default
+                // scaffold — they exist here only because this CLI's own
+                // generated forms need them: every form pattern (SimpleList,
+                // SimpleListDetails, DetailsMaster, DetailsTransaction)
+                // references them via <DataGroup>, and the metadata reader
                 // rejects the form with "Field group 'Overview' does not exist"
-                // when the underlying table lacks them (issue #91 follow-up).
-                // AutoReport is the standard AX lookup/report group. All three
-                // are populated with every effective field so any pattern's
-                // grid/group controls resolve.
+                // when the underlying table lacks them (issue #91 follow-up). They
+                // are populated with every effective field so the grid/group
+                // controls resolve.
                 new XElement("FieldGroups",
-                    BuildFieldGroup("AutoReport", effectiveFields),
+                    BuildEmptyFieldGroup("AutoReport"),
+                    BuildEmptyFieldGroup("AutoLookup"),
+                    BuildEmptyFieldGroup("AutoIdentification", autoPopulate: true),
+                    BuildEmptyFieldGroup("AutoSummary"),
+                    BuildEmptyFieldGroup("AutoBrowse"),
                     BuildFieldGroup("Overview", effectiveFields),
                     BuildFieldGroup("General", effectiveFields)),
                 indexesEl));
     }
+
+    /// <summary>
+    /// Builds one of the five default, initially-empty <c>AxTableFieldGroup</c>
+    /// elements VS/AOT stamps on every new table (AutoReport, AutoLookup,
+    /// AutoIdentification, AutoSummary, AutoBrowse). Only AutoIdentification
+    /// carries <c>AutoPopulate</c>.
+    /// </summary>
+    private static XElement BuildEmptyFieldGroup(string name, bool autoPopulate = false) =>
+        new XElement("AxTableFieldGroup",
+            new XElement("Name", name),
+            autoPopulate ? new XElement("AutoPopulate", "Yes") : null,
+            new XElement("Fields"));
 
     private static XElement BuildFieldGroup(string name, IReadOnlyList<TableFieldSpec> fields) =>
         new XElement("AxTableFieldGroup",

--- a/tests/D365FO.Cli.Tests/TablePatternScaffoldingTests.cs
+++ b/tests/D365FO.Cli.Tests/TablePatternScaffoldingTests.cs
@@ -165,6 +165,94 @@ public class TablePatternScaffoldingTests
         Assert.Null(doc.Root!.Element("Indexes"));
     }
 
+    // --- issue #110: generated tables must carry the same five default field
+    //     groups Visual Studio / the AOT stamps on every new table, and must
+    //     NOT emit shouldThrowExceptionOnZeroDelete (not part of the fresh
+    //     VS scaffold — ground-truthed against shipped standard-model tables).
+
+    [Fact]
+    public void Table_emits_the_five_default_AOT_field_groups_in_order()
+    {
+        var doc = XppScaffolder.Table("FmThing", pattern: TablePattern.Main);
+        var groupNames = doc.Root!.Element("FieldGroups")!.Elements("AxTableFieldGroup")
+            .Select(g => g.Element("Name")!.Value).ToList();
+
+        Assert.Equal(
+            new[] { "AutoReport", "AutoLookup", "AutoIdentification", "AutoSummary", "AutoBrowse", "Overview", "General" },
+            groupNames);
+    }
+
+    [Theory]
+    [InlineData("AutoReport")]
+    [InlineData("AutoLookup")]
+    [InlineData("AutoIdentification")]
+    [InlineData("AutoSummary")]
+    [InlineData("AutoBrowse")]
+    public void Default_AOT_field_groups_are_empty_even_when_the_table_has_fields(string groupName)
+    {
+        // Ground truth: VS does NOT auto-populate these groups with fields, even
+        // once the table has real fields (verified against shipped tables, e.g.
+        // ApplicationCommon\AgentFeedUserPreference.xml,
+        // ApplicationSuite\Foundation\AssetAddition.xml).
+        var doc = XppScaffolder.Table("FmCustomer", pattern: TablePattern.Main);
+        var group = doc.Root!.Element("FieldGroups")!.Elements("AxTableFieldGroup")
+            .Single(g => g.Element("Name")!.Value == groupName);
+
+        var fieldsEl = group.Element("Fields")!;
+        Assert.False(fieldsEl.HasElements);
+    }
+
+    [Fact]
+    public void AutoIdentification_field_group_has_AutoPopulate_Yes()
+    {
+        var doc = XppScaffolder.Table("FmThing", pattern: TablePattern.Main);
+        var group = doc.Root!.Element("FieldGroups")!.Elements("AxTableFieldGroup")
+            .Single(g => g.Element("Name")!.Value == "AutoIdentification");
+
+        Assert.Equal("Yes", group.Element("AutoPopulate")!.Value);
+    }
+
+    [Theory]
+    [InlineData("AutoReport")]
+    [InlineData("AutoLookup")]
+    [InlineData("AutoSummary")]
+    [InlineData("AutoBrowse")]
+    public void Only_AutoIdentification_field_group_carries_AutoPopulate(string groupName)
+    {
+        var doc = XppScaffolder.Table("FmThing", pattern: TablePattern.Main);
+        var group = doc.Root!.Element("FieldGroups")!.Elements("AxTableFieldGroup")
+            .Single(g => g.Element("Name")!.Value == groupName);
+
+        Assert.Null(group.Element("AutoPopulate"));
+    }
+
+    [Fact]
+    public void Overview_and_General_field_groups_stay_populated_for_form_compatibility()
+    {
+        // Not part of the AOT default scaffold, but required so this CLI's own
+        // generated forms (which reference them via <DataGroup>) compile — see
+        // issue #91 follow-up.
+        var doc = XppScaffolder.Table("FmCustomer", pattern: TablePattern.Main);
+        var overview = doc.Root!.Element("FieldGroups")!.Elements("AxTableFieldGroup")
+            .Single(g => g.Element("Name")!.Value == "Overview");
+        var general = doc.Root!.Element("FieldGroups")!.Elements("AxTableFieldGroup")
+            .Single(g => g.Element("Name")!.Value == "General");
+
+        Assert.True(overview.Element("Fields")!.HasElements);
+        Assert.True(general.Element("Fields")!.HasElements);
+    }
+
+    [Fact]
+    public void Generated_table_does_not_emit_shouldThrowExceptionOnZeroDelete()
+    {
+        // VS/AOT does not generate this method on a fresh table — it's a
+        // developer override some standard tables happen to add, not a
+        // scaffold default. Confirmed by sampling shipped standard-model
+        // tables: only a small minority carry it.
+        var doc = XppScaffolder.Table("FmThing", pattern: TablePattern.Main);
+        Assert.DoesNotContain("shouldThrowExceptionOnZeroDelete", doc.ToString());
+    }
+
     // --- issue #91: AxTableField is abstract — every field needs a concrete
     //     i:type discriminator or the metadata reader rejects the whole table.
 


### PR DESCRIPTION
## Summary
- `generate table` omitted the field groups Visual Studio's real "Add Table" wizard always creates, and the emitted set didn't match AOT defaults.
- `XppScaffolder.Table()` now emits the 5 real VS/AOT default field groups (`AutoReport`, `AutoLookup`, `AutoIdentification` with `AutoPopulate=Yes`, `AutoSummary`, `AutoBrowse`, all with empty `<Fields />`) ahead of the existing populated `Overview`/`General` groups.

Fixes #110.

## Test plan
- [x] 6 new tests in `TablePatternScaffoldingTests.cs` covering field-group order, emptiness, AutoPopulate, and that `Overview`/`General` remain populated
- [x] `dotnet test d365fo-cli.slnx` — 479/479 passing

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>