### PR TITLE
feat: add generate systest command (ATL-ready MVP) (#107)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,3 +17,6 @@ memory/
 
 # Upstream porting scratch (TS sources exported from d365fo-mcp-server)
 .porting/
+
+# Agent workflow scratch worktrees
+.claude/worktrees/

--- a/README.md
+++ b/README.md
@@ -228,7 +228,7 @@ See [docs/TOKEN_ECONOMICS.md](docs/TOKEN_ECONOMICS.md) for the full analysis and
 | **Form patterns** | `form-pattern analyze` (advisor), `form-pattern spec` (catalog), `form-pattern validate` (FP001–FP010) — mirrors the MCP `object_patterns` tool (`domain=form`) |
 | **Find** | `find related`, `find coc`, `find relations`, `find usages`, `find extensions`, `find event-handlers`, `find references`, `find form-patterns`, `find batch-jobs` (the extensibility ones mirror the MCP `extension_info` tool) |
 | **Read** | `read class`, `read table`, `read form` (= MCP `get_method`) |
-| **Generate** | `generate table\|class\|coc\|form\|entity\|extension\|event-handler\|privilege\|duty\|role\|report\|sysoperation\|number-sequence\|workflow\|menu-item\|edt\|enum\|query\|business-event\|custom-service\|migration-script\|runbase\|security-policy` |
+| **Generate** | `generate table\|class\|coc\|form\|entity\|extension\|event-handler\|privilege\|duty\|role\|report\|sysoperation\|number-sequence\|workflow\|menu-item\|edt\|enum\|query\|business-event\|custom-service\|migration-script\|runbase\|security-policy\|systest` |
 | **Labels** | `labels search\|resolve\|info\|create\|rename\|delete` — search/resolve plus in-place `*.label.txt` edits, multi-language via `--lang` (mirrors the MCP `labels` tool) |
 | **Analyze** | `analyze completeness`, `analyze integration`, `analyze impact`, `lint`, `suggest edt`, `suggest extension`, `report-integrations` |
 | **Review** | `review diff` |

--- a/docs/CAPABILITIES.md
+++ b/docs/CAPABILITIES.md
@@ -188,6 +188,7 @@ All scaffolders write atomically (`.tmp` + move, `.bak` on overwrite). Pass `--i
 | `generate custom-service` | `AxService` + service class + `AxServiceGroup` |
 | `generate runbase` | `RunBase` / `RunBaseBatch` skeleton with dialog parameters |
 | `generate security-policy` | `AxSecurityPolicy` (XDS row-level security) |
+| `generate systest` | `SysTestCase` skeleton — `[SysTestMethod]` Arrange/Act/Assert stub, optional `[SysTestCaseDataDependency]` and `--atl` `AtlDataRootNode` wiring (ATL-ready MVP, no test-logic generation) |
 | `generate migration-script` | Data-fix `Runnable` class with `ttsbegin`/`ttscommit` batching |
 | `generate simple-list` | Alias for `generate form --pattern SimpleList` |
 

--- a/scripts/emit-skills.ps1
+++ b/scripts/emit-skills.ps1
@@ -21,11 +21,12 @@
 #>
 [CmdletBinding()]
 param(
-    [string]$Source  = (Join-Path $PSScriptRoot '..' 'skills' '_source'),
-    [string]$OutRoot = (Join-Path $PSScriptRoot '..' 'skills')
+    [string]$Source  = (Join-Path (Join-Path $PSScriptRoot '..') (Join-Path 'skills' '_source')),
+    [string]$OutRoot = (Join-Path $PSScriptRoot (Join-Path '..' 'skills'))
 )
 
 $ErrorActionPreference = 'Stop'
+$Utf8NoBom = [System.Text.UTF8Encoding]::new($false)
 
 function Split-Frontmatter {
     param([string]$Content)
@@ -83,7 +84,7 @@ applyTo: '$glob'
 "@
     $path = Join-Path $OutDir "$id.instructions.md"
     New-Item -ItemType Directory -Force -Path (Split-Path $path) | Out-Null
-    Set-Content -Path $path -Value "$fm`n$Body" -Encoding utf8 -NoNewline
+    [System.IO.File]::WriteAllText($path, "$fm`n$Body", $Utf8NoBom)
     Write-Host "  [copilot]   $path"
 }
 
@@ -106,7 +107,7 @@ description: $desc
     $dir = Join-Path $OutDir $id
     New-Item -ItemType Directory -Force -Path $dir | Out-Null
     $path = Join-Path $dir 'SKILL.md'
-    Set-Content -Path $path -Value "$fm`n$Body" -Encoding utf8 -NoNewline
+    [System.IO.File]::WriteAllText($path, "$fm`n$Body", $Utf8NoBom)
     Write-Host "  [anthropic] $path"
 }
 
@@ -122,7 +123,7 @@ if ($files.Count -eq 0) { Write-Warning "No source skills found."; exit 0 }
 
 foreach ($f in $files) {
     Write-Host "» $($f.Name)"
-    $raw = Get-Content -Raw -Path $f.FullName
+    $raw = [System.IO.File]::ReadAllText($f.FullName, [System.Text.Encoding]::UTF8)
     $split = Split-Frontmatter -Content $raw
     $meta = Parse-Yaml -Text $split.Frontmatter
     if (-not $meta.id)          { throw "Missing 'id' in $($f.Name)." }

--- a/skills/_source/business-events-authoring.md
+++ b/skills/_source/business-events-authoring.md
@@ -31,7 +31,7 @@ A custom business event consists of exactly two classes:
    - Implements buildContract() to populate the payload
    - Has a static newFrom<Context>(...) factory
 
-2. Contract class — implements BusinessEventsContract
+2. Contract class — extends BusinessEventsContract
    - Decorated with [DataContractAttribute]
    - One parmXxx() accessor per payload field, decorated with [DataMemberAttribute]
 ```
@@ -75,10 +75,10 @@ d365fo generate business-event CustPaymentBusinessEvent \
 
 ```xpp
 [BusinessEvents(
-    classStr(CustPaymentBusinessEvent),
     classStr(CustPaymentBusinessEventContract),
-    "CustomerPayments",
-    "@MyModel:CustPaymentBusinessEventDescription")]
+    'MyModel:CustPaymentBusinessEventName',
+    'MyModel:CustPaymentBusinessEventDescription',
+    ModuleAxapta::Customer)]
 public final class CustPaymentBusinessEvent extends BusinessEventsBase
 {
     private CustTrans custTrans;
@@ -148,7 +148,7 @@ public final class CustPaymentBusinessEventContract extends BusinessEventsContra
 
 ## Firing the event
 
-Call the static factory from the business process at the right lifecycle point — typically in a table `insert` / `update` override, a posting engine, or a workflow action:
+Call the static factory from the business process at the right lifecycle point — typically in a table `insert` / `update` override, a posting engine, or a workflow action. `BusinessEventsBase` exposes the send operation as a `public final` **instance** method (`send()`), not a static publisher — construct the event, then call `.send()` on it:
 
 ```xpp
 // In CustTrans.insert() CoC or a posting service method:
@@ -160,8 +160,7 @@ final class CustTrans_MyExt
         next insert();
 
         // Fire after successful insert
-        BusinessEventsBase::publish(
-            CustPaymentBusinessEvent::newFromCustTrans(this));
+        CustPaymentBusinessEvent::newFromCustTrans(this).send();
     }
 }
 ```
@@ -183,9 +182,9 @@ After scaffolding and compiling:
 
 ## Hard rules
 
-- **`[BusinessEvents(...)]` must be on the event class declaration** — not on methods. Four arguments: `classStr(EventClass)`, `classStr(ContractClass)`, `"CategoryString"`, `"@File:DescriptionLabel"`.
+- **`[BusinessEvents(...)]` must be on the event class declaration** — not on methods. The `BusinessEventsAttribute` constructor is `new(ClassName _businessEventsContractClassStr, LabelString _nameLabel, LabelString _descriptionLabel, ModuleAxapta _module)` — four arguments: `classStr(ContractClass)`, a name-label token, a description-label token, and a `ModuleAxapta::<Module>` enum value (not a free-text category, and no `classStr(EventClass)` — the attribute already decorates the event class itself).
 - **`buildContract()` is called by the framework** — return the populated contract instance; never return `null`.
 - **Contract `parmXxx()` accessors must be decorated with `[DataMemberAttribute]`** — the serialization layer uses these to build the JSON payload.
 - **Use EDTs for payload fields** (e.g. `CustAccount`, `AmountCur`) — not primitive types. Run `d365fo get edt <Name>` to confirm the EDT exists.
-- **Never call `BusinessEventsBase::publish()` inside a `ttsbegin`/`ttscommit` block** unless you intend to publish on rollback too. Call it after the outermost `ttscommit` or in the `postInsert`/`postUpdate` framework hook.
-- **Category string is free text** — use a meaningful module-scoped category (e.g. `"CustomerPayments"`, `"InventoryEvents"`) so the catalog is navigable.
+- **Never call `.send()` inside a `ttsbegin`/`ttscommit` block** unless you intend to publish on rollback too. Call it after the outermost `ttscommit` or in the `postInsert`/`postUpdate` framework hook. `send()` is a `public final` instance method on `BusinessEventsBase` (there is also `sendOnUserConnection(UserConnection)`) — there is no static `publish()` method.
+- **The catalog category comes from the `ModuleAxapta` enum value passed to `[BusinessEvents(...)]`**, not free text — pick the enum member matching the module the event belongs to (e.g. `ModuleAxapta::Customer`, `ModuleAxapta::Inventory`; run `d365fo get enum ModuleAxapta` for the full list).

--- a/skills/_source/coc-extension-authoring.md
+++ b/skills/_source/coc-extension-authoring.md
@@ -26,7 +26,7 @@ strategy, and a **grounding token**. Do NOT issue separate `get class` /
 
 If `existingCocExtensions` is non-empty, enumerate them to the user and stop before writing another wrapper. Stacking duplicates risks ordering bugs.
 
-Pass the token to the generator: `d365fo generate coc <TargetClass> --method <method> --install-to <Model> --grounding-token <token>`. For any hand-written wrapper body, run `d365fo validate references --file <f>` + `d365fo validate xpp --file <f>` BEFORE writing — exit code 2 means hallucinated symbols / BP errors to fix first.
+Pass the token to the generator: `d365fo generate coc <TargetClass> --method <method> --install-to <Model> --grounding-token <token>`. For any hand-written wrapper body, run `d365fo validate references <f>` + `d365fo validate xpp <f>` BEFORE writing (the file is a positional argument, not `--file`; omit it to read from stdin) — exit code 2 means hallucinated symbols / BP errors to fix first.
 
 Fallback (prepare unavailable): `d365fo get class <TargetClass>` + `d365fo find coc <TargetClass>::<method>`.
 

--- a/skills/_source/custom-service-authoring.md
+++ b/skills/_source/custom-service-authoring.md
@@ -6,7 +6,7 @@ applyTo:
   - "**/AxServiceGroup/**"
   - "**/*Service.xml"
   - "**/*ServiceGroup.xml"
-appliesWhen: User intent mentions custom service, service class, service group, JSON endpoint, SOAP endpoint, REST API from X++, [ServiceAttribute], or AxServiceGroup.
+appliesWhen: User intent mentions custom service, service class, service group, JSON endpoint, SOAP endpoint, REST API from X++, AxService, or AxServiceGroup.
 ---
 
 > ⛔ **NEVER write X++ AOT XML files directly** via PowerShell, terminal file commands (`Set-Content`, `Out-File`, `New-Item`), editor write tools, or any raw text approach. The XML schema is proprietary. **ALWAYS use `d365fo generate …` commands** to produce correct AOT XML. If `d365fo` is unavailable in PATH, stop and ask the user to install it.
@@ -26,10 +26,12 @@ appliesWhen: User intent mentions custom service, service class, service group, 
 A D365FO custom service requires three artifacts:
 
 ```
-1. Service class  — decorated with [ServiceAttribute]
+1. Service class  — a plain X++ class (no class-level service attribute
+   exists in X++ — the AxService object below is what wires it up)
    - Parameters/return types use [DataContractAttribute] classes
 
 2. AxService XML  — declares the service class + operation bindings
+   (each AxServiceOperation maps an operation Name to a Method on the class)
 
 3. AxServiceGroup XML  — registers the service into a named group
    (determines the REST URL path segment)
@@ -53,15 +55,23 @@ d365fo report-integrations --model <ModelName> --output json
 ## Scaffolding
 
 ```sh
-d365fo generate custom-service VendorLookupService \
-  --operation Lookup:lookupVendor \
-  --operation Create:createVendor \
+d365fo generate custom-service VendorLookup \
+  --group-name VendorLookupServiceGroup \
+  --operation lookupVendor:VendorLookupResponse \
+  --operation createVendor:boolean \
+  --contract-param VendorLookupRequest \
   --install-to MyModel
 ```
 
+`--operation` takes `<name>:<returnType>` — the same `<name>` is used both as the
+`AxServiceOperation` `Name` and as the generated X++ method name (there is no
+separate operation-name-to-method-name mapping). `--contract-param <ContractClass>`
+applies that single parameter type to every generated operation method.
+`--class-name` defaults to `<NAME>Service` and `--group-name` defaults to `<NAME>Group`.
+
 This produces:
-- `AxClass/VendorLookupService.xml` — the service class
-- `AxService/VendorLookupService.xml` — service descriptor
+- `AxService/VendorLookup.xml` — service descriptor (`Name` = the positional argument)
+- `AxClass/VendorLookupService.xml` — the service class (`--class-name` defaulted)
 - `AxServiceGroup/VendorLookupServiceGroup.xml` — service group
 
 ---
@@ -69,7 +79,6 @@ This produces:
 ## Service class skeleton
 
 ```xpp
-[ServiceAttribute]
 public class VendorLookupService
 {
     public VendorLookupResponse lookupVendor(VendorLookupRequest _request)
@@ -80,6 +89,11 @@ public class VendorLookupService
     }
 }
 ```
+
+There is no class-level attribute that marks a class as a service — the
+class is just a plain X++ class. The `AxService` XML object (below) is what
+exposes it: it references the class by name and lists each callable method
+as an `AxServiceOperation`.
 
 ## Request / Response contract classes
 
@@ -117,16 +131,20 @@ public class VendorLookupResponse
 
 ```xml
 <AxService>
-  <Name>VendorLookupService</Name>
-  <ClassName>VendorLookupService</ClassName>
-  <Operations>
+  <Name>VendorLookup</Name>
+  <Class>VendorLookupService</Class>
+  <ServiceOperations>
     <AxServiceOperation>
-      <Name>lookup</Name>
-      <MethodName>lookupVendor</MethodName>
+      <Name>lookupVendor</Name>
+      <Method>lookupVendor</Method>
     </AxServiceOperation>
-  </Operations>
+  </ServiceOperations>
 </AxService>
 ```
+
+The operation's `Method` element names the X++ method on the class named by
+`Class`; `Name` is the external operation name used in the REST URL and is
+typically the same string as `Method`.
 
 ## AxServiceGroup XML structure
 
@@ -135,11 +153,15 @@ public class VendorLookupResponse
   <Name>VendorLookupServiceGroup</Name>
   <Services>
     <AxServiceGroupService>
-      <ServiceName>VendorLookupService</ServiceName>
+      <Name>VendorLookup</Name>
+      <Service>VendorLookup</Service>
     </AxServiceGroupService>
   </Services>
 </AxServiceGroup>
 ```
+
+`Service` references the `AxService` object's `Name`; `Name` on the
+`AxServiceGroupService` is conventionally the same value.
 
 ---
 
@@ -155,9 +177,11 @@ Content-Type: application/json
 { "AccountNum": "US-001" }
 ```
 
-Example for the scaffold above:
+Example for the scaffold above (`<ServiceName>` is the `AxService` object's
+`Name`, i.e. the positional argument passed to `d365fo generate custom-service`
+— not the `AxClass` service-class name):
 ```
-POST https://myenv.operations.dynamics.com/api/services/VendorLookupServiceGroup/VendorLookupService/lookup
+POST https://myenv.operations.dynamics.com/api/services/VendorLookupServiceGroup/VendorLookup/lookupVendor
 ```
 
 ---
@@ -174,7 +198,7 @@ Use Azure AD OAuth2:
 ## Hard rules
 
 - **Request/response types must be `[DataContractAttribute]` classes.** Primitive types (`str`, `int`) are also accepted for simple services.
-- **Public methods in a `[ServiceAttribute]`-decorated class are automatically exposed** and do not require `[SysEntryPointAttribute]`.
+- **There is no `[ServiceAttribute]` class-level decorator in X++.** A service class is a plain class; exposure comes entirely from the `AxService` object listing its methods as `AxServiceOperation` entries. Exposed methods do not require `[SysEntryPointAttribute]`.
 - **`[DataMemberAttribute]` on every parmXxx accessor** — the JSON serializer uses member names from this attribute.
 - **Service group name determines the URL** — choose a stable, module-scoped name; renaming it breaks all callers.
 - **Never include `ttsbegin/ttscommit` in service methods** unless you own the full transaction scope. If the service calls a framework method that manages its own transaction, wrap at a higher level.

--- a/skills/_source/data-entity-scaffolding.md
+++ b/skills/_source/data-entity-scaffolding.md
@@ -27,7 +27,10 @@ d365fo search edt  <Edt>        --output json    # for any EDT mappings
 ## Scaffolding
 
 ```sh
-# Minimal — exposes one table; OData names default to <Name>Entity / <Name>Entities
+# Minimal — without --public-entity/--public-collection, PublicEntityName
+# defaults to the literal ENTITY argument and PublicCollectionName to
+# ENTITY + "s" (naive pluralization, e.g. FmVehicleEntity / FmVehicleEntitys) —
+# always pass both explicitly for clean OData names.
 d365fo generate entity FmVehicleEntity \
     --table FmVehicle \
     --all-fields \
@@ -37,13 +40,14 @@ d365fo generate entity FmVehicleEntity \
 d365fo generate entity FmVehicleEntity \
     --table FmVehicle \
     --field VIN --field Make --field Year \
-    --public-entity-name FleetVehicle \
-    --public-collection-name FleetVehicles \
+    --public-entity FleetVehicle \
+    --public-collection FleetVehicles \
     --install-to FleetManagement
 ```
 
-The CLI returns `{path, bytes, backup, fieldCount, publicEntityName,
-publicCollectionName}`. Never request the full XML back.
+The CLI returns `{kind, name, table, path, bytes, fieldCount, fieldsFromTable}`
+(plus `backup` when `--overwrite` replaces an existing file). Never request
+the full XML back.
 
 ## OData naming conventions (D365FO)
 

--- a/skills/_source/event-handler-authoring.md
+++ b/skills/_source/event-handler-authoring.md
@@ -47,7 +47,7 @@ the user explicitly requests a separate class.
 ```sh
 d365fo generate event-handler MyClass_CustTableHandler \
     --source-kind Table \
