### PR TITLE
docs: correct remaining 5 KB files against live D365FO VM (audit part 2/2)

### DIFF
--- a/skills/_source/sysoperation-batch-patterns.md
+++ b/skills/_source/sysoperation-batch-patterns.md
@@ -119,6 +119,6 @@ d365fo generate migration-script FmVehicleMigration \
 
 - Always run migration scripts in a test environment before production.
 - Use `--batch-size` to avoid long-running transactions. Default is 1000.
-- Migration classes implement `SysRunnable` — run via `SysRunnable::run()` or from a `RunBase` dialog.
+- The scaffolded class extends `SysRunnable` and exposes a static `main(Args _args)` entry point that constructs the class and calls the instance `run()` method — invoke via **Right-click → Open** in Visual Studio (or wrap the call in a batch/RunBase wrapper). There is no static `SysRunnable::run()` call.
 - Never delete source data in the same script — use a separate cleanup script after validation.
 - After migration, validate row counts: `select count(*) from FmVehicle`.

--- a/skills/_source/table-scaffolding.md
+++ b/skills/_source/table-scaffolding.md
@@ -161,9 +161,13 @@ This emits:
 - An EDT with `NumberSequence=Yes` and `NumberSequenceModule` set.
 - A `NumberSeqFormHandler` extension class for the target form's `init()`.
 
-Manual consumption in X++:
+Manual consumption in X++ — the `numRef<EdtName>()` accessor lives as a `static
+NumberSequenceReference` method on the module's **own parameter table** (e.g.
+`FmParameters`, mirroring how `CustParameters::numRefCustAccount()` returns
+`NumberSeqReference::findReference(extendedTypeNum(CustAccount))` in the real
+platform) — **not** on `CompanyInfo` (no such class exists in modern D365FO):
 ```xpp
-NumberSeq numSeq = NumberSeq::newGetNum(CompanyInfo::numRefMySequence());
+NumberSeq numSeq = NumberSeq::newGetNum(FmParameters::numRefMySequence());
 str nextNum = numSeq.num();
 numSeq.used();   // or numSeq.abort() to roll back
 ```

--- a/skills/_source/x++-class-authoring.md
+++ b/skills/_source/x++-class-authoring.md
@@ -62,7 +62,7 @@ Modern replacement for `RunBaseBatch`. **Always use SysOperation for new batch c
 1. Structure: **DataContract** (parameters) + **Service** (logic) + **Controller** (execution mode).
 2. DataContract: decorate `parmXxx()` methods with `[DataMemberAttribute]`. Never use `pack()`/`unpack()`.
 3. Controller sets execution mode: `Synchronous`, `Asynchronous`, or `ScheduledBatch`.
-4. For SSRS report data providers: extend `SRSReportDataProviderBase` instead of `SysOperationServiceBase`.
+4. For SSRS report data providers: extend `SrsReportDataProviderBase` instead of `SysOperationServiceBase`.
 5. Custom dialog: use `SysOperationAutomaticUIBuilder`; link via `[SysOperationContractProcessingAttribute(classStr(MyUIBuilder))]` on the DataContract.
 
 **Scaffold with the CLI** — generates the DataContract, Service, and Controller XML in one command:
@@ -95,27 +95,43 @@ d365fo generate runbase <Name> \
 
 ## SysPlugin — extensible dispatch without `if`/`else`
 
-For enum-based strategy dispatching where new implementations must be addable without changing existing code:
+For strategy dispatching where new implementations must be addable without changing existing code, use the real `SysPluginFactory` platform API:
 
