### PR TITLE
feat: structured method-level modify via D365FO.Bridge (#112)

### DIFF
--- a/README.md
+++ b/README.md
@@ -143,6 +143,9 @@ d365fo generate form FmVehicles \
 d365fo generate datasource-method FmVehicles --datasource FmVehicle --list      # show overridable methods
 d365fo generate datasource-method FmVehicles --datasource FmVehicle --method active
 d365fo generate control-method    FmVehicles --control VIN --method modified
+
+# Replace an existing method's body on a live class/table/edt/form (Windows VM, D365FO_BRIDGE_ENABLED=1)
+d365fo modify method class CustBalance calc --body "return 2;"
 ```
 
 Full walkthrough: **[docs/SETUP.md](docs/SETUP.md)**
@@ -173,7 +176,7 @@ Reference the `SKILL.md` files from `skills/anthropic/` in your session prompt o
 
 ### MCP (Claude Desktop, Continue, VS Code MCP)
 
-The bundled `d365fo-mcp` adapter speaks JSON-RPC 2.0 over the same index. Its tool surface is **consolidated** into 20 discriminator-based tools (e.g. `search`, `get_object_info`, `get_method`, `labels`, `security_info`, `extension_info`, `object_patterns`, `generate_object`, `analyze`, `models`) — see [docs/MIGRATION_FROM_MCP.md](docs/MIGRATION_FROM_MCP.md):
+The bundled `d365fo-mcp` adapter speaks JSON-RPC 2.0 over the same index. Its tool surface is **consolidated** into 22 discriminator-based tools (e.g. `search`, `get_object_info`, `get_method`, `labels`, `security_info`, `extension_info`, `object_patterns`, `generate_object`, `modify_method`, `analyze`, `models`) — see [docs/MIGRATION_FROM_MCP.md](docs/MIGRATION_FROM_MCP.md):
 
 ```json
 {

--- a/docs/CAPABILITIES.md
+++ b/docs/CAPABILITIES.md
@@ -191,6 +191,7 @@ All scaffolders write atomically (`.tmp` + move, `.bak` on overwrite). Pass `--i
 | `generate systest` | `SysTestCase` skeleton — `[SysTestMethod]` Arrange/Act/Assert stub, optional `[SysTestCaseDataDependency]` and `--atl` `AtlDataRootNode` wiring (ATL-ready MVP, no test-logic generation) |
 | `generate migration-script` | Data-fix `Runnable` class with `ttsbegin`/`ttscommit` batching |
 | `generate simple-list` | Alias for `generate form --pattern SimpleList` |
+| `modify method` | Replace an existing method's body on a live class/table/edt/form via D365FO.Bridge (`IMetadataProvider`, structured `XDocument` replace — no CDATA string surgery, no on-disk fallback). Reference/BP validation always blocks on error-severity findings. |
 
 ### Scaffolding validation helpers
 
@@ -313,7 +314,7 @@ Returns `UNSUPPORTED_PLATFORM` on non-Windows.
 
 ## MCP server
 
-Exposes the same index and scaffolding surface as the CLI over the `ModelContextProtocol` C# SDK via stdio. The tool surface is **consolidated** into **20 discriminator-based tools** (`search`, `get_object_info`, `get_method`, `labels`, `security_info`, `extension_info`, `object_patterns`, `generate_object`, `analyze`, `models`, …) instead of one tool per object type — mirroring the upstream `d365fo-mcp-server` (which sits at 26). A single tool dispatches on a `type` / `objectType` / `mode` / `action` / `domain` / `include` field. See [MIGRATION_FROM_MCP.md](MIGRATION_FROM_MCP.md) for the full old→new mapping.
+Exposes the same index and scaffolding surface as the CLI over the `ModelContextProtocol` C# SDK via stdio. The tool surface is **consolidated** into **22 discriminator-based tools** (`search`, `get_object_info`, `get_method`, `labels`, `security_info`, `extension_info`, `object_patterns`, `generate_object`, `modify_method`, `analyze`, `models`, …) instead of one tool per object type — mirroring the upstream `d365fo-mcp-server` (which sits at 26). A single tool dispatches on a `type` / `objectType` / `mode` / `action` / `domain` / `include` field. See [MIGRATION_FROM_MCP.md](MIGRATION_FROM_MCP.md) for the full old→new mapping.
 
 ```jsonc
 {

--- a/docs/MIGRATION_FROM_MCP.md
+++ b/docs/MIGRATION_FROM_MCP.md
@@ -95,10 +95,13 @@ renaming `form_pattern` → `object_patterns`.
 | `find_references` | — | reverse references via regex scan of indexed X++ source (was CLI-only) |
 | `validate_object_naming`, `get_workspace_info`, `suggest_edt`, `batch_get_info`, `lint`, `stats`, `index_status`, `index_history` | — | kept (parity names) |
 
-This adapter exposes **20 unified MCP tools** (the upstream `d365fo-mcp-server`
-sits at 26 — it additionally ships `get_knowledge`, `analyze_code`,
-`d365fo_file`, `undo_last_modification`, `validate_code`, `verify_d365fo_project`
-and the SDLC/build tools, which here are CLI-only or covered by Skills).
+This adapter exposes **22 unified MCP tools**, including `modify_method`
+(structured method-body replace via D365FO.Bridge — the `d365fo_file(action=modify)`
+counterpart). The upstream `d365fo-mcp-server` sits at 26 — it additionally ships
+`get_knowledge`, `analyze_code`, `d365fo_file` (`action=create`, covered here by
+`generate_object`), `undo_last_modification`, `validate_code`,
+`verify_d365fo_project` and the SDLC/build tools, which here are CLI-only or
+covered by Skills.
 
 Run `d365fo schema --full` for the machine-readable command/tool manifest; every
 CLI command's `mcpTool` field names the unified MCP tool it maps to.
@@ -155,7 +158,7 @@ commands. Both surfaces use the same discriminator-based naming.
 | `generate_object` (`objectType=table`) | `d365fo generate table <Name> --pattern <P> --field …` |
 | `generate_object` (`objectType=form`) | `d365fo generate form <Name> --pattern <P>` (pattern-gated write) |
 | `generate_object` (XML-only `objectType=…`) | `d365fo generate edt\|enum\|query\|sysoperation\|business-event\|runbase\|security-policy` (XML only) |
-| `d365fo_file` (`action=modify`) | targeted editor edit of CDATA method bodies + `d365fo index refresh`; structural changes via `generate … --overwrite` |
+| `d365fo_file` (`action=modify`) / `modify_method` | `d365fo modify method <kind> <Object> <Method> --body "…"` (structured `XDocument` replace via D365FO.Bridge/`IMetadataProvider` — never CDATA string surgery; reference/BP validation always blocks on error-severity findings) |
 | `undo_last_modification` | `.bak` backups written by every overwrite + `git checkout` |
 | `labels` (`action=create\|rename\|delete`) | `d365fo labels create\|rename\|delete` (multi-language via `--lang`) |
 | `review_workspace_changes` | `d365fo review diff` |

--- a/src/D365FO.Bridge/Handlers.cs
+++ b/src/D365FO.Bridge/Handlers.cs
@@ -47,6 +47,78 @@ namespace D365FO.Bridge
         internal JsonObject ReadForm(JsonObject args) { return ReadArtifact(args, "Forms", "form"); }
 
         /// <summary>
+        /// Read an artefact and hand back its <b>raw XmlSerializer XML</b> (not the
+        /// reflection-based JSON projection <see cref="AxSerializer"/> produces) —
+        /// the byte-for-byte counterpart of the <c>xml</c> blob <see cref="UpdateObject"/>
+        /// accepts. Used by <c>d365fo modify method</c> (issue #112) to round-trip a
+        /// single method body through <c>IMetadataProvider</c> without ever touching
+        /// on-disk XML directly: read here, do a structured (XDocument-element)
+        /// replace of one &lt;Method&gt;'s &lt;Source&gt;, write back via
+        /// <see cref="UpdateObject"/>. The XML shape is whatever this process's
+        /// <see cref="XmlSerializer"/> produces for the live Ax* instance — it need
+        /// not match Visual Studio's on-disk formatting because it never reaches
+        /// disk itself; <see cref="MetadataBootstrap.SaveArtifact"/> re-serialises
+        /// through the provider on write, same as every other write path here.
+        /// </summary>
+        internal JsonObject ReadObjectXml(JsonObject args)
+        {
+            string kind = args != null ? (string)args["kind"] : null;
+            string name = args != null ? (string)args["name"] : null;
+            if (string.IsNullOrWhiteSpace(kind)) return Fail("MISSING_ARG", "kind is required");
+            if (string.IsNullOrWhiteSpace(name)) return Fail("MISSING_ARG", "name is required");
+            if (!MetadataBootstrap.KindToCollection.TryGetValue(kind, out var collectionName))
+            {
+                return Fail("INVALID_KIND", "kind must be one of: class, table, edt, enum, form");
+            }
+
+            if (!MetadataBootstrap.TryInitialize())
+            {
+                return Fail("METADATA_UNAVAILABLE",
+                    MetadataBootstrap.LastError ??
+                    "IMetadataProvider failed to initialise; set D365FO_PACKAGES_PATH on a D365FO VM.");
+            }
+
+            object artifact;
+            try
+            {
+                artifact = MetadataBootstrap.ReadArtifact(collectionName, name);
+            }
+            catch (Exception ex)
+            {
+                return Fail("READ_FAILED", ex.GetType().Name + ": " + ex.Message);
+            }
+
+            if (artifact == null)
+            {
+                return Fail("NOT_FOUND", kind + " '" + name + "' was not returned by IMetadataProvider.");
+            }
+
+            string xml;
+            try
+            {
+                var serializer = new XmlSerializer(artifact.GetType());
+                using (var sw = new StringWriter())
+                {
+                    serializer.Serialize(sw, artifact);
+                    xml = sw.ToString();
+                }
+            }
+            catch (Exception ex)
+            {
+                return Fail("SERIALIZE_FAILED", ex.GetType().Name + ": " + ex.Message);
+            }
+
+            return new JsonObject
+            {
+                ["ok"] = true,
+                ["kind"] = kind,
+                ["name"] = name,
+                ["source"] = "bridge",
+                ["xml"] = xml,
+            };
+        }
+
+        /// <summary>
         /// UseEnumValue=No (required for extensible enums) omits the &lt;Value&gt;
         /// element from the XML entirely, so AxEnumValue.Value deserialises to its
         /// int default (0) for every member — no exception, no fallback. The value

--- a/src/D365FO.Bridge/Program.cs
+++ b/src/D365FO.Bridge/Program.cs
@@ -106,6 +106,8 @@ namespace D365FO.Bridge
                     return Ok(idNode, handlers.ReadEnum(paramsNode as JsonObject));
                 case "readForm":
                     return Ok(idNode, handlers.ReadForm(paramsNode as JsonObject));
+                case "readObjectXml":
+                    return Ok(idNode, handlers.ReadObjectXml(paramsNode as JsonObject));
                 case "createObject":
                 case "saveObject":
                     return Ok(idNode, handlers.SaveObject(paramsNode as JsonObject));

--- a/src/D365FO.Cli/Commands/Modify/ModifyMethodCommand.cs
+++ b/src/D365FO.Cli/Commands/Modify/ModifyMethodCommand.cs
@@ -1,0 +1,66 @@
+using D365FO.Cli;
+using D365FO.Core;
+using D365FO.Core.Bridge;
+using D365FO.Core.Index;
+using Spectre.Console.Cli;
+
+namespace D365FO.Cli.Commands.Modify;
+
+/// <summary>
+/// Replace the body of an existing method on a live class/table/EDT/form via
+/// <c>D365FO.Bridge</c> — the structured (never CDATA-string-surgery) counterpart
+/// of upstream's <c>d365fo_file(action=modify)</c> (issue #112). Unlike the
+/// <c>generate</c> family this has no on-disk scaffold mode: it always round-trips
+/// the live object through <c>IMetadataProvider</c>.
+/// </summary>
+public sealed class ModifyMethodCommand : Command<ModifyMethodCommand.Settings>
+{
+    public sealed class Settings : D365OutputSettings
+    {
+        [CommandArgument(0, "<KIND>")]
+        [System.ComponentModel.Description("Object kind: class, table, edt, or form.")]
+        public string Kind { get; init; } = "";
+
+        [CommandArgument(1, "<OBJECT>")]
+        [System.ComponentModel.Description("Object name (resolved via the index; --model overrides).")]
+        public string ObjectName { get; init; } = "";
+
+        [CommandArgument(2, "<METHOD>")]
+        [System.ComponentModel.Description("Existing method name whose body is being replaced.")]
+        public string Method { get; init; } = "";
+
+        [CommandOption("--body <XPP>")]
+        [System.ComponentModel.Description("New X++ method body (statements only — no signature/braces). Required.")]
+        public string? Body { get; init; }
+
+        [CommandOption("--model <MODEL>")]
+        [System.ComponentModel.Description("Owning model. Resolved via the index when omitted.")]
+        public string? Model { get; init; }
+
+        [CommandOption("--grounding-token <TOKEN>")]
+        [System.ComponentModel.Description("Grounding token from `d365fo prepare change`/`prepare create`. Required for the token check when D365FO_GROUNDING_ENFORCE=true; the reference/BP validation gate itself always blocks on error-severity findings.")]
+        public string? GroundingToken { get; init; }
+    }
+
+    public override int Execute(CommandContext ctx, Settings settings)
+    {
+        var kind = OutputMode.Resolve(settings.Output);
+
+        if (string.IsNullOrWhiteSpace(settings.Body))
+            return RenderHelpers.Render(kind, ToolResult<object>.Fail(D365FoErrorCodes.BadInput, "--body <XPP> is required."));
+
+        MetadataRepository? repo = null;
+        try { repo = RepoFactory.Create(); } catch { /* degrade to bridge-only; engine surfaces a warning */ }
+
+        var request = new MethodModifyEngine.ModifyRequest(
+            settings.Kind,
+            settings.ObjectName,
+            settings.Method,
+            settings.Body!,
+            settings.Model,
+            settings.GroundingToken);
+
+        var result = MethodModifyEngine.Modify(request, repo);
+        return RenderHelpers.Render(kind, result);
+    }
+}

--- a/src/D365FO.Cli/Program.cs
+++ b/src/D365FO.Cli/Program.cs
@@ -7,6 +7,7 @@ using D365FO.Cli.Commands.Generate;
 using D365FO.Cli.Commands.Get;
 using D365FO.Cli.Commands.Index;
 using D365FO.Cli.Commands.Models;
+using D365FO.Cli.Commands.Modify;
 using D365FO.Cli.Commands.Ops;
 using D365FO.Cli.Commands.Read;
 using D365FO.Cli.Commands.Resolve;
@@ -224,6 +225,12 @@ app.Configure(cfg =>
         b.AddCommand<GenerateRunBaseCommand>("runbase").WithDescription("Scaffold a RunBase/RunBaseBatch class with dialog and pack/unpack.");
         b.AddCommand<GenerateSecurityPolicyCommand>("security-policy").WithDescription("Scaffold an AxSecurityPolicy (XDS) XML.");
         b.AddCommand<GenerateSysTestCommand>("systest").WithDescription("Scaffold an ATL-ready SysTestCase class (Arrange/Act/Assert skeleton).");
+    });
+
+    cfg.AddBranch("modify", b =>
+    {
+        b.SetDescription("Structured, live edits to existing AOT objects via D365FO.Bridge (Windows VM). No on-disk fallback.");
+        b.AddCommand<ModifyMethodCommand>("method").WithDescription("Replace the body of an existing method on a class/table/edt/form.");
     });
 
     cfg.AddBranch("analyze", b =>

--- a/src/D365FO.Core/Bridge/MethodModifyEngine.cs
+++ b/src/D365FO.Core/Bridge/MethodModifyEngine.cs
@@ -1,0 +1,374 @@
+// <copyright file="MethodModifyEngine.cs" company="d365fo-cli contributors">
+// MIT
+// </copyright>
+
+using System.Text.Json.Nodes;
+using System.Xml.Linq;
+using D365FO.Core.Guardrails;
+using D365FO.Core.Index;
+using D365FO.Core.Validation;
+
+namespace D365FO.Core.Bridge;
+
+/// <summary>
+/// Structured method-level modify via <c>D365FO.Bridge</c> (issue #112) — the CLI/MCP
+/// parity feature for upstream <c>d365fo_file(action=modify)</c>. Round-trips a single
+/// method body through Microsoft's <c>IMetadataProvider</c>:
+/// <list type="number">
+/// <item><description>read the live object as XML via the bridge's <c>readObjectXml</c>
+/// (never the on-disk file, never the SQLite index — those only supply the owning
+/// model name and better error messages),</description></item>
+/// <item><description>locate the target <c>&lt;Method&gt;</c> with <see cref="XDocument"/>
+/// element navigation (never raw string/regex surgery on the XML text),</description></item>
+/// <item><description>run <see cref="ReferenceResolver"/> + <see cref="XppValidator"/> over
+/// the replacement body and fail closed on any error-severity violation,</description></item>
+/// <item><description>write the modified document back via the bridge's
+/// <c>updateObject</c>, which itself round-trips through <c>IMetadataProvider</c>.</description></item>
+/// </list>
+/// There is deliberately no on-disk fallback: when the bridge is unavailable (non-Windows,
+/// or <c>D365FO_BRIDGE_ENABLED</c> not set) this fails <see cref="D365FoErrorCodes.BridgeRequired"/>
+/// rather than falling back to CDATA string-replacement, which is exactly the failure mode
+/// this command replaces (see docs/MIGRATION_FROM_MCP.md).
+/// </summary>
+public static class MethodModifyEngine
+{
+    private static readonly IReadOnlyDictionary<string, string> SupportedKinds =
+        new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase)
+        {
+            ["class"] = "class",
+            ["table"] = "table",
+            ["edt"] = "edt",
+            ["form"] = "form",
+        };
+
+    /// <summary>Inputs for a single method-body replacement.</summary>
+    public sealed record ModifyRequest(
+        string Kind,
+        string ObjectName,
+        string MethodName,
+        string NewBody,
+        string? Model = null,
+        string? GroundingToken = null);
+
+    /// <summary>
+    /// Build <see cref="BridgeOptions"/> from the unified config resolver (env vars or
+    /// settings.json) — the same values <c>D365FO.Cli.Commands.Get.BridgeGate</c> uses,
+    /// duplicated here so this engine has no dependency on the CLI project.
+    /// </summary>
+    public static BridgeOptions DefaultBridgeOptions() => new()
+    {
+        MetadataBinPath = D365FoSettings.Resolve("D365FO_BIN_PATH"),
+        PackagesPath = D365FoSettings.Resolve("D365FO_PACKAGES_PATH"),
+        CustomPackagesPaths = D365FoSettings.FromEnvironment().CustomPackagesPaths,
+        XrefConnectionString = D365FoSettings.Resolve("D365FO_XREF_CONNECTIONSTRING"),
+    };
+
+    /// <summary>
+    /// Entry point used by the CLI (<c>d365fo modify method</c>) and the MCP
+    /// <c>modify_method</c> tool. Spawns (or resolves) the bridge process itself and
+    /// fails <see cref="D365FoErrorCodes.BridgeRequired"/> up front when it is not
+    /// available — no XML fallback is attempted.
+    /// </summary>
+    public static ToolResult<object> Modify(ModifyRequest request, MetadataRepository? repo, BridgeOptions? bridgeOptions = null)
+    {
+        var options = bridgeOptions ?? DefaultBridgeOptions();
+        if (!BridgeClient.IsAvailable(options))
+        {
+            return ToolResult<object>.Fail(D365FoErrorCodes.BridgeRequired,
+                "d365fo modify method requires D365FO.Bridge (.NET Framework 4.8, Windows-only, IMetadataProvider-backed) — " +
+                "it is not available in this environment (non-Windows OS, or the bridge executable could not be resolved).",
+                "Run on a D365FO VM with D365FO_BRIDGE_ENABLED=1 and D365FO_BRIDGE_PATH / D365FO_PACKAGES_PATH set. " +
+                "This command intentionally has no raw-XML fallback (see docs/MIGRATION_FROM_MCP.md, issue #112).");
+        }
+
+        using var client = new BridgeClient(options);
+        return ModifyCore(request, repo, client);
+    }
+
+    /// <summary>
+    /// The bridge round-trip itself, decoupled from process spawning so tests can pass
+    /// a fake in-process <see cref="BridgeClient"/> (see <c>BridgeClientTests.FakeBridge</c>
+    /// pattern). Callers are responsible for the <see cref="D365FoErrorCodes.BridgeRequired"/>
+    /// availability gate — <see cref="Modify"/> does that for real callers.
+    /// </summary>
+    internal static ToolResult<object> ModifyCore(ModifyRequest request, MetadataRepository? repo, BridgeClient client)
+    {
+        var kind = (request.Kind ?? string.Empty).Trim().ToLowerInvariant();
+        if (!SupportedKinds.ContainsKey(kind))
+        {
+            return ToolResult<object>.Fail(D365FoErrorCodes.BadInput,
+                $"Unsupported object kind '{request.Kind}'. Supported: {string.Join(", ", SupportedKinds.Keys)}.",
+                "Enums have no method bodies to modify; use `d365fo generate enum` to change values.");
+        }
+        if (string.IsNullOrWhiteSpace(request.ObjectName))
+            return ToolResult<object>.Fail(D365FoErrorCodes.BadInput, "Object name is required.");
+        if (string.IsNullOrWhiteSpace(request.MethodName))
+            return ToolResult<object>.Fail(D365FoErrorCodes.BadInput, "Method name is required.");
+        if (string.IsNullOrWhiteSpace(request.NewBody))
+            return ToolResult<object>.Fail(D365FoErrorCodes.BadInput, "A method body is required.");
+
+        // ---- 1. Resolve the owning model (index lookup; --model overrides) ----
+        var model = request.Model;
+        if (string.IsNullOrWhiteSpace(model) && repo is not null)
+        {
+            model = kind switch
+            {
+                "class" => repo.GetClassDetails(request.ObjectName)?.Class.Model,
+                "table" => repo.GetTableDetails(request.ObjectName)?.Table.Model,
+                "edt" => repo.GetEdt(request.ObjectName)?.Model,
+                "form" => repo.GetForm(request.ObjectName)?.Form.Model,
+                _ => null,
+            };
+        }
+        if (string.IsNullOrWhiteSpace(model))
+        {
+            return ToolResult<object>.Fail(NotFoundCodeFor(kind),
+                $"{kind} '{request.ObjectName}' was not found in the SQLite index and no --model override was supplied.",
+                "Run `d365fo index build` + `d365fo index extract`, or pass --model <MODEL> explicitly.");
+        }
+
+        // ---- 2. Read the live object via the bridge ----
+        JsonObject? readResult;
+        try
+        {
+            readResult = client.SendAsync("readObjectXml", new JsonObject { ["kind"] = kind, ["name"] = request.ObjectName })
+                .GetAwaiter().GetResult();
+        }
+        catch (BridgeException ex)
+        {
+            return ToolResult<object>.Fail(D365FoErrorCodes.BridgeRequired, "Bridge error while reading the object: " + ex.Message);
+        }
+        if (readResult is null)
+            return ToolResult<object>.Fail(D365FoErrorCodes.BridgeRequired, "Bridge returned no result for readObjectXml.");
+        if ((bool?)readResult["ok"] != true)
+        {
+            var code = (string?)readResult["error"] ?? "READ_FAILED";
+            var msg = (string?)readResult["message"] ?? "unknown error";
+            return ToolResult<object>.Fail(code == "NOT_FOUND" ? NotFoundCodeFor(kind) : code,
+                $"Bridge could not read {kind} '{request.ObjectName}': {msg}");
+        }
+        var xml = (string?)readResult["xml"];
+        if (string.IsNullOrWhiteSpace(xml))
+            return ToolResult<object>.Fail("READ_FAILED", "Bridge returned an empty xml payload for " + request.ObjectName + ".");
+
+        // ---- 3. Locate the target method (structured XDocument navigation) ----
+        XDocument doc;
+        try
+        {
+            doc = XDocument.Parse(xml);
+        }
+        catch (Exception ex)
+        {
+            return ToolResult<object>.Fail("READ_FAILED", "Could not parse XML returned by the bridge: " + ex.Message);
+        }
+
+        var methodsContainer = LocateMethodsContainer(doc.Root);
+        if (methodsContainer is null)
+        {
+            return ToolResult<object>.Fail(D365FoErrorCodes.MethodNotFound,
+                $"{kind} '{request.ObjectName}' has no top-level <Methods> container — nothing to modify.");
+        }
+
+        var existing = methodsContainer.Elements()
+            .FirstOrDefault(e => e.Name.LocalName == "Method" &&
+                                  string.Equals(Local(e, "Name"), request.MethodName, StringComparison.OrdinalIgnoreCase));
+        if (existing is null)
+        {
+            var known = methodsContainer.Elements()
+                .Where(e => e.Name.LocalName == "Method")
+                .Select(e => Local(e, "Name"))
+                .Where(n => !string.IsNullOrEmpty(n))
+                .ToList();
+            return ToolResult<object>.Fail(D365FoErrorCodes.MethodNotFound,
+                $"Method '{request.MethodName}' does not exist on {kind} '{request.ObjectName}'.",
+                known.Count > 0
+                    ? $"Existing methods: {string.Join(", ", known)}."
+                    : $"{request.ObjectName} declares no methods. Use `d365fo generate` commands to scaffold a new object instead.");
+        }
+
+        var oldBody = Local(existing, "Source") ?? string.Empty;
+
+        // ---- 4. Grounding + fail-closed validation gate ----
+        var warnings = new List<string>();
+        var (grounding, gateFailure) = CheckGrounding(request, repo, warnings);
+        if (gateFailure is not null) return gateFailure;
+
+        // ---- 5. Structured replace: only the <Source> CDATA of the matched <Method> ----
+        var srcEl = existing.Elements().FirstOrDefault(e => e.Name.LocalName == "Source");
+        if (srcEl is null)
+        {
+            srcEl = new XElement(existing.Name.Namespace + "Source");
+            existing.Add(srcEl);
+        }
+        srcEl.ReplaceAll(new XCData(request.NewBody));
+
+        // ---- 6. Write back via the bridge (IMetadataProvider, never disk) ----
+        var newXml = doc.ToString(SaveOptions.DisableFormatting);
+        JsonObject? updateResult;
+        try
+        {
+            updateResult = client.SendAsync("updateObject", new JsonObject
+            {
+                ["kind"] = kind,
+                ["name"] = request.ObjectName,
+                ["model"] = model,
+                ["xml"] = newXml,
+            }).GetAwaiter().GetResult();
+        }
+        catch (BridgeException ex)
+        {
+            return ToolResult<object>.Fail(D365FoErrorCodes.WriteFailed, "Bridge error while writing the object: " + ex.Message);
+        }
+        if (updateResult is null)
+            return ToolResult<object>.Fail(D365FoErrorCodes.WriteFailed, "Bridge returned no result for updateObject.");
+        if ((bool?)updateResult["ok"] != true)
+        {
+            var code = (string?)updateResult["error"] ?? D365FoErrorCodes.WriteFailed;
+            var msg = (string?)updateResult["message"] ?? "unknown error";
+            return ToolResult<object>.Fail(code, $"Bridge could not update {kind} '{request.ObjectName}': {msg}");
+        }
+
+        // Incremental refresh: the touched model's index rows are now stale. No
+        // single-object refresh primitive exists yet (index refresh is model-scoped),
+        // so — mirroring the existing form-method commands (GenerateFormMethodCommands) —
+        // surface a warning instead of re-entrantly invoking the index pipeline.
+        warnings.Add($"Index not auto-refreshed — run `d365fo index refresh --model {model}` so '{request.MethodName}' is searchable.");
+
+        return ToolResult<object>.Success(new
+        {
+            kind,
+            name = request.ObjectName,
+            method = request.MethodName,
+            model,
+            source = "bridge",
+            oldBody,
+            newBody = request.NewBody,
+            grounding,
+        }, warnings);
+    }
+
+    /// <summary>
+    /// Grounding token (opt-in enforcement, same convention as
+    /// <c>D365FO.Cli.Commands.Generate.GroundingGate</c>) plus an <b>unconditional</b>
+    /// reference/BP validation gate — acceptance criteria for #112 requires the write
+    /// to be blocked on validation failure regardless of D365FO_GROUNDING_ENFORCE,
+    /// since this mutates a live, already-shipped object rather than a scaffold file.
+    /// </summary>
+    private static (object Grounding, ToolResult<object>? Failure) CheckGrounding(
+        ModifyRequest request, MetadataRepository? repo, List<string> warnings)
+    {
+        int refErrors = 0, refWarnings = 0, bpErrors = 0, bpWarnings = 0, verified = 0;
+        var violationDetails = new List<string>();
+
+        if (repo is not null)
+        {
+            try
+            {
+                var resolved = ReferenceResolver.Resolve(request.NewBody, repo);
+                verified = resolved.VerifiedCount;
+                foreach (var v in resolved.Violations)
+                {
+                    if (v.Severity == "error") refErrors++; else refWarnings++;
+                    violationDetails.Add($"[{v.Kind}] line {v.Line}: {v.Identifier} — {v.Detail}");
+                }
+
+                var stats = repo.HasPropertyStats() ? repo : (IPropertyStatsProvider?)null;
+                foreach (var v in XppValidator.Validate(request.NewBody, XppValidator.CodeTypeXpp, stats))
+                {
+                    if (v.Severity == "error") bpErrors++; else bpWarnings++;
+                    violationDetails.Add($"[{v.Rule}] line {v.Line}: {v.Excerpt} — {v.Fix}");
+                }
+            }
+            catch (Exception ex)
+            {
+                warnings.Add("validation self-check skipped: " + ex.Message);
+            }
+        }
+        else
+        {
+            warnings.Add("validation self-check skipped: no index available (run `d365fo index build` + `d365fo index extract`).");
+        }
+
+        var enforceToken = ProvenanceStore.EnforcementEnabled;
+        bool tokenValid = false;
+        string? tokenReason = null;
+        if (!string.IsNullOrWhiteSpace(request.GroundingToken) || enforceToken)
+        {
+            (tokenValid, var reason) = ProvenanceStore.Validate(request.GroundingToken, request.ObjectName);
+            if (!tokenValid)
+            {
+                tokenReason = reason;
+                if (enforceToken)
+                {
+                    var groundingFail = new
+                    {
+                        enforced = true,
+                        tokenValid = false,
+                    };
+                    return (groundingFail, ToolResult<object>.Fail(D365FoErrorCodes.GroundingRequired, reason,
+                        $"Run `d365fo prepare change {request.ObjectName} --method {request.MethodName}` and pass the returned token via --grounding-token."));
+                }
+                warnings.Add("grounding: " + reason);
+            }
+        }
+
+        var grounding = new
+        {
+            enforced = enforceToken,
+            tokenSupplied = !string.IsNullOrWhiteSpace(request.GroundingToken),
+            tokenValid,
+            tokenReason,
+            verifiedReferences = verified,
+            referenceErrors = refErrors,
+            referenceWarnings = refWarnings,
+            bpErrors,
+            bpWarnings,
+            violations = violationDetails.Count > 0 ? violationDetails : null,
+        };
+
+        if (refErrors > 0 || bpErrors > 0)
+        {
+            return (grounding, ToolResult<object>.Fail(D365FoErrorCodes.ValidationFailed,
+                $"New body for {request.ObjectName}::{request.MethodName} contains {refErrors} unresolved reference(s) " +
+                $"and {bpErrors} BP error(s):\n" + string.Join("\n", violationDetails),
+                "Fix the identifiers / BP issues (`d365fo validate references`, `d365fo validate xpp`), then retry. " +
+                "Unlike `generate`, this gate is not bypassable via D365FO_GROUNDING_ENFORCE — it always blocks writes to a live object."));
+        }
+
+        foreach (var detail in violationDetails)
+            warnings.Add("validation: " + detail);
+
+        return (grounding, null);
+    }
+
+    private static string NotFoundCodeFor(string kind) => kind switch
+    {
+        "class" => D365FoErrorCodes.ClassNotFound,
+        "table" => D365FoErrorCodes.TableNotFound,
+        "edt" => D365FoErrorCodes.EdtNotFound,
+        "form" => D365FoErrorCodes.FormNotFound,
+        _ => "NOT_FOUND",
+    };
+
+    /// <summary>
+    /// Locate the top-level method container: a direct child <c>&lt;Methods&gt;</c>
+    /// of the root (AxTable's shape) or a <c>&lt;Methods&gt;</c> whose parent is
+    /// <c>&lt;SourceCode&gt;</c> (AxClass/AxForm's shape) — mirrors the same
+    /// resolution order <c>MetadataExtractor.ExtractMethodsWithSources</c> uses, so
+    /// "the method the index knows about" and "the method this command edits" never
+    /// disagree. Deliberately ignores nested Methods containers under DataSources/
+    /// DataControls (form datasource/control override methods — see
+    /// <c>FormMethodScaffolder</c>, which has its own dedicated commands).
+    /// </summary>
+    internal static XElement? LocateMethodsContainer(XElement? root)
+    {
+        if (root is null) return null;
+        return root.Elements().FirstOrDefault(x => x.Name.LocalName == "Methods")
+               ?? root.Descendants().FirstOrDefault(x =>
+                   x.Name.LocalName == "Methods" &&
+                   x.Parent is { } p && p.Name.LocalName == "SourceCode");
+    }
+
+    private static string? Local(XElement parent, string localName)
+        => parent.Elements().FirstOrDefault(e => e.Name.LocalName == localName)?.Value;
+}

--- a/src/D365FO.Core/D365FoErrorCodes.cs
+++ b/src/D365FO.Core/D365FoErrorCodes.cs
@@ -55,4 +55,9 @@ public static class D365FoErrorCodes
 
     // MCP dispatcher
     public const string UnknownTool = "UNKNOWN_TOOL";
+
+    // Bridge / structured method modify (#112)
+    public const string BridgeRequired = "BRIDGE_REQUIRED";
+    public const string ValidationFailed = "VALIDATION_FAILED";
+    public const string GroundingRequired = "GROUNDING_REQUIRED";
 }

--- a/src/D365FO.Mcp/ToolCatalog.cs
+++ b/src/D365FO.Mcp/ToolCatalog.cs
@@ -35,7 +35,7 @@ public static class ToolCatalog
         // XML-only, but the whole tool is flagged write so clients confirm before
         // any write objectType runs). `labels` mixes read actions (search/info)
         // with write actions (create/rename/delete) — flagged here too.
-        "generate_object", "labels",
+        "generate_object", "labels", "modify_method",
     };
 
     /// <summary>