-    --source CustTable \
+    --source-object CustTable \
     --event Inserted \
     --install-to MyModel
 ```
@@ -57,23 +57,28 @@ Generated attribute: `[DataEventHandler(tableStr(CustTable), DataEventType::Inse
 D365FO `DataEventType` values: `ValidatingFieldValue`, `ValidatedField`,
 `ValidatingDelete`, `ValidatedDelete`, `ValidatingWrite`, `ValidatedWrite`,
 `Inserting`, `Inserted`, `Updating`, `Updated`, `Deleting`, `Deleted`,
-`InitializingRecord`, `InitializedRecord`, `Modifying`, `Modified`.
+`InitializingRecord`, `InitializedRecord`, `ModifyingField`, `ModifiedField`.
 
 ## Form / FormDataSource / FormControl events → form-specific attributes
 
 ```sh
 d365fo generate event-handler MyClass_FormHandler \
     --source-kind Form \
-    --source CustTable \
+    --source-object CustTable \
     --event Initialized \
     --install-to MyModel
 
 d365fo generate event-handler MyClass_FormDsHandler \
     --source-kind FormDataSource \
-    --source CustTable.CustTable \
-    --event ExecuteQuery \
+    --source-object "CustTable, CustTable" \
+    --event QueryExecuting \
     --install-to MyModel
 ```
+
+`--source-object` for `FormDataSource` is passed through verbatim into
+`formDataSourceStr(...)`, so it must already be the two comma-separated
+`<Form>, <DataSource>` arguments (e.g. `"CustTable, CustTable"`) — a dotted
+`Form.DataSource` value produces invalid X++.
 
 Attribute shapes: `[FormEventHandler(formStr(...), FormEventType::...)]`,
 `[FormDataSourceEventHandler(formDataSourceStr(form, ds), FormDataSourceEventType::...)]`.
@@ -87,7 +92,7 @@ events — those are `DataEventHandler`.
 ```sh
 d365fo generate event-handler MyClass_DelegateHandler \
     --source-kind Class \
-    --source SalesFormLetter \
+    --source-object SalesFormLetter \
     --event onPosted \
     --install-to MyModel
 ```

--- a/skills/_source/form-pattern-scaffolding.md
+++ b/skills/_source/form-pattern-scaffolding.md
@@ -36,7 +36,7 @@ CORRECT — always:
 ## Pre-flight
 
 ```sh
-d365fo search form <Name> --output json          # collision check
+d365fo search any <Name> --kind form --output json   # collision check (no dedicated `search form`)
 d365fo get table <PrimaryTable> --output json    # field list for the grid
 
 # Pattern spec — required structure, versions, when-to-use, reference forms
@@ -138,11 +138,12 @@ section template is `--section Name:Caption` (split on the first `:`).
   `<DataSourceReferences>`, `<DataSources>`, methods, extension properties,
   and pattern metadata exactly.
 - After changing form XML, validate XML well-formedness, run
-  `d365fo validate xpp --file <file> --code-type xml-any --output json`, run
+  `d365fo validate xpp <file> --code-type xml-any --output json` (file is a
+  positional argument, not `--file`), run
   `d365fo index refresh --model <Model>`, and re-read with
   `d365fo get form <Form> --output json`.
 - Never use `Dialog` or `TableOfContents` patterns for transactional grids.
-- Pre-flight `search form <Name>` before scaffolding to avoid collisions.
+- Pre-flight `search any <Name> --kind form` before scaffolding to avoid collisions (there is no dedicated `search form` subcommand).
 - Caption strings must be labels (BP `BPErrorLabelIsText`) — never raw text.
 - After scaffolding, run `d365fo build` only on user request.
 

--- a/skills/_source/integration-patterns.md
+++ b/skills/_source/integration-patterns.md
@@ -23,7 +23,7 @@ appliesWhen: User intent mentions OData, REST API, custom service, SOAP, DMF, Da
 
 | Pattern | Direction | Latency | Volume | Entry point |
 |---------|-----------|---------|--------|-------------|
-| **OData REST API** | In + Out | Synchronous, real-time | Record-level | `data/<EntityName>` endpoint |
+| **OData REST API** | In + Out | Synchronous, real-time | Record-level | `data/<PublicCollectionName>` endpoint |
 | **Custom Services** | In | Synchronous | Operation-level | SOAP + JSON REST endpoint |
 | **Data Management Framework (DMF)** | In + Out | Async batch | Bulk | Import/export jobs, staging tables |
 | **Business Events** | Out | Near-real-time | Event-driven | Service Bus, Event Grid, Power Automate, Logic Apps |
@@ -34,11 +34,11 @@ appliesWhen: User intent mentions OData, REST API, custom service, SOAP, DMF, Da
 
 **Purpose:** real-time synchronous CRUD from external systems — Power Platform, Logic Apps, third-party ERPs.
 
-**Endpoint:** `https://{env}.cloudax.dynamics.com/data/{PublicEntityName}`
+**Endpoint:** `https://{env}.cloudax.dynamics.com/data/{PublicCollectionName}`
 
 **Requirements for a working OData entity:**
 
-- `EnablePublicAPI = Yes` on the `AxDataEntityView`
+- `IsPublic = Yes` on the `AxDataEntityView`
 - A unique `PublicEntityName` (the OData entity type) and `PublicCollectionName` (the collection URL segment)
 - At least one key field with `AlternateKey = Yes` on a unique index
 - All mandatory fields mapped in the entity
@@ -58,7 +58,7 @@ d365fo get table <SourceTable> --output json | jq '.data.indexes[] | select(.alt
 # 4. Scaffold a new entity if needed
 d365fo generate entity <Name> --table <T> \
   --all-fields \
-  --public-entity-name <Singular> --public-collection-name <Plural> \
+  --public-entity <Singular> --public-collection <Plural> \
   --out c:/AOT/MyModel/AxDataEntityView/<Name>.xml
 ```
 
@@ -119,8 +119,8 @@ d365fo generate custom-service <Name> \
 
 **Requirements for DMF-capable entity:**
 
-- `EnableDataManagementCapabilities = Yes` on the `AxDataEntityView`
-- A staging table (`StagingTable` property set)
+- `DataManagementEnabled = Yes` on the `AxDataEntityView`
+- A staging table (`DataManagementStagingTable` property set)
 - Change tracking support (for incremental export)
 
 **CLI workflow:**
@@ -129,12 +129,12 @@ d365fo generate custom-service <Name> \
 # 1. Find the entity
 d365fo search entity <Name> --output json
 
-# 2. Check DMF capability and staging table presence
-d365fo get entity <Name> --output json | jq '{enableDMF: .data.enableDataManagementCapabilities, stagingTable: .data.stagingTable}'
+# 2. Check staging table presence (a non-empty value implies DMF is wired up)
+d365fo get entity <Name> --output json | jq '.data.entity.stagingTable'
 
 # 3. Scaffold a DMF-capable entity (staging table must be created separately)
-d365fo generate entity <Name> --table <T> --all-fields --out …
-# Then hand-edit to set EnableDataManagementCapabilities + StagingTable
+d365fo generate entity <Name> --table <T> --all-fields \
+  --data-management --staging-table <Name>Staging --out …
 ```
 
 **Notes:**

--- a/skills/_source/label-translation.md
+++ b/skills/_source/label-translation.md
@@ -41,9 +41,12 @@ d365fo labels create "@FleetManagement:VehicleVin" "VIN" \
 
 - The `<KEY>` form `@File:Key` must match the target `.label.txt` filename
   (`@FleetManagement:VehicleVin` → `FleetManagement.label.txt`).
-- `--lang` is required when the file does not embed a single language stem
-  (`FleetManagement.en-us.label.txt`).
-- The CLI writes atomically (`.tmp` + move; `.bak` retained on overwrite).
+- `--lang` only affects path resolution when using `--install-to <MODEL>`; it
+  has no effect when `--file` is given directly — pass the full path to the
+  target `<Name>.<lang>.label.txt` file yourself.
+- The CLI writes atomically (`.tmp` + move; `.bak` retained whenever the
+  target file already existed, on both first-write-to-existing-file and
+  `--overwrite`).
 
 ## 3. Rename a label key (refactor across the model)
 
@@ -82,5 +85,9 @@ d365fo labels delete @FleetManagement:DeprecatedKey --file <path>.label.txt
 ## EDT-label inheritance — exception
 
 When adding a field whose EDT already carries a `Label`, do **NOT** create
-a new label or pass `--label` on the field — the field inherits the EDT
-caption. Only override when the table needs a different caption deliberately.
+a new label for it — an `AxTableField` with no `<Label>` element inherits
+the EDT's caption at runtime. `d365fo generate table --field <name>:<edt>`
+never emits a per-field `<Label>` (there is no per-field `--label` option
+today — `--label` on `generate table` sets the *table's* caption, not a
+field's). Only add a table-level `--label`/field-level label override when
+the table or field needs a caption different from the EDT's.

--- a/skills/_source/model-dependency-and-coupling.md
+++ b/skills/_source/model-dependency-and-coupling.md
@@ -4,7 +4,7 @@ description: Inspect indexed D365FO models, their declared dependencies, and arc
 applyTo:
   - "**/Descriptor/*.xml"
   - "**/AxModel/**"
-appliesWhen: User intent mentions model dependencies, layer (sys/syp/isv/iss/cus/cup/usr/usp), coupling, fan-in / fan-out / instability metrics, or "which model contains object X".
+appliesWhen: User intent mentions model dependencies, layer (sys/syp/cus/var/isv/usr, incl. patch layers), coupling, fan-in / fan-out / instability metrics, or "which model contains object X".
 ---
 
 > ⛔ **NEVER write X++ AOT XML files directly** via PowerShell, terminal file commands (`Set-Content`, `Out-File`, `New-Item`), editor write tools, or any raw text approach. The XML schema (`<AxClass>`, `<AxTable>`, `<AxForm>`, `<Methods>`, `<SourceCode>`) is proprietary — LLMs have not been trained on it reliably. **ALWAYS use `d365fo generate …` commands** to produce correct AOT XML. If `d365fo` is unavailable in PATH, stop and ask the user to install it.
@@ -25,7 +25,11 @@ d365fo models list --output json
 d365fo models deps FleetManagement --output json
 ```
 
-Output shape: `{name, publisher, layer, version, customizable, dependsOn[], dependedBy[]}`.
+`models list` output shape: `{count, items: [{modelId, name, publisher,
+layer, isCustom}]}` (`publisher`/`layer` are frequently absent — omitted
+when the Descriptor XML didn't populate them). `models deps` output shape:
+`{model: {modelId, name, publisher, layer, isCustom}, dependsOn: string[],
+dependedBy: string[]}`.
 
 ## Coupling metrics
 
@@ -45,8 +49,10 @@ Output highlights:
 
 ## When to invoke
 
-- Before introducing a new dependency: confirm the target model isn't
-  customer-layer (`layer: cus*`) when you're an ISV.
+- Before introducing a new dependency: check `models list`/`models deps` for
+  the target's layer — a model can only *depend on* strictly lower-or-equal
+  layers (e.g. a `cus`-layer model must not depend on an `isv`- or
+  `usr`-layer one).
 - During architectural review: `cycles[]` must be empty; fan-out outliers
   flag candidates for splitting.
 - When CoC / extensions don't take effect: `models deps` reveals if your
@@ -54,10 +60,14 @@ Output highlights:
 
 ## Hard rules
 
-- Never extend / depend on a `cus*` (customer-layer) model from an ISV model
-  — D365FO disallows the upward dependency.
+- Layer ordering (lowest → highest): `sys → syp → gls → glp → dis → dip →
+  cus → cup → var → vap → isv → isp → usr → usp` (each `Descriptor/*.xml`
+  stores the numeric layer id, e.g. `<Layer>8</Layer>` = `var`). Each layer
+  can only consume (depend on) *lower* layers — a `cus`-layer model cannot
+  depend on an `isv`- or `usr`-layer model; the reverse is allowed. In
+  practice most customer extension work happens in `usr` (the highest
+  layer) precisely so it can reference everything below it, including
+  installed ISV solutions.
 - Never introduce a cycle — even a 2-node cycle blocks compilation.
-- Layer ordering (lowest → highest): `sys → syp → isv → iss → cus → cup → usr → usp`.
-  Each layer can only consume *lower* layers.
 - After modifying any `Descriptor/*.xml`, run `d365fo index refresh` so
   subsequent `models deps` / `models coupling` reflects reality.

--- a/skills/_source/object-extension-authoring.md
+++ b/skills/_source/object-extension-authoring.md
@@ -27,10 +27,10 @@ appliesWhen: User intent mentions extending a Table / Form / Edt / Enum, adding 
 
 | Standard object you want to change | Use |
 |---|---|
-| Add a field/index/relation to `CustTable` | `extension Table CustTable <Suffix>` |
-| Add a control / data source / FastTab to a standard form | `extension Form CustTableListPage <Suffix>` |
-| Tighten an EDT (e.g. lengthen a string, adjust label) | `extension Edt CustAccount <Suffix>` |
-| Add new members to a base enum | `extension Enum NoYes <Suffix>` |
+| Add a field/index/relation to `CustTable` | `extension Table CustTable --suffix <Suffix>` |
+| Add a control / data source / FastTab to a standard form | `extension Form CustTableListPage --suffix <Suffix>` |
+| Tighten an EDT (e.g. lengthen a string, adjust label) | `extension Edt CustAccount --suffix <Suffix>` |
+| Add new members to a base enum | `extension Enum NoYes --suffix <Suffix>` |
 | Add behaviour to a class method | **NOT this** — use `coc-extension-authoring` instead |
 
 ## Pre-flight (ONE call)
@@ -86,17 +86,23 @@ Before scaffolding a new extension, inspect the existing result from
 
 ```sh
 # Add fields to standard CustTable in the FleetManagement model
-d365fo generate extension Table CustTable Fleet --install-to FleetManagement
+d365fo generate extension Table CustTable --suffix Fleet --install-to FleetManagement
 
 # Form extension targeting CustTableListPage
-d365fo generate extension Form CustTableListPage Fleet --install-to FleetManagement
+d365fo generate extension Form CustTableListPage --suffix Fleet --install-to FleetManagement
 
 # Tighten the CustAccount EDT
-d365fo generate extension Edt CustAccount Fleet --install-to FleetManagement
+d365fo generate extension Edt CustAccount --suffix Fleet --install-to FleetManagement
 
 # Add an enum member to NoYes
-d365fo generate extension Enum NoYes Fleet --install-to FleetManagement
+d365fo generate extension Enum NoYes --suffix Fleet --install-to FleetManagement
 ```
+
+`generate extension` takes exactly two positional arguments (`<KIND> <TARGET>`);
+the suffix is a named `--suffix <SUFFIX>` option, not a third positional
+argument — passing it positionally fails with "Could not match '<value>' with
+an argument." If `--suffix` is omitted it defaults to the `--install-to`
+model name (or `Extension`).
 
 The scaffold emits a minimal `<AxXxxExtension>` element with the
 `<Name>Target.Suffix</Name>` shape Visual Studio expects. After scaffolding,
@@ -130,7 +136,7 @@ d365fo generate enum CustCustomStatus \
   --out c:/AOT/MyModel/AxEnum/CustCustomStatus.xml
 ```
 
-`--base-type` accepts `String`, `Integer`, `Real`, `Int64`, `Date`, `UtcDateTime`, `Enum`, `Guid`. Enums are `IsExtensible=Yes` by default — pass `--no-extensible` to opt out.
+`--base-type` accepts `String`, `Integer`, `Real`, `Int64`, `Date`, `UtcDateTime`, `Enum`, `Guid`. Enums are `IsExtensible=Yes` by default — pass `--non-extensible` to opt out (`--no-extensible` is not a recognized flag and is silently ignored, leaving the enum extensible).
 
 ## XDS Security Policy scaffolding
 
@@ -148,7 +154,7 @@ d365fo generate security-policy CustCustomSecurityPolicy \
   --out c:/AOT/MyModel/AxSecurityPolicy/CustCustomSecurityPolicy.xml
 ```
 
-`--operation` accepts `All`, `Select`, `Insert`, `Update`, `Delete`. The policy query (`--policy-query`) is a separate `AxQuery` AOT object that must already exist or be scaffolded with `d365fo generate query`.
+`--operation` accepts only `Select` (default) or `All` — `Insert`/`Update`/`Delete` are rejected with "Unknown --operation '<value>'. Expected Select | All." The policy query (`--policy-query`) is a separate `AxQuery` AOT object that must already exist or be scaffolded with `d365fo generate query`.
 
 After scaffolding, verify with:
 ```sh
@@ -164,7 +170,8 @@ d365fo get security-policy CustCustomSecurityPolicy --output json
 - Never rewrite an existing extension XML file wholesale. Preserve unrelated
   nodes and only add the requested structural element(s).
 - After changing extension XML, validate XML well-formedness, run
-  `d365fo validate xpp --file <file> --code-type xml-any --output json`, run
+  `d365fo validate xpp <file> --code-type xml-any --output json` (file is a
+  positional argument, not `--file`), run
   `d365fo index refresh --model <Model>`, and re-read the target metadata.
 - Never use `extension` for class behaviour changes — that is CoC's job
   (`d365fo generate coc <Class>`).

--- a/skills/_source/review-and-checkpoint-workflow.md
+++ b/skills/_source/review-and-checkpoint-workflow.md
@@ -1,6 +1,6 @@
 ---
 id: review-and-checkpoint-workflow
-description: Use Git as the review layer for AI-driven D365FO edits, and use `d365fo review diff` to get an AOT-semantic summary of XML changes. Invoke whenever the user is about to start a non-trivial change, before "accepting" AI edits, or wants a structural diff (added classes, modified table fields, new CoC wrappers).
+description: Use Git as the review layer for AI-driven D365FO edits, and use `d365fo review diff` for a shallow BP-style probe (missing EDT/Label, hard-coded strings, dynamic query) over changed AxTable/AxClass XML on top of the raw byte diff. Invoke whenever the user is about to start a non-trivial change, before "accepting" AI edits, or wants a quick heuristic pass over what changed.
 applyTo:
   - "**/AxClass/**"
   - "**/AxTable/**"
@@ -15,8 +15,8 @@ appliesWhen: User intent mentions reviewing changes, accepting / rejecting AI ed
 # Git-checkpoint review workflow
 
 > Visual Studio 2022 has no inline accept/reject UI for AI edits. Use Git as
-> the review layer; pair with `d365fo review diff` for an AOT-semantic
-> summary on top of the raw byte diff.
+> the review layer; pair with `d365fo review diff` for a quick heuristic
+> probe on top of the raw byte diff.
 
 ## 1. Before starting any non-trivial task
 
@@ -68,24 +68,33 @@ For new forms based on an example, compare the pattern metadata and required
 controls/datasources from the example. Missing ActionPane/Body/Tab/FastTab/grid
 or QuickFilter elements are not acceptable just because the XML parses.
 
-## 3. After the task — AOT-semantic review
+## 3. After the task — review the diff
 
 ```sh
 # Raw byte diff (as usual)
 git diff --stat
 git diff <ref> -- AxClass/ AxTable/ AxForm/
 
-# AOT-semantic diff — added classes, modified table fields, new CoC wrappers …
+# Shallow BP-style probe over changed AxTable/AxClass XML in the working tree
+# vs --base (git diff --name-only under the hood; not a full structural diff)
 d365fo review diff --base <ref> --output json
-d365fo review diff --base HEAD~1 --output json | jq '.data.added,.data.modified'
+d365fo review diff --base HEAD~1 --output json | jq '.data.violations'
 ```
 
-`review diff` is **complementary** to `git diff`, not a replacement:
+`review diff` is **complementary** to `git diff`, not a replacement — and it
+is a shallow regex/XML probe, not a compiler-grade structural diff. It does
+NOT report added classes, modified fields, or new CoC wrappers. It only
+scans changed `.xml`/`.xpp` files and flags a small fixed set of issues:
+fields with no `<ExtendedDataType>` or no `<Label>` in changed
+`AxTable/…` XML, and hard-coded string literals / dynamic-`Query`
+construction in changed `AxClass/…` XML. Output shape: `{baseRev, headRev,
+changedFiles, violationCount, violations: [{file, rule, severity, message,
+…}]}`.
 
 | Tool | Shows | Best for |
 |---|---|---|
 | `git diff` | Raw bytes per file | Spotting whitespace / unintended edits |
-| `d365fo review diff` | Structural deltas (added field, new wrapper, index change) | Reviewer summary, PR descriptions |
+| `d365fo review diff` | A handful of BP-style probes (missing EDT/Label, hard-coded strings, dynamic query) over changed AxTable/AxClass XML | A fast heuristic pass before `bp check` — not a substitute for reading the diff |
 
 ## 4. Accept / reject
 
@@ -103,4 +112,4 @@ d365fo review diff --base HEAD~1 --output json | jq '.data.added,.data.modified'
 - Always include the `.bak` files in `.gitignore` for the user's repo so
   scaffold-overwrite backups don't pollute commits.
 - Always show `d365fo review diff` output BEFORE asking the user to accept
-  — they need the structural summary to make a decision.
+  — they need the heuristic-probe summary to make a decision.

--- a/skills/_source/security-hierarchy-trace.md
+++ b/skills/_source/security-hierarchy-trace.md
@@ -14,15 +14,24 @@ appliesWhen: User intent mentions security, roles, duties, privileges, entry poi
 
 ## Workflow
 
-1. **Top-down** — which entry points does a role reach?
+1. **Top-down** — which entry points does a role reach? `security coverage
+   <Name> --type Role` always returns an empty `routes[]` (`Role` is not a
+   valid `--type`, and the coverage lookup is a reverse/bottom-up query, not
+   a forward one) — walk the hierarchy explicitly instead:
    ```sh
-   d365fo security coverage <RoleName> --type Role --output json
+   d365fo security role <RoleName> --output json       # -> duties[] + privileges[]
+   d365fo security duty <DutyName> --output json        # -> privileges[]
+   d365fo security privilege <PrivilegeName> --output json  # -> entryPoints[] (objectName + objectType)
    ```
 
 2. **Bottom-up** — which roles reach this object?
    ```sh
-   d365fo security coverage <ObjectName> --type Menuitem --output json
-   # type may be Table, Form, Report, Class, Menuitem
+   d365fo security coverage <ObjectName> --type MenuItemDisplay --output json
+   # --type is matched literally against the indexed AOT ObjectType, so use the
+   # exact value: MenuItemDisplay | MenuItemAction | MenuItemOutput | Table |
+   # Form | Report | Class. The CLI's own default/listed value "Menuitem" does
+   # NOT occur in real data and always returns an empty routes[] — always pass
+   # the specific MenuItem* kind.
    ```
 
 3. The response contains `routes[*]` of shape
@@ -68,4 +77,9 @@ d365fo generate duty FmNewDuty --privilege FmSomePrivilege \
 ```
 
 **Scaffold order:** menu item → privilege (references the menu item) → duty (bundles privileges) → role (bundles duties).
-Always run `d365fo security coverage <Name> --type Role --output json` after to verify the new objects appear in the hierarchy.
+Always verify the new objects appear in the hierarchy afterwards — `d365fo
+security coverage <Name> --type Role --output json` always returns an empty
+`routes[]` (see Workflow above); instead run `d365fo security role
+<RoleName> --output json` to confirm the duties/privileges are attached, and
+`d365fo security coverage <EntryPointName> --type MenuItemDisplay --output
+json` to confirm the new role reaches the target entry point.

--- a/skills/_source/xpp-best-practice-rules.md
+++ b/skills/_source/xpp-best-practice-rules.md
@@ -63,7 +63,7 @@ For *filter-only* joins use `exists join` / `notExists join`. For complex correl
 
 ### `BPCheckAlternateKeyAbsent` — every table needs an alternate key
 
-A unique index on the natural key, marked `AlternateKey = Yes`. The CLI's `d365fo generate table` template emits a `<Pkey>` index with `AlternateKey = Yes` — don't strip it.
+A unique index on the natural key, marked `AlternateKey = Yes`. The CLI's `d365fo generate table` template emits a `PrimaryIdx` index with `<AlternateKey>Yes</AlternateKey>` — don't strip it.
 
 ### `BPErrorUnknownLabel` — labels referenced must exist
 
@@ -107,7 +107,7 @@ d365fo generate table FmVehicle \
 
 ```sh
 # In-process heuristics — fast, runs anywhere, useful for CI:
-d365fo lint --output sarif > lint.sarif
+d365fo lint --format sarif > lint.sarif
 
 # Run specific method-flag categories (detected at index-extract time):
 d365fo lint --category today-usage          # BPUpgradeCodeToday: today() calls
@@ -118,7 +118,7 @@ d365fo lint --category doc-comment-missing  # BPXmlDocNoDocumentationComments
 d365fo bp check --output json
 ```
 
-Six categories are now available: `table-no-index`, `ext-named-not-attributed`, `string-without-edt`, `today-usage`, `do-insert-update`, `doc-comment-missing`. The method-flag categories are populated at extract time by scanning `<Source>` text — no full body is stored. Re-run `d365fo index refresh` after editing source before linting.
+Sixteen categories are now available: `table-no-index`, `ext-named-not-attributed`, `string-without-edt`, `today-usage`, `do-insert-update`, `doc-comment-missing`, `nested-select`, `insert-in-loop`, `tts-try-catch`, `empty-table-method`, `batch-no-cango`, `force-literals`, `public-instance-field`, `cache-lookup-mismatch`, `missing-delete-action`, `no-alternate-key`. The method-flag categories are populated at extract time by scanning `<Source>` text — no full body is stored. Re-run `d365fo index refresh` after editing source before linting.
 
 **Never** auto-run `bp check`. It blocks the user (slow, Windows-only). Say *"Changes scaffolded. Run `d365fo bp check` when you're ready."*
 

--- a/skills/_source/xpp-database-queries.md
+++ b/skills/_source/xpp-database-queries.md
@@ -82,6 +82,7 @@ SysDa is the modern X++ query API — fluent and object-oriented. Use it when qu
 
 **Core classes:**
 - `SysDaQueryObject` — root query builder; set table buffer via constructor.
+- `SysDaSearchObject` — wraps a `SysDaQueryObject` for iteration; pass this (not the raw query object) to `SysDaSearchStatement`/`SysDaFindStatement`.
 - `SysDaSearchStatement` — execute + iterate; `SysDaFindStatement` — `firstOnly` equivalent.
 - `SysDaUpdateStatement` / `SysDaInsertStatement` / `SysDaDeleteStatement` — set-based ops.
 
@@ -91,8 +92,9 @@ var qe = new SysDaQueryObject(custTable);
 qe.whereClause(new SysDaEqualsExpression(
     new SysDaFieldExpression(custTable, fieldStr(CustTable, AccountNum)),
     new SysDaValueExpression('US-001')));
-var so = new SysDaSearchStatement();
-while (so.nextRecord(qe))
+var so = new SysDaSearchObject(qe);       // wraps the query object for iteration
+var search = new SysDaSearchStatement();
+while (search.nextRecord(so))
 {
     info(custTable.AccountNum);
 }

--- a/skills/anthropic/business-events-authoring/SKILL.md
+++ b/skills/anthropic/business-events-authoring/SKILL.md
@@ -26,7 +26,7 @@ A custom business event consists of exactly two classes:
    - Implements buildContract() to populate the payload
    - Has a static newFrom<Context>(...) factory
 
-2. Contract class — implements BusinessEventsContract
+2. Contract class — extends BusinessEventsContract
    - Decorated with [DataContractAttribute]
    - One parmXxx() accessor per payload field, decorated with [DataMemberAttribute]
 ```
@@ -70,10 +70,10 @@ d365fo generate business-event CustPaymentBusinessEvent \
 
 ```xpp
 [BusinessEvents(
-    classStr(CustPaymentBusinessEvent),
     classStr(CustPaymentBusinessEventContract),
-    "CustomerPayments",
-    "@MyModel:CustPaymentBusinessEventDescription")]
+    'MyModel:CustPaymentBusinessEventName',
+    'MyModel:CustPaymentBusinessEventDescription',
+    ModuleAxapta::Customer)]
 public final class CustPaymentBusinessEvent extends BusinessEventsBase
 {
     private CustTrans custTrans;
@@ -143,7 +143,7 @@ public final class CustPaymentBusinessEventContract extends BusinessEventsContra
 
 ## Firing the event
 
-Call the static factory from the business process at the right lifecycle point — typically in a table `insert` / `update` override, a posting engine, or a workflow action:
+Call the static factory from the business process at the right lifecycle point — typically in a table `insert` / `update` override, a posting engine, or a workflow action. `BusinessEventsBase` exposes the send operation as a `public final` **instance** method (`send()`), not a static publisher — construct the event, then call `.send()` on it:
 
 ```xpp
 // In CustTrans.insert() CoC or a posting service method:
@@ -155,8 +155,7 @@ final class CustTrans_MyExt
         next insert();
 
         // Fire after successful insert
-        BusinessEventsBase::publish(
-            CustPaymentBusinessEvent::newFromCustTrans(this));
+        CustPaymentBusinessEvent::newFromCustTrans(this).send();
     }
 }
 ```
@@ -178,9 +177,9 @@ After scaffolding and compiling:
 
 ## Hard rules
 
-- **`[BusinessEvents(...)]` must be on the event class declaration** — not on methods. Four arguments: `classStr(EventClass)`, `classStr(ContractClass)`, `"CategoryString"`, `"@File:DescriptionLabel"`.
+- **`[BusinessEvents(...)]` must be on the event class declaration** — not on methods. The `BusinessEventsAttribute` constructor is `new(ClassName _businessEventsContractClassStr, LabelString _nameLabel, LabelString _descriptionLabel, ModuleAxapta _module)` — four arguments: `classStr(ContractClass)`, a name-label token, a description-label token, and a `ModuleAxapta::<Module>` enum value (not a free-text category, and no `classStr(EventClass)` — the attribute already decorates the event class itself).
 - **`buildContract()` is called by the framework** — return the populated contract instance; never return `null`.
 - **Contract `parmXxx()` accessors must be decorated with `[DataMemberAttribute]`** — the serialization layer uses these to build the JSON payload.
 - **Use EDTs for payload fields** (e.g. `CustAccount`, `AmountCur`) — not primitive types. Run `d365fo get edt <Name>` to confirm the EDT exists.
-- **Never call `BusinessEventsBase::publish()` inside a `ttsbegin`/`ttscommit` block** unless you intend to publish on rollback too. Call it after the outermost `ttscommit` or in the `postInsert`/`postUpdate` framework hook.
-- **Category string is free text** — use a meaningful module-scoped category (e.g. `"CustomerPayments"`, `"InventoryEvents"`) so the catalog is navigable.
+- **Never call `.send()` inside a `ttsbegin`/`ttscommit` block** unless you intend to publish on rollback too. Call it after the outermost `ttscommit` or in the `postInsert`/`postUpdate` framework hook. `send()` is a `public final` instance method on `BusinessEventsBase` (there is also `sendOnUserConnection(UserConnection)`) — there is no static `publish()` method.
+- **The catalog category comes from the `ModuleAxapta` enum value passed to `[BusinessEvents(...)]`**, not free text — pick the enum member matching the module the event belongs to (e.g. `ModuleAxapta::Customer`, `ModuleAxapta::Inventory`; run `d365fo get enum ModuleAxapta` for the full list).

--- a/skills/anthropic/coc-extension-authoring/SKILL.md
+++ b/skills/anthropic/coc-extension-authoring/SKILL.md
@@ -22,7 +22,7 @@ strategy, and a **grounding token**. Do NOT issue separate `get class` /
 
 If `existingCocExtensions` is non-empty, enumerate them to the user and stop before writing another wrapper. Stacking duplicates risks ordering bugs.
 
-Pass the token to the generator: `d365fo generate coc <TargetClass> --method <method> --install-to <Model> --grounding-token <token>`. For any hand-written wrapper body, run `d365fo validate references --file <f>` + `d365fo validate xpp --file <f>` BEFORE writing — exit code 2 means hallucinated symbols / BP errors to fix first.
+Pass the token to the generator: `d365fo generate coc <TargetClass> --method <method> --install-to <Model> --grounding-token <token>`. For any hand-written wrapper body, run `d365fo validate references <f>` + `d365fo validate xpp <f>` BEFORE writing (the file is a positional argument, not `--file`; omit it to read from stdin) — exit code 2 means hallucinated symbols / BP errors to fix first.
 
 Fallback (prepare unavailable): `d365fo get class <TargetClass>` + `d365fo find coc <TargetClass>::<method>`.
 

--- a/skills/anthropic/custom-service-authoring/SKILL.md
+++ b/skills/anthropic/custom-service-authoring/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: custom-service-authoring
 description: Build or extend a D365FO custom service (JSON/SOAP REST endpoint) using the AxService + AxServiceGroup + SysOperation or plain class pattern. Invoke when the user asks to "create a custom service", "expose an X++ method as a REST endpoint", "build a service class", or "register a service group".
-applies_when: User intent mentions custom service, service class, service group, JSON endpoint, SOAP endpoint, REST API from X++, [ServiceAttribute], or AxServiceGroup.
+applies_when: User intent mentions custom service, service class, service group, JSON endpoint, SOAP endpoint, REST API from X++, AxService, or AxServiceGroup.
 ---
 > ⛔ **NEVER write X++ AOT XML files directly** via PowerShell, terminal file commands (`Set-Content`, `Out-File`, `New-Item`), editor write tools, or any raw text approach. The XML schema is proprietary. **ALWAYS use `d365fo generate …` commands** to produce correct AOT XML. If `d365fo` is unavailable in PATH, stop and ask the user to install it.
 
@@ -20,10 +20,12 @@ applies_when: User intent mentions custom service, service class, service group,
 A D365FO custom service requires three artifacts:
 
 ```
-1. Service class  — decorated with [ServiceAttribute]
+1. Service class  — a plain X++ class (no class-level service attribute
+   exists in X++ — the AxService object below is what wires it up)
    - Parameters/return types use [DataContractAttribute] classes
 
 2. AxService XML  — declares the service class + operation bindings
+   (each AxServiceOperation maps an operation Name to a Method on the class)
 
 3. AxServiceGroup XML  — registers the service into a named group
    (determines the REST URL path segment)
@@ -47,15 +49,23 @@ d365fo report-integrations --model <ModelName> --output json
 ## Scaffolding
 
 ```sh
-d365fo generate custom-service VendorLookupService \
-  --operation Lookup:lookupVendor \
-  --operation Create:createVendor \
+d365fo generate custom-service VendorLookup \
+  --group-name VendorLookupServiceGroup \
+  --operation lookupVendor:VendorLookupResponse \
+  --operation createVendor:boolean \
+  --contract-param VendorLookupRequest \
   --install-to MyModel
 ```
 
+`--operation` takes `<name>:<returnType>` — the same `<name>` is used both as the
+`AxServiceOperation` `Name` and as the generated X++ method name (there is no
+separate operation-name-to-method-name mapping). `--contract-param <ContractClass>`
+applies that single parameter type to every generated operation method.
+`--class-name` defaults to `<NAME>Service` and `--group-name` defaults to `<NAME>Group`.
+
 This produces:
-- `AxClass/VendorLookupService.xml` — the service class
-- `AxService/VendorLookupService.xml` — service descriptor
+- `AxService/VendorLookup.xml` — service descriptor (`Name` = the positional argument)
+- `AxClass/VendorLookupService.xml` — the service class (`--class-name` defaulted)
 - `AxServiceGroup/VendorLookupServiceGroup.xml` — service group
 
 ---
@@ -63,7 +73,6 @@ This produces:
 ## Service class skeleton
 
 ```xpp
-[ServiceAttribute]
 public class VendorLookupService
 {
     public VendorLookupResponse lookupVendor(VendorLookupRequest _request)
@@ -74,6 +83,11 @@ public class VendorLookupService
     }
 }
 ```
+
+There is no class-level attribute that marks a class as a service — the
+class is just a plain X++ class. The `AxService` XML object (below) is what
+exposes it: it references the class by name and lists each callable method
+as an `AxServiceOperation`.
 
 ## Request / Response contract classes
 
@@ -111,16 +125,20 @@ public class VendorLookupResponse
 
 ```xml
 <AxService>
-  <Name>VendorLookupService</Name>
-  <ClassName>VendorLookupService</ClassName>
-  <Operations>
+  <Name>VendorLookup</Name>
+  <Class>VendorLookupService</Class>
+  <ServiceOperations>
     <AxServiceOperation>
-      <Name>lookup</Name>
-      <MethodName>lookupVendor</MethodName>
+      <Name>lookupVendor</Name>
+      <Method>lookupVendor</Method>
     </AxServiceOperation>
-  </Operations>
+  </ServiceOperations>
 </AxService>
 ```
+
+The operation's `Method` element names the X++ method on the class named by
+`Class`; `Name` is the external operation name used in the REST URL and is
+typically the same string as `Method`.
 
 ## AxServiceGroup XML structure
 
@@ -129,11 +147,15 @@ public class VendorLookupResponse
   <Name>VendorLookupServiceGroup</Name>
   <Services>
     <AxServiceGroupService>
-      <ServiceName>VendorLookupService</ServiceName>
+      <Name>VendorLookup</Name>
+      <Service>VendorLookup</Service>
     </AxServiceGroupService>
   </Services>
 </AxServiceGroup>
 ```
+
+`Service` references the `AxService` object's `Name`; `Name` on the
+`AxServiceGroupService` is conventionally the same value.
 
 ---
 
@@ -149,9 +171,11 @@ Content-Type: application/json
 { "AccountNum": "US-001" }
 ```
 
-Example for the scaffold above:
+Example for the scaffold above (`<ServiceName>` is the `AxService` object's
+`Name`, i.e. the positional argument passed to `d365fo generate custom-service`
+— not the `AxClass` service-class name):
 ```
-POST https://myenv.operations.dynamics.com/api/services/VendorLookupServiceGroup/VendorLookupService/lookup
+POST https://myenv.operations.dynamics.com/api/services/VendorLookupServiceGroup/VendorLookup/lookupVendor
 ```
 
 ---
@@ -168,7 +192,7 @@ Use Azure AD OAuth2:
 ## Hard rules
 
 - **Request/response types must be `[DataContractAttribute]` classes.** Primitive types (`str`, `int`) are also accepted for simple services.
-- **Public methods in a `[ServiceAttribute]`-decorated class are automatically exposed** and do not require `[SysEntryPointAttribute]`.
+- **There is no `[ServiceAttribute]` class-level decorator in X++.** A service class is a plain class; exposure comes entirely from the `AxService` object listing its methods as `AxServiceOperation` entries. Exposed methods do not require `[SysEntryPointAttribute]`.
 - **`[DataMemberAttribute]` on every parmXxx accessor** — the JSON serializer uses member names from this attribute.
 - **Service group name determines the URL** — choose a stable, module-scoped name; renaming it breaks all callers.
 - **Never include `ttsbegin/ttscommit` in service methods** unless you own the full transaction scope. If the service calls a framework method that manages its own transaction, wrap at a higher level.

--- a/skills/anthropic/data-entity-scaffolding/SKILL.md
+++ b/skills/anthropic/data-entity-scaffolding/SKILL.md
@@ -23,7 +23,10 @@ d365fo search edt  <Edt>        --output json    # for any EDT mappings
 ## Scaffolding
 
 ```sh
-# Minimal — exposes one table; OData names default to <Name>Entity / <Name>Entities
+# Minimal — without --public-entity/--public-collection, PublicEntityName
+# defaults to the literal ENTITY argument and PublicCollectionName to
+# ENTITY + "s" (naive pluralization, e.g. FmVehicleEntity / FmVehicleEntitys) —
+# always pass both explicitly for clean OData names.
 d365fo generate entity FmVehicleEntity \
     --table FmVehicle \
     --all-fields \
@@ -33,13 +36,14 @@ d365fo generate entity FmVehicleEntity \
 d365fo generate entity FmVehicleEntity \
     --table FmVehicle \
     --field VIN --field Make --field Year \
-    --public-entity-name FleetVehicle \
-    --public-collection-name FleetVehicles \
+    --public-entity FleetVehicle \
+    --public-collection FleetVehicles \
     --install-to FleetManagement
 ```
 
-The CLI returns `{path, bytes, backup, fieldCount, publicEntityName,
-publicCollectionName}`. Never request the full XML back.
+The CLI returns `{kind, name, table, path, bytes, fieldCount, fieldsFromTable}`
+(plus `backup` when `--overwrite` replaces an existing file). Never request
+the full XML back.
 
 ## OData naming conventions (D365FO)
 

--- a/skills/anthropic/event-handler-authoring/SKILL.md
+++ b/skills/anthropic/event-handler-authoring/SKILL.md
@@ -43,7 +43,7 @@ the user explicitly requests a separate class.
 ```sh
 d365fo generate event-handler MyClass_CustTableHandler \
     --source-kind Table \
-    --source CustTable \
+    --source-object CustTable \
     --event Inserted \
     --install-to MyModel
 ```
@@ -53,23 +53,28 @@ Generated attribute: `[DataEventHandler(tableStr(CustTable), DataEventType::Inse
 D365FO `DataEventType` values: `ValidatingFieldValue`, `ValidatedField`,
 `ValidatingDelete`, `ValidatedDelete`, `ValidatingWrite`, `ValidatedWrite`,
 `Inserting`, `Inserted`, `Updating`, `Updated`, `Deleting`, `Deleted`,
-`InitializingRecord`, `InitializedRecord`, `Modifying`, `Modified`.
+`InitializingRecord`, `InitializedRecord`, `ModifyingField`, `ModifiedField`.
 
 ## Form / FormDataSource / FormControl events → form-specific attributes
 
 ```sh
 d365fo generate event-handler MyClass_FormHandler \
     --source-kind Form \
-    --source CustTable \
+    --source-object CustTable \
     --event Initialized \
     --install-to MyModel
 
 d365fo generate event-handler MyClass_FormDsHandler \
     --source-kind FormDataSource \
-    --source CustTable.CustTable \
-    --event ExecuteQuery \
+    --source-object "CustTable, CustTable" \
+    --event QueryExecuting \
     --install-to MyModel
 ```
+
+`--source-object` for `FormDataSource` is passed through verbatim into
+`formDataSourceStr(...)`, so it must already be the two comma-separated
+`<Form>, <DataSource>` arguments (e.g. `"CustTable, CustTable"`) — a dotted
+`Form.DataSource` value produces invalid X++.
 
 Attribute shapes: `[FormEventHandler(formStr(...), FormEventType::...)]`,
 `[FormDataSourceEventHandler(formDataSourceStr(form, ds), FormDataSourceEventType::...)]`.
@@ -83,7 +88,7 @@ events — those are `DataEventHandler`.
 ```sh
 d365fo generate event-handler MyClass_DelegateHandler \
     --source-kind Class \
-    --source SalesFormLetter \
+    --source-object SalesFormLetter \
     --event onPosted \
     --install-to MyModel
 ```

--- a/skills/anthropic/form-pattern-scaffolding/SKILL.md
+++ b/skills/anthropic/form-pattern-scaffolding/SKILL.md
@@ -29,7 +29,7 @@ CORRECT — always:
 ## Pre-flight
 
 ```sh
-d365fo search form <Name> --output json          # collision check
+d365fo search any <Name> --kind form --output json   # collision check (no dedicated `search form`)
 d365fo get table <PrimaryTable> --output json    # field list for the grid
 
 # Pattern spec — required structure, versions, when-to-use, reference forms
@@ -131,11 +131,12 @@ section template is `--section Name:Caption` (split on the first `:`).
   `<DataSourceReferences>`, `<DataSources>`, methods, extension properties,
   and pattern metadata exactly.
 - After changing form XML, validate XML well-formedness, run
-  `d365fo validate xpp --file <file> --code-type xml-any --output json`, run
+  `d365fo validate xpp <file> --code-type xml-any --output json` (file is a
+  positional argument, not `--file`), run
   `d365fo index refresh --model <Model>`, and re-read with
   `d365fo get form <Form> --output json`.
 - Never use `Dialog` or `TableOfContents` patterns for transactional grids.
-- Pre-flight `search form <Name>` before scaffolding to avoid collisions.
+- Pre-flight `search any <Name> --kind form` before scaffolding to avoid collisions (there is no dedicated `search form` subcommand).
 - Caption strings must be labels (BP `BPErrorLabelIsText`) — never raw text.
 - After scaffolding, run `d365fo build` only on user request.
 

--- a/skills/anthropic/integration-patterns/SKILL.md
+++ b/skills/anthropic/integration-patterns/SKILL.md
@@ -16,7 +16,7 @@ applies_when: User intent mentions OData, REST API, custom service, SOAP, DMF, D
 
 | Pattern | Direction | Latency | Volume | Entry point |
 |---------|-----------|---------|--------|-------------|
-| **OData REST API** | In + Out | Synchronous, real-time | Record-level | `data/<EntityName>` endpoint |
+| **OData REST API** | In + Out | Synchronous, real-time | Record-level | `data/<PublicCollectionName>` endpoint |
 | **Custom Services** | In | Synchronous | Operation-level | SOAP + JSON REST endpoint |
 | **Data Management Framework (DMF)** | In + Out | Async batch | Bulk | Import/export jobs, staging tables |
 | **Business Events** | Out | Near-real-time | Event-driven | Service Bus, Event Grid, Power Automate, Logic Apps |
@@ -27,11 +27,11 @@ applies_when: User intent mentions OData, REST API, custom service, SOAP, DMF, D
 
 **Purpose:** real-time synchronous CRUD from external systems — Power Platform, Logic Apps, third-party ERPs.
 
-**Endpoint:** `https://{env}.cloudax.dynamics.com/data/{PublicEntityName}`
+**Endpoint:** `https://{env}.cloudax.dynamics.com/data/{PublicCollectionName}`
 
 **Requirements for a working OData entity:**
 
-- `EnablePublicAPI = Yes` on the `AxDataEntityView`
+- `IsPublic = Yes` on the `AxDataEntityView`
 - A unique `PublicEntityName` (the OData entity type) and `PublicCollectionName` (the collection URL segment)
 - At least one key field with `AlternateKey = Yes` on a unique index
 - All mandatory fields mapped in the entity
@@ -51,7 +51,7 @@ d365fo get table <SourceTable> --output json | jq '.data.indexes[] | select(.alt
 # 4. Scaffold a new entity if needed
 d365fo generate entity <Name> --table <T> \
   --all-fields \
-  --public-entity-name <Singular> --public-collection-name <Plural> \
+  --public-entity <Singular> --public-collection <Plural> \
   --out c:/AOT/MyModel/AxDataEntityView/<Name>.xml
 ```
 
@@ -112,8 +112,8 @@ d365fo generate custom-service <Name> \
 
 **Requirements for DMF-capable entity:**
 
-- `EnableDataManagementCapabilities = Yes` on the `AxDataEntityView`
-- A staging table (`StagingTable` property set)
+- `DataManagementEnabled = Yes` on the `AxDataEntityView`
+- A staging table (`DataManagementStagingTable` property set)
 - Change tracking support (for incremental export)
 
 **CLI workflow:**
@@ -122,12 +122,12 @@ d365fo generate custom-service <Name> \
 # 1. Find the entity
 d365fo search entity <Name> --output json
 
-# 2. Check DMF capability and staging table presence
-d365fo get entity <Name> --output json | jq '{enableDMF: .data.enableDataManagementCapabilities, stagingTable: .data.stagingTable}'
+# 2. Check staging table presence (a non-empty value implies DMF is wired up)
+d365fo get entity <Name> --output json | jq '.data.entity.stagingTable'
 
 # 3. Scaffold a DMF-capable entity (staging table must be created separately)
-d365fo generate entity <Name> --table <T> --all-fields --out …
-# Then hand-edit to set EnableDataManagementCapabilities + StagingTable
+d365fo generate entity <Name> --table <T> --all-fields \
+  --data-management --staging-table <Name>Staging --out …
 ```
 
 **Notes:**

--- a/skills/anthropic/label-translation/SKILL.md
+++ b/skills/anthropic/label-translation/SKILL.md
@@ -35,9 +35,12 @@ d365fo labels create "@FleetManagement:VehicleVin" "VIN" \
 
 - The `<KEY>` form `@File:Key` must match the target `.label.txt` filename
   (`@FleetManagement:VehicleVin` → `FleetManagement.label.txt`).
-- `--lang` is required when the file does not embed a single language stem
-  (`FleetManagement.en-us.label.txt`).
-- The CLI writes atomically (`.tmp` + move; `.bak` retained on overwrite).
+- `--lang` only affects path resolution when using `--install-to <MODEL>`; it
+  has no effect when `--file` is given directly — pass the full path to the
+  target `<Name>.<lang>.label.txt` file yourself.
+- The CLI writes atomically (`.tmp` + move; `.bak` retained whenever the
+  target file already existed, on both first-write-to-existing-file and
+  `--overwrite`).
 
 ## 3. Rename a label key (refactor across the model)
 
@@ -76,5 +79,9 @@ d365fo labels delete @FleetManagement:DeprecatedKey --file <path>.label.txt
 ## EDT-label inheritance — exception
 
 When adding a field whose EDT already carries a `Label`, do **NOT** create
-a new label or pass `--label` on the field — the field inherits the EDT
-caption. Only override when the table needs a different caption deliberately.
+a new label for it — an `AxTableField` with no `<Label>` element inherits
+the EDT's caption at runtime. `d365fo generate table --field <name>:<edt>`
+never emits a per-field `<Label>` (there is no per-field `--label` option
+today — `--label` on `generate table` sets the *table's* caption, not a
+field's). Only add a table-level `--label`/field-level label override when
+the table or field needs a caption different from the EDT's.

--- a/skills/anthropic/model-dependency-and-coupling/SKILL.md
+++ b/skills/anthropic/model-dependency-and-coupling/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: model-dependency-and-coupling
 description: Inspect indexed D365FO models, their declared dependencies, and architectural coupling metrics (fan-in, fan-out, instability, cycles). Use when the user asks "what models depend on X", "is there a cycle", "what's the layer of model Y", or "show coupling".
-applies_when: User intent mentions model dependencies, layer (sys/syp/isv/iss/cus/cup/usr/usp), coupling, fan-in / fan-out / instability metrics, or "which model contains object X".
+applies_when: User intent mentions model dependencies, layer (sys/syp/cus/var/isv/usr, incl. patch layers), coupling, fan-in / fan-out / instability metrics, or "which model contains object X".
 ---
 > ⛔ **NEVER write X++ AOT XML files directly** via PowerShell, terminal file commands (`Set-Content`, `Out-File`, `New-Item`), editor write tools, or any raw text approach. The XML schema (`<AxClass>`, `<AxTable>`, `<AxForm>`, `<Methods>`, `<SourceCode>`) is proprietary — LLMs have not been trained on it reliably. **ALWAYS use `d365fo generate …` commands** to produce correct AOT XML. If `d365fo` is unavailable in PATH, stop and ask the user to install it.
 
@@ -21,7 +21,11 @@ d365fo models list --output json
 d365fo models deps FleetManagement --output json
 ```
 
-Output shape: `{name, publisher, layer, version, customizable, dependsOn[], dependedBy[]}`.
+`models list` output shape: `{count, items: [{modelId, name, publisher,
+layer, isCustom}]}` (`publisher`/`layer` are frequently absent — omitted
+when the Descriptor XML didn't populate them). `models deps` output shape:
+`{model: {modelId, name, publisher, layer, isCustom}, dependsOn: string[],
+dependedBy: string[]}`.
 
 ## Coupling metrics
 
@@ -41,8 +45,10 @@ Output highlights:
 
 ## When to invoke
 
-- Before introducing a new dependency: confirm the target model isn't
-  customer-layer (`layer: cus*`) when you're an ISV.
+- Before introducing a new dependency: check `models list`/`models deps` for
+  the target's layer — a model can only *depend on* strictly lower-or-equal
+  layers (e.g. a `cus`-layer model must not depend on an `isv`- or
+  `usr`-layer one).
 - During architectural review: `cycles[]` must be empty; fan-out outliers
   flag candidates for splitting.
 - When CoC / extensions don't take effect: `models deps` reveals if your
@@ -50,10 +56,14 @@ Output highlights:
 
 ## Hard rules
 
-- Never extend / depend on a `cus*` (customer-layer) model from an ISV model
-  — D365FO disallows the upward dependency.
+- Layer ordering (lowest → highest): `sys → syp → gls → glp → dis → dip →
+  cus → cup → var → vap → isv → isp → usr → usp` (each `Descriptor/*.xml`
+  stores the numeric layer id, e.g. `<Layer>8</Layer>` = `var`). Each layer
+  can only consume (depend on) *lower* layers — a `cus`-layer model cannot
+  depend on an `isv`- or `usr`-layer model; the reverse is allowed. In
+  practice most customer extension work happens in `usr` (the highest
+  layer) precisely so it can reference everything below it, including
+  installed ISV solutions.
 - Never introduce a cycle — even a 2-node cycle blocks compilation.
-- Layer ordering (lowest → highest): `sys → syp → isv → iss → cus → cup → usr → usp`.
-  Each layer can only consume *lower* layers.
 - After modifying any `Descriptor/*.xml`, run `d365fo index refresh` so
   subsequent `models deps` / `models coupling` reflects reality.

--- a/skills/anthropic/object-extension-authoring/SKILL.md
+++ b/skills/anthropic/object-extension-authoring/SKILL.md
@@ -16,10 +16,10 @@ applies_when: User intent mentions extending a Table / Form / Edt / Enum, adding
 
 | Standard object you want to change | Use |
 |---|---|
-| Add a field/index/relation to `CustTable` | `extension Table CustTable <Suffix>` |
-| Add a control / data source / FastTab to a standard form | `extension Form CustTableListPage <Suffix>` |
-| Tighten an EDT (e.g. lengthen a string, adjust label) | `extension Edt CustAccount <Suffix>` |
-| Add new members to a base enum | `extension Enum NoYes <Suffix>` |
+| Add a field/index/relation to `CustTable` | `extension Table CustTable --suffix <Suffix>` |
+| Add a control / data source / FastTab to a standard form | `extension Form CustTableListPage --suffix <Suffix>` |
+| Tighten an EDT (e.g. lengthen a string, adjust label) | `extension Edt CustAccount --suffix <Suffix>` |
+| Add new members to a base enum | `extension Enum NoYes --suffix <Suffix>` |
 | Add behaviour to a class method | **NOT this** — use `coc-extension-authoring` instead |
 
 ## Pre-flight (ONE call)
@@ -75,17 +75,23 @@ Before scaffolding a new extension, inspect the existing result from
 
 ```sh
 # Add fields to standard CustTable in the FleetManagement model
-d365fo generate extension Table CustTable Fleet --install-to FleetManagement
+d365fo generate extension Table CustTable --suffix Fleet --install-to FleetManagement
 
 # Form extension targeting CustTableListPage
-d365fo generate extension Form CustTableListPage Fleet --install-to FleetManagement
+d365fo generate extension Form CustTableListPage --suffix Fleet --install-to FleetManagement
 
 # Tighten the CustAccount EDT
-d365fo generate extension Edt CustAccount Fleet --install-to FleetManagement
+d365fo generate extension Edt CustAccount --suffix Fleet --install-to FleetManagement
 
 # Add an enum member to NoYes
-d365fo generate extension Enum NoYes Fleet --install-to FleetManagement
+d365fo generate extension Enum NoYes --suffix Fleet --install-to FleetManagement
 ```
+
+`generate extension` takes exactly two positional arguments (`<KIND> <TARGET>`);
+the suffix is a named `--suffix <SUFFIX>` option, not a third positional
+argument — passing it positionally fails with "Could not match '<value>' with
+an argument." If `--suffix` is omitted it defaults to the `--install-to`
+model name (or `Extension`).
 
 The scaffold emits a minimal `<AxXxxExtension>` element with the
 `<Name>Target.Suffix</Name>` shape Visual Studio expects. After scaffolding,
@@ -119,7 +125,7 @@ d365fo generate enum CustCustomStatus \
   --out c:/AOT/MyModel/AxEnum/CustCustomStatus.xml
 ```
 
-`--base-type` accepts `String`, `Integer`, `Real`, `Int64`, `Date`, `UtcDateTime`, `Enum`, `Guid`. Enums are `IsExtensible=Yes` by default — pass `--no-extensible` to opt out.
+`--base-type` accepts `String`, `Integer`, `Real`, `Int64`, `Date`, `UtcDateTime`, `Enum`, `Guid`. Enums are `IsExtensible=Yes` by default — pass `--non-extensible` to opt out (`--no-extensible` is not a recognized flag and is silently ignored, leaving the enum extensible).
 
 ## XDS Security Policy scaffolding
 
@@ -137,7 +143,7 @@ d365fo generate security-policy CustCustomSecurityPolicy \
   --out c:/AOT/MyModel/AxSecurityPolicy/CustCustomSecurityPolicy.xml
 ```
 
-`--operation` accepts `All`, `Select`, `Insert`, `Update`, `Delete`. The policy query (`--policy-query`) is a separate `AxQuery` AOT object that must already exist or be scaffolded with `d365fo generate query`.
+`--operation` accepts only `Select` (default) or `All` — `Insert`/`Update`/`Delete` are rejected with "Unknown --operation '<value>'. Expected Select | All." The policy query (`--policy-query`) is a separate `AxQuery` AOT object that must already exist or be scaffolded with `d365fo generate query`.
 
 After scaffolding, verify with:
 ```sh
@@ -153,7 +159,8 @@ d365fo get security-policy CustCustomSecurityPolicy --output json
 - Never rewrite an existing extension XML file wholesale. Preserve unrelated
   nodes and only add the requested structural element(s).
 - After changing extension XML, validate XML well-formedness, run
-  `d365fo validate xpp --file <file> --code-type xml-any --output json`, run
+  `d365fo validate xpp <file> --code-type xml-any --output json` (file is a
+  positional argument, not `--file`), run
   `d365fo index refresh --model <Model>`, and re-read the target metadata.
 - Never use `extension` for class behaviour changes — that is CoC's job
   (`d365fo generate coc <Class>`).

--- a/skills/anthropic/review-and-checkpoint-workflow/SKILL.md
+++ b/skills/anthropic/review-and-checkpoint-workflow/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: review-and-checkpoint-workflow
-description: Use Git as the review layer for AI-driven D365FO edits, and use `d365fo review diff` to get an AOT-semantic summary of XML changes. Invoke whenever the user is about to start a non-trivial change, before "accepting" AI edits, or wants a structural diff (added classes, modified table fields, new CoC wrappers).
+description: Use Git as the review layer for AI-driven D365FO edits, and use `d365fo review diff` for a shallow BP-style probe (missing EDT/Label, hard-coded strings, dynamic query) over changed AxTable/AxClass XML on top of the raw byte diff. Invoke whenever the user is about to start a non-trivial change, before "accepting" AI edits, or wants a quick heuristic pass over what changed.
 applies_when: User intent mentions reviewing changes, accepting / rejecting AI edits, "what changed", AOT diff, structural diff, or VS 2022's missing accept/undo UI.
 ---
 > ⛔ **NEVER write X++ AOT XML files directly** via PowerShell, terminal file commands (`Set-Content`, `Out-File`, `New-Item`), editor write tools, or any raw text approach. The XML schema (`<AxClass>`, `<AxTable>`, `<AxForm>`, `<Methods>`, `<SourceCode>`) is proprietary — LLMs have not been trained on it reliably. **ALWAYS use `d365fo generate …` commands** to produce correct AOT XML. If `d365fo` is unavailable in PATH, stop and ask the user to install it.
@@ -8,8 +8,8 @@ applies_when: User intent mentions reviewing changes, accepting / rejecting AI e
 # Git-checkpoint review workflow
 
 > Visual Studio 2022 has no inline accept/reject UI for AI edits. Use Git as
-> the review layer; pair with `d365fo review diff` for an AOT-semantic
-> summary on top of the raw byte diff.
+> the review layer; pair with `d365fo review diff` for a quick heuristic
+> probe on top of the raw byte diff.
 
 ## 1. Before starting any non-trivial task
 
@@ -61,24 +61,33 @@ For new forms based on an example, compare the pattern metadata and required
 controls/datasources from the example. Missing ActionPane/Body/Tab/FastTab/grid
 or QuickFilter elements are not acceptable just because the XML parses.
 
-## 3. After the task — AOT-semantic review
+## 3. After the task — review the diff
 
 ```sh
 # Raw byte diff (as usual)
 git diff --stat
 git diff <ref> -- AxClass/ AxTable/ AxForm/
 
-# AOT-semantic diff — added classes, modified table fields, new CoC wrappers …
+# Shallow BP-style probe over changed AxTable/AxClass XML in the working tree
+# vs --base (git diff --name-only under the hood; not a full structural diff)
 d365fo review diff --base <ref> --output json
-d365fo review diff --base HEAD~1 --output json | jq '.data.added,.data.modified'
+d365fo review diff --base HEAD~1 --output json | jq '.data.violations'
 ```
 
-`review diff` is **complementary** to `git diff`, not a replacement:
+`review diff` is **complementary** to `git diff`, not a replacement — and it
+is a shallow regex/XML probe, not a compiler-grade structural diff. It does
+NOT report added classes, modified fields, or new CoC wrappers. It only
+scans changed `.xml`/`.xpp` files and flags a small fixed set of issues:
+fields with no `<ExtendedDataType>` or no `<Label>` in changed
+`AxTable/…` XML, and hard-coded string literals / dynamic-`Query`
+construction in changed `AxClass/…` XML. Output shape: `{baseRev, headRev,
+changedFiles, violationCount, violations: [{file, rule, severity, message,
+…}]}`.
 
 | Tool | Shows | Best for |
 |---|---|---|
 | `git diff` | Raw bytes per file | Spotting whitespace / unintended edits |
-| `d365fo review diff` | Structural deltas (added field, new wrapper, index change) | Reviewer summary, PR descriptions |
+| `d365fo review diff` | A handful of BP-style probes (missing EDT/Label, hard-coded strings, dynamic query) over changed AxTable/AxClass XML | A fast heuristic pass before `bp check` — not a substitute for reading the diff |
 
 ## 4. Accept / reject
 
@@ -96,4 +105,4 @@ d365fo review diff --base HEAD~1 --output json | jq '.data.added,.data.modified'
 - Always include the `.bak` files in `.gitignore` for the user's repo so
   scaffold-overwrite backups don't pollute commits.
 - Always show `d365fo review diff` output BEFORE asking the user to accept
-  — they need the structural summary to make a decision.
+  — they need the heuristic-probe summary to make a decision.

--- a/skills/anthropic/security-hierarchy-trace/SKILL.md
+++ b/skills/anthropic/security-hierarchy-trace/SKILL.md
@@ -9,15 +9,24 @@ applies_when: User intent mentions security, roles, duties, privileges, entry po
 
 ## Workflow
 
-1. **Top-down** — which entry points does a role reach?
+1. **Top-down** — which entry points does a role reach? `security coverage
+   <Name> --type Role` always returns an empty `routes[]` (`Role` is not a
+   valid `--type`, and the coverage lookup is a reverse/bottom-up query, not
+   a forward one) — walk the hierarchy explicitly instead:
    ```sh
-   d365fo security coverage <RoleName> --type Role --output json
+   d365fo security role <RoleName> --output json       # -> duties[] + privileges[]
+   d365fo security duty <DutyName> --output json        # -> privileges[]
+   d365fo security privilege <PrivilegeName> --output json  # -> entryPoints[] (objectName + objectType)
    ```
 
 2. **Bottom-up** — which roles reach this object?
    ```sh
-   d365fo security coverage <ObjectName> --type Menuitem --output json
-   # type may be Table, Form, Report, Class, Menuitem
+   d365fo security coverage <ObjectName> --type MenuItemDisplay --output json
+   # --type is matched literally against the indexed AOT ObjectType, so use the
+   # exact value: MenuItemDisplay | MenuItemAction | MenuItemOutput | Table |
+   # Form | Report | Class. The CLI's own default/listed value "Menuitem" does
+   # NOT occur in real data and always returns an empty routes[] — always pass
+   # the specific MenuItem* kind.
    ```
 
 3. The response contains `routes[*]` of shape
@@ -63,4 +72,9 @@ d365fo generate duty FmNewDuty --privilege FmSomePrivilege \
 ```
 
 **Scaffold order:** menu item → privilege (references the menu item) → duty (bundles privileges) → role (bundles duties).
-Always run `d365fo security coverage <Name> --type Role --output json` after to verify the new objects appear in the hierarchy.
+Always verify the new objects appear in the hierarchy afterwards — `d365fo
+security coverage <Name> --type Role --output json` always returns an empty
+`routes[]` (see Workflow above); instead run `d365fo security role
+<RoleName> --output json` to confirm the duties/privileges are attached, and
+`d365fo security coverage <EntryPointName> --type MenuItemDisplay --output
+json` to confirm the new role reaches the target entry point.

--- a/skills/anthropic/xpp-best-practice-rules/SKILL.md
+++ b/skills/anthropic/xpp-best-practice-rules/SKILL.md
@@ -57,7 +57,7 @@ For *filter-only* joins use `exists join` / `notExists join`. For complex correl
 
 ### `BPCheckAlternateKeyAbsent` — every table needs an alternate key
 
-A unique index on the natural key, marked `AlternateKey = Yes`. The CLI's `d365fo generate table` template emits a `<Pkey>` index with `AlternateKey = Yes` — don't strip it.
+A unique index on the natural key, marked `AlternateKey = Yes`. The CLI's `d365fo generate table` template emits a `PrimaryIdx` index with `<AlternateKey>Yes</AlternateKey>` — don't strip it.
 
 ### `BPErrorUnknownLabel` — labels referenced must exist
 
@@ -101,7 +101,7 @@ d365fo generate table FmVehicle \
 
 ```sh
 # In-process heuristics — fast, runs anywhere, useful for CI:
-d365fo lint --output sarif > lint.sarif
+d365fo lint --format sarif > lint.sarif
 
 # Run specific method-flag categories (detected at index-extract time):
 d365fo lint --category today-usage          # BPUpgradeCodeToday: today() calls
@@ -112,7 +112,7 @@ d365fo lint --category doc-comment-missing  # BPXmlDocNoDocumentationComments
 d365fo bp check --output json
 ```
 
-Six categories are now available: `table-no-index`, `ext-named-not-attributed`, `string-without-edt`, `today-usage`, `do-insert-update`, `doc-comment-missing`. The method-flag categories are populated at extract time by scanning `<Source>` text — no full body is stored. Re-run `d365fo index refresh` after editing source before linting.
+Sixteen categories are now available: `table-no-index`, `ext-named-not-attributed`, `string-without-edt`, `today-usage`, `do-insert-update`, `doc-comment-missing`, `nested-select`, `insert-in-loop`, `tts-try-catch`, `empty-table-method`, `batch-no-cango`, `force-literals`, `public-instance-field`, `cache-lookup-mismatch`, `missing-delete-action`, `no-alternate-key`. The method-flag categories are populated at extract time by scanning `<Source>` text — no full body is stored. Re-run `d365fo index refresh` after editing source before linting.
 
 **Never** auto-run `bp check`. It blocks the user (slow, Windows-only). Say *"Changes scaffolded. Run `d365fo bp check` when you're ready."*
 

--- a/skills/anthropic/xpp-database-queries/SKILL.md
+++ b/skills/anthropic/xpp-database-queries/SKILL.md
@@ -76,6 +76,7 @@ SysDa is the modern X++ query API — fluent and object-oriented. Use it when qu
 
 **Core classes:**
 - `SysDaQueryObject` — root query builder; set table buffer via constructor.
+- `SysDaSearchObject` — wraps a `SysDaQueryObject` for iteration; pass this (not the raw query object) to `SysDaSearchStatement`/`SysDaFindStatement`.
 - `SysDaSearchStatement` — execute + iterate; `SysDaFindStatement` — `firstOnly` equivalent.
 - `SysDaUpdateStatement` / `SysDaInsertStatement` / `SysDaDeleteStatement` — set-based ops.
 
@@ -85,8 +86,9 @@ var qe = new SysDaQueryObject(custTable);
 qe.whereClause(new SysDaEqualsExpression(
     new SysDaFieldExpression(custTable, fieldStr(CustTable, AccountNum)),
     new SysDaValueExpression('US-001')));
-var so = new SysDaSearchStatement();
-while (so.nextRecord(qe))
+var so = new SysDaSearchObject(qe);       // wraps the query object for iteration
+var search = new SysDaSearchStatement();
+while (search.nextRecord(so))
 {
     info(custTable.AccountNum);
 }

--- a/skills/copilot/business-events-authoring.instructions.md
+++ b/skills/copilot/business-events-authoring.instructions.md
@@ -25,7 +25,7 @@ A custom business event consists of exactly two classes:
    - Implements buildContract() to populate the payload
    - Has a static newFrom<Context>(...) factory
 
-2. Contract class — implements BusinessEventsContract
+2. Contract class — extends BusinessEventsContract
    - Decorated with [DataContractAttribute]
    - One parmXxx() accessor per payload field, decorated with [DataMemberAttribute]
 ```
@@ -69,10 +69,10 @@ d365fo generate business-event CustPaymentBusinessEvent \
 
 ```xpp
 [BusinessEvents(
-    classStr(CustPaymentBusinessEvent),
     classStr(CustPaymentBusinessEventContract),
-    "CustomerPayments",
-    "@MyModel:CustPaymentBusinessEventDescription")]
+    'MyModel:CustPaymentBusinessEventName',
+    'MyModel:CustPaymentBusinessEventDescription',
+    ModuleAxapta::Customer)]
 public final class CustPaymentBusinessEvent extends BusinessEventsBase
 {
     private CustTrans custTrans;
@@ -142,7 +142,7 @@ public final class CustPaymentBusinessEventContract extends BusinessEventsContra
 
 ## Firing the event
 
-Call the static factory from the business process at the right lifecycle point — typically in a table `insert` / `update` override, a posting engine, or a workflow action:
+Call the static factory from the business process at the right lifecycle point — typically in a table `insert` / `update` override, a posting engine, or a workflow action. `BusinessEventsBase` exposes the send operation as a `public final` **instance** method (`send()`), not a static publisher — construct the event, then call `.send()` on it:
 
 ```xpp
 // In CustTrans.insert() CoC or a posting service method:
@@ -154,8 +154,7 @@ final class CustTrans_MyExt
         next insert();
 
         // Fire after successful insert
-        BusinessEventsBase::publish(
-            CustPaymentBusinessEvent::newFromCustTrans(this));
+        CustPaymentBusinessEvent::newFromCustTrans(this).send();
     }
 }
 ```
@@ -177,9 +176,9 @@ After scaffolding and compiling:
 
 ## Hard rules
 
-- **`[BusinessEvents(...)]` must be on the event class declaration** — not on methods. Four arguments: `classStr(EventClass)`, `classStr(ContractClass)`, `"CategoryString"`, `"@File:DescriptionLabel"`.
+- **`[BusinessEvents(...)]` must be on the event class declaration** — not on methods. The `BusinessEventsAttribute` constructor is `new(ClassName _businessEventsContractClassStr, LabelString _nameLabel, LabelString _descriptionLabel, ModuleAxapta _module)` — four arguments: `classStr(ContractClass)`, a name-label token, a description-label token, and a `ModuleAxapta::<Module>` enum value (not a free-text category, and no `classStr(EventClass)` — the attribute already decorates the event class itself).
 - **`buildContract()` is called by the framework** — return the populated contract instance; never return `null`.
 - **Contract `parmXxx()` accessors must be decorated with `[DataMemberAttribute]`** — the serialization layer uses these to build the JSON payload.
 - **Use EDTs for payload fields** (e.g. `CustAccount`, `AmountCur`) — not primitive types. Run `d365fo get edt <Name>` to confirm the EDT exists.
-- **Never call `BusinessEventsBase::publish()` inside a `ttsbegin`/`ttscommit` block** unless you intend to publish on rollback too. Call it after the outermost `ttscommit` or in the `postInsert`/`postUpdate` framework hook.
-- **Category string is free text** — use a meaningful module-scoped category (e.g. `"CustomerPayments"`, `"InventoryEvents"`) so the catalog is navigable.
+- **Never call `.send()` inside a `ttsbegin`/`ttscommit` block** unless you intend to publish on rollback too. Call it after the outermost `ttscommit` or in the `postInsert`/`postUpdate` framework hook. `send()` is a `public final` instance method on `BusinessEventsBase` (there is also `sendOnUserConnection(UserConnection)`) — there is no static `publish()` method.
+- **The catalog category comes from the `ModuleAxapta` enum value passed to `[BusinessEvents(...)]`**, not free text — pick the enum member matching the module the event belongs to (e.g. `ModuleAxapta::Customer`, `ModuleAxapta::Inventory`; run `d365fo get enum ModuleAxapta` for the full list).

--- a/skills/copilot/coc-extension-authoring.instructions.md
+++ b/skills/copilot/coc-extension-authoring.instructions.md
@@ -21,7 +21,7 @@ strategy, and a **grounding token**. Do NOT issue separate `get class` /
 
 If `existingCocExtensions` is non-empty, enumerate them to the user and stop before writing another wrapper. Stacking duplicates risks ordering bugs.
 
-Pass the token to the generator: `d365fo generate coc <TargetClass> --method <method> --install-to <Model> --grounding-token <token>`. For any hand-written wrapper body, run `d365fo validate references --file <f>` + `d365fo validate xpp --file <f>` BEFORE writing — exit code 2 means hallucinated symbols / BP errors to fix first.
+Pass the token to the generator: `d365fo generate coc <TargetClass> --method <method> --install-to <Model> --grounding-token <token>`. For any hand-written wrapper body, run `d365fo validate references <f>` + `d365fo validate xpp <f>` BEFORE writing (the file is a positional argument, not `--file`; omit it to read from stdin) — exit code 2 means hallucinated symbols / BP errors to fix first.
 
 Fallback (prepare unavailable): `d365fo get class <TargetClass>` + `d365fo find coc <TargetClass>::<method>`.
 

--- a/skills/copilot/custom-service-authoring.instructions.md
+++ b/skills/copilot/custom-service-authoring.instructions.md
@@ -19,10 +19,12 @@ applyTo: '**/AxService/**,**/AxServiceGroup/**,**/*Service.xml,**/*ServiceGroup.
 A D365FO custom service requires three artifacts:
 
 ```
-1. Service class  — decorated with [ServiceAttribute]
+1. Service class  — a plain X++ class (no class-level service attribute
+   exists in X++ — the AxService object below is what wires it up)
    - Parameters/return types use [DataContractAttribute] classes
 
 2. AxService XML  — declares the service class + operation bindings
+   (each AxServiceOperation maps an operation Name to a Method on the class)
 
 3. AxServiceGroup XML  — registers the service into a named group
    (determines the REST URL path segment)
@@ -46,15 +48,23 @@ d365fo report-integrations --model <ModelName> --output json
 ## Scaffolding
 
 ```sh
-d365fo generate custom-service VendorLookupService \
-  --operation Lookup:lookupVendor \
-  --operation Create:createVendor \
+d365fo generate custom-service VendorLookup \
+  --group-name VendorLookupServiceGroup \
+  --operation lookupVendor:VendorLookupResponse \
+  --operation createVendor:boolean \
+  --contract-param VendorLookupRequest \
   --install-to MyModel
 ```
 
+`--operation` takes `<name>:<returnType>` — the same `<name>` is used both as the
+`AxServiceOperation` `Name` and as the generated X++ method name (there is no
+separate operation-name-to-method-name mapping). `--contract-param <ContractClass>`
+applies that single parameter type to every generated operation method.
+`--class-name` defaults to `<NAME>Service` and `--group-name` defaults to `<NAME>Group`.
+
 This produces:
-- `AxClass/VendorLookupService.xml` — the service class
-- `AxService/VendorLookupService.xml` — service descriptor
+- `AxService/VendorLookup.xml` — service descriptor (`Name` = the positional argument)
+- `AxClass/VendorLookupService.xml` — the service class (`--class-name` defaulted)
 - `AxServiceGroup/VendorLookupServiceGroup.xml` — service group
 
 ---
@@ -62,7 +72,6 @@ This produces:
 ## Service class skeleton
 
 ```xpp
-[ServiceAttribute]
 public class VendorLookupService
 {
     public VendorLookupResponse lookupVendor(VendorLookupRequest _request)
@@ -73,6 +82,11 @@ public class VendorLookupService
     }
 }
 ```
+
+There is no class-level attribute that marks a class as a service — the
+class is just a plain X++ class. The `AxService` XML object (below) is what
+exposes it: it references the class by name and lists each callable method
+as an `AxServiceOperation`.
 
 ## Request / Response contract classes
 
@@ -110,16 +124,20 @@ public class VendorLookupResponse
 
 ```xml
 <AxService>
-  <Name>VendorLookupService</Name>
-  <ClassName>VendorLookupService</ClassName>
-  <Operations>
+  <Name>VendorLookup</Name>
+  <Class>VendorLookupService</Class>
+  <ServiceOperations>
     <AxServiceOperation>
-      <Name>lookup</Name>
-      <MethodName>lookupVendor</MethodName>
+      <Name>lookupVendor</Name>
+      <Method>lookupVendor</Method>
     </AxServiceOperation>
-  </Operations>
+  </ServiceOperations>
 </AxService>
 ```
+
+The operation's `Method` element names the X++ method on the class named by
+`Class`; `Name` is the external operation name used in the REST URL and is
+typically the same string as `Method`.
 
 ## AxServiceGroup XML structure
 
@@ -128,11 +146,15 @@ public class VendorLookupResponse
   <Name>VendorLookupServiceGroup</Name>
   <Services>
     <AxServiceGroupService>
-      <ServiceName>VendorLookupService</ServiceName>
+      <Name>VendorLookup</Name>
+      <Service>VendorLookup</Service>
     </AxServiceGroupService>
   </Services>
 </AxServiceGroup>
 ```
+
+`Service` references the `AxService` object's `Name`; `Name` on the
+`AxServiceGroupService` is conventionally the same value.
 
 ---
 
@@ -148,9 +170,11 @@ Content-Type: application/json
 { "AccountNum": "US-001" }
 ```
 
-Example for the scaffold above:
+Example for the scaffold above (`<ServiceName>` is the `AxService` object's
+`Name`, i.e. the positional argument passed to `d365fo generate custom-service`
+— not the `AxClass` service-class name):
 ```
-POST https://myenv.operations.dynamics.com/api/services/VendorLookupServiceGroup/VendorLookupService/lookup
+POST https://myenv.operations.dynamics.com/api/services/VendorLookupServiceGroup/VendorLookup/lookupVendor
 ```
 
 ---
@@ -167,7 +191,7 @@ Use Azure AD OAuth2:
 ## Hard rules
 
 - **Request/response types must be `[DataContractAttribute]` classes.** Primitive types (`str`, `int`) are also accepted for simple services.
-- **Public methods in a `[ServiceAttribute]`-decorated class are automatically exposed** and do not require `[SysEntryPointAttribute]`.
+- **There is no `[ServiceAttribute]` class-level decorator in X++.** A service class is a plain class; exposure comes entirely from the `AxService` object listing its methods as `AxServiceOperation` entries. Exposed methods do not require `[SysEntryPointAttribute]`.
 - **`[DataMemberAttribute]` on every parmXxx accessor** — the JSON serializer uses member names from this attribute.
 - **Service group name determines the URL** — choose a stable, module-scoped name; renaming it breaks all callers.
 - **Never include `ttsbegin/ttscommit` in service methods** unless you own the full transaction scope. If the service calls a framework method that manages its own transaction, wrap at a higher level.

--- a/skills/copilot/data-entity-scaffolding.instructions.md
+++ b/skills/copilot/data-entity-scaffolding.instructions.md
@@ -22,7 +22,10 @@ d365fo search edt  <Edt>        --output json    # for any EDT mappings
 ## Scaffolding
 
 ```sh
-# Minimal — exposes one table; OData names default to <Name>Entity / <Name>Entities
+# Minimal — without --public-entity/--public-collection, PublicEntityName
+# defaults to the literal ENTITY argument and PublicCollectionName to
+# ENTITY + "s" (naive pluralization, e.g. FmVehicleEntity / FmVehicleEntitys) —
+# always pass both explicitly for clean OData names.
 d365fo generate entity FmVehicleEntity \
     --table FmVehicle \
     --all-fields \
@@ -32,13 +35,14 @@ d365fo generate entity FmVehicleEntity \
 d365fo generate entity FmVehicleEntity \
     --table FmVehicle \
     --field VIN --field Make --field Year \
-    --public-entity-name FleetVehicle \
-    --public-collection-name FleetVehicles \
+    --public-entity FleetVehicle \
+    --public-collection FleetVehicles \
     --install-to FleetManagement
 ```
 
-The CLI returns `{path, bytes, backup, fieldCount, publicEntityName,
-publicCollectionName}`. Never request the full XML back.
+The CLI returns `{kind, name, table, path, bytes, fieldCount, fieldsFromTable}`
+(plus `backup` when `--overwrite` replaces an existing file). Never request
+the full XML back.
 
 ## OData naming conventions (D365FO)
 

--- a/skills/copilot/event-handler-authoring.instructions.md
+++ b/skills/copilot/event-handler-authoring.instructions.md
@@ -42,7 +42,7 @@ the user explicitly requests a separate class.
 ```sh
 d365fo generate event-handler MyClass_CustTableHandler \
     --source-kind Table \
-    --source CustTable \
+    --source-object CustTable \
     --event Inserted \
     --install-to MyModel
 ```
@@ -52,23 +52,28 @@ Generated attribute: `[DataEventHandler(tableStr(CustTable), DataEventType::Inse
 D365FO `DataEventType` values: `ValidatingFieldValue`, `ValidatedField`,
 `ValidatingDelete`, `ValidatedDelete`, `ValidatingWrite`, `ValidatedWrite`,
 `Inserting`, `Inserted`, `Updating`, `Updated`, `Deleting`, `Deleted`,
-`InitializingRecord`, `InitializedRecord`, `Modifying`, `Modified`.
+`InitializingRecord`, `InitializedRecord`, `ModifyingField`, `ModifiedField`.
 
 ## Form / FormDataSource / FormControl events → form-specific attributes
 
 ```sh
 d365fo generate event-handler MyClass_FormHandler \
     --source-kind Form \
-    --source CustTable \
+    --source-object CustTable \
     --event Initialized \
     --install-to MyModel
 
 d365fo generate event-handler MyClass_FormDsHandler \
     --source-kind FormDataSource \
-    --source CustTable.CustTable \
-    --event ExecuteQuery \
+    --source-object "CustTable, CustTable" \
+    --event QueryExecuting \
     --install-to MyModel
 ```
+
+`--source-object` for `FormDataSource` is passed through verbatim into
+`formDataSourceStr(...)`, so it must already be the two comma-separated
+`<Form>, <DataSource>` arguments (e.g. `"CustTable, CustTable"`) — a dotted
+`Form.DataSource` value produces invalid X++.
 
 Attribute shapes: `[FormEventHandler(formStr(...), FormEventType::...)]`,
 `[FormDataSourceEventHandler(formDataSourceStr(form, ds), FormDataSourceEventType::...)]`.
@@ -82,7 +87,7 @@ events — those are `DataEventHandler`.
 ```sh
 d365fo generate event-handler MyClass_DelegateHandler \
     --source-kind Class \
-    --source SalesFormLetter \
+    --source-object SalesFormLetter \
     --event onPosted \
     --install-to MyModel
 ```

--- a/skills/copilot/form-pattern-scaffolding.instructions.md
+++ b/skills/copilot/form-pattern-scaffolding.instructions.md
@@ -28,7 +28,7 @@ CORRECT — always:
 ## Pre-flight
 
 ```sh
-d365fo search form <Name> --output json          # collision check
+d365fo search any <Name> --kind form --output json   # collision check (no dedicated `search form`)
 d365fo get table <PrimaryTable> --output json    # field list for the grid
 
 # Pattern spec — required structure, versions, when-to-use, reference forms
@@ -130,11 +130,12 @@ section template is `--section Name:Caption` (split on the first `:`).
   `<DataSourceReferences>`, `<DataSources>`, methods, extension properties,
   and pattern metadata exactly.
 - After changing form XML, validate XML well-formedness, run
-  `d365fo validate xpp --file <file> --code-type xml-any --output json`, run
+  `d365fo validate xpp <file> --code-type xml-any --output json` (file is a
+  positional argument, not `--file`), run
   `d365fo index refresh --model <Model>`, and re-read with
   `d365fo get form <Form> --output json`.
 - Never use `Dialog` or `TableOfContents` patterns for transactional grids.
-- Pre-flight `search form <Name>` before scaffolding to avoid collisions.
+- Pre-flight `search any <Name> --kind form` before scaffolding to avoid collisions (there is no dedicated `search form` subcommand).
 - Caption strings must be labels (BP `BPErrorLabelIsText`) — never raw text.
 - After scaffolding, run `d365fo build` only on user request.
 

--- a/skills/copilot/integration-patterns.instructions.md
+++ b/skills/copilot/integration-patterns.instructions.md
@@ -15,7 +15,7 @@ applyTo: '**/AxDataEntityView/**,**/AxService/**,**/AxServiceGroup/**,**/*Entity
 
 | Pattern | Direction | Latency | Volume | Entry point |
 |---------|-----------|---------|--------|-------------|
-| **OData REST API** | In + Out | Synchronous, real-time | Record-level | `data/<EntityName>` endpoint |
+| **OData REST API** | In + Out | Synchronous, real-time | Record-level | `data/<PublicCollectionName>` endpoint |
 | **Custom Services** | In | Synchronous | Operation-level | SOAP + JSON REST endpoint |
 | **Data Management Framework (DMF)** | In + Out | Async batch | Bulk | Import/export jobs, staging tables |
 | **Business Events** | Out | Near-real-time | Event-driven | Service Bus, Event Grid, Power Automate, Logic Apps |
@@ -26,11 +26,11 @@ applyTo: '**/AxDataEntityView/**,**/AxService/**,**/AxServiceGroup/**,**/*Entity
 
 **Purpose:** real-time synchronous CRUD from external systems — Power Platform, Logic Apps, third-party ERPs.
 
-**Endpoint:** `https://{env}.cloudax.dynamics.com/data/{PublicEntityName}`
+**Endpoint:** `https://{env}.cloudax.dynamics.com/data/{PublicCollectionName}`
 
 **Requirements for a working OData entity:**
 
-- `EnablePublicAPI = Yes` on the `AxDataEntityView`
+- `IsPublic = Yes` on the `AxDataEntityView`
 - A unique `PublicEntityName` (the OData entity type) and `PublicCollectionName` (the collection URL segment)
 - At least one key field with `AlternateKey = Yes` on a unique index
 - All mandatory fields mapped in the entity
@@ -50,7 +50,7 @@ d365fo get table <SourceTable> --output json | jq '.data.indexes[] | select(.alt
 # 4. Scaffold a new entity if needed
 d365fo generate entity <Name> --table <T> \
   --all-fields \
-  --public-entity-name <Singular> --public-collection-name <Plural> \
+  --public-entity <Singular> --public-collection <Plural> \
   --out c:/AOT/MyModel/AxDataEntityView/<Name>.xml
 ```
 
@@ -111,8 +111,8 @@ d365fo generate custom-service <Name> \
 
 **Requirements for DMF-capable entity:**
 
-- `EnableDataManagementCapabilities = Yes` on the `AxDataEntityView`
-- A staging table (`StagingTable` property set)
+- `DataManagementEnabled = Yes` on the `AxDataEntityView`
+- A staging table (`DataManagementStagingTable` property set)
 - Change tracking support (for incremental export)
 
 **CLI workflow:**
@@ -121,12 +121,12 @@ d365fo generate custom-service <Name> \
 # 1. Find the entity
 d365fo search entity <Name> --output json
 
-# 2. Check DMF capability and staging table presence
-d365fo get entity <Name> --output json | jq '{enableDMF: .data.enableDataManagementCapabilities, stagingTable: .data.stagingTable}'
+# 2. Check staging table presence (a non-empty value implies DMF is wired up)
+d365fo get entity <Name> --output json | jq '.data.entity.stagingTable'
 
 # 3. Scaffold a DMF-capable entity (staging table must be created separately)
-d365fo generate entity <Name> --table <T> --all-fields --out …
-# Then hand-edit to set EnableDataManagementCapabilities + StagingTable
+d365fo generate entity <Name> --table <T> --all-fields \
+  --data-management --staging-table <Name>Staging --out …
 ```
 
 **Notes:**

--- a/skills/copilot/label-translation.instructions.md
+++ b/skills/copilot/label-translation.instructions.md
@@ -34,9 +34,12 @@ d365fo labels create "@FleetManagement:VehicleVin" "VIN" \
 
 - The `<KEY>` form `@File:Key` must match the target `.label.txt` filename
   (`@FleetManagement:VehicleVin` → `FleetManagement.label.txt`).
-- `--lang` is required when the file does not embed a single language stem
-  (`FleetManagement.en-us.label.txt`).
-- The CLI writes atomically (`.tmp` + move; `.bak` retained on overwrite).
+- `--lang` only affects path resolution when using `--install-to <MODEL>`; it
+  has no effect when `--file` is given directly — pass the full path to the
+  target `<Name>.<lang>.label.txt` file yourself.
+- The CLI writes atomically (`.tmp` + move; `.bak` retained whenever the
+  target file already existed, on both first-write-to-existing-file and
+  `--overwrite`).
 
 ## 3. Rename a label key (refactor across the model)
 
@@ -75,5 +78,9 @@ d365fo labels delete @FleetManagement:DeprecatedKey --file <path>.label.txt
 ## EDT-label inheritance — exception
 
 When adding a field whose EDT already carries a `Label`, do **NOT** create
-a new label or pass `--label` on the field — the field inherits the EDT
-caption. Only override when the table needs a different caption deliberately.
+a new label for it — an `AxTableField` with no `<Label>` element inherits
+the EDT's caption at runtime. `d365fo generate table --field <name>:<edt>`
+never emits a per-field `<Label>` (there is no per-field `--label` option
+today — `--label` on `generate table` sets the *table's* caption, not a
+field's). Only add a table-level `--label`/field-level label override when
+the table or field needs a caption different from the EDT's.

--- a/skills/copilot/model-dependency-and-coupling.instructions.md
+++ b/skills/copilot/model-dependency-and-coupling.instructions.md
@@ -20,7 +20,11 @@ d365fo models list --output json
 d365fo models deps FleetManagement --output json
 ```
 
-Output shape: `{name, publisher, layer, version, customizable, dependsOn[], dependedBy[]}`.
+`models list` output shape: `{count, items: [{modelId, name, publisher,
+layer, isCustom}]}` (`publisher`/`layer` are frequently absent — omitted
+when the Descriptor XML didn't populate them). `models deps` output shape:
+`{model: {modelId, name, publisher, layer, isCustom}, dependsOn: string[],
+dependedBy: string[]}`.
 
 ## Coupling metrics
 
@@ -40,8 +44,10 @@ Output highlights:
 
 ## When to invoke
 
-- Before introducing a new dependency: confirm the target model isn't
-  customer-layer (`layer: cus*`) when you're an ISV.
+- Before introducing a new dependency: check `models list`/`models deps` for
+  the target's layer — a model can only *depend on* strictly lower-or-equal
+  layers (e.g. a `cus`-layer model must not depend on an `isv`- or
+  `usr`-layer one).
 - During architectural review: `cycles[]` must be empty; fan-out outliers
   flag candidates for splitting.
 - When CoC / extensions don't take effect: `models deps` reveals if your
@@ -49,10 +55,14 @@ Output highlights:
 
 ## Hard rules
 
-- Never extend / depend on a `cus*` (customer-layer) model from an ISV model
-  — D365FO disallows the upward dependency.
+- Layer ordering (lowest → highest): `sys → syp → gls → glp → dis → dip →
+  cus → cup → var → vap → isv → isp → usr → usp` (each `Descriptor/*.xml`
+  stores the numeric layer id, e.g. `<Layer>8</Layer>` = `var`). Each layer
+  can only consume (depend on) *lower* layers — a `cus`-layer model cannot
+  depend on an `isv`- or `usr`-layer model; the reverse is allowed. In
+  practice most customer extension work happens in `usr` (the highest
+  layer) precisely so it can reference everything below it, including
+  installed ISV solutions.
 - Never introduce a cycle — even a 2-node cycle blocks compilation.
-- Layer ordering (lowest → highest): `sys → syp → isv → iss → cus → cup → usr → usp`.
-  Each layer can only consume *lower* layers.
 - After modifying any `Descriptor/*.xml`, run `d365fo index refresh` so
   subsequent `models deps` / `models coupling` reflects reality.

--- a/skills/copilot/object-extension-authoring.instructions.md
+++ b/skills/copilot/object-extension-authoring.instructions.md
@@ -15,10 +15,10 @@ applyTo: '**/AxTableExtension/**,**/AxFormExtension/**,**/AxEdtExtension/**,**/A
 
 | Standard object you want to change | Use |
 |---|---|
-| Add a field/index/relation to `CustTable` | `extension Table CustTable <Suffix>` |
-| Add a control / data source / FastTab to a standard form | `extension Form CustTableListPage <Suffix>` |
-| Tighten an EDT (e.g. lengthen a string, adjust label) | `extension Edt CustAccount <Suffix>` |
-| Add new members to a base enum | `extension Enum NoYes <Suffix>` |
+| Add a field/index/relation to `CustTable` | `extension Table CustTable --suffix <Suffix>` |
+| Add a control / data source / FastTab to a standard form | `extension Form CustTableListPage --suffix <Suffix>` |
+| Tighten an EDT (e.g. lengthen a string, adjust label) | `extension Edt CustAccount --suffix <Suffix>` |
+| Add new members to a base enum | `extension Enum NoYes --suffix <Suffix>` |
 | Add behaviour to a class method | **NOT this** — use `coc-extension-authoring` instead |
 
 ## Pre-flight (ONE call)
@@ -74,17 +74,23 @@ Before scaffolding a new extension, inspect the existing result from
 
 ```sh
 # Add fields to standard CustTable in the FleetManagement model
-d365fo generate extension Table CustTable Fleet --install-to FleetManagement
+d365fo generate extension Table CustTable --suffix Fleet --install-to FleetManagement
 
 # Form extension targeting CustTableListPage
-d365fo generate extension Form CustTableListPage Fleet --install-to FleetManagement
+d365fo generate extension Form CustTableListPage --suffix Fleet --install-to FleetManagement
 
 # Tighten the CustAccount EDT
-d365fo generate extension Edt CustAccount Fleet --install-to FleetManagement
+d365fo generate extension Edt CustAccount --suffix Fleet --install-to FleetManagement
 
 # Add an enum member to NoYes
-d365fo generate extension Enum NoYes Fleet --install-to FleetManagement
+d365fo generate extension Enum NoYes --suffix Fleet --install-to FleetManagement
 ```
+
+`generate extension` takes exactly two positional arguments (`<KIND> <TARGET>`);
+the suffix is a named `--suffix <SUFFIX>` option, not a third positional
+argument — passing it positionally fails with "Could not match '<value>' with
+an argument." If `--suffix` is omitted it defaults to the `--install-to`
+model name (or `Extension`).
 
 The scaffold emits a minimal `<AxXxxExtension>` element with the
 `<Name>Target.Suffix</Name>` shape Visual Studio expects. After scaffolding,
@@ -118,7 +124,7 @@ d365fo generate enum CustCustomStatus \
   --out c:/AOT/MyModel/AxEnum/CustCustomStatus.xml
 ```
 
-`--base-type` accepts `String`, `Integer`, `Real`, `Int64`, `Date`, `UtcDateTime`, `Enum`, `Guid`. Enums are `IsExtensible=Yes` by default — pass `--no-extensible` to opt out.
+`--base-type` accepts `String`, `Integer`, `Real`, `Int64`, `Date`, `UtcDateTime`, `Enum`, `Guid`. Enums are `IsExtensible=Yes` by default — pass `--non-extensible` to opt out (`--no-extensible` is not a recognized flag and is silently ignored, leaving the enum extensible).
 
 ## XDS Security Policy scaffolding
 
@@ -136,7 +142,7 @@ d365fo generate security-policy CustCustomSecurityPolicy \
   --out c:/AOT/MyModel/AxSecurityPolicy/CustCustomSecurityPolicy.xml
 ```
 
-`--operation` accepts `All`, `Select`, `Insert`, `Update`, `Delete`. The policy query (`--policy-query`) is a separate `AxQuery` AOT object that must already exist or be scaffolded with `d365fo generate query`.
+`--operation` accepts only `Select` (default) or `All` — `Insert`/`Update`/`Delete` are rejected with "Unknown --operation '<value>'. Expected Select | All." The policy query (`--policy-query`) is a separate `AxQuery` AOT object that must already exist or be scaffolded with `d365fo generate query`.
 
 After scaffolding, verify with:
 ```sh
@@ -152,7 +158,8 @@ d365fo get security-policy CustCustomSecurityPolicy --output json
 - Never rewrite an existing extension XML file wholesale. Preserve unrelated
   nodes and only add the requested structural element(s).
 - After changing extension XML, validate XML well-formedness, run
-  `d365fo validate xpp --file <file> --code-type xml-any --output json`, run
+  `d365fo validate xpp <file> --code-type xml-any --output json` (file is a
+  positional argument, not `--file`), run
   `d365fo index refresh --model <Model>`, and re-read the target metadata.
 - Never use `extension` for class behaviour changes — that is CoC's job
   (`d365fo generate coc <Class>`).

--- a/skills/copilot/review-and-checkpoint-workflow.instructions.md
+++ b/skills/copilot/review-and-checkpoint-workflow.instructions.md
@@ -1,5 +1,5 @@
 ---
-description: Use Git as the review layer for AI-driven D365FO edits, and use `d365fo review diff` to get an AOT-semantic summary of XML changes. Invoke whenever the user is about to start a non-trivial change, before "accepting" AI edits, or wants a structural diff (added classes, modified table fields, new CoC wrappers).
+description: Use Git as the review layer for AI-driven D365FO edits, and use `d365fo review diff` for a shallow BP-style probe (missing EDT/Label, hard-coded strings, dynamic query) over changed AxTable/AxClass XML on top of the raw byte diff. Invoke whenever the user is about to start a non-trivial change, before "accepting" AI edits, or wants a quick heuristic pass over what changed.
 applyTo: '**/AxClass/**,**/AxTable/**,**/AxForm/**,**/*.xpp,**/*.xml'
 ---
 > ⛔ **NEVER write X++ AOT XML files directly** via PowerShell, terminal file commands (`Set-Content`, `Out-File`, `New-Item`), editor write tools, or any raw text approach. The XML schema (`<AxClass>`, `<AxTable>`, `<AxForm>`, `<Methods>`, `<SourceCode>`) is proprietary — LLMs have not been trained on it reliably. **ALWAYS use `d365fo generate …` commands** to produce correct AOT XML. If `d365fo` is unavailable in PATH, stop and ask the user to install it.
@@ -7,8 +7,8 @@ applyTo: '**/AxClass/**,**/AxTable/**,**/AxForm/**,**/*.xpp,**/*.xml'
 # Git-checkpoint review workflow
 
 > Visual Studio 2022 has no inline accept/reject UI for AI edits. Use Git as
-> the review layer; pair with `d365fo review diff` for an AOT-semantic
-> summary on top of the raw byte diff.
+> the review layer; pair with `d365fo review diff` for a quick heuristic
+> probe on top of the raw byte diff.
 
 ## 1. Before starting any non-trivial task
 
@@ -60,24 +60,33 @@ For new forms based on an example, compare the pattern metadata and required
 controls/datasources from the example. Missing ActionPane/Body/Tab/FastTab/grid
 or QuickFilter elements are not acceptable just because the XML parses.
 
-## 3. After the task — AOT-semantic review
+## 3. After the task — review the diff
 
 ```sh
 # Raw byte diff (as usual)
 git diff --stat
 git diff <ref> -- AxClass/ AxTable/ AxForm/
 
-# AOT-semantic diff — added classes, modified table fields, new CoC wrappers …
+# Shallow BP-style probe over changed AxTable/AxClass XML in the working tree
+# vs --base (git diff --name-only under the hood; not a full structural diff)
 d365fo review diff --base <ref> --output json
-d365fo review diff --base HEAD~1 --output json | jq '.data.added,.data.modified'
+d365fo review diff --base HEAD~1 --output json | jq '.data.violations'
 ```
 
-`review diff` is **complementary** to `git diff`, not a replacement:
+`review diff` is **complementary** to `git diff`, not a replacement — and it
+is a shallow regex/XML probe, not a compiler-grade structural diff. It does
+NOT report added classes, modified fields, or new CoC wrappers. It only
+scans changed `.xml`/`.xpp` files and flags a small fixed set of issues:
+fields with no `<ExtendedDataType>` or no `<Label>` in changed
+`AxTable/…` XML, and hard-coded string literals / dynamic-`Query`
+construction in changed `AxClass/…` XML. Output shape: `{baseRev, headRev,
+changedFiles, violationCount, violations: [{file, rule, severity, message,
+…}]}`.
 
 | Tool | Shows | Best for |
 |---|---|---|
 | `git diff` | Raw bytes per file | Spotting whitespace / unintended edits |
-| `d365fo review diff` | Structural deltas (added field, new wrapper, index change) | Reviewer summary, PR descriptions |
+| `d365fo review diff` | A handful of BP-style probes (missing EDT/Label, hard-coded strings, dynamic query) over changed AxTable/AxClass XML | A fast heuristic pass before `bp check` — not a substitute for reading the diff |
 
 ## 4. Accept / reject
 
@@ -95,4 +104,4 @@ d365fo review diff --base HEAD~1 --output json | jq '.data.added,.data.modified'
 - Always include the `.bak` files in `.gitignore` for the user's repo so
   scaffold-overwrite backups don't pollute commits.
 - Always show `d365fo review diff` output BEFORE asking the user to accept
-  — they need the structural summary to make a decision.
+  — they need the heuristic-probe summary to make a decision.

--- a/skills/copilot/security-hierarchy-trace.instructions.md
+++ b/skills/copilot/security-hierarchy-trace.instructions.md
@@ -8,15 +8,24 @@ applyTo: '**/AxSecurityRole/**,**/AxSecurityDuty/**,**/AxSecurityPrivilege/**'
 
 ## Workflow
 
-1. **Top-down** — which entry points does a role reach?
+1. **Top-down** — which entry points does a role reach? `security coverage
+   <Name> --type Role` always returns an empty `routes[]` (`Role` is not a
+   valid `--type`, and the coverage lookup is a reverse/bottom-up query, not
+   a forward one) — walk the hierarchy explicitly instead:
    ```sh
-   d365fo security coverage <RoleName> --type Role --output json
+   d365fo security role <RoleName> --output json       # -> duties[] + privileges[]
+   d365fo security duty <DutyName> --output json        # -> privileges[]
+   d365fo security privilege <PrivilegeName> --output json  # -> entryPoints[] (objectName + objectType)
    ```
 
 2. **Bottom-up** — which roles reach this object?
    ```sh
-   d365fo security coverage <ObjectName> --type Menuitem --output json
-   # type may be Table, Form, Report, Class, Menuitem
+   d365fo security coverage <ObjectName> --type MenuItemDisplay --output json
+   # --type is matched literally against the indexed AOT ObjectType, so use the
+   # exact value: MenuItemDisplay | MenuItemAction | MenuItemOutput | Table |
+   # Form | Report | Class. The CLI's own default/listed value "Menuitem" does
+   # NOT occur in real data and always returns an empty routes[] — always pass
+   # the specific MenuItem* kind.
    ```
 
 3. The response contains `routes[*]` of shape
@@ -62,4 +71,9 @@ d365fo generate duty FmNewDuty --privilege FmSomePrivilege \
 ```
 
 **Scaffold order:** menu item → privilege (references the menu item) → duty (bundles privileges) → role (bundles duties).
-Always run `d365fo security coverage <Name> --type Role --output json` after to verify the new objects appear in the hierarchy.
+Always verify the new objects appear in the hierarchy afterwards — `d365fo
+security coverage <Name> --type Role --output json` always returns an empty
+`routes[]` (see Workflow above); instead run `d365fo security role
+<RoleName> --output json` to confirm the duties/privileges are attached, and
+`d365fo security coverage <EntryPointName> --type MenuItemDisplay --output
+json` to confirm the new role reaches the target entry point.

--- a/skills/copilot/xpp-best-practice-rules.instructions.md
+++ b/skills/copilot/xpp-best-practice-rules.instructions.md
@@ -56,7 +56,7 @@ For *filter-only* joins use `exists join` / `notExists join`. For complex correl
 
 ### `BPCheckAlternateKeyAbsent` — every table needs an alternate key
 
-A unique index on the natural key, marked `AlternateKey = Yes`. The CLI's `d365fo generate table` template emits a `<Pkey>` index with `AlternateKey = Yes` — don't strip it.
+A unique index on the natural key, marked `AlternateKey = Yes`. The CLI's `d365fo generate table` template emits a `PrimaryIdx` index with `<AlternateKey>Yes</AlternateKey>` — don't strip it.
 
 ### `BPErrorUnknownLabel` — labels referenced must exist
 
@@ -100,7 +100,7 @@ d365fo generate table FmVehicle \
 
 ```sh
 # In-process heuristics — fast, runs anywhere, useful for CI:
-d365fo lint --output sarif > lint.sarif
+d365fo lint --format sarif > lint.sarif
 
 # Run specific method-flag categories (detected at index-extract time):
 d365fo lint --category today-usage          # BPUpgradeCodeToday: today() calls
@@ -111,7 +111,7 @@ d365fo lint --category doc-comment-missing  # BPXmlDocNoDocumentationComments
 d365fo bp check --output json
 ```
 
-Six categories are now available: `table-no-index`, `ext-named-not-attributed`, `string-without-edt`, `today-usage`, `do-insert-update`, `doc-comment-missing`. The method-flag categories are populated at extract time by scanning `<Source>` text — no full body is stored. Re-run `d365fo index refresh` after editing source before linting.
+Sixteen categories are now available: `table-no-index`, `ext-named-not-attributed`, `string-without-edt`, `today-usage`, `do-insert-update`, `doc-comment-missing`, `nested-select`, `insert-in-loop`, `tts-try-catch`, `empty-table-method`, `batch-no-cango`, `force-literals`, `public-instance-field`, `cache-lookup-mismatch`, `missing-delete-action`, `no-alternate-key`. The method-flag categories are populated at extract time by scanning `<Source>` text — no full body is stored. Re-run `d365fo index refresh` after editing source before linting.
 
 **Never** auto-run `bp check`. It blocks the user (slow, Windows-only). Say *"Changes scaffolded. Run `d365fo bp check` when you're ready."*
 

--- a/skills/copilot/xpp-database-queries.instructions.md
+++ b/skills/copilot/xpp-database-queries.instructions.md
@@ -75,6 +75,7 @@ SysDa is the modern X++ query API — fluent and object-oriented. Use it when qu
 
 **Core classes:**
 - `SysDaQueryObject` — root query builder; set table buffer via constructor.
+- `SysDaSearchObject` — wraps a `SysDaQueryObject` for iteration; pass this (not the raw query object) to `SysDaSearchStatement`/`SysDaFindStatement`.
 - `SysDaSearchStatement` — execute + iterate; `SysDaFindStatement` — `firstOnly` equivalent.
 - `SysDaUpdateStatement` / `SysDaInsertStatement` / `SysDaDeleteStatement` — set-based ops.
 
@@ -84,8 +85,9 @@ var qe = new SysDaQueryObject(custTable);
 qe.whereClause(new SysDaEqualsExpression(
     new SysDaFieldExpression(custTable, fieldStr(CustTable, AccountNum)),
     new SysDaValueExpression('US-001')));
-var so = new SysDaSearchStatement();
-while (so.nextRecord(qe))
+var so = new SysDaSearchObject(qe);       // wraps the query object for iteration
+var search = new SysDaSearchStatement();
+while (search.nextRecord(so))
 {
     info(custTable.AccountNum);
 }

--- a/src/D365FO.Cli/Commands/Generate/GenerateSysTestCommand.cs
+++ b/src/D365FO.Cli/Commands/Generate/GenerateSysTestCommand.cs
@@ -1,0 +1,141 @@
+using D365FO.Core;
+using D365FO.Core.Index;
+using D365FO.Core.Scaffolding;
+using Spectre.Console.Cli;
+
+namespace D365FO.Cli.Commands.Generate;
+
+/// <summary>
+/// Scaffolds a minimal, ATL-ready <c>SysTestCase</c> class (issue #107): a
+/// <c>[SysTestMethod]</c> Arrange/Act/Assert skeleton, optionally attributed
+/// with <c>[SysTestCaseDataDependency]</c> and wired for ATL via
+/// <c>AtlDataRootNode</c>. MVP scope — no test-logic generation. The optional
+/// <c>--class</c>/<c>--table</c>/<c>--method</c> source is resolved against
+/// the index (must exist) but only informs naming/context.
+/// </summary>
+public sealed class GenerateSysTestCommand : Command<GenerateSysTestCommand.Settings>
+{
+    public sealed class Settings : GenerateSettings
+    {
+        [CommandArgument(0, "<NAME>")]
+        [System.ComponentModel.Description("Test class name (e.g. CustServiceTest).")]
+        public string Name { get; init; } = "";
+
+        [CommandOption("--data-area-id <COMPANY>")]
+        [System.ComponentModel.Description("Company emitted as [SysTestCaseDataDependency('<Company>')]. Omitted entirely when not set.")]
+        public string? DataAreaId { get; init; }
+
+        [CommandOption("--atl")]
+        [System.ComponentModel.Description("Emit an AtlDataRootNode field and a setUpTestCase() that constructs it (after calling super()).")]
+        public bool Atl { get; init; }
+
+        [CommandOption("--class <CLASS>")]
+        [System.ComponentModel.Description("Source class this test targets. Resolved against the index (must exist); used for naming/context only.")]
+        public string? Class { get; init; }
+
+        [CommandOption("--table <TABLE>")]
+        [System.ComponentModel.Description("Source table this test targets. Resolved against the index (must exist); used for naming/context only.")]
+        public string? Table { get; init; }
+
+        [CommandOption("--method <METHOD>")]
+        [System.ComponentModel.Description("Method on --class or --table. Resolved against the index (must exist); becomes the generated test method's subject.")]
+        public string? Method { get; init; }
+    }
+
+    public override int Execute(CommandContext ctx, Settings settings)
+    {
+        var kind = OutputMode.Resolve(settings.Output);
+
+        if (string.IsNullOrWhiteSpace(settings.Name))
+            return RenderHelpers.Render(kind, ToolResult<object>.Fail(D365FoErrorCodes.BadInput, "Test class name required."));
+
+        var hasClass = !string.IsNullOrWhiteSpace(settings.Class);
+        var hasTable = !string.IsNullOrWhiteSpace(settings.Table);
+        if (hasClass && hasTable)
+            return RenderHelpers.Render(kind, ToolResult<object>.Fail(D365FoErrorCodes.BadInput, "Specify only one of --class or --table."));
+        if (!hasClass && !hasTable && !string.IsNullOrWhiteSpace(settings.Method))
+            return RenderHelpers.Render(kind, ToolResult<object>.Fail(D365FoErrorCodes.BadInput, "--method requires --class or --table."));
+
+        string? subject = null;
+        string? sourceKind = null;
+        string? sourceName = null;
+
+        if (hasClass || hasTable)
+        {
+            var repo = RepoFactory.Create();
+            var owner = (hasClass ? settings.Class : settings.Table)!;
+            sourceKind = hasClass ? "class" : "table";
+            sourceName = owner;
+
+            if (hasClass)
+            {
+                if (repo.GetClassDetails(owner) is null)
+                {
+                    var hint = NameSuggester.HintFor(repo, NameSuggester.Kind.Class, owner)
+                               ?? "Run 'd365fo index build' after extracting metadata.";
+                    return RenderHelpers.Render(kind,
+                        ToolResult<object>.Fail(D365FoErrorCodes.ClassNotFound, $"Class '{owner}' not found in index.", hint));
+                }
+            }
+            else
+            {
+                if (repo.GetTableDetails(owner) is null)
+                {
+                    var hint = NameSuggester.HintFor(repo, NameSuggester.Kind.Table, owner)
+                               ?? "Run 'd365fo index build' after extracting metadata.";
+                    return RenderHelpers.Render(kind,
+                        ToolResult<object>.Fail(D365FoErrorCodes.TableNotFound, $"Table '{owner}' not found in index.", hint));
+                }
+            }
+
+            if (!string.IsNullOrWhiteSpace(settings.Method))
+            {
+                if (repo.FindMethod(owner, settings.Method!) is null)
+                {
+                    return RenderHelpers.Render(kind, ToolResult<object>.Fail(D365FoErrorCodes.MethodNotFound,
+                        $"Method '{settings.Method}' not found on {sourceKind} '{owner}' in index.",
+                        $"Use 'd365fo get {sourceKind} {owner}' to see the real method list."));
+                }
+                subject = settings.Method;
+            }
+        }
+
+        var hasInstall = !string.IsNullOrWhiteSpace(settings.InstallTo);
+        var hasOut     = !string.IsNullOrWhiteSpace(settings.Out);
+        if (!hasInstall && !hasOut)
+            return RenderHelpers.Render(kind, ToolResult<object>.Fail(D365FoErrorCodes.BadInput, "--out or --install-to is required."));
+
+        var outPath = settings.Out;
+        if (hasInstall && !hasOut)
+        {
+            outPath = GenerateInstaller.ResolveInstallPath(kind, "AxClass", settings.Name, settings.InstallTo!, out var fail);
+            if (fail.HasValue) return fail.Value;
+        }
+
+        try
+        {
+            var doc = SysTestScaffolder.TestClass(settings.Name, settings.DataAreaId, settings.Atl, subject);
+            var res = ScaffoldFileWriter.Write(doc, outPath!, settings.Overwrite);
+            var testMethodName = $"{subject ?? "subject"}_scenario_expectedResult";
+
+            return RenderHelpers.Render(kind, ToolResult<object>.Success(new
+            {
+                kind       = "SysTest",
+                name       = settings.Name,
+                extends    = "SysTestCase",
+                dataAreaId = settings.DataAreaId,
+                atl        = settings.Atl,
+                source     = sourceKind is null ? null : new { kind = sourceKind, name = sourceName, method = settings.Method },
+                testMethod = testMethodName,
+                path       = res.Path,
+                bytes      = res.Bytes,
+                backup     = res.BackupPath,
+                model      = settings.InstallTo,
+            }));
+        }
+        catch (Exception ex)
+        {
+            return RenderHelpers.Render(kind, ToolResult<object>.Fail(D365FoErrorCodes.WriteFailed, ex.Message));
+        }
+    }
+}

--- a/src/D365FO.Cli/Commands/Review/ReviewDiffCommand.cs
+++ b/src/D365FO.Cli/Commands/Review/ReviewDiffCommand.cs
@@ -72,7 +72,7 @@ public sealed class ReviewDiffCommand : Command<ReviewDiffCommand.Settings>
         }));
     }
 