-1. Define an extensible enum (`IsExtensible=Yes`) with a value per strategy.
-2. Create an interface or abstract class for the strategy.
-3. Decorate concrete implementations with `[ExportMetadataAttribute(enumStr(MyEnum), MyEnum::Value)]`.
-4. Resolve at runtime: `SysPluginFactory::Instance(enumStr(MyEnum), enumValue)`.
+1. Define an interface or abstract base class for the strategy, identified by its namespace + class name (`_baseClassNamespace` / `_baseClassName`).
+2. Tag concrete implementations so the managed extensibility layer can discover them (see existing platform plugin implementations for current attribute usage).
+3. Build a `SysPluginMetadataCollection` and populate it with `.SetValue(key, val)` name/value pairs identifying the specific derived type you want.
+4. Resolve at runtime with the real signature: `SysPluginFactory::Instance(str _baseClassNamespace, str _baseClassName, SysPluginMetadataCollection _metadataCollection)` — **not** an enum-keyed call; there is no `enumStr(...)`/`ExportMetadataAttribute` overload.
 
-New strategies require only a new class + enum value — no changes to callers.
+New strategies require only a new class + metadata registration — no changes to callers.
 
 ## Number Sequence Integration
 
-Key classes: `NumberSeqModule`, `NumberSeqApplicationModule`, `NumberSeqScope`.
+Key classes: the abstract base `NumberSeqApplicationModule` and `NumberSeqScope`.
+Concrete per-module classes are named `NumberSeqModule<Module>` (e.g.
+`NumberSeqModuleCustomer`, `NumberSeqModuleVendor`) — there is no bare
+`NumberSeqModule` class; it is only a naming convention.
 
 **Adding a new sequence:**
-1. Extend `NumberSeqApplicationModule` via CoC; add a reference in `loadModule()`.
+1. For an **existing** module, CoC-extend its concrete class, e.g.
+   `[ExtensionOf(classStr(NumberSeqModuleCustomer))]`, and add a reference in
+   `loadModule()`. For a **brand-new** custom module, create a new class that
+   `extends NumberSeqApplicationModule` directly (there's no existing subclass
+   to CoC against).
 2. Create an EDT for the field; set `NumberSequence=Yes` and `NumberSequenceModule` on it.
-3. In form `init()`: call `NumberSeqFormHandler::newForm()` for auto-generation in UI.
+3. On the form: add a lazy-getter method (conventionally named
+   `numberSeqFormHandler()`) that returns
+   `NumberSeqFormHandler::newForm(<Module>Parameters::numRef<Edt>().NumberSequenceId, element, <table>_ds, fieldNum(<Table>, <Field>))`,
+   then call `element.numberSeqFormHandler().formMethodDataSourceCreate(...)` /
+   `formMethodDataSourceWrite()` / `formMethodDataSourceValidateWrite(...)` /
+   `formMethodDataSourceDelete()` from the datasource's `create()`, `write()`,
+   `validateWrite()`, and `delete()` overrides — this is not a one-time call in `init()`.
 
-**Manual consumption:**
+**Manual consumption** — the `numRef<Edt>()` accessor is a `static
+NumberSequenceReference` method on the module's own parameter table (e.g.
+`CustParameters::numRefCustAccount()` calling
+`NumberSeqReference::findReference(extendedTypeNum(CustAccount))`), not on `CompanyInfo`:
 ```xpp
-NumberSeq numSeq = NumberSeq::newGetNum(CompanyInfo::numRefMySequence());
+NumberSeq numSeq = NumberSeq::newGetNum(FmParameters::numRefMySequence());
 str nextNum = numSeq.num();
 // ... use nextNum ...
 numSeq.used();   // or numSeq.abort() to roll back
@@ -123,14 +139,22 @@ numSeq.used();   // or numSeq.abort() to roll back
 
 ## Workflow Development
 
-Key base classes: `WorkflowDocument`, `WorkflowType`, `WorkflowApproval`, `WorkflowTask`.
+Key base classes: `WorkflowDocument` and `WorkflowType` are hand-authored X++
+subclasses. Approvals and tasks are **not** subclassed directly in X++ — they
+are configured declaratively in the AOT Workflow editor and are backed by
+framework classes named `WorkflowModelApproval`/`WorkflowStep_Approval` and
+`WorkflowModelTask`/`WorkflowStep_Task`/`WorkflowModelAutomatedTask` (there is
+no bare `WorkflowApproval` or `WorkflowTask` class).
 
 **Every workflow needs:**
 - `WorkflowDocument` subclass — defines which table fields are available as conditions.
-- `SubmitToWorkflowMenuItem` action menu item — the submit button on the form.
+- A submit action, conventionally a per-module class named `<Module>SubmitToWorkflow`
+  (e.g. `CatProductSubmitToWorkflow`, `TrvSubmitToWorkflow`) wired to a menu item —
+  there is no shared `SubmitToWorkflowMenuItem` base class to extend; each module
+  implements its own.
 - `canSubmitToWorkflow()` method on the table — controls when submit is enabled.
 
-Structure: Document → Type → Approvals/Tasks → EventHandlers.
+Structure: Document → Type → Approvals/Tasks (configured in the Workflow editor) → EventHandlers.
 Approval/Task event handlers use `WorkflowWorkItemActionManager` for complete/reject/delegate.
 
 ```sh