@@ -343,6 +343,19 @@ public static class ToolCatalog
                         $"Unknown objectType '{Str(p, "objectType")}' for generate_object.",
                         "Write: table, class, coc, form. XML-only: edt, enum, query, sysoperation, business-event, runbase, security-policy."),
             }),
+
+        new Descriptor("modify_method",
+            "Replace the body of an EXISTING method on a live class/table/edt/form via D365FO.Bridge " +
+            "(Windows VM, requires D365FO_BRIDGE_ENABLED=1). Reads the object through IMetadataProvider, " +
+            "structurally replaces one <Method>'s source (never raw XML/CDATA string surgery), runs the same " +
+            "reference/BP validation gate as generate_object and blocks the write on any error-severity finding " +
+            "(unconditionally — not gated by D365FO_GROUNDING_ENFORCE), then writes back through the provider. " +
+            "No on-disk fallback: fails BRIDGE_REQUIRED when the bridge is unavailable. Use generate_object to " +
+            "create new objects/methods; use this only to change an existing method's body.",
+            Schema(("kind", "string", true), ("name", "string", true), ("method", "string", true),
+                   ("body", "string", true), ("model", "string", false), ("groundingToken", "string", false)),
+            (h, p) => h.ModifyMethod(Str(p, "kind"), Str(p, "name"), Str(p, "method"), Str(p, "body"),
+                        StrOrNull(p, "model"), StrOrNull(p, "groundingToken"))),
 
         new Descriptor("suggest_edt",
             "Suggest indexed EDTs for a field name using similarity heuristics. Returns confidence-ranked candidates.",

--- a/src/D365FO.Mcp/ToolHandlers.cs
+++ b/src/D365FO.Mcp/ToolHandlers.cs
@@ -981,6 +981,20 @@ public sealed class ToolHandlers
         return WriteScaffold(doc, name, "AxTable", "AxTable", installTo, outPath, overwrite, extra);
     }
 