-    private static void InspectTableXml(string path, string text, List<object> bag)
+    internal static void InspectTableXml(string path, string text, List<object> bag)
     {
         XDocument doc;
         try { doc = XDocument.Parse(text); }
@@ -81,15 +81,26 @@ public sealed class ReviewDiffCommand : Command<ReviewDiffCommand.Settings>
             bag.Add(new { file = path, rule = "XML_PARSE", severity = "error", message = ex.Message });
             return;
         }
-        var fields = doc.Descendants().Where(e => e.Name.LocalName.StartsWith("AxTableField", StringComparison.Ordinal));
+        // Real field definitions live only under AxTable/Fields/AxTableField*.
+        // Never descend into <FieldGroups> — <AxTableFieldGroup> names and
+        // <AxTableFieldGroupField><DataField> references are not fields and
+        // must not be evaluated as such.
+        var fieldsContainer = doc.Root?.Elements().FirstOrDefault(e => e.Name.LocalName == "Fields");
+        var fields = fieldsContainer?.Elements().Where(e => e.Name.LocalName.StartsWith("AxTableField", StringComparison.Ordinal))
+            ?? Enumerable.Empty<XElement>();
         foreach (var f in fields)
         {
             var name = f.Elements().FirstOrDefault(e => e.Name.LocalName == "Name")?.Value ?? "?";
-            var hasEdt = f.Elements().Any(e => e.Name.LocalName == "ExtendedDataType");
+            var edtValue = f.Elements().FirstOrDefault(e => e.Name.LocalName == "ExtendedDataType")?.Value;
+            var enumValue = f.Elements().FirstOrDefault(e => e.Name.LocalName == "EnumType")?.Value;
+            // EnumType is an equivalent, valid type declaration for AxTableFieldEnum
+            // fields — either it or a non-empty ExtendedDataType satisfies the rule,
+            // and both also carry an inherited label from their type definition.
+            var hasTypeDeclaration = !string.IsNullOrWhiteSpace(edtValue) || !string.IsNullOrWhiteSpace(enumValue);
             var hasLabel = f.Elements().Any(e => e.Name.LocalName == "Label");
-            if (!hasEdt)
+            if (!hasTypeDeclaration)
                 bag.Add(new { file = path, rule = "FIELD_WITHOUT_EDT", severity = "warning", field = name, message = $"Field '{name}' has no ExtendedDataType; prefer typed EDTs over raw types." });
-            if (!hasLabel)
+            if (!hasLabel && !hasTypeDeclaration)
                 bag.Add(new { file = path, rule = "FIELD_WITHOUT_LABEL", severity = "info", field = name, message = $"Field '{name}' has no Label; required for user-facing fields." });
         }
     }