--- a/skills/anthropic/sysoperation-batch-patterns/SKILL.md
+++ b/skills/anthropic/sysoperation-batch-patterns/SKILL.md
@@ -111,6 +111,6 @@ d365fo generate migration-script FmVehicleMigration \
 
 - Always run migration scripts in a test environment before production.
 - Use `--batch-size` to avoid long-running transactions. Default is 1000.
-- Migration classes implement `SysRunnable` — run via `SysRunnable::run()` or from a `RunBase` dialog.
+- The scaffolded class extends `SysRunnable` and exposes a static `main(Args _args)` entry point that constructs the class and calls the instance `run()` method — invoke via **Right-click → Open** in Visual Studio (or wrap the call in a batch/RunBase wrapper). There is no static `SysRunnable::run()` call.
 - Never delete source data in the same script — use a separate cleanup script after validation.
 - After migration, validate row counts: `select count(*) from FmVehicle`.

--- a/skills/anthropic/table-scaffolding/SKILL.md
+++ b/skills/anthropic/table-scaffolding/SKILL.md
@@ -157,9 +157,13 @@ This emits:
 - An EDT with `NumberSequence=Yes` and `NumberSequenceModule` set.
 - A `NumberSeqFormHandler` extension class for the target form's `init()`.
 
-Manual consumption in X++:
+Manual consumption in X++ — the `numRef<EdtName>()` accessor lives as a `static
+NumberSequenceReference` method on the module's **own parameter table** (e.g.
+`FmParameters`, mirroring how `CustParameters::numRefCustAccount()` returns
+`NumberSeqReference::findReference(extendedTypeNum(CustAccount))` in the real
+platform) — **not** on `CompanyInfo` (no such class exists in modern D365FO):
 ```xpp
-NumberSeq numSeq = NumberSeq::newGetNum(CompanyInfo::numRefMySequence());
+NumberSeq numSeq = NumberSeq::newGetNum(FmParameters::numRefMySequence());
 str nextNum = numSeq.num();
 numSeq.used();   // or numSeq.abort() to roll back
 ```

--- a/skills/anthropic/x++-class-authoring/SKILL.md
+++ b/skills/anthropic/x++-class-authoring/SKILL.md
@@ -57,7 +57,7 @@ Modern replacement for `RunBaseBatch`. **Always use SysOperation for new batch c
 1. Structure: **DataContract** (parameters) + **Service** (logic) + **Controller** (execution mode).
 2. DataContract: decorate `parmXxx()` methods with `[DataMemberAttribute]`. Never use `pack()`/`unpack()`.
 3. Controller sets execution mode: `Synchronous`, `Asynchronous`, or `ScheduledBatch`.