+    /// <summary>
+    /// Structured method-level modify via D365FO.Bridge (issue #112) — parity with
+    /// upstream's <c>d365fo_file(action=modify)</c>. No on-disk fallback: fails
+    /// <c>BRIDGE_REQUIRED</c> when the bridge is unavailable.
+    /// </summary>
+    public ToolResult<object> ModifyMethod(
+        string kind, string name, string method, string body,
+        string? model = null, string? groundingToken = null)
+    {
+        var request = new D365FO.Core.Bridge.MethodModifyEngine.ModifyRequest(
+            kind, name, method, body, model, groundingToken);
+        return D365FO.Core.Bridge.MethodModifyEngine.Modify(request, _repo);
+    }
+
     public ToolResult<object> GenerateClass(
         string name, string? extends, bool nonFinal,
         string? installTo, string? outPath, bool overwrite)

--- a/tests/D365FO.Core.Tests/MethodModifyEngineTests.cs
+++ b/tests/D365FO.Core.Tests/MethodModifyEngineTests.cs
@@ -1,0 +1,246 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Text;
+using System.Text.Json.Nodes;
+using System.Threading.Tasks;
+using D365FO.Core;
+using D365FO.Core.Bridge;
+using D365FO.Core.Extract;
+using D365FO.Core.Index;
+using Xunit;
+
+namespace D365FO.Core.Tests;
+
+/// <summary>
+/// Issue #112: structured method-level modify via D365FO.Bridge. Exercises
+/// <see cref="MethodModifyEngine.ModifyCore"/> against a fake bridge (no real
+/// process spawned) so the read → structured-replace → validate → write
+/// sequence is verified without a D365FO VM.
+/// </summary>
+public sealed class MethodModifyEngineTests : IDisposable
+{
+    private readonly string _dbPath = Path.Combine(Path.GetTempPath(), $"methodmodify-{Guid.NewGuid():N}.sqlite");
+    private readonly MetadataRepository _repo;
+
+    public MethodModifyEngineTests()
+    {
+        _repo = new MetadataRepository(_dbPath);
+        _repo.EnsureSchema();
+        var batch = new ExtractBatch(
+            Model: "ApplicationSuite",
+            Publisher: "Microsoft",
+            Layer: "app",
+            IsCustom: false,
+            Tables: Array.Empty<ExtractedTable>(),
+            Classes: new[]
+            {
+                new ExtractedClass("CustBalance", null, false, false, "x", new[]
+                {
+                    new ExtractedMethod("calc", "real calc()", "real", false),
+                }),
+            },
+            Edts: Array.Empty<ExtractedEdt>(),
+            Enums: Array.Empty<ExtractedEnum>(),
+            MenuItems: Array.Empty<ExtractedMenuItem>(),
+            CocExtensions: Array.Empty<ExtractedCoc>(),
+            Labels: Array.Empty<ExtractedLabel>());
+        _repo.ApplyExtract(batch);
+    }
+
+    public void Dispose()
+    {
+        Microsoft.Data.Sqlite.SqliteConnection.ClearAllPools();
+        foreach (var ext in new[] { "", "-wal", "-shm" })
+        {
+            var p = _dbPath + ext;
+            if (File.Exists(p)) { try { File.Delete(p); } catch { } }
+        }
+    }
+
+    private const string ClassXmlWithMethod =
+        "<AxClass><Name>CustBalance</Name><SourceCode><Methods>" +
+        "<Method><Name>calc</Name><Source><![CDATA[\n    real calc()\n    {\n        return 1;\n    }\n]]></Source></Method>" +
+        "</Methods></SourceCode></AxClass>";
+
+    [Fact]
+    public async Task Modify_replaces_method_source_and_writes_back_through_bridge()
+    {
+        JsonObject? capturedUpdateArgs = null;
+        using var harness = FakeBridge.Create(request =>
+        {
+            var method = (string?)request["method"];
+            if (method == "readObjectXml")
+            {
+                return Response(request, new JsonObject { ["ok"] = true, ["xml"] = ClassXmlWithMethod });
+            }
+            if (method == "updateObject")
+            {
+                capturedUpdateArgs = (JsonObject?)request["params"];
+                return Response(request, new JsonObject { ["ok"] = true });
+            }
+            throw new InvalidOperationException("unexpected method: " + method);
+        });
+
+        var req = new MethodModifyEngine.ModifyRequest("class", "CustBalance", "calc", "return 2;", Model: "ApplicationSuite");
+        var result = MethodModifyEngine.ModifyCore(req, _repo, harness.Client);
+
+        Assert.True(result.Ok);
+        Assert.NotNull(capturedUpdateArgs);
+        Assert.Equal("ApplicationSuite", (string?)capturedUpdateArgs!["model"]);
+        Assert.Contains("return 2;", (string?)capturedUpdateArgs["xml"]);
+        Assert.DoesNotContain("return 1;", (string?)capturedUpdateArgs["xml"]);
+    }
+
+    [Fact]
+    public void Modify_unknown_method_fails_METHOD_NOT_FOUND_with_known_methods_hint()
+    {
+        using var harness = FakeBridge.Create(request =>
+            Response(request, new JsonObject { ["ok"] = true, ["xml"] = ClassXmlWithMethod }));
+
+        var req = new MethodModifyEngine.ModifyRequest("class", "CustBalance", "doesNotExist", "return 2;", Model: "ApplicationSuite");
+        var result = MethodModifyEngine.ModifyCore(req, _repo, harness.Client);
+
+        Assert.False(result.Ok);
+        Assert.Equal(D365FoErrorCodes.MethodNotFound, result.Error!.Code);
+        Assert.Contains("calc", result.Error.Hint);
+    }
+
+    [Fact]
+    public void Modify_unsupported_kind_fails_BAD_INPUT_without_calling_bridge()
+    {
+        using var harness = FakeBridge.Create(_ => throw new InvalidOperationException("bridge should not be called"));
+
+        var req = new MethodModifyEngine.ModifyRequest("enum", "SomeEnum", "x", "y");
+        var result = MethodModifyEngine.ModifyCore(req, _repo, harness.Client);
+
+        Assert.False(result.Ok);
+        Assert.Equal(D365FoErrorCodes.BadInput, result.Error!.Code);
+    }
+
+    [Fact]
+    public void Modify_unresolvable_model_fails_before_touching_bridge()
+    {
+        using var harness = FakeBridge.Create(_ => throw new InvalidOperationException("bridge should not be called"));
+
+        var req = new MethodModifyEngine.ModifyRequest("class", "NoSuchClassInIndex", "calc", "return 2;");
+        var result = MethodModifyEngine.ModifyCore(req, _repo, harness.Client);
+
+        Assert.False(result.Ok);
+        Assert.Equal(D365FoErrorCodes.ClassNotFound, result.Error!.Code);
+    }
+
+    [Fact]
+    public void Modify_bridge_read_failure_surfaces_as_failure()
+    {
+        using var harness = FakeBridge.Create(request =>
+            Response(request, new JsonObject { ["ok"] = false, ["error"] = "NOT_FOUND", ["message"] = "no such object" }));
+
+        var req = new MethodModifyEngine.ModifyRequest("class", "CustBalance", "calc", "return 2;", Model: "ApplicationSuite");
+        var result = MethodModifyEngine.ModifyCore(req, _repo, harness.Client);
+
+        Assert.False(result.Ok);
+        Assert.Equal(D365FoErrorCodes.ClassNotFound, result.Error!.Code);
+    }
+
+    [Fact]
+    public void LocateMethodsContainer_finds_table_shape_direct_child()
+    {
+        var doc = System.Xml.Linq.XDocument.Parse("<AxTable><Methods><Method><Name>m</Name></Method></Methods></AxTable>");
+        var container = MethodModifyEngine.LocateMethodsContainer(doc.Root);
+        Assert.NotNull(container);
+        Assert.Equal("Methods", container!.Name.LocalName);
+    }
+
+    [Fact]
+    public void LocateMethodsContainer_ignores_nested_datasource_methods()
+    {
+        var doc = System.Xml.Linq.XDocument.Parse(
+            "<AxForm><SourceCode><DataSources><DataSource><Methods><Method><Name>m</Name></Method></Methods></DataSource></DataSources></SourceCode></AxForm>");
+        var container = MethodModifyEngine.LocateMethodsContainer(doc.Root);
+        Assert.Null(container);
+    }
+
+    private static JsonObject Response(JsonObject request, JsonObject result) => new()
+    {
+        ["jsonrpc"] = "2.0",
+        ["id"] = request["id"]?.DeepClone(),
+        ["result"] = result,
+    };
+
+    /// <summary>
+    /// Minimal fake bridge: routes each request line to <paramref name="respondWith"/>
+    /// and feeds the returned JSON-RPC envelope back as the next response line.
+    /// Mirrors <c>BridgeClientTests.FakeBridge</c> (kept separate/internal to each
+    /// test file rather than shared, per this repo's existing test-fixture style).
+    /// </summary>
+    private sealed class FakeBridge : IDisposable
+    {
+        public BridgeClient Client { get; }
+
+        private FakeBridge(BridgeClient client) => Client = client;
+
+        public static FakeBridge Create(Func<JsonObject, JsonObject> respondWith)
+        {
+            var reader = new DeferredResponseReader(respondWith);
+            var client = new BridgeClient(writer: new TeeWriter(reader), reader: reader);
+            return new FakeBridge(client);
+        }
+
+        public void Dispose() => Client.Dispose();
+    }
+
+    private sealed class TeeWriter : TextWriter
+    {
+        private readonly DeferredResponseReader signal;
+        private readonly StringBuilder buffer = new();
+
+        public TeeWriter(DeferredResponseReader signal) => this.signal = signal;
+
+        public override Encoding Encoding => Encoding.UTF8;
+
+        public override void Write(char value)
+        {
+            if (value == '\n')
+            {
+                var line = buffer.ToString();
+                buffer.Clear();
+                signal.OnRequest(line);
+            }
+            else
+            {
+                buffer.Append(value);
+            }
+        }
+
+        public override void Write(string? value)
+        {
+            if (value is null) return;
+            foreach (var ch in value) Write(ch);
+        }
+
+        public override void WriteLine(string? value)
+        {
+            Write(value);
+            Write('\n');
+        }
+    }
+
+    private sealed class DeferredResponseReader : TextReader
+    {
+        private readonly Func<JsonObject, JsonObject> respondWith;
+        private readonly Queue<string> queued = new();
+
+        public DeferredResponseReader(Func<JsonObject, JsonObject> respondWith) => this.respondWith = respondWith;
+
+        public void OnRequest(string requestLine)
+        {
+            var parsed = JsonNode.Parse(requestLine) as JsonObject
+                ?? throw new InvalidOperationException("bad request JSON");
+            var response = respondWith(parsed);
+            queued.Enqueue(response.ToJsonString());
+        }
+
+        public override string? ReadLine() => queued.Count == 0 ? null : queued.Dequeue();
+    }
+}


