### PR TITLE
Fix case-insensitive ExtensionOf extraction

### DIFF
--- a/src/D365FO.Core/Extract/MetadataExtractor.cs
+++ b/src/D365FO.Core/Extract/MetadataExtractor.cs
@@ -950,7 +950,8 @@ public sealed class MetadataExtractor
     // form/table — that's what downstream queries key on.
     private static readonly System.Text.RegularExpressions.Regex ExtensionOfRx = new(
         @"\[\s*ExtensionOf\s*\(\s*(?<kind>\w+)Str\s*\(\s*(?<name>[A-Za-z_][A-Za-z0-9_]*)",
-        System.Text.RegularExpressions.RegexOptions.Compiled);
+        System.Text.RegularExpressions.RegexOptions.Compiled |
+        System.Text.RegularExpressions.RegexOptions.IgnoreCase);
 
     private static IEnumerable<ExtractedCoc> DetectCoc(ExtractedClass c)
     {

--- a/tests/D365FO.Core.Tests/ExtractPipelineTests.cs
+++ b/tests/D365FO.Core.Tests/ExtractPipelineTests.cs
@@ -489,6 +489,39 @@ class BaseClass extends SysOperationServiceBase
     }
 
     [Fact]
+    public void MetadataExtractor_detects_ExtensionOf_intrinsics_case_insensitively()
+    {
+        var model = Path.Combine(_workRoot, "PkgCocCase", "PkgCocCase");
+        Directory.CreateDirectory(Path.Combine(model, "AxClass"));
+        File.WriteAllText(Path.Combine(model, "AxClass", "Unrelated_Extension.xml"), """
+            <AxClass>
+              <Name>Unrelated_Extension</Name>
+              <SourceCode>
+                <Declaration><![CDATA[
+            [extensionof(tablestr(CustTable))]
+            final class Unrelated_Extension
+            {
+            }
+                ]]></Declaration>
+                <Methods>
+                  <Method>
+                    <Name>update</Name>
+                    <Source><![CDATA[public void update() { next update(); }]]></Source>
+                  </Method>
+                </Methods>
+              </SourceCode>
+            </AxClass>
+            """);
+
+        var batches = new MetadataExtractor().ExtractAll(_workRoot).ToList();
+        var batch = batches.Single(b => b.Model == "PkgCocCase");
+        var coc = Assert.Single(batch.CocExtensions);
+        Assert.Equal("CustTable", coc.TargetClass);
+        Assert.Equal("update", coc.TargetMethod);
+        Assert.Equal("Unrelated_Extension", coc.ExtensionClass);
+    }
+
+    [Fact]
     public void MetadataExtractor_today_in_comment_does_not_flag_HasTodayCall()
     {
         var model = Path.Combine(_workRoot, "PkgFix5", "PkgFix5");


### PR DESCRIPTION
## Summary

- parse `ExtensionOf` attributes and `*Str` intrinsics case-insensitively
- add a regression test that prevents the naming-convention fallback from masking incorrect target extraction

## Why

X++ identifiers are case-insensitive, but `ExtensionOfRx` was compiled without `RegexOptions.IgnoreCase`. Valid declarations such as `[extensionof(tablestr(CustTable))]` could therefore be missed, causing the extractor to record an incorrect CoC target from the class-name fallback or omit the CoC entry.

## Validation

- targeted regression test passed
- Release solution build passed
- D365FO.Cli.Tests: 204 passed
- D365FO.Core.Tests: 338 passed

Fixes #128