-4. For SSRS report data providers: extend `SRSReportDataProviderBase` instead of `SysOperationServiceBase`.
+4. For SSRS report data providers: extend `SrsReportDataProviderBase` instead of `SysOperationServiceBase`.
 5. Custom dialog: use `SysOperationAutomaticUIBuilder`; link via `[SysOperationContractProcessingAttribute(classStr(MyUIBuilder))]` on the DataContract.
 
 **Scaffold with the CLI** — generates the DataContract, Service, and Controller XML in one command:
@@ -90,27 +90,43 @@ d365fo generate runbase <Name> \
 
 ## SysPlugin — extensible dispatch without `if`/`else`
 
-For enum-based strategy dispatching where new implementations must be addable without changing existing code:
+For strategy dispatching where new implementations must be addable without changing existing code, use the real `SysPluginFactory` platform API:
 
-1. Define an extensible enum (`IsExtensible=Yes`) with a value per strategy.
-2. Create an interface or abstract class for the strategy.
-3. Decorate concrete implementations with `[ExportMetadataAttribute(enumStr(MyEnum), MyEnum::Value)]`.
-4. Resolve at runtime: `SysPluginFactory::Instance(enumStr(MyEnum), enumValue)`.
+1. Define an interface or abstract base class for the strategy, identified by its namespace + class name (`_baseClassNamespace` / `_baseClassName`).
+2. Tag concrete implementations so the managed extensibility layer can discover them (see existing platform plugin implementations for current attribute usage).
+3. Build a `SysPluginMetadataCollection` and populate it with `.SetValue(key, val)` name/value pairs identifying the specific derived type you want.
+4. Resolve at runtime with the real signature: `SysPluginFactory::Instance(str _baseClassNamespace, str _baseClassName, SysPluginMetadataCollection _metadataCollection)` — **not** an enum-keyed call; there is no `enumStr(...)`/`ExportMetadataAttribute` overload.
 
-New strategies require only a new class + enum value — no changes to callers.
+New strategies require only a new class + metadata registration — no changes to callers.
 
 ## Number Sequence Integration
 
-Key classes: `NumberSeqModule`, `NumberSeqApplicationModule`, `NumberSeqScope`.
+Key classes: the abstract base `NumberSeqApplicationModule` and `NumberSeqScope`.
+Concrete per-module classes are named `NumberSeqModule<Module>` (e.g.
+`NumberSeqModuleCustomer`, `NumberSeqModuleVendor`) — there is no bare
+`NumberSeqModule` class; it is only a naming convention.
 
 **Adding a new sequence:**
-1. Extend `NumberSeqApplicationModule` via CoC; add a reference in `loadModule()`.
+1. For an **existing** module, CoC-extend its concrete class, e.g.
+   `[ExtensionOf(classStr(NumberSeqModuleCustomer))]`, and add a reference in
+   `loadModule()`. For a **brand-new** custom module, create a new class that
+   `extends NumberSeqApplicationModule` directly (there's no existing subclass
+   to CoC against).
 2. Create an EDT for the field; set `NumberSequence=Yes` and `NumberSequenceModule` on it.
-3. In form `init()`: call `NumberSeqFormHandler::newForm()` for auto-generation in UI.
+3. On the form: add a lazy-getter method (conventionally named
+   `numberSeqFormHandler()`) that returns
+   `NumberSeqFormHandler::newForm(<Module>Parameters::numRef<Edt>().NumberSequenceId, element, <table>_ds, fieldNum(<Table>, <Field>))`,
+   then call `element.numberSeqFormHandler().formMethodDataSourceCreate(...)` /
+   `formMethodDataSourceWrite()` / `formMethodDataSourceValidateWrite(...)` /
+   `formMethodDataSourceDelete()` from the datasource's `create()`, `write()`,
+   `validateWrite()`, and `delete()` overrides — this is not a one-time call in `init()`.
 