### PR DESCRIPTION
## Summary
- Adds `d365fo modify method <kind> <object> <method> --body <xpp>` and the matching MCP `modify_method` tool — CLI/MCP parity with upstream's `d365fo_file(action=modify)`.
- Reads the live class/table/edt/form through `IMetadataProvider` (D365FO.Bridge `readObjectXml`), structurally replaces one `<Method>`'s `<Source>` via `XDocument` element navigation (never CDATA string surgery), runs the same reference/BP validation gate `generate` uses — but **unconditionally** blocking on error-severity findings (not gated by `D365FO_GROUNDING_ENFORCE`, since this mutates an already-shipped live object) — then writes back through the bridge.
- No on-disk fallback: fails `BRIDGE_REQUIRED` when the bridge is unavailable, matching the "no raw-XML fallback" failure mode this replaces.

Closes #112.

## Test plan
- [x] `dotnet build d365fo-cli.slnx` — clean (incl. D365FO.Bridge net48)
- [x] `dotnet test d365fo-cli.slnx` — 548/548 passing, including new `MethodModifyEngineTests` (success round-trip, method-not-found hint, unsupported kind, unresolvable model, bridge read failure, `LocateMethodsContainer` table/form-nested shapes) against a fake in-memory bridge
- [ ] Manual smoke test on a D365FO VM with `D365FO_BRIDGE_ENABLED=1` (not available in this environment)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DfskzQYA9qygzw44aZiaYk