--- a/src/D365FO.Cli/Program.cs
+++ b/src/D365FO.Cli/Program.cs
@@ -223,6 +223,7 @@ app.Configure(cfg =>
         b.AddCommand<GenerateMigrationScriptCommand>("migration-script").WithDescription("Scaffold a SysRunnable data-migration class.");
         b.AddCommand<GenerateRunBaseCommand>("runbase").WithDescription("Scaffold a RunBase/RunBaseBatch class with dialog and pack/unpack.");
         b.AddCommand<GenerateSecurityPolicyCommand>("security-policy").WithDescription("Scaffold an AxSecurityPolicy (XDS) XML.");
+        b.AddCommand<GenerateSysTestCommand>("systest").WithDescription("Scaffold an ATL-ready SysTestCase class (Arrange/Act/Assert skeleton).");
     });
 
     cfg.AddBranch("analyze", b =>

--- a/src/D365FO.Core/Index/MetadataRepository.cs
+++ b/src/D365FO.Core/Index/MetadataRepository.cs
@@ -438,7 +438,7 @@ public sealed partial class MetadataRepository
                 WHERE LabelFts MATCH @q
                 ORDER BY rank
                 LIMIT @limit";
-                return conn.Query<LabelMatch>(sql, new { q = query, limit }).ToList();
+                return ReadLabelMatches(conn.Query(sql, new { q = query, limit }));
             }
             else
             {
@@ -449,7 +449,7 @@ public sealed partial class MetadataRepository
                   AND LOWER(Language) IN @langs
                 ORDER BY rank
                 LIMIT @limit";
-                return conn.Query<LabelMatch>(sql, new { q = query, langs = langsLower, limit }).ToList();
+                return ReadLabelMatches(conn.Query(sql, new { q = query, langs = langsLower, limit }));
             }
         }
         catch (Microsoft.Data.Sqlite.SqliteException)