-**Manual consumption:**
+**Manual consumption** — the `numRef<Edt>()` accessor is a `static
+NumberSequenceReference` method on the module's own parameter table (e.g.
+`CustParameters::numRefCustAccount()` calling
+`NumberSeqReference::findReference(extendedTypeNum(CustAccount))`), not on `CompanyInfo`:
 ```xpp
-NumberSeq numSeq = NumberSeq::newGetNum(CompanyInfo::numRefMySequence());
+NumberSeq numSeq = NumberSeq::newGetNum(FmParameters::numRefMySequence());
 str nextNum = numSeq.num();
 // ... use nextNum ...
 numSeq.used();   // or numSeq.abort() to roll back
@@ -118,14 +134,22 @@ numSeq.used();   // or numSeq.abort() to roll back
 
 ## Workflow Development
 
-Key base classes: `WorkflowDocument`, `WorkflowType`, `WorkflowApproval`, `WorkflowTask`.
+Key base classes: `WorkflowDocument` and `WorkflowType` are hand-authored X++
+subclasses. Approvals and tasks are **not** subclassed directly in X++ — they
+are configured declaratively in the AOT Workflow editor and are backed by
+framework classes named `WorkflowModelApproval`/`WorkflowStep_Approval` and
+`WorkflowModelTask`/`WorkflowStep_Task`/`WorkflowModelAutomatedTask` (there is
+no bare `WorkflowApproval` or `WorkflowTask` class).
 
 **Every workflow needs:**
 - `WorkflowDocument` subclass — defines which table fields are available as conditions.
-- `SubmitToWorkflowMenuItem` action menu item — the submit button on the form.
+- A submit action, conventionally a per-module class named `<Module>SubmitToWorkflow`
+  (e.g. `CatProductSubmitToWorkflow`, `TrvSubmitToWorkflow`) wired to a menu item —
+  there is no shared `SubmitToWorkflowMenuItem` base class to extend; each module
+  implements its own.
 - `canSubmitToWorkflow()` method on the table — controls when submit is enabled.
 
-Structure: Document → Type → Approvals/Tasks → EventHandlers.
+Structure: Document → Type → Approvals/Tasks (configured in the Workflow editor) → EventHandlers.
 Approval/Task event handlers use `WorkflowWorkItemActionManager` for complete/reject/delegate.
 
 ```sh

--- a/skills/copilot/sysoperation-batch-patterns.instructions.md
+++ b/skills/copilot/sysoperation-batch-patterns.instructions.md
@@ -110,6 +110,6 @@ d365fo generate migration-script FmVehicleMigration \
 
 - Always run migration scripts in a test environment before production.
 - Use `--batch-size` to avoid long-running transactions. Default is 1000.
-- Migration classes implement `SysRunnable` — run via `SysRunnable::run()` or from a `RunBase` dialog.
+- The scaffolded class extends `SysRunnable` and exposes a static `main(Args _args)` entry point that constructs the class and calls the instance `run()` method — invoke via **Right-click → Open** in Visual Studio (or wrap the call in a batch/RunBase wrapper). There is no static `SysRunnable::run()` call.
 - Never delete source data in the same script — use a separate cleanup script after validation.
 - After migration, validate row counts: `select count(*) from FmVehicle`.

--- a/skills/copilot/table-scaffolding.instructions.md
+++ b/skills/copilot/table-scaffolding.instructions.md
@@ -156,9 +156,13 @@ This emits:
 - An EDT with `NumberSequence=Yes` and `NumberSequenceModule` set.
 - A `NumberSeqFormHandler` extension class for the target form's `init()`.
 
-Manual consumption in X++:
+Manual consumption in X++ — the `numRef<EdtName>()` accessor lives as a `static
+NumberSequenceReference` method on the module's **own parameter table** (e.g.
+`FmParameters`, mirroring how `CustParameters::numRefCustAccount()` returns
+`NumberSeqReference::findReference(extendedTypeNum(CustAccount))` in the real
+platform) — **not** on `CompanyInfo` (no such class exists in modern D365FO):
 ```xpp
-NumberSeq numSeq = NumberSeq::newGetNum(CompanyInfo::numRefMySequence());
+NumberSeq numSeq = NumberSeq::newGetNum(FmParameters::numRefMySequence());
 str nextNum = numSeq.num();
 numSeq.used();   // or numSeq.abort() to roll back
 ```

--- a/skills/copilot/x++-class-authoring.instructions.md
+++ b/skills/copilot/x++-class-authoring.instructions.md
@@ -56,7 +56,7 @@ Modern replacement for `RunBaseBatch`. **Always use SysOperation for new batch c
 1. Structure: **DataContract** (parameters) + **Service** (logic) + **Controller** (execution mode).
 2. DataContract: decorate `parmXxx()` methods with `[DataMemberAttribute]`. Never use `pack()`/`unpack()`.
 3. Controller sets execution mode: `Synchronous`, `Asynchronous`, or `ScheduledBatch`.
-4. For SSRS report data providers: extend `SRSReportDataProviderBase` instead of `SysOperationServiceBase`.
+4. For SSRS report data providers: extend `SrsReportDataProviderBase` instead of `SysOperationServiceBase`.
 5. Custom dialog: use `SysOperationAutomaticUIBuilder`; link via `[SysOperationContractProcessingAttribute(classStr(MyUIBuilder))]` on the DataContract.
 
 **Scaffold with the CLI** — generates the DataContract, Service, and Controller XML in one command:
@@ -89,27 +89,43 @@ d365fo generate runbase <Name> \
 
 ## SysPlugin — extensible dispatch without `if`/`else`
 
-For enum-based strategy dispatching where new implementations must be addable without changing existing code:
+For strategy dispatching where new implementations must be addable without changing existing code, use the real `SysPluginFactory` platform API:
 
-1. Define an extensible enum (`IsExtensible=Yes`) with a value per strategy.
-2. Create an interface or abstract class for the strategy.
-3. Decorate concrete implementations with `[ExportMetadataAttribute(enumStr(MyEnum), MyEnum::Value)]`.
-4. Resolve at runtime: `SysPluginFactory::Instance(enumStr(MyEnum), enumValue)`.
+1. Define an interface or abstract base class for the strategy, identified by its namespace + class name (`_baseClassNamespace` / `_baseClassName`).
+2. Tag concrete implementations so the managed extensibility layer can discover them (see existing platform plugin implementations for current attribute usage).
+3. Build a `SysPluginMetadataCollection` and populate it with `.SetValue(key, val)` name/value pairs identifying the specific derived type you want.
+4. Resolve at runtime with the real signature: `SysPluginFactory::Instance(str _baseClassNamespace, str _baseClassName, SysPluginMetadataCollection _metadataCollection)` — **not** an enum-keyed call; there is no `enumStr(...)`/`ExportMetadataAttribute` overload.
 
-New strategies require only a new class + enum value — no changes to callers.
+New strategies require only a new class + metadata registration — no changes to callers.
 
 ## Number Sequence Integration
 
-Key classes: `NumberSeqModule`, `NumberSeqApplicationModule`, `NumberSeqScope`.
+Key classes: the abstract base `NumberSeqApplicationModule` and `NumberSeqScope`.
+Concrete per-module classes are named `NumberSeqModule<Module>` (e.g.
+`NumberSeqModuleCustomer`, `NumberSeqModuleVendor`) — there is no bare
+`NumberSeqModule` class; it is only a naming convention.
 
 **Adding a new sequence:**
-1. Extend `NumberSeqApplicationModule` via CoC; add a reference in `loadModule()`.
+1. For an **existing** module, CoC-extend its concrete class, e.g.
+   `[ExtensionOf(classStr(NumberSeqModuleCustomer))]`, and add a reference in
+   `loadModule()`. For a **brand-new** custom module, create a new class that
+   `extends NumberSeqApplicationModule` directly (there's no existing subclass
+   to CoC against).
 2. Create an EDT for the field; set `NumberSequence=Yes` and `NumberSequenceModule` on it.