@@ -467,6 +467,22 @@ public sealed partial class MetadataRepository
             return results;
         }
     }
+
+    /// <summary>
+    /// Maps rows from the <c>LabelFts</c> virtual table into <see cref="LabelMatch"/>.
+    /// FTS5 columns carry no declared SQLite type, so on a zero-row result set
+    /// Dapper's strongly-typed <c>Query&lt;LabelMatch&gt;</c> infers every column as
+    /// <c>byte[]</c> and fails to find a matching constructor (see issue #115).
+    /// Querying as <c>dynamic</c> and converting by hand sidesteps that
+    /// materialization entirely, for both the empty and non-empty cases.
+    /// </summary>
+    private static List<LabelMatch> ReadLabelMatches(IEnumerable<dynamic> rows) =>
+        rows.Select(row => new LabelMatch(
+                (string)Convert.ChangeType(row.File, typeof(string)),
+                (string)Convert.ChangeType(row.Language, typeof(string)),
+                (string)Convert.ChangeType(row.Key, typeof(string)),
+                row.Value is null ? null : (string)Convert.ChangeType(row.Value, typeof(string))))
+            .ToList();
 
     /// <summary>
     /// Number of method bodies currently in the opt-in <c>MethodSourceFts</c>

--- a/src/D365FO.Core/Scaffolding/SysTestScaffolder.cs
+++ b/src/D365FO.Core/Scaffolding/SysTestScaffolder.cs
@@ -1,0 +1,96 @@
+using System.Xml.Linq;
+
+namespace D365FO.Core.Scaffolding;
+
+/// <summary>
+/// Scaffolds a minimal, ATL-ready <c>SysTestCase</c> skeleton (issue #107).
+/// MVP scope only: no automatic assertion/test-logic generation, no ATL
+/// Entity/Query/Specification generation — the <c>--atl</c> flag emits only
+/// the <c>AtlDataRootNode</c> field and its <c>construct()</c> call inside
+/// <c>setUpTestCase()</c>, leaving actual ATL object wiring to the developer
+/// (or Microsoft's ATL Wizards).
+/// </summary>
+public static class SysTestScaffolder
+{
+    /// <summary>
+    /// Scaffolds an <c>AxClass</c> extending <c>SysTestCase</c> with a single
+    /// <c>[SysTestMethod]</c> Arrange/Act/Assert skeleton.
+    /// </summary>
+    /// <param name="className">Test class name (e.g. <c>CustServiceTest</c>).</param>
+    /// <param name="dataAreaId">
+    /// Company for <c>[SysTestCaseDataDependency('&lt;Company&gt;')]</c>. The
+    /// attribute is omitted entirely when null/blank — the MVP invents no
+    /// fallback company.
+    /// </param>
+    /// <param name="atl">
+    /// When true, adds an <c>AtlDataRootNode data;</c> field and a
+    /// <c>setUpTestCase()</c> override that calls <c>super();</c> then
+    /// <c>data = AtlDataRootNode::construct();</c>.
+    /// </param>
+    /// <param name="subject">
+    /// Optional subject for the generated test method name
+    /// (<c>&lt;subject&gt;_scenario_expectedResult</c>). Typically the resolved
+    /// <c>--method</c> value; defaults to the literal <c>subject</c> placeholder
+    /// when no source method was supplied.
+    /// </param>
+    public static XDocument TestClass(
+        string className,
+        string? dataAreaId = null,
+        bool atl = false,
+        string? subject = null)
+    {
+        var testMethodSubject = string.IsNullOrWhiteSpace(subject) ? "subject" : subject;
+        var testMethodName = $"{testMethodSubject}_scenario_expectedResult";
+
+        var attributeLine = string.IsNullOrWhiteSpace(dataAreaId)
+            ? ""
+            : $"[SysTestCaseDataDependency('{dataAreaId}')]\n";
+
+        var fieldDecl = atl ? "    AtlDataRootNode data;\n" : "";
+
+        var declaration =
+            attributeLine +
+            $"public class {className} extends SysTestCase\n" +
+            "{\n" +
+            fieldDecl +
+            "}\n";
+
+        var methodElements = new List<XElement>();
+
+        if (atl)
+        {
+            var setUpTestCaseSrc =
+                "public void setUpTestCase()\n" +
+                "{\n" +
+                "    super();\n" +
+                "\n" +
+                "    data = AtlDataRootNode::construct();\n" +
+                "}\n";
+            methodElements.Add(new XElement("Method",
+                new XElement("Name", "setUpTestCase"),
+                new XElement("Source", setUpTestCaseSrc)));
+        }
+
+        var testMethodSrc =
+            "[SysTestMethod]\n" +
+            $"public void {testMethodName}()\n" +
+            "{\n" +
+            "    // Arrange\n" +
+            "\n" +
+            "    // Act\n" +
+            "\n" +
+            "    // Assert\n" +
+            "}\n";
+        methodElements.Add(new XElement("Method",
+            new XElement("Name", testMethodName),
+            new XElement("Source", testMethodSrc)));
+
+        return new XDocument(
+            new XElement("AxClass",
+                new XElement("Name", className),
+                new XElement("Extends", "SysTestCase"),
+                new XElement("SourceCode",
+                    new XElement("Declaration", declaration),
+                    new XElement("Methods", methodElements))));
+    }
+}