-3. In form `init()`: call `NumberSeqFormHandler::newForm()` for auto-generation in UI.
+3. On the form: add a lazy-getter method (conventionally named
+   `numberSeqFormHandler()`) that returns
+   `NumberSeqFormHandler::newForm(<Module>Parameters::numRef<Edt>().NumberSequenceId, element, <table>_ds, fieldNum(<Table>, <Field>))`,
+   then call `element.numberSeqFormHandler().formMethodDataSourceCreate(...)` /
+   `formMethodDataSourceWrite()` / `formMethodDataSourceValidateWrite(...)` /
+   `formMethodDataSourceDelete()` from the datasource's `create()`, `write()`,
+   `validateWrite()`, and `delete()` overrides — this is not a one-time call in `init()`.
 
-**Manual consumption:**
+**Manual consumption** — the `numRef<Edt>()` accessor is a `static
+NumberSequenceReference` method on the module's own parameter table (e.g.
+`CustParameters::numRefCustAccount()` calling
+`NumberSeqReference::findReference(extendedTypeNum(CustAccount))`), not on `CompanyInfo`:
 ```xpp
-NumberSeq numSeq = NumberSeq::newGetNum(CompanyInfo::numRefMySequence());
+NumberSeq numSeq = NumberSeq::newGetNum(FmParameters::numRefMySequence());
 str nextNum = numSeq.num();
 // ... use nextNum ...
 numSeq.used();   // or numSeq.abort() to roll back
@@ -117,14 +133,22 @@ numSeq.used();   // or numSeq.abort() to roll back
 
 ## Workflow Development
 
-Key base classes: `WorkflowDocument`, `WorkflowType`, `WorkflowApproval`, `WorkflowTask`.
+Key base classes: `WorkflowDocument` and `WorkflowType` are hand-authored X++
+subclasses. Approvals and tasks are **not** subclassed directly in X++ — they
+are configured declaratively in the AOT Workflow editor and are backed by
+framework classes named `WorkflowModelApproval`/`WorkflowStep_Approval` and
+`WorkflowModelTask`/`WorkflowStep_Task`/`WorkflowModelAutomatedTask` (there is
+no bare `WorkflowApproval` or `WorkflowTask` class).
 
 **Every workflow needs:**
 - `WorkflowDocument` subclass — defines which table fields are available as conditions.
-- `SubmitToWorkflowMenuItem` action menu item — the submit button on the form.
+- A submit action, conventionally a per-module class named `<Module>SubmitToWorkflow`
+  (e.g. `CatProductSubmitToWorkflow`, `TrvSubmitToWorkflow`) wired to a menu item —
+  there is no shared `SubmitToWorkflowMenuItem` base class to extend; each module
+  implements its own.
 - `canSubmitToWorkflow()` method on the table — controls when submit is enabled.
 
-Structure: Document → Type → Approvals/Tasks → EventHandlers.
+Structure: Document → Type → Approvals/Tasks (configured in the Workflow editor) → EventHandlers.
 Approval/Task event handlers use `WorkflowWorkItemActionManager` for complete/reject/delegate.
 
 ```sh


### PR DESCRIPTION
## Summary

Completes the `skills/_source` knowledge-base accuracy audit started in a1a0206 (14/19 files verified and corrected). This PR verifies and corrects the remaining 5 files against a live D365FO VM's metadata (`K:\AosService\PackagesLocalDirectory`, 196 models) and this repo's own CLI scaffolder source.

**`sysoperation-batch-patterns.md`**
- Fixed the migration-script invocation description. The scaffolder (`MigrationScriptScaffolder.cs`) generates a class extending `SysRunnable` with an **instance** `run()` method invoked from a static `main(Args _args)` — not a static `SysRunnable::run()` call, and there's no `RunBase` dialog integration as previously claimed.
- All CLI flags/commands (`generate sysoperation`, `generate runbase`, `generate migration-script`, execution modes, migration modes, default batch size) were checked against `src/D365FO.Cli/Commands/Generate/*.cs` and found accurate — no changes needed there.

**`table-scaffolding.md`**
- Fixed the number-sequence "manual consumption" snippet: it referenced `CompanyInfo::numRefMySequence()`, but no `CompanyInfo` class exists anywhere in the VM's 196 models. The real accessor is a `static NumberSequenceReference` method on the module's own parameter table (verified via `CustParameters::numRefCustAccount()` → `NumberSeqReference::findReference(extendedTypeNum(CustAccount))` in `ApplicationSuite`). Updated the example to `FmParameters::numRefMySequence()`, consistent with the file's own `FmParameters` pattern example.
- Table pattern presets, aliases, `TableGroup`/`TableType` distinction, and `generate table`/`generate query`/`generate number-sequence` flags were all checked against `TablePattern.cs` and the `Generate*Command.cs` files and found accurate.

**`x++-class-authoring.md`** (largest set of fixes)
- `SRSReportDataProviderBase` → corrected casing to the real `SrsReportDataProviderBase`.
- SysPlugin section rewritten to match the real `SysPluginFactory::Instance(str _baseClassNamespace, str _baseClassName, SysPluginMetadataCollection _metadataCollection)` signature — the doc's enum-keyed `ExportMetadataAttribute`/`SysPluginFactory::Instance(enumStr(...), ...)` pattern doesn't exist in the platform.
- Number Sequence Integration: clarified that `NumberSeqModule` is not a real class (only a naming convention — concrete classes are `NumberSeqModule<Module>`, e.g. `NumberSeqModuleCustomer`, all extending the real abstract base `NumberSeqApplicationModule`); corrected the CoC-target guidance and the UI-wiring step (a `numberSeqFormHandler()` getter called from datasource `create()`/`write()`/`validateWrite()`/`delete()` overrides, not a one-time call in `init()`, per the real `CustTable` form pattern); fixed the same `CompanyInfo` issue as above.
- Workflow Development: `WorkflowApproval`/`WorkflowTask` aren't real class names (real: `WorkflowModelApproval`/`WorkflowStep_Approval`, `WorkflowModelTask`/`WorkflowStep_Task`) and `SubmitToWorkflowMenuItem` isn't a shared base class — real pattern is a per-module class (e.g. `CatProductSubmitToWorkflow`, `TrvSubmitToWorkflow`).

**`xpp-class-and-method-rules.md`** and **`xpp-statement-and-type-rules.md`**
- Fully audited. These are general X++ language rules (access modifiers, `const`/`var`, `prmIsDefault`, casting, null-sentinels, `using` blocks, extension-method syntax) rather than platform-class references. Spot-checked several concrete claims against the VM and CLI source (`prmIsDefault` usage, `RunBase` pack/unpack/dialog/getFromDialog/canGoBatch/run all exist, `const` keyword real, extension-method `_Extension` static-class pattern confirmed via `DictDataEntity_Extension`, CLI flags `d365fo read class --method --declaration`, `d365fo labels search --lang`) — all checked out accurate. No changes made; this is a targeted-correction pass, not a rewrite.

## Test plan

- [x] Ran `scripts/emit-skills.ps1` after editing the 3 changed `skills/_source/*.md` files.
- [x] Verified `git status --porcelain skills/copilot skills/anthropic skills/_source` shows exactly the 9 expected files (3 source + 3 anthropic + 3 copilot compiled counterparts) and nothing else — confirming the compiled output matches source and no other skill drifted.
- [x] Confirmed via `git diff origin/main -- <5 files>` that no upstream changes landed on these files since the audit started, so this PR is a clean, isolated correction.
- [ ] CI `skills` job (drift check) — pending, will report status once checks run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DfskzQYA9qygzw44aZiaYk