--- a/src/D365FO.Core/Scaffolding/XppScaffolder.cs
+++ b/src/D365FO.Core/Scaffolding/XppScaffolder.cs
@@ -126,20 +126,48 @@ public static class XppScaffolder
                 // predictable physical ordering (validate xpp XML005).
                 indexesEl is null ? null : new XElement("ClusteredIndex", "PrimaryIdx"),
                 new XElement("Fields", fieldEls),
-                // "Overview" and "General" are referenced by <DataGroup> in every
-                // generated form pattern (SimpleList, SimpleListDetails,
-                // DetailsMaster, DetailsTransaction) — the metadata reader
+                // Visual Studio / the AOT stamps every new table with five default
+                // field groups, all initially empty (issue #110). Ground-truthed
+                // against shipped standard-model tables on a real AOS
+                // (e.g. ApplicationCommon\AgentFeedUserPreference.xml,
+                // ApplicationSuite\Foundation\AssetAddition.xml): VS does NOT
+                // auto-populate AutoReport (or any of the five) with fields, even
+                // once the table has real fields — the developer assigns them
+                // later in the AOT designer. AutoIdentification is the only one
+                // that carries a property, <AutoPopulate>Yes</AutoPopulate>. We
+                // match that shape exactly instead of pre-populating AutoReport.
+                //
+                // "Overview" and "General" are NOT part of the AOT default
+                // scaffold — they exist here only because this CLI's own
+                // generated forms need them: every form pattern (SimpleList,
+                // SimpleListDetails, DetailsMaster, DetailsTransaction)
+                // references them via <DataGroup>, and the metadata reader
                 // rejects the form with "Field group 'Overview' does not exist"
-                // when the underlying table lacks them (issue #91 follow-up).
-                // AutoReport is the standard AX lookup/report group. All three
-                // are populated with every effective field so any pattern's
-                // grid/group controls resolve.
+                // when the underlying table lacks them (issue #91 follow-up). They
+                // are populated with every effective field so the grid/group
+                // controls resolve.
                 new XElement("FieldGroups",
-                    BuildFieldGroup("AutoReport", effectiveFields),
+                    BuildEmptyFieldGroup("AutoReport"),
+                    BuildEmptyFieldGroup("AutoLookup"),
+                    BuildEmptyFieldGroup("AutoIdentification", autoPopulate: true),
+                    BuildEmptyFieldGroup("AutoSummary"),
+                    BuildEmptyFieldGroup("AutoBrowse"),
                     BuildFieldGroup("Overview", effectiveFields),
                     BuildFieldGroup("General", effectiveFields)),
                 indexesEl));
     }
+
+    /// <summary>
+    /// Builds one of the five default, initially-empty <c>AxTableFieldGroup</c>
+    /// elements VS/AOT stamps on every new table (AutoReport, AutoLookup,
+    /// AutoIdentification, AutoSummary, AutoBrowse). Only AutoIdentification
+    /// carries <c>AutoPopulate</c>.
+    /// </summary>
+    private static XElement BuildEmptyFieldGroup(string name, bool autoPopulate = false) =>
+        new XElement("AxTableFieldGroup",
+            new XElement("Name", name),
+            autoPopulate ? new XElement("AutoPopulate", "Yes") : null,
+            new XElement("Fields"));
 
     private static XElement BuildFieldGroup(string name, IReadOnlyList<TableFieldSpec> fields) =>
         new XElement("AxTableFieldGroup",

--- a/src/D365FO.Core/Scaffolding/XppScaffolder.cs
+++ b/src/D365FO.Core/Scaffolding/XppScaffolder.cs
@@ -970,6 +970,10 @@ public static class XppScaffolder
         // the root element (it is emitted by Visual Studio on every AxEnum file). IsExtensible
         // is a CLR bool, so the DataContractSerializer expects "true"/"false" — the NoYes-style
         // "Yes"/"No" written previously produced an invalid file VS refused to read.
+        // VS's build-time validation additionally rejects IsExtensible=true unless
+        // UseEnumValue is explicitly "No" ("UseEnumValue property must be set to 'No' when
+        // the IsExtensible property is 'True'."). UseEnumValue is itself a NoYes-style enum
+        // property (unlike IsExtensible), so it takes "Yes"/"No", not "true"/"false".
         XNamespace xsi = "http://www.w3.org/2001/XMLSchema-instance";
         return new XDocument(
             new XElement("AxEnum",
@@ -977,6 +981,7 @@ public static class XppScaffolder
                 new XElement("Name", name),
                 string.IsNullOrEmpty(label) ? null : new XElement("Label", label),
                 new XElement("IsExtensible", isExtensible ? "true" : "false"),
+                isExtensible ? new XElement("UseEnumValue", "No") : null,
                 enumVals.Count > 0 ? new XElement("EnumValues", valEls) : null));
     }
 

--- a/tests/D365FO.Cli.Tests/ReviewDiffInspectTableXmlTests.cs
+++ b/tests/D365FO.Cli.Tests/ReviewDiffInspectTableXmlTests.cs
@@ -1,0 +1,135 @@
+using D365FO.Cli.Commands.Review;
+
+namespace D365FO.Cli.Tests;
+
+/// <summary>
+/// Repro for GitHub issue #117: FIELD_WITHOUT_EDT / FIELD_WITHOUT_LABEL must
+/// only evaluate real field definitions under AxTable/Fields/AxTableField*,
+/// never &lt;FieldGroups&gt; contents, and must treat &lt;EnumType&gt; as an
+/// equivalent, label-bearing type declaration alongside &lt;ExtendedDataType&gt;.
+/// </summary>
+public class ReviewDiffInspectTableXmlTests
+{
+    // Minimal repro from the issue: 3 well-typed fields (two via ExtendedDataType,
+    // one enum field via EnumType) plus 6 field groups (the standard auto-groups
+    // and one custom group) referencing those fields by <DataField>.
+    private const string MinimalReproXml = """
+        <?xml version="1.0" encoding="utf-8"?>
+        <AxTable xmlns:i="http://www.w3.org/2001/XMLSchema-instance">
+          <Name>MyTable</Name>
+          <FieldGroups>
+            <AxTableFieldGroup>
+              <Name>AutoReport</Name>
+              <Fields>
+                <AxTableFieldGroupField><DataField>FieldA</DataField></AxTableFieldGroupField>
+                <AxTableFieldGroupField><DataField>FieldB</DataField></AxTableFieldGroupField>
+                <AxTableFieldGroupField><DataField>FieldC</DataField></AxTableFieldGroupField>
+              </Fields>
+            </AxTableFieldGroup>
+            <AxTableFieldGroup>
+              <Name>AutoLookup</Name>
+              <Fields>
+                <AxTableFieldGroupField><DataField>FieldA</DataField></AxTableFieldGroupField>
+                <AxTableFieldGroupField><DataField>FieldB</DataField></AxTableFieldGroupField>
+              </Fields>
+            </AxTableFieldGroup>
+            <AxTableFieldGroup>
+              <Name>AutoSummary</Name>
+              <Fields>
+                <AxTableFieldGroupField><DataField>FieldA</DataField></AxTableFieldGroupField>
+              </Fields>
+            </AxTableFieldGroup>
+            <AxTableFieldGroup>
+              <Name>AutoIdentification</Name>
+              <AutoPopulate>Yes</AutoPopulate>
+              <Fields>
+                <AxTableFieldGroupField><DataField>FieldA</DataField></AxTableFieldGroupField>
+                <AxTableFieldGroupField><DataField>FieldB</DataField></AxTableFieldGroupField>
+              </Fields>
+            </AxTableFieldGroup>
+            <AxTableFieldGroup>
+              <Name>AutoBrowse</Name>
+              <Fields />
+            </AxTableFieldGroup>
+            <AxTableFieldGroup>
+              <Name>Overview</Name>
+              <Label>@MyModel:MyTableLabel</Label>
+              <Fields>
+                <AxTableFieldGroupField><DataField>FieldA</DataField></AxTableFieldGroupField>
+                <AxTableFieldGroupField><DataField>FieldB</DataField></AxTableFieldGroupField>
+                <AxTableFieldGroupField><DataField>FieldC</DataField></AxTableFieldGroupField>
+              </Fields>
+            </AxTableFieldGroup>
+          </FieldGroups>
+          <Fields>
+            <AxTableField xmlns="" i:type="AxTableFieldString">
+              <Name>FieldA</Name>
+              <ExtendedDataType>MyStringEdtA</ExtendedDataType>
+              <Mandatory>Yes</Mandatory>
+            </AxTableField>
+            <AxTableField xmlns="" i:type="AxTableFieldEnum">
+              <Name>FieldB</Name>
+              <EnumType>MyEnumType</EnumType>
+            </AxTableField>
+            <AxTableField xmlns="" i:type="AxTableFieldString">
+              <Name>FieldC</Name>
+              <ExtendedDataType>MyStringEdtB</ExtendedDataType>
+              <Mandatory>Yes</Mandatory>
+            </AxTableField>
+          </Fields>
+        </AxTable>
+        """;
+
+    [Fact]
+    public void FieldGroups_and_typed_fields_produce_zero_violations()
+    {
+        var violations = new List<object>();
+
+        ReviewDiffCommand.InspectTableXml("Metadata/MyModel/AxTable/MyTable.xml", MinimalReproXml, violations);
+
+        Assert.Empty(violations);
+    }
+
+    [Fact]
+    public void FieldGroup_names_are_not_treated_as_fields()
+    {
+        var violations = new List<object>();
+
+        ReviewDiffCommand.InspectTableXml("t.xml", MinimalReproXml, violations);
+
+        var fieldNames = violations
+            .Select(v => v.GetType().GetProperty("field")!.GetValue(v) as string)
+            .ToList();
+
+        Assert.DoesNotContain("AutoReport", fieldNames);
+        Assert.DoesNotContain("AutoLookup", fieldNames);
+        Assert.DoesNotContain("AutoSummary", fieldNames);
+        Assert.DoesNotContain("AutoIdentification", fieldNames);
+        Assert.DoesNotContain("AutoBrowse", fieldNames);
+        Assert.DoesNotContain("Overview", fieldNames);
+        Assert.DoesNotContain("?", fieldNames);
+    }
+
+    [Fact]
+    public void Field_with_raw_type_and_no_label_still_flagged()
+    {
+        const string xml = """
+            <?xml version="1.0" encoding="utf-8"?>
+            <AxTable xmlns:i="http://www.w3.org/2001/XMLSchema-instance">
+              <Name>MyTable</Name>
+              <Fields>
+                <AxTableField xmlns="" i:type="AxTableFieldString">
+                  <Name>RawField</Name>
+                </AxTableField>
+              </Fields>
+            </AxTable>
+            """;
+        var violations = new List<object>();
+
+        ReviewDiffCommand.InspectTableXml("t.xml", xml, violations);
+
+        var rules = violations.Select(v => v.GetType().GetProperty("rule")!.GetValue(v) as string).ToList();
+        Assert.Contains("FIELD_WITHOUT_EDT", rules);
+        Assert.Contains("FIELD_WITHOUT_LABEL", rules);
+    }
+}

--- a/tests/D365FO.Cli.Tests/ScaffoldingSnapshotTests.cs
+++ b/tests/D365FO.Cli.Tests/ScaffoldingSnapshotTests.cs
@@ -441,6 +441,176 @@ public class ScaffoldingSnapshotTests
         Assert.DoesNotContain("[SysEntryPointAttribute", lookupSrc);
     }
 
+    // ---- SysTest (issue #107) ----
+
+    [Fact]
+    public void SysTest_extends_SysTestCase_and_emits_default_test_method()
+    {
+        var doc = SysTestScaffolder.TestClass("CustServiceTest");
+        var root = doc.Root!;
+        Assert.Equal("AxClass", root.Name.LocalName);
+        Assert.Equal("CustServiceTest", root.Element("Name")!.Value);
+        Assert.Equal("SysTestCase", root.Element("Extends")!.Value);
+
+        var decl = root.Element("SourceCode")!.Element("Declaration")!.Value;
+        Assert.Contains("public class CustServiceTest extends SysTestCase", decl);
+        Assert.DoesNotContain("SysTestCaseDataDependency", decl);
+        Assert.DoesNotContain("AtlDataRootNode", decl);
+
+        var methods = root.Element("SourceCode")!.Element("Methods")!.Elements("Method").ToList();
+        var testMethod = Assert.Single(methods);
+        Assert.Equal("subject_scenario_expectedResult", testMethod.Element("Name")!.Value);
+        var src = testMethod.Element("Source")!.Value;
+        Assert.Contains("[SysTestMethod]", src);
+        Assert.Contains("// Arrange", src);
+        Assert.Contains("// Act", src);
+        Assert.Contains("// Assert", src);
+    }
+
+    [Fact]
+    public void SysTest_data_area_id_emits_SysTestCaseDataDependency_attribute()
+    {
+        var doc = SysTestScaffolder.TestClass("CustServiceTest", dataAreaId: "USMF");
+        var decl = doc.Root!.Element("SourceCode")!.Element("Declaration")!.Value;
+        Assert.Contains("[SysTestCaseDataDependency('USMF')]", decl);
+    }
+
+    [Fact]
+    public void SysTest_without_data_area_id_omits_attribute_entirely()
+    {
+        var doc = SysTestScaffolder.TestClass("CustServiceTest");
+        var decl = doc.Root!.Element("SourceCode")!.Element("Declaration")!.Value;
+        Assert.DoesNotContain("SysTestCaseDataDependency", decl);
+    }
+
+    [Fact]
+    public void SysTest_atl_adds_field_and_setUpTestCase_calling_super_first()
+    {
+        var doc = SysTestScaffolder.TestClass("CustServiceTest", atl: true);
+        var decl = doc.Root!.Element("SourceCode")!.Element("Declaration")!.Value;
+        Assert.Contains("AtlDataRootNode data;", decl);
+
+        var methods = doc.Root.Element("SourceCode")!.Element("Methods")!.Elements("Method").ToList();
+        var setUp = methods.First(m => m.Element("Name")!.Value == "setUpTestCase");
+        var src = setUp.Element("Source")!.Value;
+        Assert.True(src.IndexOf("super();", StringComparison.Ordinal) < src.IndexOf("AtlDataRootNode::construct();", StringComparison.Ordinal),
+            "super() must be called before AtlDataRootNode::construct()");
+    }
+
+    [Fact]
+    public void SysTest_without_atl_has_no_field_or_setUpTestCase()
+    {
+        var doc = SysTestScaffolder.TestClass("CustServiceTest", atl: false);
+        var decl = doc.Root!.Element("SourceCode")!.Element("Declaration")!.Value;
+        Assert.DoesNotContain("AtlDataRootNode", decl);
+
+        var methods = doc.Root.Element("SourceCode")!.Element("Methods")!.Elements("Method");
+        Assert.DoesNotContain(methods, m => m.Element("Name")!.Value == "setUpTestCase");
+    }
+
+    [Fact]
+    public void SysTest_subject_from_resolved_method_names_the_test_method()
+    {
+        var doc = SysTestScaffolder.TestClass("CustServiceCreateCustomerTest", subject: "createCustomer");
+        var methods = doc.Root!.Element("SourceCode")!.Element("Methods")!.Elements("Method").ToList();
+        var testMethod = Assert.Single(methods);
+        Assert.Equal("createCustomer_scenario_expectedResult", testMethod.Element("Name")!.Value);
+    }
+
+    [Fact]
+    public void GenerateSysTestCommand_class_not_found_fails_with_clear_error()
+    {
+        var outPath = System.IO.Path.Combine(System.IO.Path.GetTempPath(), $"d365fo-cli-test-systest-{System.Guid.NewGuid():N}.xml");
+        var cmd = new GenerateSysTestCommand();
+        var settings = new GenerateSysTestCommand.Settings
+        {
+            Name = "CustServiceTest",
+            Class = "ThisClassDoesNotExistAnywhere",
+            Out = outPath,
+            Overwrite = true,
+        };
+
+        var oldDb = System.Environment.GetEnvironmentVariable("D365FO_INDEX_DB");
+        var forcedMissingDb = System.IO.Path.Combine(System.IO.Path.GetTempPath(), $"d365fo-cli-missing-{System.Guid.NewGuid():N}.sqlite");
+        if (System.IO.File.Exists(forcedMissingDb)) System.IO.File.Delete(forcedMissingDb);
+
+        try
+        {
+            System.Environment.SetEnvironmentVariable("D365FO_INDEX_DB", forcedMissingDb);
+            var exit = cmd.Execute(null!, settings);
+            Assert.Equal(1, exit);
+            Assert.False(System.IO.File.Exists(outPath));
+        }
+        finally
+        {
+            System.Environment.SetEnvironmentVariable("D365FO_INDEX_DB", oldDb);
+            if (System.IO.File.Exists(outPath)) System.IO.File.Delete(outPath);
+        }
+    }
+
+    [Fact]
+    public void GenerateSysTestCommand_class_and_table_together_is_rejected()
+    {
+        var cmd = new GenerateSysTestCommand();
+        var settings = new GenerateSysTestCommand.Settings
+        {
+            Name = "CustServiceTest",
+            Class = "CustService",
+            Table = "CustTable",
+            Out = System.IO.Path.Combine(System.IO.Path.GetTempPath(), $"d365fo-cli-test-systest-{System.Guid.NewGuid():N}.xml"),
+        };
+        var exit = cmd.Execute(null!, settings);
+        Assert.Equal(1, exit);
+    }
+
+    [Fact]
+    public void GenerateSysTestCommand_method_without_class_or_table_is_rejected()
+    {
+        var cmd = new GenerateSysTestCommand();
+        var settings = new GenerateSysTestCommand.Settings
+        {
+            Name = "CustServiceTest",
+            Method = "createCustomer",
+            Out = System.IO.Path.Combine(System.IO.Path.GetTempPath(), $"d365fo-cli-test-systest-{System.Guid.NewGuid():N}.xml"),
+        };
+        var exit = cmd.Execute(null!, settings);
+        Assert.Equal(1, exit);
+    }
+
+    [Fact]
+    public void GenerateSysTestCommand_writes_file_and_reports_extends_SysTestCase()
+    {
+        var outPath = System.IO.Path.Combine(System.IO.Path.GetTempPath(), $"d365fo-cli-test-systest-{System.Guid.NewGuid():N}.xml");
+        if (System.IO.File.Exists(outPath)) System.IO.File.Delete(outPath);
+
+        var cmd = new GenerateSysTestCommand();
+        var settings = new GenerateSysTestCommand.Settings
+        {
+            Name = "CustServiceTest",
+            DataAreaId = "USMF",
+            Atl = true,
+            Out = outPath,
+            Overwrite = true,
+        };
+
+        try
+        {
+            var exit = cmd.Execute(null!, settings);
+            Assert.Equal(0, exit);
+
+            var doc = XDocument.Load(outPath);
+            Assert.Equal("AxClass", doc.Root!.Name.LocalName);
+            Assert.Equal("SysTestCase", doc.Root.Element("Extends")!.Value);
+            var decl = doc.Root.Element("SourceCode")!.Element("Declaration")!.Value;
+            Assert.Contains("[SysTestCaseDataDependency('USMF')]", decl);
+            Assert.Contains("AtlDataRootNode data;", decl);
+        }
+        finally
+        {
+            if (System.IO.File.Exists(outPath)) System.IO.File.Delete(outPath);
+        }
+    }
+
     // ---- MenuItem (issue #102) ----
 
     [Fact]

--- a/tests/D365FO.Cli.Tests/ScaffoldingSnapshotTests.cs
+++ b/tests/D365FO.Cli.Tests/ScaffoldingSnapshotTests.cs
@@ -337,6 +337,31 @@ public class ScaffoldingSnapshotTests
         Assert.Equal("1", items[1].Element("Value")!.Value);
     }
 
+    [Fact]
+    public void Enum_extensible_sets_UseEnumValue_No()
+    {
+        // VS build validation: "UseEnumValue property must be set to 'No' when the
+        // IsExtensible property is 'True'." UseEnumValue is a NoYes-style enum property
+        // (unlike the CLR-bool IsExtensible), so it takes "Yes"/"No", not "true"/"false".
+        var vals = new[] { new EnumValueSpec("Draft", 0), new EnumValueSpec("Validated", 1), new EnumValueSpec("Completed", 2) };
+        var doc = XppScaffolder.Enum("MyEnumStatusType", vals, isExtensible: true, label: "test status");
+        var root = doc.Root!;
+        Assert.Equal("true", root.Element("IsExtensible")!.Value);
+        Assert.Equal("No", root.Element("UseEnumValue")!.Value);
+    }
+
+    [Fact]
+    public void Enum_non_extensible_does_not_emit_UseEnumValue()
+    {
+        // UseEnumValue is only forced when IsExtensible=true; a non-extensible enum has no
+        // build-rule requiring it, so the element is omitted (VS defaults it to Yes).
+        var vals = new[] { new EnumValueSpec("None", 0) };
+        var doc = XppScaffolder.Enum("MyEnum", vals, isExtensible: false);
+        var root = doc.Root!;
+        Assert.Equal("false", root.Element("IsExtensible")!.Value);
+        Assert.Null(root.Element("UseEnumValue"));
+    }
+
     // ---- Query (Phase 2) ----
 
     [Fact]

--- a/tests/D365FO.Cli.Tests/TablePatternScaffoldingTests.cs
+++ b/tests/D365FO.Cli.Tests/TablePatternScaffoldingTests.cs
@@ -165,6 +165,94 @@ public class TablePatternScaffoldingTests
         Assert.Null(doc.Root!.Element("Indexes"));
     }
 
+    // --- issue #110: generated tables must carry the same five default field
+    //     groups Visual Studio / the AOT stamps on every new table, and must
+    //     NOT emit shouldThrowExceptionOnZeroDelete (not part of the fresh
+    //     VS scaffold — ground-truthed against shipped standard-model tables).
+
+    [Fact]
+    public void Table_emits_the_five_default_AOT_field_groups_in_order()
+    {
+        var doc = XppScaffolder.Table("FmThing", pattern: TablePattern.Main);
+        var groupNames = doc.Root!.Element("FieldGroups")!.Elements("AxTableFieldGroup")
+            .Select(g => g.Element("Name")!.Value).ToList();
+
+        Assert.Equal(
+            new[] { "AutoReport", "AutoLookup", "AutoIdentification", "AutoSummary", "AutoBrowse", "Overview", "General" },
+            groupNames);
+    }
+
+    [Theory]
+    [InlineData("AutoReport")]
+    [InlineData("AutoLookup")]
+    [InlineData("AutoIdentification")]
+    [InlineData("AutoSummary")]
+    [InlineData("AutoBrowse")]
+    public void Default_AOT_field_groups_are_empty_even_when_the_table_has_fields(string groupName)
+    {
+        // Ground truth: VS does NOT auto-populate these groups with fields, even
+        // once the table has real fields (verified against shipped tables, e.g.
+        // ApplicationCommon\AgentFeedUserPreference.xml,
+        // ApplicationSuite\Foundation\AssetAddition.xml).
+        var doc = XppScaffolder.Table("FmCustomer", pattern: TablePattern.Main);
+        var group = doc.Root!.Element("FieldGroups")!.Elements("AxTableFieldGroup")
+            .Single(g => g.Element("Name")!.Value == groupName);
+
+        var fieldsEl = group.Element("Fields")!;
+        Assert.False(fieldsEl.HasElements);
+    }
+
+    [Fact]
+    public void AutoIdentification_field_group_has_AutoPopulate_Yes()
+    {
+        var doc = XppScaffolder.Table("FmThing", pattern: TablePattern.Main);
+        var group = doc.Root!.Element("FieldGroups")!.Elements("AxTableFieldGroup")
+            .Single(g => g.Element("Name")!.Value == "AutoIdentification");
+
+        Assert.Equal("Yes", group.Element("AutoPopulate")!.Value);
+    }
+
+    [Theory]
+    [InlineData("AutoReport")]
+    [InlineData("AutoLookup")]
+    [InlineData("AutoSummary")]
+    [InlineData("AutoBrowse")]
+    public void Only_AutoIdentification_field_group_carries_AutoPopulate(string groupName)
+    {
+        var doc = XppScaffolder.Table("FmThing", pattern: TablePattern.Main);
+        var group = doc.Root!.Element("FieldGroups")!.Elements("AxTableFieldGroup")
+            .Single(g => g.Element("Name")!.Value == groupName);
+
+        Assert.Null(group.Element("AutoPopulate"));
+    }
+
+    [Fact]
+    public void Overview_and_General_field_groups_stay_populated_for_form_compatibility()
+    {
+        // Not part of the AOT default scaffold, but required so this CLI's own
+        // generated forms (which reference them via <DataGroup>) compile — see
+        // issue #91 follow-up.
+        var doc = XppScaffolder.Table("FmCustomer", pattern: TablePattern.Main);
+        var overview = doc.Root!.Element("FieldGroups")!.Elements("AxTableFieldGroup")
+            .Single(g => g.Element("Name")!.Value == "Overview");
+        var general = doc.Root!.Element("FieldGroups")!.Elements("AxTableFieldGroup")
+            .Single(g => g.Element("Name")!.Value == "General");
+
+        Assert.True(overview.Element("Fields")!.HasElements);
+        Assert.True(general.Element("Fields")!.HasElements);
+    }
+
+    [Fact]
+    public void Generated_table_does_not_emit_shouldThrowExceptionOnZeroDelete()
+    {
+        // VS/AOT does not generate this method on a fresh table — it's a
+        // developer override some standard tables happen to add, not a
+        // scaffold default. Confirmed by sampling shipped standard-model
+        // tables: only a small minority carry it.
+        var doc = XppScaffolder.Table("FmThing", pattern: TablePattern.Main);
+        Assert.DoesNotContain("shouldThrowExceptionOnZeroDelete", doc.ToString());
+    }
+
     // --- issue #91: AxTableField is abstract — every field needs a concrete
     //     i:type discriminator or the metadata reader rejects the whole table.
 

--- a/tests/D365FO.Core.Tests/LabelFtsTests.cs
+++ b/tests/D365FO.Core.Tests/LabelFtsTests.cs
@@ -57,6 +57,33 @@ public class LabelFtsTests
         }
     }
 
+    [Fact]
+    public void Fts_search_with_zero_results_returns_empty_list()
+    {
+        var db = Path.Combine(Path.GetTempPath(), $"d365fo-fts-{Guid.NewGuid():N}.sqlite");
+        try
+        {
+            var repo = new MetadataRepository(db);
+            repo.EnsureSchema();
+            repo.UpsertModel("Fleet", "Contoso", "usr", true);
+            // Only index an English label; searching for a term that only
+            // exists in a non-indexed language (or nowhere) must yield zero
+            // matches from the FTS5 MATCH query, not throw during
+            // materialization (see issue #115).
+            Insert(db, 1, "Vehicle fleet operations", "en-us", "VehicleFleet", "Vehicles.en-us");
+
+            var hits = repo.SearchLabelsFts("zzzznonexistentterm", new[] { "en-us" }, 10);
+            Assert.Empty(hits);
+
+            var likeHits = repo.SearchLabels("zzzznonexistentterm", new[] { "en-us" }, 10);
+            Assert.Empty(likeHits);
+        }
+        finally
+        {
+            try { File.Delete(db); } catch { }
+        }
+    }
+
     private static void Insert(string db, long labelId, string value, string lang, string key, string file)
     {
         using var conn = new Microsoft.Data.Sqlite.SqliteConnection($"Data Source={db}");


### PR DESCRIPTION
## Summary
- Adds `generate systest <NAME>` — scaffolds an `AxClass extends SysTestCase` with a `[SysTestMethod]` Arrange/Act/Assert skeleton.
- `--data-area-id` emits `[SysTestCaseDataDependency('<Company>')]` (omitted entirely when unset).
- `--atl` adds an `AtlDataRootNode data;` field and a `setUpTestCase()` override (`super()` then `data = AtlDataRootNode::construct();`).
- `--class`/`--table` + `--method` resolve against the index (must exist) and name the generated test method `<method>_scenario_expectedResult`; used for naming/context only.
- MVP scope, deliberately: no automatic assertion/test-logic generation, no ATL Entity/Query/Specification generation — matches the scope agreed for #107.

Closes #107.

## Test plan
- [x] New scaffolding tests in `ScaffoldingSnapshotTests.cs` (class shape, `--atl` field/method emission, data-area attribute, method-name derivation)
- [x] `dotnet build d365fo-cli.slnx` — clean
- [x] `dotnet test d365fo-cli.slnx` — 489/489 passing

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>