### PR TITLE
feat: modification journal + undo (#113)

### DIFF
--- a/README.md
+++ b/README.md
@@ -235,6 +235,7 @@ See [docs/TOKEN_ECONOMICS.md](docs/TOKEN_ECONOMICS.md) for the full analysis and
 | **Read** | `read class`, `read table`, `read form` (= MCP `get_method`) |
 | **Generate** | `generate table\|class\|coc\|form\|entity\|extension\|event-handler\|privilege\|duty\|role\|report\|sysoperation\|number-sequence\|workflow\|menu-item\|edt\|enum\|query\|business-event\|custom-service\|migration-script\|runbase\|security-policy\|systest` |
 | **Labels** | `labels search\|resolve\|info\|create\|rename\|delete` — search/resolve plus in-place `*.label.txt` edits, multi-language via `--lang` (mirrors the MCP `labels` tool) |
+| **Journal / undo** | `undo [--steps N] [--dry-run]`, `journal list`, `delete` (kind/name, bridge or on-disk) — deterministic single-command rollback for every write path (mirrors the MCP `undo_last_modification` tool) |
 | **Analyze** | `analyze completeness`, `analyze integration`, `analyze impact`, `lint`, `suggest edt`, `suggest extension`, `report-integrations` |
 | **Review** | `review diff` |
 | **Models** | `models list`, `models deps`, `models coupling` |

--- a/docs/CAPABILITIES.md
+++ b/docs/CAPABILITIES.md
@@ -262,6 +262,33 @@ d365fo labels delete Key           --file path/Foo.en-us.label.txt
 
 ---
 
+## Modification journal & undo
+
+Every metadata write — `generate *`, `labels create\|rename\|delete`, and `delete` — appends
+an entry to a size-capped, FIFO-pruned journal at `<index-dir>/journal/`, whether the write
+went to disk or through the metadata bridge. `d365fo undo` replays entries in reverse through
+the SAME write path that produced them, restoring the exact pre-image.
+
+```sh
+d365fo journal list --output json                  # inspect the stack, most-recent-first
+d365fo undo --dry-run --output json                # preview what would be reverted
+d365fo undo --output json                           # revert the last write
+d365fo undo --steps 3 --output json                 # revert the last 3 writes
+
+# Delete an AOT object (journaled, so it can be undone)
+d365fo delete --kind table --name OldTable --path C:\pkg\MyModel\MyModel\AxTable\OldTable.xml
+d365fo delete --kind class --name OldClass --install-to MyModel   # via the metadata bridge
+```
+
+- **create → undo** removes the file (and its `.rnrproj` entry, when the model has one with an explicit item list).
+- **update → undo** restores the exact pre-image bytes.
+- **delete → undo** recreates the file from its pre-image.
+- Works identically with `D365FO_BRIDGE_ENABLED=1` or unset — bridge-mediated writes undo through `deleteObject`/`updateObject`/`createObject`.
+
+MCP parity: `undo_last_modification` (`steps`, `dryRun`) and `journal_list` (`limit`).
+
+---
+
 ## Review
 
 ```sh

--- a/docs/EXAMPLES.md
+++ b/docs/EXAMPLES.md
@@ -599,6 +599,33 @@ d365fo label delete RenamedKey         --file path/Foo.en-us.label.txt
 
 ---
 
+## Journal / undo
+
+```sh
+# Inspect the stack (most-recent-first)
+d365fo journal list --output json
+d365fo journal list --limit 5 --output json
+
+# Preview before committing to an undo
+d365fo undo --dry-run --output json
+
+# Revert the last write, or the last N
+d365fo undo --output json
+d365fo undo --steps 3 --output json
+
+# Delete an AOT object (journaled — undo-able like any other write)
+d365fo delete --kind table --name OldTable --path C:\pkg\MyModel\MyModel\AxTable\OldTable.xml
+d365fo delete --kind class --name OldClass --install-to MyModel   # via the metadata bridge
+```
+
+Every `generate *`, `labels create\|rename\|delete`, and `delete` write appends an entry to a
+size-capped journal at `<index-dir>/journal/`. `undo` replays entries in reverse through the
+same write path that produced them (disk or bridge), restoring the exact pre-image — a create
+is removed, an update/delete is restored byte-for-byte. Stops at the first failure so older
+entries are never skipped.
+
+---
+
 ## Review
 
 ```sh

--- a/docs/MIGRATION_FROM_MCP.md
+++ b/docs/MIGRATION_FROM_MCP.md
@@ -151,13 +151,14 @@ renaming `form_pattern` → `object_patterns`.
 | `find_references` | — | reverse references via regex scan of indexed X++ source (was CLI-only) |
 | `validate_object_naming`, `get_workspace_info`, `suggest_edt`, `batch_get_info`, `lint`, `stats`, `index_status`, `index_history` | — | kept (parity names) |
 
-This adapter exposes **22 unified MCP tools**, including `modify_method`
-(structured method-body replace via D365FO.Bridge — the `d365fo_file(action=modify)`
-counterpart). The upstream `d365fo-mcp-server` sits at 26 — it additionally ships
-`get_knowledge`, `analyze_code`, `d365fo_file` (`action=create`, covered here by
-`generate_object`), `undo_last_modification`, `validate_code`,
-`verify_d365fo_project` and the SDLC/build tools, which here are CLI-only or
-covered by Skills.
+This adapter exposes **23 unified MCP tools**, including `modify_method` (structured
+method-body replace via D365FO.Bridge — the `d365fo_file(action=modify)` counterpart) and
+`undo_last_modification` / `journal_list` (issue #113 — full parity with upstream's undo,
+backed by the modification journal described below). The upstream `d365fo-mcp-server`
+sits at 26 — it additionally ships `get_knowledge`, `analyze_code`, `d365fo_file`
+(`action=create`, covered here by `generate_object`), `validate_code`,
+`verify_d365fo_project` and the SDLC/build tools, which here are CLI-only or covered by
+Skills.
 
 Run `d365fo schema --full` for the machine-readable command/tool manifest; every
 CLI command's `mcpTool` field names the unified MCP tool it maps to.
@@ -215,10 +216,34 @@ commands. Both surfaces use the same discriminator-based naming.
 | `generate_object` (`objectType=form`) | `d365fo generate form <Name> --pattern <P>` (pattern-gated write) |
 | `generate_object` (XML-only `objectType=…`) | `d365fo generate edt\|enum\|query\|sysoperation\|business-event\|runbase\|security-policy` (XML only) |
 | `d365fo_file` (`action=modify`) / `modify_method` | `d365fo modify method <kind> <Object> <Method> --body "…"` (structured `XDocument` replace via D365FO.Bridge/`IMetadataProvider` — never CDATA string surgery; reference/BP validation always blocks on error-severity findings) |
-| `undo_last_modification` | `.bak` backups written by every overwrite + `git checkout` |
+| `undo_last_modification` | `d365fo undo [--steps N] [--dry-run]` — reverts the last N modification-journal entries (see below) |
 | `labels` (`action=create\|rename\|delete`) | `d365fo labels create\|rename\|delete` (multi-language via `--lang`) |
 | `review_workspace_changes` | `d365fo review diff` |
 | `update_symbol_index` | `d365fo index refresh [--model <M>]` |
+
+#### Modification journal (issue #113)
+
+Every write path — `generate <kind> [--out\|--install-to]`, `labels create\|rename\|delete`,
+and `delete` — appends an entry to a journal stored at `<index-dir>/journal/` (next to the
+SQLite index; `d365fo journal list --output json` inspects it, size-capped with FIFO
+pruning). Each entry records the timestamp, command, object identity, operation
+(create/update/delete), and either the exact pre-image (update/delete) or a tombstone
+(create) — plus a `.rnrproj` project-file delta when the model has one with an explicit item
+list (most headless/VM installs don't; D365FO's build/sync tooling discovers objects by
+directory convention regardless).
+
+`d365fo undo [--steps N] [--dry-run]` replays the last N entries **in reverse, through the
+same write path that produced them** — on-disk file I/O, or the bridge's live
+`IMetadataProvider` when `D365FO_BRIDGE_ENABLED=1` was used for the original write — so undo
+behaves identically whether or not the bridge is enabled:
+- **create → undo** removes the file (and its `.rnrproj` entry, if one was added).
+- **update → undo** restores the exact pre-image bytes.
+- **delete → undo** (via `d365fo delete`) recreates the file from its pre-image.
+
+`--dry-run` previews what would be reverted without changing anything — use this before an
+agent commits to an undo. `undo` stops at the first failure so older entries are never
+skipped silently. The MCP adapter exposes the same engine as `undo_last_modification`
+(`steps`, `dryRun`) and `journal_list` (`limit`).
 
 ### Ops (Windows VM)
 

--- a/src/D365FO.Bridge/Handlers.cs
+++ b/src/D365FO.Bridge/Handlers.cs
@@ -50,15 +50,22 @@ namespace D365FO.Bridge
         /// Read an artefact and hand back its <b>raw XmlSerializer XML</b> (not the
         /// reflection-based JSON projection <see cref="AxSerializer"/> produces) —
         /// the byte-for-byte counterpart of the <c>xml</c> blob <see cref="UpdateObject"/>
-        /// accepts. Used by <c>d365fo modify method</c> (issue #112) to round-trip a
-        /// single method body through <c>IMetadataProvider</c> without ever touching
-        /// on-disk XML directly: read here, do a structured (XDocument-element)
-        /// replace of one &lt;Method&gt;'s &lt;Source&gt;, write back via
-        /// <see cref="UpdateObject"/>. The XML shape is whatever this process's
-        /// <see cref="XmlSerializer"/> produces for the live Ax* instance — it need
-        /// not match Visual Studio's on-disk formatting because it never reaches
-        /// disk itself; <see cref="MetadataBootstrap.SaveArtifact"/> re-serialises
-        /// through the provider on write, same as every other write path here.
+        /// accepts. Two consumers:
+        /// <list type="bullet">
+        /// <item><description><c>d365fo modify method</c> (issue #112) round-trips a single
+        /// method body through <c>IMetadataProvider</c> without ever touching on-disk XML
+        /// directly: read here, do a structured (XDocument-element) replace of one
+        /// &lt;Method&gt;'s &lt;Source&gt;, write back via <see cref="UpdateObject"/>.</description></item>
+        /// <item><description>The modification journal / <c>d365fo undo</c> (issue #113) calls
+        /// this before a bridge update/delete to capture the exact pre-image, so undo can
+        /// round-trip it straight back through <c>updateObject</c>/<c>createObject</c> — the
+        /// JSON shape from <c>readClass</c>/<c>readTable</c>/... is lossy for that purpose (it
+        /// is shaped for display, not for re-serialization).</description></item>
+        /// </list>
+        /// The XML shape is whatever this process's <see cref="XmlSerializer"/> produces for
+        /// the live Ax* instance — it need not match Visual Studio's on-disk formatting because
+        /// it never reaches disk itself; <see cref="MetadataBootstrap.SaveArtifact"/>
+        /// re-serialises through the provider on write, same as every other write path here.
         /// </summary>
         internal JsonObject ReadObjectXml(JsonObject args)
         {

--- a/src/D365FO.Cli/Commands/Agent/SchemaCommand.cs
+++ b/src/D365FO.Cli/Commands/Agent/SchemaCommand.cs
@@ -137,6 +137,8 @@ public sealed class SchemaCommand : Command<SchemaCommand.Settings>
         C("labels create", "Create or update a label entry.", ["<KEY>", "<VALUE>"], ["--file", "--overwrite", "--output"], ["labels (action=create)"], true),
         C("labels rename", "Rename a label key.", ["<OLD>", "<NEW>"], ["--file", "--overwrite", "--output"], ["labels (action=rename)"], true),
         C("labels delete", "Delete a label key.", ["<KEY>"], ["--file", "--output"], ["labels (action=delete)"], true),
+        C("undo", "Revert the last N modification-journal entries (create removed, update/delete restored to their exact pre-image).", [], ["--steps", "--dry-run", "--db", "--output"], ["undo_last_modification"], true),
+        C("journal list", "Inspect the modification-journal stack, most-recent-first.", [], ["--limit", "--db", "--output"], ["journal_list"], true),
 
         // Typed search/get commands (kind-specific) — all fold into the unified
         // `search` / `get_object_info` MCP tools via a `type`/`objectType` field.
@@ -211,6 +213,8 @@ public sealed class SchemaCommand : Command<SchemaCommand.Settings>
         C("generate duty", "Scaffold a security duty.", ["<NAME>"], ["--privilege", "--label", "--into-role", "--out", "--overwrite", "--install-to", "--output"], []),
         C("generate role", "Scaffold or merge a security role.", ["<NAME>"], ["--duty", "--privilege", "--label", "--description", "--add-to", "--out", "--overwrite", "--install-to", "--output"], []),
         C("generate report", "Scaffold AxReport and RDP skeleton.", ["<NAME>"], ["--dp", "--tmp", "--dataset", "--caption", "--field", "--parameter", "--extra-dataset", "--out-dp", "--out-contract", "--out", "--overwrite", "--install-to", "--output"], []),
+
+        C("delete", "Delete an AOT object (bridge or on-disk), journaled for `undo`.", [], ["--kind", "--name", "--install-to", "--path", "--model", "--output"], []),
 
         C("analyze completeness", "Cross-check workspace AOT XML against the index.", [], ["--workspace", "--output"], []),
         C("analyze integration", "Cross-check data entities for OData/DMF readiness.", [], ["--model", "--output"], ["analyze (mode=integration)"]),

--- a/src/D365FO.Cli/Commands/Generate/GenerateCommands.cs
+++ b/src/D365FO.Cli/Commands/Generate/GenerateCommands.cs
@@ -1,4 +1,5 @@
 using D365FO.Core;
+using D365FO.Core.Journal;
 using D365FO.Core.Scaffolding;
 using Spectre.Console.Cli;
 using D365FO.Cli.Commands.Get;
@@ -71,6 +72,35 @@ internal static class GenerateInstaller
         catch { return null; }
     }
 
+    /// <summary>
+    /// Best-effort modification-journal append (issue #113) for a bridge-mediated create.
+    /// Tombstone entry (no pre-image, since nothing existed before) — undo replays it by
+    /// calling the bridge's <c>deleteObject</c>. Never lets a journal failure fail the
+    /// create it is recording.
+    /// </summary>
+    private static void RecordBridgeCreate(string axKind, string name, string model)
+    {
+        try
+        {
+            ModificationJournal.ForIndex().Append(new JournalEntry(
+                Id: Guid.NewGuid().ToString("N"),
+                TimestampUtc: DateTimeOffset.UtcNow,
+                Command: $"generate {axKind} --install-to",
+                TargetType: JournalTargetType.AotObject,
+                Kind: axKind,
+                ObjectName: name,
+                SecondaryKey: null,
+                Model: model,
+                Operation: JournalOperation.Create,
+                WritePath: JournalWritePath.Bridge,
+                TargetPath: null,
+                PreImage: null,
+                IsTombstone: true,
+                RnrProjDelta: null));
+        }
+        catch { /* best-effort */ }
+    }
+
     internal enum InstallOutcome { CreatedViaApi, WriteScaffold, Failed }
 
     /// <summary>
@@ -88,7 +118,11 @@ internal static class GenerateInstaller
 
         // 1) Metadata-API path — canonical, consistent output.
         var (ok, err) = BridgeGate.TrySaveObject(axKind, name, model, xml);
-        if (ok) return (InstallOutcome.CreatedViaApi, null, null, warnings);
+        if (ok)
+        {
+            RecordBridgeCreate(axKind, name, model);
+            return (InstallOutcome.CreatedViaApi, null, null, warnings);
+        }
 
         // 2) Fallback — write the scaffold into the model folder if resolvable.
         var folder = BridgeGate.TryGetModelFolder(model);

--- a/src/D365FO.Cli/Commands/Generate/GenerateFormMethodCommands.cs
+++ b/src/D365FO.Cli/Commands/Generate/GenerateFormMethodCommands.cs
@@ -1,6 +1,7 @@
 using System.Xml.Linq;
 using D365FO.Cli.Commands.Get;
 using D365FO.Core;
+using D365FO.Core.Journal;
 using D365FO.Core.Scaffolding;
 using Spectre.Console.Cli;
 
@@ -101,6 +102,15 @@ internal static class FormMethodImpl
         var (formPath, resolveFail) = ResolveFormPath(kind, s.Form);
         if (resolveFail.HasValue) return resolveFail.Value;
 
+        // Captured BEFORE injection mutates the in-memory document — the exact pre-image
+        // the journal needs to restore on `d365fo undo` (issue #113).
+        string preImageXml;
+        try { preImageXml = System.IO.File.ReadAllText(formPath!); }
+        catch (Exception ex)
+        {
+            return RenderHelpers.Render(kind, ToolResult<object>.Fail(D365FoErrorCodes.SourceUnreadable, $"Failed to read form XML: {ex.Message}"));
+        }
+
         XDocument doc;
         try { doc = XDocument.Load(formPath!, LoadOptions.PreserveWhitespace); }
         catch (Exception ex)
@@ -190,6 +200,8 @@ internal static class FormMethodImpl
             if (!ok)
                 return RenderHelpers.Render(kind, ToolResult<object>.Fail("INSTALL_FAILED",
                     $"Could not update form '{formName}' in model '{s.InstallTo}' via the metadata bridge: {err}"));
+            RecordJournalUpdate("form", formName, s.InstallTo, JournalWritePath.Bridge, null, preImageXml,
+                $"generate {(target == FormMethodCatalog.Target.DataSource ? "datasource-method" : "control-method")} --install-to");
             return RenderHelpers.Render(kind, ToolResult<object>.Success(PayloadFor("bridge", null), warnings));
         }
 
@@ -201,6 +213,15 @@ internal static class FormMethodImpl
         catch (Exception ex)
         {
             return RenderHelpers.Render(kind, ToolResult<object>.Fail(D365FoErrorCodes.WriteFailed, ex.Message));
+        }
+
+        // Only journal a pre-image when the write landed on the SAME path we read from —
+        // `--out <other path>` is a copy-out, not a mutation of the source form, so there
+        // is nothing on the target path to restore an undo to.
+        if (string.Equals(System.IO.Path.GetFullPath(outPath), System.IO.Path.GetFullPath(formPath!), StringComparison.OrdinalIgnoreCase))
+        {
+            RecordJournalUpdate("form", formName, null, JournalWritePath.Disk, outPath, preImageXml,
+                $"generate {(target == FormMethodCatalog.Target.DataSource ? "datasource-method" : "control-method")}");
         }
 
         return RenderHelpers.Render(kind, ToolResult<object>.Success(PayloadFor("scaffold", outPath), warnings));
@@ -241,6 +262,36 @@ internal static class FormMethodImpl
             return (null, RenderHelpers.Render(kind, ToolResult<object>.Fail(D365FoErrorCodes.FormNotFound,
                 $"Could not resolve form '{form}' via the index: {ex.Message}. Pass a file path instead.")));
         }
+    }
+
+    /// <summary>
+    /// Best-effort modification-journal append (issue #113) for a datasource/control method
+    /// injection — always an Update (the form already existed), never lets a journal failure
+    /// fail the write it is recording.
+    /// </summary>
+    private static void RecordJournalUpdate(
+        string aotKind, string objectName, string? model, JournalWritePath writePath,
+        string? targetPath, string preImage, string command)
+    {
+        try
+        {
+            ModificationJournal.ForIndex().Append(new JournalEntry(
+                Id: Guid.NewGuid().ToString("N"),
+                TimestampUtc: DateTimeOffset.UtcNow,
+                Command: command,
+                TargetType: JournalTargetType.AotObject,
+                Kind: aotKind,
+                ObjectName: objectName,
+                SecondaryKey: null,
+                Model: model,
+                Operation: JournalOperation.Update,
+                WritePath: writePath,
+                TargetPath: targetPath,
+                PreImage: preImage,
+                IsTombstone: false,
+                RnrProjDelta: null));
+        }
+        catch { /* best-effort */ }
     }
 
     /// <summary>Write the document atomically (.tmp → move), keeping a .bak of any prior file.</summary>

--- a/src/D365FO.Cli/Commands/Get/BridgeGate.cs
+++ b/src/D365FO.Cli/Commands/Get/BridgeGate.cs
@@ -123,6 +123,73 @@ internal static class BridgeGate
     }
 
     /// <summary>
+    /// Delete an existing Ax* object in <paramref name="model"/> via the live metadata
+    /// provider (bridge <c>deleteObject</c>). Used by <c>d365fo delete</c> and, in reverse,
+    /// by <c>d365fo undo</c> to revert a bridge-mediated create (issue #113).
+    /// Returns (true, null) on success, (false, message) on any failure.
+    /// </summary>
+    internal static (bool ok, string? error) TryDeleteObject(string kind, string name, string model)
+    {
+        if (!BridgeClient.IsAvailable())
+        {
+            return (false, "bridge is not available (set D365FO_BRIDGE_ENABLED=1 and D365FO_BRIDGE_PATH).");
+        }
+
+        try
+        {
+            var options = DefaultOptions();
+            using var client = new BridgeClient(options);
+            var args = new JsonObject
+            {
+                ["kind"] = kind,
+                ["name"] = name,
+                ["model"] = model,
+            };
+
+            var result = client.SendAsync("deleteObject", args).GetAwaiter().GetResult();
+            if (result is null) return (false, "bridge returned no result");
+
+            var ok = (bool?)result["ok"] ?? false;
+            if (!ok)
+            {
+                var err = (string?)result["error"] ?? "UNKNOWN";
+                var msg = (string?)result["message"] ?? string.Empty;
+                return (false, err + ": " + msg);
+            }
+            return (true, null);
+        }
+        catch (BridgeException ex)
+        {
+            return (false, "bridge error: " + ex.Message);
+        }
+    }
+
+    /// <summary>
+    /// Read a live Ax* object back as raw XML via the bridge's <c>readObjectXml</c> — used to
+    /// capture an exact pre-image before a bridge delete so <c>d365fo undo</c> can recreate it
+    /// (issue #113). Returns null on any failure, including bridge unavailability.
+    /// </summary>
+    internal static string? TryReadObjectXml(string kind, string name)
+    {
+        if (!BridgeClient.IsAvailable()) return null;
+        try
+        {
+            var options = DefaultOptions();
+            using var client = new BridgeClient(options);
+            var result = client.SendAsync("readObjectXml", new JsonObject { ["kind"] = kind, ["name"] = name })
+                .GetAwaiter().GetResult();
+            if (result is null) return null;
+            var ok = (bool?)result["ok"] ?? false;
+            if (!ok) return null;
+            return (string?)result["xml"];
+        }
+        catch (BridgeException)
+        {
+            return null;
+        }
+    }
+
+    /// <summary>
     /// Query the DYNAMICSXREFDB for reverse references via the bridge.
     /// Returns the raw bridge JSON (tag _source already included by the
     /// bridge) or null on any failure — callers fall back to the regex

--- a/src/D365FO.Cli/Commands/Journal/DeleteObjectCommand.cs
+++ b/src/D365FO.Cli/Commands/Journal/DeleteObjectCommand.cs
@@ -1,0 +1,124 @@
+using D365FO.Cli.Commands.Get;
+using D365FO.Core;
+using D365FO.Core.Journal;
+using D365FO.Core.Scaffolding;
+using Spectre.Console.Cli;
+
+namespace D365FO.Cli.Commands.Journal;
+
+/// <summary>
+/// Delete an AOT object — either via the live metadata provider (bridge <c>deleteObject</c>,
+/// <c>--install-to</c>) or a direct on-disk file delete (<c>--path</c>). Added alongside the
+/// modification journal (issue #113) so the "delete → undo restores the file" acceptance
+/// criterion is reachable through the CLI, not just through the journal/undo engine's unit
+/// tests: both paths capture the exact pre-image before removing anything, so `d365fo undo`
+/// can recreate the object afterwards.
+/// </summary>
+public sealed class DeleteObjectCommand : Command<DeleteObjectCommand.Settings>
+{
+    public sealed class Settings : D365OutputSettings
+    {
+        [CommandOption("--kind <KIND>")]
+        [System.ComponentModel.Description("AOT kind: class | table | edt | enum | form.")]
+        public string Kind { get; init; } = "";
+
+        [CommandOption("--name <NAME>")]
+        [System.ComponentModel.Description("Object name.")]
+        public string Name { get; init; } = "";
+
+        [CommandOption("--install-to <MODEL>")]
+        [System.ComponentModel.Description("Delete via the metadata bridge (D365FO_BRIDGE_ENABLED=1). Mutually exclusive with --path.")]
+        public string? InstallTo { get; init; }
+
+        [CommandOption("--path <PATH>")]
+        [System.ComponentModel.Description("Delete the on-disk XML file directly at this path. Mutually exclusive with --install-to.")]
+        public string? Path { get; init; }
+
+        [CommandOption("--model <MODEL>")]
+        [System.ComponentModel.Description("Model name for --path deletes (used only for the optional .rnrproj bookkeeping delta; not required).")]
+        public string? Model { get; init; }
+    }
+
+    public override int Execute(CommandContext ctx, Settings settings)
+    {
+        var kind = OutputMode.Resolve(settings.Output);
+        if (string.IsNullOrWhiteSpace(settings.Kind))
+            return RenderHelpers.Render(kind, ToolResult<object>.Fail(D365FoErrorCodes.BadInput, "--kind <KIND> is required."));
+        if (string.IsNullOrWhiteSpace(settings.Name))
+            return RenderHelpers.Render(kind, ToolResult<object>.Fail(D365FoErrorCodes.BadInput, "--name <NAME> is required."));
+
+        var hasInstall = !string.IsNullOrWhiteSpace(settings.InstallTo);
+        var hasPath = !string.IsNullOrWhiteSpace(settings.Path);
+        if (hasInstall == hasPath)
+            return RenderHelpers.Render(kind, ToolResult<object>.Fail(D365FoErrorCodes.BadInput,
+                "Exactly one of --install-to <MODEL> or --path <PATH> is required."));
+
+        if (hasInstall)
+        {
+            var axKind = settings.Kind.Trim().ToLowerInvariant();
+            // Capture the exact pre-image BEFORE deleting so `d365fo undo` can recreate it.
+            var preImage = BridgeGate.TryReadObjectXml(axKind, settings.Name);
+            if (preImage is null)
+                return RenderHelpers.Render(kind, ToolResult<object>.Fail(D365FoErrorCodes.WriteFailed,
+                    $"Could not read '{settings.Name}' via the bridge before deleting — refusing to delete without a pre-image to undo with.",
+                    "Ensure D365FO_BRIDGE_ENABLED=1 and the object exists in the given model."));
+
+            var (ok, err) = BridgeGate.TryDeleteObject(axKind, settings.Name, settings.InstallTo!);
+            if (!ok)
+                return RenderHelpers.Render(kind, ToolResult<object>.Fail(D365FoErrorCodes.DeleteFailed,
+                    $"Could not delete {axKind} '{settings.Name}' in model '{settings.InstallTo}' via the metadata bridge: {err}"));
+
+            RecordBridgeDelete(axKind, settings.Name, settings.InstallTo!, preImage);
+            return RenderHelpers.Render(kind, ToolResult<object>.Success(new
+            {
+                kind = axKind,
+                name = settings.Name,
+                model = settings.InstallTo,
+                source = "bridge",
+            }, new List<string> { "Index not auto-refreshed — run `d365fo index refresh --model " + settings.InstallTo + "`." }));
+        }
+
+        try
+        {
+            var res = ScaffoldFileWriter.Delete(settings.Path!, settings.Model);
+            return RenderHelpers.Render(kind, ToolResult<object>.Success(new
+            {
+                kind = settings.Kind,
+                name = settings.Name,
+                path = res.Path,
+                source = "scaffold",
+            }, new List<string> { "Index not auto-refreshed — run `d365fo index refresh`." }));
+        }
+        catch (FileNotFoundException)
+        {
+            return RenderHelpers.Render(kind, ToolResult<object>.Fail(D365FoErrorCodes.SourceUnreadable, $"File not found: {settings.Path}"));
+        }
+        catch (Exception ex)
+        {
+            return RenderHelpers.Render(kind, ToolResult<object>.Fail(D365FoErrorCodes.DeleteFailed, ex.Message));
+        }
+    }
+
+    private static void RecordBridgeDelete(string axKind, string name, string model, string preImage)
+    {
+        try
+        {
+            ModificationJournal.ForIndex().Append(new JournalEntry(
+                Id: Guid.NewGuid().ToString("N"),
+                TimestampUtc: DateTimeOffset.UtcNow,
+                Command: "delete --install-to",
+                TargetType: JournalTargetType.AotObject,
+                Kind: axKind,
+                ObjectName: name,
+                SecondaryKey: null,
+                Model: model,
+                Operation: JournalOperation.Delete,
+                WritePath: JournalWritePath.Bridge,
+                TargetPath: null,
+                PreImage: preImage,
+                IsTombstone: false,
+                RnrProjDelta: null));
+        }
+        catch { /* best-effort */ }
+    }
+}

--- a/src/D365FO.Cli/Commands/Journal/JournalCommands.cs
+++ b/src/D365FO.Cli/Commands/Journal/JournalCommands.cs
@@ -1,0 +1,143 @@
+using D365FO.Core;
+using D365FO.Core.Journal;
+using Spectre.Console.Cli;
+
+namespace D365FO.Cli.Commands.Journal;
+
+/// <summary>
+/// <c>d365fo undo [--steps N] [--dry-run]</c> — revert the last N modification-journal
+/// entries, replaying each in reverse through the same write path (disk or bridge) that
+/// produced it (issue #113). Deterministic, single-command rollback for agent loops: a
+/// failed build/BP check can be undone without relying on <c>.bak</c> files or a clean git
+/// worktree over <c>PackagesLocalDirectory</c>.
+/// </summary>
+public sealed class UndoCommand : Command<UndoCommand.Settings>
+{
+    public sealed class Settings : D365OutputSettings
+    {
+        [CommandOption("--steps <N>")]
+        [System.ComponentModel.Description("Number of journal entries to revert, most-recent-first (default 1).")]
+        public int Steps { get; init; } = 1;
+
+        [CommandOption("--dry-run")]
+        [System.ComponentModel.Description("Preview what would be reverted without changing anything.")]
+        public bool DryRun { get; init; }
+
+        [CommandOption("--db <PATH>")]
+        public string? DatabasePath { get; init; }
+    }
+
+    public override int Execute(CommandContext ctx, Settings settings)
+    {
+        var kind = OutputMode.Resolve(settings.Output);
+        var journal = ModificationJournal.ForIndex(settings.DatabasePath);
+
+        if (journal.Count() == 0)
+            return RenderHelpers.Render(kind, ToolResult<object>.Fail(D365FoErrorCodes.JournalEmpty,
+                "The modification journal is empty — nothing to undo.",
+                "Every write from `generate`, `labels create|rename|delete`, and `delete` appends an entry here."));
+
+        var steps = settings.Steps <= 0 ? 1 : settings.Steps;
+        var result = UndoEngine.Undo(journal, steps, settings.DryRun);
+
+        var touchedModels = result.Steps
+            .Where(s => s.Ok && !string.IsNullOrWhiteSpace(s.Entry.Model))
+            .Select(s => s.Entry.Model!)
+            .Distinct(StringComparer.OrdinalIgnoreCase)
+            .ToList();
+
+        var warnings = new List<string>();
+        if (!settings.DryRun && touchedModels.Count > 0)
+            warnings.Add($"Index not auto-refreshed for {string.Join(", ", touchedModels)} — run `d365fo index refresh --model <MODEL>` (or without --model) so reverted objects are searchable again.");
+        foreach (var rnr in result.Steps.Where(s => s.RnrProjWarning is not null).Select(s => s.RnrProjWarning!))
+            warnings.Add(rnr);
+
+        var payload = new
+        {
+            dryRun = result.DryRun,
+            requestedSteps = steps,
+            reverted = result.Steps.Count(s => s.Ok),
+            steps = result.Steps.Select(s => new
+            {
+                id = s.Entry.Id,
+                timestampUtc = s.Entry.TimestampUtc,
+                command = s.Entry.Command,
+                targetType = s.Entry.TargetType.ToString(),
+                kind = s.Entry.Kind,
+                name = s.Entry.ObjectName,
+                model = s.Entry.Model,
+                operation = s.Entry.Operation.ToString(),
+                writePath = s.Entry.WritePath.ToString(),
+                target = s.Entry.TargetPath,
+                ok = s.Ok,
+                error = s.Error,
+                detail = s.Detail,
+            }),
+        };
+
+        if (!result.AllOk)
+        {
+            var failedStep = result.Steps.FirstOrDefault(s => !s.Ok);
+            return RenderHelpers.Render(kind, ToolResult<object>.Fail(D365FoErrorCodes.UndoFailed,
+                $"Undo stopped after {result.Steps.Count(s => s.Ok)} of {steps} step(s): {failedStep?.Error}",
+                "Earlier (older) journal entries were left untouched. Fix the underlying issue (e.g. bridge unavailable) and retry `d365fo undo`.")
+                with { Data = payload });
+        }
+
+        return RenderHelpers.Render(kind, ToolResult<object>.Success(payload, warnings.Count > 0 ? warnings : null));
+    }
+}
+
+/// <summary>
+/// <c>d365fo journal list [--limit N]</c> — inspect the modification-journal stack without
+/// reverting anything.
+/// </summary>
+public sealed class JournalListCommand : Command<JournalListCommand.Settings>
+{
+    public sealed class Settings : D365OutputSettings
+    {
+        [CommandOption("-n|--limit <N>")]
+        [System.ComponentModel.Description("Row cap, most-recent-first (default 50).")]
+        public int Limit { get; init; } = 50;
+
+        [CommandOption("--db <PATH>")]
+        public string? DatabasePath { get; init; }
+    }
+
+    public override int Execute(CommandContext ctx, Settings settings)
+    {
+        var kind = OutputMode.Resolve(settings.Output);
+        var journal = ModificationJournal.ForIndex(settings.DatabasePath);
+        var limit = settings.Limit <= 0 ? 50 : settings.Limit;
+        var entries = journal.List(limit);
+
+        return RenderHelpers.Render(kind, ToolResult<object>.Success(new
+        {
+            journalDirectory = journal.JournalDirectory,
+            count = entries.Count,
+            totalCount = journal.Count(),
+            entries = entries.Select(e => new
+            {
+                id = e.Id,
+                timestampUtc = e.TimestampUtc,
+                command = e.Command,
+                targetType = e.TargetType.ToString(),
+                kind = e.Kind,
+                name = e.ObjectName,
+                secondaryKey = e.SecondaryKey,
+                model = e.Model,
+                operation = e.Operation.ToString(),
+                writePath = e.WritePath.ToString(),
+                target = e.TargetPath,
+                hasPreImage = e.PreImage is not null,
+                isTombstone = e.IsTombstone,
+                rnrProjDelta = e.RnrProjDelta is null ? null : new
+                {
+                    e.RnrProjDelta.RnrProjPath,
+                    e.RnrProjDelta.Include,
+                    e.RnrProjDelta.WasAdded,
+                },
+            }),
+        }));
+    }
+}

--- a/src/D365FO.Cli/Commands/Label/LabelWriteCommands.cs
+++ b/src/D365FO.Cli/Commands/Label/LabelWriteCommands.cs
@@ -1,4 +1,5 @@
 using D365FO.Core;
+using D365FO.Core.Journal;
 using D365FO.Core.Labels;
 using Spectre.Console.Cli;
 
@@ -108,6 +109,7 @@ public sealed class LabelCreateCommand : Command<LabelCreateCommand.Settings>
                         "KEY_EXISTS",
                         $"Label '{settings.Key}' already exists in {file}. Pass --overwrite to replace.",
                         hint: $"Existing value: {res.OldValue}"));
+                LabelJournalRecorder.RecordCreateOrUpdate(res, "labels create");
                 results.Add(new
                 {
                     outcome = res.Outcome.ToString(),
@@ -187,6 +189,7 @@ public sealed class LabelRenameCommand : Command<LabelRenameCommand.Settings>
         try
         {
             var res = LabelFileWriter.Rename(settings.File!, settings.OldKey, settings.NewKey, settings.Overwrite);
+            LabelJournalRecorder.RecordRename(res, settings.OldKey, "labels rename");
             return res.Outcome switch
             {
                 WriteOutcome.FileMissing => RenderHelpers.Render(kind, ToolResult<object>.Fail("FILE_NOT_FOUND", $"Label file not found: {settings.File}")),
@@ -231,6 +234,7 @@ public sealed class LabelDeleteCommand : Command<LabelDeleteCommand.Settings>
         try
         {
             var res = LabelFileWriter.Delete(settings.File!, settings.Key);
+            LabelJournalRecorder.RecordDelete(res, "labels delete");
             return res.Outcome switch
             {
                 WriteOutcome.FileMissing => RenderHelpers.Render(kind, ToolResult<object>.Fail("FILE_NOT_FOUND", $"Label file not found: {settings.File}")),

--- a/src/D365FO.Cli/Program.cs
+++ b/src/D365FO.Cli/Program.cs
@@ -270,6 +270,15 @@ app.Configure(cfg =>
         b.AddCommand<DaemonWarmupCommand>("warmup").WithDescription("Pre-warm the SQLite page cache for faster first queries.");
     });
 
+    cfg.AddCommand<D365FO.Cli.Commands.Journal.UndoCommand>("undo").WithDescription("Revert the last N modification-journal entries (create removed, update/delete restored to their exact pre-image).");
+    cfg.AddCommand<D365FO.Cli.Commands.Journal.DeleteObjectCommand>("delete").WithDescription("Delete an AOT object (bridge or on-disk), journaled for `d365fo undo`.");
+
+    cfg.AddBranch("journal", b =>
+    {
+        b.SetDescription("Inspect the modification journal (issue #113).");
+        b.AddCommand<D365FO.Cli.Commands.Journal.JournalListCommand>("list").WithDescription("List journal entries, most-recent-first.");
+    });
+
     cfg.AddCommand<BuildCommand>("build").WithDescription("Invoke MSBuild (Windows VM).");
     cfg.AddCommand<SyncCommand>("sync").WithDescription("Run DB sync (Windows VM).");
     cfg.AddCommand<DoctorCommand>("doctor").WithDescription("Diagnose environment.");

--- a/src/D365FO.Core/D365FoErrorCodes.cs
+++ b/src/D365FO.Core/D365FoErrorCodes.cs
@@ -65,4 +65,10 @@ public static class D365FoErrorCodes
     public const string Unauthorized = "UNAUTHORIZED";
     public const string ModeNotAllowed = "MODE_NOT_ALLOWED";
     public const string RateLimited = "RATE_LIMITED";
+
+    // Modification journal / undo (issue #113)
+    public const string JournalEmpty = "JOURNAL_EMPTY";
+    public const string UndoFailed = "UNDO_FAILED";
+    public const string InstallFailed = "INSTALL_FAILED";
+    public const string DeleteFailed = "DELETE_FAILED";
 }

--- a/src/D365FO.Core/Journal/JournalEntry.cs
+++ b/src/D365FO.Core/Journal/JournalEntry.cs
@@ -1,0 +1,69 @@
+namespace D365FO.Core.Journal;
+
+/// <summary>The mutation a journal entry records.</summary>
+public enum JournalOperation
+{
+    /// <summary>A new object/label key was created. Pre-image is a tombstone (null) — undo deletes it.</summary>
+    Create,
+
+    /// <summary>An existing object/label value was overwritten in place. Pre-image is the exact prior bytes/value.</summary>
+    Update,
+
+    /// <summary>An object/label key was removed. Pre-image is the exact bytes/value that existed before removal.</summary>
+    Delete,
+
+    /// <summary>A label key was renamed in place (labels only — AOT objects have no rename primitive here).</summary>
+    Rename,
+}
+
+/// <summary>Which write path produced the entry — determines how <c>undo</c> replays it.</summary>
+public enum JournalWritePath
+{
+    /// <summary>Plain file I/O (<c>ScaffoldFileWriter</c> / <c>LabelFileWriter</c> / direct file delete).</summary>
+    Disk,
+
+    /// <summary>Round-tripped through <c>D365FO.Bridge</c>'s live <c>IMetadataProvider</c>.</summary>
+    Bridge,
+}
+
+/// <summary>What kind of artefact the entry targets — selects the replay engine.</summary>
+public enum JournalTargetType
+{
+    /// <summary>An AOT object (class/table/edt/enum/form/…), replayed via disk file I/O or the bridge.</summary>
+    AotObject,
+
+    /// <summary>A <c>*.label.txt</c> resource key, replayed via <see cref="D365FO.Core.Labels.LabelFileWriter"/>.</summary>
+    Label,
+}
+
+/// <summary>
+/// Best-effort <c>.rnrproj</c> (Visual Studio Dynamics project file) item-list delta captured
+/// alongside an on-disk create/delete. D365FO's build/sync tooling discovers AOT objects by
+/// directory convention, not by an explicit project item list, so most installs never touch a
+/// <c>.rnrproj</c> at all — this only fires when the model's project file already enumerates
+/// items explicitly (see <see cref="RnrProjRegistry"/>). <paramref name="WasAdded"/> records the
+/// direction of the change the original write made, so undo can invert it precisely:
+/// <c>true</c> = the write ADDED this item (a create) → undo must REMOVE it;
+/// <c>false</c> = the write REMOVED this item (a delete) → undo must RE-ADD it.
+/// </summary>
+public sealed record RnrProjDelta(string RnrProjPath, string ItemElementName, string Include, bool WasAdded);
+
+/// <summary>
+/// A single reversible write, captured by every write path that funnels through
+/// <c>ScaffoldFileWriter</c>, <c>LabelFileWriter</c>, or the bridge create/update/delete verbs.
+/// </summary>
+public sealed record JournalEntry(
+    string Id,
+    DateTimeOffset TimestampUtc,
+    string Command,
+    JournalTargetType TargetType,
+    string Kind,
+    string ObjectName,
+    string? SecondaryKey,
+    string? Model,
+    JournalOperation Operation,
+    JournalWritePath WritePath,
+    string? TargetPath,
+    string? PreImage,
+    bool IsTombstone,
+    RnrProjDelta? RnrProjDelta);

--- a/src/D365FO.Core/Journal/LabelJournalRecorder.cs
+++ b/src/D365FO.Core/Journal/LabelJournalRecorder.cs
@@ -1,0 +1,95 @@
+using D365FO.Core.Labels;
+
+namespace D365FO.Core.Journal;
+
+/// <summary>
+/// Best-effort modification-journal append for label writes (issue #113). Shared by both
+/// call sites that write through <see cref="LabelFileWriter"/> — the CLI's
+/// <c>LabelCreateCommand</c>/<c>LabelRenameCommand</c>/<c>LabelDeleteCommand</c> and the MCP
+/// <c>labels</c> tool's <c>CreateLabel</c>/<c>RenameLabel</c>/<c>DeleteLabel</c> handlers —
+/// so a write journaled from either surface is undo-able the same way. Never lets a journal
+/// failure fail the label write it is recording.
+/// </summary>
+public static class LabelJournalRecorder
+{
+    public static void RecordCreateOrUpdate(WriteResult res, string command)
+    {
+        try
+        {
+            JournalOperation? op = res.Outcome switch
+            {
+                WriteOutcome.Created => JournalOperation.Create,
+                WriteOutcome.Updated => JournalOperation.Update,
+                _ => null,
+            };
+            if (op is null) return; // KeyExists / NoChange / FileMissing / … — nothing was written
+
+            ModificationJournal.ForIndex().Append(new JournalEntry(
+                Id: Guid.NewGuid().ToString("N"),
+                TimestampUtc: DateTimeOffset.UtcNow,
+                Command: command,
+                TargetType: JournalTargetType.Label,
+                Kind: "label",
+                ObjectName: res.Key,
+                SecondaryKey: null,
+                Model: null,
+                Operation: op.Value,
+                WritePath: JournalWritePath.Disk,
+                TargetPath: res.Path,
+                PreImage: op == JournalOperation.Update ? res.OldValue : null,
+                IsTombstone: op == JournalOperation.Create,
+                RnrProjDelta: null));
+        }
+        catch { /* best-effort */ }
+    }
+
+    public static void RecordRename(WriteResult res, string oldKey, string command)
+    {
+        try
+        {
+            if (res.Outcome != WriteOutcome.Renamed) return;
+
+            ModificationJournal.ForIndex().Append(new JournalEntry(
+                Id: Guid.NewGuid().ToString("N"),
+                TimestampUtc: DateTimeOffset.UtcNow,
+                Command: command,
+                TargetType: JournalTargetType.Label,
+                Kind: "label",
+                ObjectName: res.Key, // new key
+                SecondaryKey: oldKey,
+                Model: null,
+                Operation: JournalOperation.Rename,
+                WritePath: JournalWritePath.Disk,
+                TargetPath: res.Path,
+                PreImage: null,
+                IsTombstone: false,
+                RnrProjDelta: null));
+        }
+        catch { /* best-effort */ }
+    }
+
+    public static void RecordDelete(WriteResult res, string command)
+    {
+        try
+        {
+            if (res.Outcome != WriteOutcome.Deleted) return;
+
+            ModificationJournal.ForIndex().Append(new JournalEntry(
+                Id: Guid.NewGuid().ToString("N"),
+                TimestampUtc: DateTimeOffset.UtcNow,
+                Command: command,
+                TargetType: JournalTargetType.Label,
+                Kind: "label",
+                ObjectName: res.Key,
+                SecondaryKey: null,
+                Model: null,
+                Operation: JournalOperation.Delete,
+                WritePath: JournalWritePath.Disk,
+                TargetPath: res.Path,
+                PreImage: res.OldValue,
+                IsTombstone: false,
+                RnrProjDelta: null));
+        }
+        catch { /* best-effort */ }
+    }
+}

--- a/src/D365FO.Core/Journal/ModificationJournal.cs
+++ b/src/D365FO.Core/Journal/ModificationJournal.cs
@@ -1,0 +1,183 @@
+using System.Text.Json;
+using System.Text.Json.Serialization;
+
+namespace D365FO.Core.Journal;
+
+/// <summary>
+/// File-backed FIFO journal of reversible writes, stored one JSON file per entry under
+/// <c>&lt;index-dir&gt;/journal/</c> (next to the SQLite index — see <see cref="ForIndex"/>).
+/// Filenames embed the UTC timestamp (<c>Ticks</c>, zero-padded) so lexical directory order is
+/// chronological order: the last file is the top of the undo stack. Size-capped — <see cref="Append"/>
+/// prunes the oldest entries (by filename order) once the directory exceeds <see cref="MaxBytes"/>
+/// or <see cref="MaxEntries"/>, mirroring <c>ProvenanceStore</c>'s file-per-record convention.
+/// </summary>
+public sealed class ModificationJournal
+{
+    /// <summary>Default cap: keep the journal directory under ~50 MB.</summary>
+    public const long DefaultMaxBytes = 50_000_000;
+
+    /// <summary>Default cap: keep at most this many entries regardless of size.</summary>
+    public const int DefaultMaxEntries = 500;
+
+    private static readonly JsonSerializerOptions StorageOptions = new(JsonSerializerDefaults.General)
+    {
+        WriteIndented = false,
+        Converters = { new JsonStringEnumConverter() },
+    };
+
+    public string JournalDirectory { get; }
+    public long MaxBytes { get; }
+    public int MaxEntries { get; }
+
+    public ModificationJournal(string journalDirectory, long maxBytes = DefaultMaxBytes, int maxEntries = DefaultMaxEntries)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(journalDirectory);
+        JournalDirectory = journalDirectory;
+        MaxBytes = maxBytes;
+        MaxEntries = maxEntries;
+    }
+
+    /// <summary>
+    /// Resolve the journal directory next to the active SQLite index
+    /// (<c>&lt;dirname(DatabasePath)&gt;/journal</c>), honouring the same
+    /// <c>--db</c>/<c>D365FO_INDEX_DB</c> override chain as <c>RepoFactory</c>-style
+    /// callers. Size/entry caps are overridable via <c>D365FO_JOURNAL_MAX_BYTES</c> /
+    /// <c>D365FO_JOURNAL_MAX_ENTRIES</c> for tests and unusually write-heavy sessions.
+    /// </summary>
+    public static ModificationJournal ForIndex(string? databasePathOverride = null)
+    {
+        var settings = D365FoSettings.FromEnvironment(databasePathOverride);
+        var dbDir = Path.GetDirectoryName(Path.GetFullPath(settings.DatabasePath));
+        var journalDir = Path.Combine(string.IsNullOrEmpty(dbDir) ? "." : dbDir, "journal");
+
+        var maxBytes = DefaultMaxBytes;
+        var maxBytesRaw = D365FoSettings.Resolve("D365FO_JOURNAL_MAX_BYTES");
+        if (!string.IsNullOrWhiteSpace(maxBytesRaw) && long.TryParse(maxBytesRaw, out var parsedBytes) && parsedBytes > 0)
+            maxBytes = parsedBytes;
+
+        var maxEntries = DefaultMaxEntries;
+        var maxEntriesRaw = D365FoSettings.Resolve("D365FO_JOURNAL_MAX_ENTRIES");
+        if (!string.IsNullOrWhiteSpace(maxEntriesRaw) && int.TryParse(maxEntriesRaw, out var parsedEntries) && parsedEntries > 0)
+            maxEntries = parsedEntries;
+
+        return new ModificationJournal(journalDir, maxBytes, maxEntries);
+    }
+
+    /// <summary>
+    /// Append a new entry (assigning <see cref="JournalEntry.Id"/>/<see cref="JournalEntry.TimestampUtc"/>
+    /// if not already set) and prune the oldest entries until the directory is back under both caps.
+    /// Best-effort by design — callers wrap this in try/catch so a journal failure never blocks the
+    /// underlying write it is trying to record.
+    /// </summary>
+    public JournalEntry Append(JournalEntry entry)
+    {
+        ArgumentNullException.ThrowIfNull(entry);
+        Directory.CreateDirectory(JournalDirectory);
+
+        var stamped = entry with
+        {
+            Id = string.IsNullOrWhiteSpace(entry.Id) ? Guid.NewGuid().ToString("N") : entry.Id,
+            TimestampUtc = entry.TimestampUtc == default ? DateTimeOffset.UtcNow : entry.TimestampUtc,
+        };
+
+        var path = PathFor(stamped);
+        var json = JsonSerializer.Serialize(stamped, StorageOptions);
+        var tmp = path + ".tmp";
+        File.WriteAllText(tmp, json);
+        File.Move(tmp, path, overwrite: true);
+
+        Prune();
+        return stamped;
+    }
+
+    /// <summary>
+    /// List entries, most-recent-first (top of the undo stack first). Corrupt/unreadable entry
+    /// files are silently skipped — a single bad file must not make the whole journal unusable.
+    /// </summary>
+    public IReadOnlyList<JournalEntry> List(int? limit = null)
+    {
+        if (!Directory.Exists(JournalDirectory)) return Array.Empty<JournalEntry>();
+
+        var files = Directory.EnumerateFiles(JournalDirectory, "*.json")
+            .OrderByDescending(f => f, StringComparer.Ordinal)
+            .ToList();
+
+        var results = new List<JournalEntry>(limit ?? files.Count);
+        foreach (var file in files)
+        {
+            if (limit.HasValue && results.Count >= limit.Value) break;
+            var entry = TryRead(file);
+            if (entry is not null) results.Add(entry);
+        }
+        return results;
+    }
+
+    /// <summary>The most recent entry, or null when the journal is empty.</summary>
+    public JournalEntry? Peek() => List(1).FirstOrDefault();
+
+    /// <summary>Remove an entry by id (called after a successful undo). No-op if already gone.</summary>
+    public bool Remove(string id)
+    {
+        if (!Directory.Exists(JournalDirectory)) return false;
+        foreach (var file in Directory.EnumerateFiles(JournalDirectory, "*.json"))
+        {
+            var entry = TryRead(file);
+            if (entry is not null && string.Equals(entry.Id, id, StringComparison.Ordinal))
+            {
+                try { File.Delete(file); return true; }
+                catch { return false; }
+            }
+        }
+        return false;
+    }
+
+    /// <summary>Total entry count currently on disk.</summary>
+    public int Count() => Directory.Exists(JournalDirectory)
+        ? Directory.EnumerateFiles(JournalDirectory, "*.json").Count()
+        : 0;
+
+    private string PathFor(JournalEntry entry)
+        => Path.Combine(JournalDirectory, $"{entry.TimestampUtc.UtcTicks:D19}_{entry.Id}.json");
+
+    private static JournalEntry? TryRead(string file)
+    {
+        try
+        {
+            var json = File.ReadAllText(file);
+            return JsonSerializer.Deserialize<JournalEntry>(json, StorageOptions);
+        }
+        catch
+        {
+            return null;
+        }
+    }
+
+    /// <summary>FIFO prune: delete the oldest files (ascending filename order) until under both caps.</summary>
+    private void Prune()
+    {
+        try
+        {
+            var files = Directory.EnumerateFiles(JournalDirectory, "*.json")
+                .Select(f => new FileInfo(f))
+                .OrderBy(f => f.Name, StringComparer.Ordinal)
+                .ToList();
+
+            long total = files.Sum(f => f.Length);
+            int count = files.Count;
+            int i = 0;
+            while (i < files.Count && (total > MaxBytes || count > MaxEntries))
+            {
+                var f = files[i];
+                try
+                {
+                    total -= f.Length;
+                    count--;
+                    f.Delete();
+                }
+                catch { /* best-effort */ }
+                i++;
+            }
+        }
+        catch { /* best-effort: pruning must never break Append */ }
+    }
+}

--- a/src/D365FO.Core/Journal/RnrProjRegistry.cs
+++ b/src/D365FO.Core/Journal/RnrProjRegistry.cs
@@ -1,0 +1,151 @@
+using System.Xml.Linq;
+
+namespace D365FO.Core.Journal;
+
+/// <summary>
+/// Best-effort synchronisation of a model's <c>.rnrproj</c> (Visual Studio "Dynamics 365 Project")
+/// item list with on-disk object create/delete. D365FO's build/sync/AOT tooling discovers objects
+/// by directory convention (<c>Ax&lt;Kind&gt;\&lt;Name&gt;.xml</c> under the model folder) — the
+/// <c>.rnrproj</c> file only drives what Visual Studio's Solution Explorer shows under the model's
+/// project node. Most headless/VM installs never have a project file with an explicit item list at
+/// all, so this is deliberately a no-op (returns null, no exception) whenever:
+/// <list type="bullet">
+///   <item><description>no <c>*.rnrproj</c> file exists next to the model folder, or</description></item>
+///   <item><description>the located project file has no <c>ItemGroup</c> with typed entries in the
+///   shape Visual Studio emits (<c>&lt;Compile Include="Ax&lt;Kind&gt;\&lt;Name&gt;.xml" /&gt;</c>).</description></item>
+/// </list>
+/// When a project file DOES enumerate items explicitly, a create adds the matching entry and a
+/// delete removes it — <see cref="JournalEntry.RnrProjDelta"/> records exactly what changed so
+/// <c>undo</c> can invert it via <see cref="Invert"/>.
+/// </summary>
+public static class RnrProjRegistry
+{
+    private const string ItemElementName = "Compile";
+
+    /// <summary>
+    /// Locate a <c>.rnrproj</c> for <paramref name="modelFolder"/> — checked in the folder itself
+    /// and its immediate parent, non-recursive, to keep the search bounded and side-effect free.
+    /// </summary>
+    public static string? FindRnrProj(string modelFolder)
+    {
+        if (string.IsNullOrWhiteSpace(modelFolder) || !Directory.Exists(modelFolder)) return null;
+        try
+        {
+            var here = Directory.EnumerateFiles(modelFolder, "*.rnrproj").FirstOrDefault();
+            if (here is not null) return here;
+
+            var parent = Directory.GetParent(modelFolder)?.FullName;
+            if (parent is not null && Directory.Exists(parent))
+                return Directory.EnumerateFiles(parent, "*.rnrproj").FirstOrDefault();
+        }
+        catch { /* best-effort */ }
+        return null;
+    }
+
+    /// <summary>
+    /// On object CREATE: if a <c>.rnrproj</c> with an explicit item list exists and does not
+    /// already reference <paramref name="axSubfolder"/>\<paramref name="objectName"/>.xml, add it.
+    /// Returns null (no-op) when no applicable project file was found or the entry already existed.
+    /// </summary>
+    public static RnrProjDelta? TryRegisterCreate(string modelFolder, string axSubfolder, string objectName)
+    {
+        var rnrproj = FindRnrProj(modelFolder);
+        if (rnrproj is null) return null;
+
+        var include = Path.Combine(axSubfolder, objectName + ".xml");
+        try
+        {
+            var doc = XDocument.Load(rnrproj, LoadOptions.PreserveWhitespace);
+            var ns = doc.Root?.Name.Namespace ?? XNamespace.None;
+            var itemGroups = doc.Root?.Elements(ns + "ItemGroup").ToList();
+            if (itemGroups is null || itemGroups.Count == 0) return null; // not an item-list-shaped project — leave alone
+
+            if (HasInclude(itemGroups, include)) return null; // already registered
+
+            itemGroups[0].Add(new XElement(ns + ItemElementName, new XAttribute("Include", include)));
+            doc.Save(rnrproj);
+            return new RnrProjDelta(rnrproj, ItemElementName, include, WasAdded: true);
+        }
+        catch
+        {
+            return null; // best-effort — never fail the underlying object write over this
+        }
+    }
+
+    /// <summary>
+    /// On object DELETE: if a <c>.rnrproj</c> with an explicit item list references
+    /// <paramref name="axSubfolder"/>\<paramref name="objectName"/>.xml, remove it.
+    /// Returns null (no-op) when no applicable project file was found or no entry existed.
+    /// </summary>
+    public static RnrProjDelta? TryRegisterDelete(string modelFolder, string axSubfolder, string objectName)
+    {
+        var rnrproj = FindRnrProj(modelFolder);
+        if (rnrproj is null) return null;
+
+        var include = Path.Combine(axSubfolder, objectName + ".xml");
+        try
+        {
+            var doc = XDocument.Load(rnrproj, LoadOptions.PreserveWhitespace);
+            var ns = doc.Root?.Name.Namespace ?? XNamespace.None;
+            var itemGroups = doc.Root?.Elements(ns + "ItemGroup").ToList();
+            if (itemGroups is null || itemGroups.Count == 0) return null;
+
+            var match = FindInclude(itemGroups, include);
+            if (match is null) return null; // nothing to remove
+
+            match.Remove();
+            doc.Save(rnrproj);
+            return new RnrProjDelta(rnrproj, ItemElementName, include, WasAdded: false);
+        }
+        catch
+        {
+            return null;
+        }
+    }
+
+    /// <summary>
+    /// Invert a previously-captured delta: undo of a create removes the entry it added; undo of a
+    /// delete re-adds the entry it removed. Best-effort — swallows all failures (surfaced by the
+    /// caller as a warning, never as an undo failure, since the object file itself is authoritative).
+    /// </summary>
+    public static bool Invert(RnrProjDelta delta)
+    {
+        try
+        {
+            if (!File.Exists(delta.RnrProjPath)) return false;
+            var doc = XDocument.Load(delta.RnrProjPath, LoadOptions.PreserveWhitespace);
+            var ns = doc.Root?.Name.Namespace ?? XNamespace.None;
+            var itemGroups = doc.Root?.Elements(ns + "ItemGroup").ToList();
+            if (itemGroups is null || itemGroups.Count == 0) return false;
+
+            if (delta.WasAdded)
+            {
+                // Original write ADDED the entry -> undo REMOVES it.
+                var match = FindInclude(itemGroups, delta.Include);
+                if (match is null) return false;
+                match.Remove();
+            }
+            else
+            {
+                // Original write REMOVED the entry -> undo RE-ADDS it.
+                if (HasInclude(itemGroups, delta.Include)) return true; // already present
+                itemGroups[0].Add(new XElement(ns + delta.ItemElementName, new XAttribute("Include", delta.Include)));
+            }
+
+            doc.Save(delta.RnrProjPath);
+            return true;
+        }
+        catch
+        {
+            return false;
+        }
+    }
+
+    private static bool HasInclude(IEnumerable<XElement> itemGroups, string include)
+        => FindInclude(itemGroups, include) is not null;
+
+    private static XElement? FindInclude(IEnumerable<XElement> itemGroups, string include)
+        => itemGroups.SelectMany(g => g.Elements())
+            .FirstOrDefault(e => string.Equals(
+                (string?)e.Attribute("Include"), include, StringComparison.OrdinalIgnoreCase));
+}

--- a/src/D365FO.Core/Journal/RnrProjRegistry.cs
+++ b/src/D365FO.Core/Journal/RnrProjRegistry.cs
@@ -52,7 +52,7 @@ public static class RnrProjRegistry
         var rnrproj = FindRnrProj(modelFolder);
         if (rnrproj is null) return null;
 
-        var include = Path.Combine(axSubfolder, objectName + ".xml");
+        var include = axSubfolder + "\\" + objectName + ".xml";
         try
         {
             var doc = XDocument.Load(rnrproj, LoadOptions.PreserveWhitespace);
@@ -82,7 +82,7 @@ public static class RnrProjRegistry
         var rnrproj = FindRnrProj(modelFolder);
         if (rnrproj is null) return null;
 
-        var include = Path.Combine(axSubfolder, objectName + ".xml");
+        var include = axSubfolder + "\\" + objectName + ".xml";
         try
         {
             var doc = XDocument.Load(rnrproj, LoadOptions.PreserveWhitespace);
@@ -144,8 +144,13 @@ public static class RnrProjRegistry
     private static bool HasInclude(IEnumerable<XElement> itemGroups, string include)
         => FindInclude(itemGroups, include) is not null;
 
+    // .rnrproj files are always Windows/Visual-Studio-authored (backslash-separated Include
+    // paths) regardless of which OS this CLI runs on — normalize both sides so a lookup for
+    // "AxTable\Foo.xml" matches an on-disk entry that (rarely) uses "AxTable/Foo.xml" or vice versa.
     private static XElement? FindInclude(IEnumerable<XElement> itemGroups, string include)
         => itemGroups.SelectMany(g => g.Elements())
             .FirstOrDefault(e => string.Equals(
-                (string?)e.Attribute("Include"), include, StringComparison.OrdinalIgnoreCase));
+                Normalize((string?)e.Attribute("Include")), Normalize(include), StringComparison.OrdinalIgnoreCase));
+
+    private static string? Normalize(string? path) => path?.Replace('/', '\\');
 }

--- a/src/D365FO.Core/Journal/UndoEngine.cs
+++ b/src/D365FO.Core/Journal/UndoEngine.cs
@@ -1,0 +1,304 @@
+using System.Text.Json.Nodes;
+using D365FO.Core.Bridge;
+using D365FO.Core.Labels;
+
+namespace D365FO.Core.Journal;
+
+/// <summary>
+/// Replays journal entries in reverse through the SAME write path that produced them — plain
+/// file I/O for <see cref="JournalWritePath.Disk"/>, the live <c>IMetadataProvider</c> (via
+/// <see cref="BridgeClient"/>) for <see cref="JournalWritePath.Bridge"/> — restoring the exact
+/// pre-image bytes/value captured at write time. This is the shared engine behind <c>d365fo undo</c>
+/// and the MCP <c>undo_last_modification</c> tool.
+/// </summary>
+public static class UndoEngine
+{
+    public sealed record UndoStepResult(JournalEntry Entry, bool Ok, string? Error, string? Detail, string? RnrProjWarning);
+
+    public sealed record UndoResult(IReadOnlyList<UndoStepResult> Steps, bool DryRun)
+    {
+        public bool AllOk => Steps.All(s => s.Ok);
+    }
+
+    /// <summary>
+    /// Undo the last <paramref name="steps"/> entries (most-recent-first). Stops at the first
+    /// failure so older entries are never skipped over silently — the journal stays a strict
+    /// stack. In <paramref name="dryRun"/> mode nothing is written or removed; each step is
+    /// previewed only.
+    /// </summary>
+    /// <param name="bridgeClientFactory">
+    /// Test seam: when supplied, its return value is used for every bridge-written entry
+    /// instead of spawning a real <c>D365FO.Bridge.exe</c> — the caller owns disposal (see
+    /// <c>BridgeClientTests.FakeBridge</c> for the in-memory stdio pattern this is meant to
+    /// plug into). When omitted, a real <see cref="BridgeClient"/> is created lazily on the
+    /// first bridge-written entry, reused for the rest of this call, and disposed at the end.
+    /// </param>
+    public static UndoResult Undo(
+        ModificationJournal journal,
+        int steps,
+        bool dryRun,
+        Func<BridgeClient>? bridgeClientFactory = null)
+    {
+        ArgumentNullException.ThrowIfNull(journal);
+        var entries = journal.List(Math.Max(1, steps));
+        var results = new List<UndoStepResult>(entries.Count);
+
+        BridgeClient? ownedClient = null;
+        try
+        {
+            foreach (var entry in entries)
+            {
+                if (dryRun)
+                {
+                    results.Add(new UndoStepResult(entry, true, null, Preview(entry), null));
+                    continue;
+                }
+
+                BridgeClient? bridgeClient = null;
+                if (entry.TargetType == JournalTargetType.AotObject && entry.WritePath == JournalWritePath.Bridge)
+                {
+                    if (bridgeClientFactory is not null)
+                    {
+                        bridgeClient = bridgeClientFactory();
+                    }
+                    else
+                    {
+                        ownedClient ??= new BridgeClient(DefaultBridgeOptions());
+                        bridgeClient = ownedClient;
+                    }
+                }
+
+                var (ok, error, detail, rnrWarn) = ReplayOne(entry, bridgeClient);
+                results.Add(new UndoStepResult(entry, ok, error, detail, rnrWarn));
+                if (ok)
+                {
+                    journal.Remove(entry.Id);
+                }
+                else
+                {
+                    break; // fail-fast — leave this and older entries in the journal
+                }
+            }
+        }
+        finally
+        {
+            ownedClient?.Dispose();
+        }
+
+        return new UndoResult(results, dryRun);
+    }
+
+    private static string Preview(JournalEntry e) => e.Operation switch
+    {
+        JournalOperation.Create => $"would delete {DisplayTarget(e)} (undo the create)",
+        JournalOperation.Update => $"would restore the pre-image of {DisplayTarget(e)}",
+        JournalOperation.Delete => $"would recreate {DisplayTarget(e)} from its pre-image",
+        JournalOperation.Rename => $"would rename '{e.ObjectName}' back to '{e.SecondaryKey}' in {e.TargetPath}",
+        _ => $"would revert {DisplayTarget(e)}",
+    };
+
+    private static string DisplayTarget(JournalEntry e)
+        => e.WritePath == JournalWritePath.Bridge
+            ? $"{e.Kind} '{e.ObjectName}' (model {e.Model})"
+            : e.TargetPath ?? $"{e.Kind} '{e.ObjectName}'";
+
+    private static (bool ok, string? error, string? detail, string? rnrWarn) ReplayOne(
+        JournalEntry entry, BridgeClient? bridgeClient)
+    {
+        try
+        {
+            return entry.TargetType switch
+            {
+                JournalTargetType.Label => ReplayLabel(entry),
+                JournalTargetType.AotObject => entry.WritePath switch
+                {
+                    JournalWritePath.Disk => ReplayDisk(entry),
+                    JournalWritePath.Bridge => ReplayBridge(entry, bridgeClient!),
+                    _ => (false, $"Unknown write path '{entry.WritePath}'.", null, null),
+                },
+                _ => (false, $"Unknown target type '{entry.TargetType}'.", null, null),
+            };
+        }
+        catch (Exception ex)
+        {
+            return (false, ex.Message, null, null);
+        }
+    }
+
+    // ---- disk replay (AOT objects) --------------------------------------
+
+    private static (bool, string?, string?, string?) ReplayDisk(JournalEntry entry)
+    {
+        if (string.IsNullOrWhiteSpace(entry.TargetPath))
+            return (false, "Journal entry has no target path.", null, null);
+
+        string? rnrWarn = null;
+        switch (entry.Operation)
+        {
+            case JournalOperation.Create:
+                if (File.Exists(entry.TargetPath))
+                {
+                    File.Delete(entry.TargetPath);
+                }
+                if (entry.RnrProjDelta is not null && !RnrProjRegistry.Invert(entry.RnrProjDelta))
+                    rnrWarn = $".rnrproj entry for '{entry.ObjectName}' could not be removed automatically — check {entry.RnrProjDelta.RnrProjPath}.";
+                return (true, null, $"deleted {entry.TargetPath}", rnrWarn);
+
+            case JournalOperation.Update:
+                if (entry.PreImage is null)
+                    return (false, "No pre-image recorded for this update — cannot restore exact bytes.", null, null);
+                AtomicWriteText(entry.TargetPath, entry.PreImage);
+                return (true, null, $"restored pre-image of {entry.TargetPath}", null);
+
+            case JournalOperation.Delete:
+                if (entry.PreImage is null)
+                    return (false, "No pre-image recorded for this delete — cannot restore the file.", null, null);
+                AtomicWriteText(entry.TargetPath, entry.PreImage);
+                if (entry.RnrProjDelta is not null && !RnrProjRegistry.Invert(entry.RnrProjDelta))
+                    rnrWarn = $".rnrproj entry for '{entry.ObjectName}' could not be restored automatically — check {entry.RnrProjDelta.RnrProjPath}.";
+                return (true, null, $"recreated {entry.TargetPath}", rnrWarn);
+
+            default:
+                return (false, $"Operation '{entry.Operation}' is not valid for an on-disk AOT object.", null, null);
+        }
+    }
+
+    private static void AtomicWriteText(string path, string content)
+    {
+        var full = Path.GetFullPath(path);
+        var dir = Path.GetDirectoryName(full);
+        if (!string.IsNullOrEmpty(dir)) Directory.CreateDirectory(dir);
+        var tmp = full + ".undo.tmp";
+        File.WriteAllText(tmp, content);
+        File.Move(tmp, full, overwrite: true);
+    }
+
+    // ---- bridge replay (AOT objects) -------------------------------------
+
+    private static (bool, string?, string?, string?) ReplayBridge(JournalEntry entry, BridgeClient client)
+    {
+        JsonObject? result;
+        string detail;
+        try
+        {
+            switch (entry.Operation)
+            {
+                case JournalOperation.Create:
+                    result = client.SendAsync("deleteObject", new JsonObject
+                    {
+                        ["kind"] = entry.Kind,
+                        ["name"] = entry.ObjectName,
+                        ["model"] = entry.Model,
+                    }).GetAwaiter().GetResult();
+                    detail = $"deleted {entry.Kind} '{entry.ObjectName}' via bridge";
+                    break;
+
+                case JournalOperation.Update:
+                    if (entry.PreImage is null)
+                        return (false, "No pre-image recorded for this update — cannot restore exact XML.", null, null);
+                    result = client.SendAsync("updateObject", new JsonObject
+                    {
+                        ["kind"] = entry.Kind,
+                        ["name"] = entry.ObjectName,
+                        ["model"] = entry.Model,
+                        ["xml"] = entry.PreImage,
+                    }).GetAwaiter().GetResult();
+                    detail = $"restored pre-image of {entry.Kind} '{entry.ObjectName}' via bridge";
+                    break;
+
+                case JournalOperation.Delete:
+                    if (entry.PreImage is null)
+                        return (false, "No pre-image recorded for this delete — cannot recreate the object.", null, null);
+                    result = client.SendAsync("createObject", new JsonObject
+                    {
+                        ["kind"] = entry.Kind,
+                        ["name"] = entry.ObjectName,
+                        ["model"] = entry.Model,
+                        ["xml"] = entry.PreImage,
+                    }).GetAwaiter().GetResult();
+                    detail = $"recreated {entry.Kind} '{entry.ObjectName}' via bridge";
+                    break;
+
+                default:
+                    return (false, $"Operation '{entry.Operation}' is not valid for a bridge-written AOT object.", null, null);
+            }
+        }
+        catch (BridgeException ex)
+        {
+            return (false, "Bridge error: " + ex.Message, null, null);
+        }
+
+        if (result is null)
+            return (false, "Bridge is not available (D365FO_BRIDGE_ENABLED / D365FO_BRIDGE_PATH) or returned no result.", null, null);
+        var ok = (bool?)result["ok"] ?? false;
+        if (!ok)
+        {
+            var code = (string?)result["error"] ?? "UNKNOWN";
+            var msg = (string?)result["message"] ?? string.Empty;
+            return (false, $"{code}: {msg}", null, null);
+        }
+        return (true, null, detail, null);
+    }
+
+    /// <summary>
+    /// Build <see cref="BridgeOptions"/> from the unified config resolver — duplicated (rather than
+    /// referencing <c>D365FO.Cli.Commands.Get.BridgeGate</c>) so this Core-level engine has no
+    /// dependency on the CLI project, matching the existing precedent in
+    /// <c>MethodModifyEngine.DefaultBridgeOptions</c>.
+    /// </summary>
+    public static BridgeOptions DefaultBridgeOptions() => new()
+    {
+        MetadataBinPath = D365FoSettings.Resolve("D365FO_BIN_PATH"),
+        PackagesPath = D365FoSettings.Resolve("D365FO_PACKAGES_PATH"),
+        CustomPackagesPaths = D365FoSettings.FromEnvironment().CustomPackagesPaths,
+        XrefConnectionString = D365FoSettings.Resolve("D365FO_XREF_CONNECTIONSTRING"),
+    };
+
+    // ---- label replay ------------------------------------------------------
+
+    private static (bool, string?, string?, string?) ReplayLabel(JournalEntry entry)
+    {
+        if (string.IsNullOrWhiteSpace(entry.TargetPath))
+            return (false, "Journal entry has no label file path.", null, null);
+
+        switch (entry.Operation)
+        {
+            case JournalOperation.Create:
+            {
+                var res = LabelFileWriter.Delete(entry.TargetPath, entry.ObjectName);
+                return res.Outcome is WriteOutcome.Deleted or WriteOutcome.KeyMissing
+                    ? (true, null, $"removed label '{entry.ObjectName}' from {entry.TargetPath}", null)
+                    : (false, $"Could not remove label '{entry.ObjectName}': {res.Outcome}", null, null);
+            }
+
+            case JournalOperation.Update:
+            {
+                if (entry.PreImage is null)
+                    return (false, "No pre-image recorded for this label update.", null, null);
+                LabelFileWriter.CreateOrUpdate(entry.TargetPath, entry.ObjectName, entry.PreImage, overwrite: true);
+                return (true, null, $"restored label '{entry.ObjectName}' in {entry.TargetPath}", null);
+            }
+
+            case JournalOperation.Delete:
+            {
+                if (entry.PreImage is null)
+                    return (false, "No pre-image recorded for this label delete.", null, null);
+                LabelFileWriter.CreateOrUpdate(entry.TargetPath, entry.ObjectName, entry.PreImage, overwrite: true);
+                return (true, null, $"recreated label '{entry.ObjectName}' in {entry.TargetPath}", null);
+            }
+
+            case JournalOperation.Rename:
+            {
+                if (string.IsNullOrWhiteSpace(entry.SecondaryKey))
+                    return (false, "No original key recorded for this rename.", null, null);
+                var res = LabelFileWriter.Rename(entry.TargetPath, entry.ObjectName, entry.SecondaryKey, overwrite: true);
+                return res.Outcome is WriteOutcome.Renamed or WriteOutcome.NoChange
+                    ? (true, null, $"renamed '{entry.ObjectName}' back to '{entry.SecondaryKey}' in {entry.TargetPath}", null)
+                    : (false, $"Could not rename '{entry.ObjectName}' back to '{entry.SecondaryKey}': {res.Outcome}", null, null);
+            }
+
+            default:
+                return (false, $"Operation '{entry.Operation}' is not valid for a label entry.", null, null);
+        }
+    }
+}

--- a/src/D365FO.Core/Scaffolding/XppScaffolder.cs
+++ b/src/D365FO.Core/Scaffolding/XppScaffolder.cs
@@ -1,6 +1,7 @@
 using System.Xml.Linq;
 using System.Xml;
 using D365FO.Core.Guardrails;
+using D365FO.Core.Journal;
 
 namespace D365FO.Core.Scaffolding;
 
@@ -1139,6 +1140,63 @@ public static class ScaffoldFileWriter
         return WriteCore(xml, path, overwrite, declarationOnSaveFromXDoc: false, null);
     }
 
+    public sealed record DeleteResult(string Path, string PreImage);
+
+    /// <summary>
+    /// Delete an on-disk AOT object file, capturing its exact pre-image bytes and journaling the
+    /// delete (best-effort) so <c>d365fo undo</c> can restore it. Counterpart to <c>Write</c>
+    /// for the disk write path's create/delete symmetry — see <see cref="D365FO.Core.Journal.UndoEngine"/>.
+    /// </summary>
+    public static DeleteResult Delete(string path, string? model = null)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(path);
+        var full = Path.GetFullPath(path);
+
+        var cfg = D365FoSettings.FromEnvironment();
+        PathGuard.EnsureWithinBoundary(full, new[] { cfg.PackagesPath, cfg.WorkspacePath }.Concat(cfg.CustomPackagesPaths).ToArray());
+
+        if (!File.Exists(full))
+            throw new FileNotFoundException($"Target does not exist: {full}", full);
+
+        var preImage = SafeReadAllText(full);
+        var (kind, objectName) = InferKindAndName(full);
+        var effectiveModel = model ?? InferModel(full);
+
+        RnrProjDelta? delta = null;
+        if (effectiveModel is not null)
+        {
+            var modelFolder = Path.GetDirectoryName(Path.GetDirectoryName(full));
+            var axSubfolder = Path.GetFileName(Path.GetDirectoryName(full));
+            if (!string.IsNullOrEmpty(modelFolder) && !string.IsNullOrEmpty(axSubfolder))
+                delta = RnrProjRegistry.TryRegisterDelete(modelFolder!, axSubfolder!, objectName);
+        }
+
+        File.Delete(full);
+
+        try
+        {
+            var entry = new JournalEntry(
+                Id: Guid.NewGuid().ToString("N"),
+                TimestampUtc: DateTimeOffset.UtcNow,
+                Command: "delete",
+                TargetType: JournalTargetType.AotObject,
+                Kind: kind,
+                ObjectName: objectName,
+                SecondaryKey: null,
+                Model: effectiveModel,
+                Operation: JournalOperation.Delete,
+                WritePath: JournalWritePath.Disk,
+                TargetPath: full,
+                PreImage: preImage,
+                IsTombstone: false,
+                RnrProjDelta: delta);
+            ModificationJournal.ForIndex().Append(entry);
+        }
+        catch { /* best-effort */ }
+
+        return new DeleteResult(full, preImage);
+    }
+
     private static void EnsureConcreteAxRoot(string? rootLocalName)
     {
         if (rootLocalName is not null && _abstractAxRoots.Contains(rootLocalName))
@@ -1200,6 +1258,11 @@ public static class ScaffoldFileWriter
         var dir = Path.GetDirectoryName(full);
         if (!string.IsNullOrEmpty(dir)) Directory.CreateDirectory(dir);
 
+        // Captured BEFORE any mutation so the journal entry holds the exact pre-image bytes —
+        // independent of the .bak file below, which the write path keeps for immediate manual
+        // recovery but is not itself part of the journal's reversible-write contract.
+        string? preImage = File.Exists(full) ? SafeReadAllText(full) : null;
+
         string? backup = null;
         if (File.Exists(full))
         {
@@ -1242,6 +1305,115 @@ public static class ScaffoldFileWriter
         }
 
         var bytes = new FileInfo(full).Length;
+        RecordJournalEntry(full, preImage);
         return new WriteResult(full, bytes, backup);
+    }
+
+    /// <summary>
+    /// Best-effort modification-journal append (issue #113) — never lets a journal failure
+    /// fail the write it is recording. Fires for EVERY caller of <see cref="Write(XDocument,string,bool)"/>
+    /// / <see cref="Write(string,string,bool)"/>: the CLI `generate *` commands, the MCP
+    /// `generate_object` tool, and any future disk-scaffold caller — this is the single choke
+    /// point the journal's "shared by every write path" design relies on for on-disk writes.
+    /// Kind/ObjectName/Model are inferred from the written XML and the D365FO packages layout
+    /// convention (&lt;root&gt;\&lt;Model&gt;\&lt;Model&gt;\Ax&lt;Kind&gt;\&lt;Name&gt;.xml) —
+    /// best-effort: when the path doesn't match that convention, Model is left null and the
+    /// entry is still recorded (disk replay only needs the path + pre-image, not the model).
+    /// </summary>
+    private static void RecordJournalEntry(string fullPath, string? preImage)
+    {
+        try
+        {
+            var (kind, objectName) = InferKindAndName(fullPath);
+            var model = InferModel(fullPath);
+            RnrProjDelta? delta = null;
+            if (preImage is null && model is not null)
+            {
+                var modelFolder = Path.GetDirectoryName(Path.GetDirectoryName(fullPath));
+                var axSubfolder = Path.GetFileName(Path.GetDirectoryName(fullPath));
+                if (!string.IsNullOrEmpty(modelFolder) && !string.IsNullOrEmpty(axSubfolder))
+                    delta = RnrProjRegistry.TryRegisterCreate(modelFolder!, axSubfolder!, objectName);
+            }
+
+            var entry = new JournalEntry(
+                Id: Guid.NewGuid().ToString("N"),
+                TimestampUtc: DateTimeOffset.UtcNow,
+                Command: "scaffold-write",
+                TargetType: JournalTargetType.AotObject,
+                Kind: kind,
+                ObjectName: objectName,
+                SecondaryKey: null,
+                Model: model,
+                Operation: preImage is null ? JournalOperation.Create : JournalOperation.Update,
+                WritePath: JournalWritePath.Disk,
+                TargetPath: fullPath,
+                PreImage: preImage,
+                IsTombstone: preImage is null,
+                RnrProjDelta: delta);
+
+            ModificationJournal.ForIndex().Append(entry);
+        }
+        catch
+        {
+            // Best-effort: the journal is a convenience, not a correctness requirement of the
+            // write itself. Never let it turn a successful scaffold write into a failure.
+        }
+    }
+
+    private static string SafeReadAllText(string path)
+    {
+        try { return File.ReadAllText(path); }
+        catch { return string.Empty; }
+    }
+
+    /// <summary>
+    /// Best-effort Kind/Name inference from the just-written XML: Kind from the root element's
+    /// local name (leading "Ax" stripped — purely descriptive, not the bridge kind vocabulary,
+    /// since disk-only journal entries never need to name a bridge collection), Name from the
+    /// root's child &lt;Name&gt; element (the universal AOT convention), falling back to the
+    /// file name when either is missing.
+    /// </summary>
+    private static (string kind, string objectName) InferKindAndName(string fullPath)
+    {
+        var fallbackName = Path.GetFileNameWithoutExtension(fullPath);
+        try
+        {
+            var root = XElement.Load(fullPath);
+            var localName = root.Name.LocalName;
+            var kind = localName.StartsWith("Ax", StringComparison.Ordinal) && localName.Length > 2
+                ? localName[2..]
+                : localName;
+            var name = root.Elements().FirstOrDefault(e => e.Name.LocalName == "Name")?.Value;
+            return (string.IsNullOrEmpty(kind) ? "object" : kind, string.IsNullOrWhiteSpace(name) ? fallbackName : name);
+        }
+        catch
+        {
+            return ("object", fallbackName);
+        }
+    }
+
+    /// <summary>
+    /// Best-effort Model inference from the D365FO packages layout convention
+    /// (&lt;root&gt;\&lt;Model&gt;\&lt;Model&gt;\Ax&lt;Kind&gt;\&lt;Name&gt;.xml — see
+    /// <c>GenerateInstaller.ResolveInstallPath</c>). Only trusts the inference when the two
+    /// model-name path segments actually match; otherwise returns null rather than guessing.
+    /// </summary>
+    private static string? InferModel(string fullPath)
+    {
+        try
+        {
+            var axSubfolderDir = Path.GetDirectoryName(fullPath); // .../<Model>/<Model>/Ax<Kind>
+            var modelDir = Path.GetDirectoryName(axSubfolderDir); // .../<Model>/<Model>
+            var modelParentDir = Path.GetDirectoryName(modelDir); // .../<Model>
+            var inner = modelDir is null ? null : Path.GetFileName(modelDir);
+            var outer = modelParentDir is null ? null : Path.GetFileName(modelParentDir);
+            return !string.IsNullOrEmpty(inner) && string.Equals(inner, outer, StringComparison.OrdinalIgnoreCase)
+                ? inner
+                : null;
+        }
+        catch
+        {
+            return null;
+        }
     }
 }

--- a/src/D365FO.Mcp/ToolCatalog.cs
+++ b/src/D365FO.Mcp/ToolCatalog.cs
@@ -35,7 +35,10 @@ public static class ToolCatalog
         // XML-only, but the whole tool is flagged write so clients confirm before
         // any write objectType runs). `labels` mixes read actions (search/info)
         // with write actions (create/rename/delete) — flagged here too.
-        "generate_object", "labels", "modify_method",
+        // `undo_last_modification` mutates the file system (or the live metadata
+        // provider) just like the write it reverts — flagged write even though its
+        // `dryRun` mode is read-only, since clients gate on the tool, not the call.
+        "generate_object", "labels", "modify_method", "undo_last_modification",
     };
 
     /// <summary>
@@ -426,6 +429,24 @@ public static class ToolCatalog
             "Recent ExtractionRuns telemetry (per-model timings). Returns newest first.",
             Schema(("limit", "integer", false), ("model", "string", false)),
             (h, p) => h.IndexHistory(Int(p, "limit", 50), Str(p, "model"))),
+
+        // ---- Modification journal / undo (issue #113) ----
+
+        new Descriptor("undo_last_modification",
+            "Revert the last `steps` writes (default 1) made by `generate_object` / `labels` (create/rename/delete) / " +
+            "`delete` — CLI parity for upstream `undo_last_modification`. Replays each entry in reverse through the " +
+            "SAME write path that produced it (on-disk file, or the live metadata provider when the bridge was used), " +
+            "restoring the exact pre-image: a create is removed, an update/delete is restored byte-for-byte. Stops at " +
+            "the first failure so older entries are never skipped. Pass `dryRun=true` to preview without changing " +
+            "anything — always do this first when unsure what will be reverted.",
+            Schema(("steps", "integer", false), ("dryRun", "boolean", false)),
+            (h, p) => h.UndoLastModification(Int(p, "steps", 1), Bool(p, "dryRun"))),
+
+        new Descriptor("journal_list",
+            "Inspect the modification-journal stack (most-recent-first) without reverting anything — " +
+            "see what `undo_last_modification` would act on.",
+            Schema(("limit", "integer", false)),
+            (h, p) => h.JournalList(Int(p, "limit", 50))),
     };
 
     // ---- JSON helpers ----

--- a/src/D365FO.Mcp/ToolHandlers.cs
+++ b/src/D365FO.Mcp/ToolHandlers.cs
@@ -501,6 +501,7 @@ public sealed class ToolHandlers
                 return ToolResult<object>.Fail("KEY_EXISTS",
                     $"Label '{key}' already exists; pass overwrite=true to replace.",
                     hint: $"Existing value: {res.OldValue}");
+            D365FO.Core.Journal.LabelJournalRecorder.RecordCreateOrUpdate(res, "labels(create)");
             return ToolResult<object>.Success(new
             {
                 outcome = res.Outcome.ToString(),
@@ -557,6 +558,7 @@ public sealed class ToolHandlers
         try
         {
             var res = D365FO.Core.Labels.LabelFileWriter.Rename(file, oldKey, newKey, overwrite);
+            D365FO.Core.Journal.LabelJournalRecorder.RecordRename(res, oldKey, "labels(rename)");
             return res.Outcome switch
             {
                 D365FO.Core.Labels.WriteOutcome.FileMissing => ToolResult<object>.Fail("FILE_NOT_FOUND", $"Label file not found: {file}"),
@@ -585,6 +587,7 @@ public sealed class ToolHandlers
         try
         {
             var res = D365FO.Core.Labels.LabelFileWriter.Delete(file, key);
+            D365FO.Core.Journal.LabelJournalRecorder.RecordDelete(res, "labels(delete)");
             return res.Outcome switch
             {
                 D365FO.Core.Labels.WriteOutcome.FileMissing => ToolResult<object>.Fail("FILE_NOT_FOUND", $"Label file not found: {file}"),
@@ -602,6 +605,99 @@ public sealed class ToolHandlers
         {
             return ToolResult<object>.Fail(D365FoErrorCodes.WriteFailed, ex.Message);
         }
+    }
+
+    // ---- modification journal / undo (issue #113) ----------------------
+
+    /// <summary>
+    /// MCP parity for upstream <c>undo_last_modification</c>: revert the last
+    /// <paramref name="steps"/> journal entries, replaying each in reverse through the same
+    /// write path (disk or bridge) that produced it. See <c>d365fo undo</c> /
+    /// <see cref="D365FO.Core.Journal.UndoEngine"/>.
+    /// </summary>
+    public ToolResult<object> UndoLastModification(int steps, bool dryRun)
+    {
+        var journal = D365FO.Core.Journal.ModificationJournal.ForIndex();
+        if (journal.Count() == 0)
+            return ToolResult<object>.Fail(D365FoErrorCodes.JournalEmpty,
+                "The modification journal is empty — nothing to undo.",
+                "Every write from `generate_object` and `labels` (create/rename/delete) appends an entry here.");
+
+        var effectiveSteps = steps <= 0 ? 1 : steps;
+        var result = D365FO.Core.Journal.UndoEngine.Undo(journal, effectiveSteps, dryRun);
+
+        var touchedModels = result.Steps
+            .Where(s => s.Ok && !string.IsNullOrWhiteSpace(s.Entry.Model))
+            .Select(s => s.Entry.Model!)
+            .Distinct(StringComparer.OrdinalIgnoreCase)
+            .ToList();
+        var warnings = new List<string>();
+        if (!dryRun && touchedModels.Count > 0)
+            warnings.Add($"Index not auto-refreshed for {string.Join(", ", touchedModels)} — run `update_symbol_index` so reverted objects are searchable again.");
+        foreach (var rnr in result.Steps.Where(s => s.RnrProjWarning is not null).Select(s => s.RnrProjWarning!))
+            warnings.Add(rnr);
+
+        var payload = new
+        {
+            dryRun = result.DryRun,
+            requestedSteps = effectiveSteps,
+            reverted = result.Steps.Count(s => s.Ok),
+            steps = result.Steps.Select(s => new
+            {
+                id = s.Entry.Id,
+                timestampUtc = s.Entry.TimestampUtc,
+                command = s.Entry.Command,
+                targetType = s.Entry.TargetType.ToString(),
+                kind = s.Entry.Kind,
+                name = s.Entry.ObjectName,
+                model = s.Entry.Model,
+                operation = s.Entry.Operation.ToString(),
+                writePath = s.Entry.WritePath.ToString(),
+                target = s.Entry.TargetPath,
+                ok = s.Ok,
+                error = s.Error,
+                detail = s.Detail,
+            }),
+        };
+
+        if (!result.AllOk)
+        {
+            var failedStep = result.Steps.FirstOrDefault(s => !s.Ok);
+            return ToolResult<object>.Fail(D365FoErrorCodes.UndoFailed,
+                    $"Undo stopped after {result.Steps.Count(s => s.Ok)} of {effectiveSteps} step(s): {failedStep?.Error}",
+                    "Earlier (older) journal entries were left untouched.")
+                with { Data = payload };
+        }
+
+        return ToolResult<object>.Success(payload, warnings.Count > 0 ? warnings : null);
+    }
+
+    /// <summary>Inspect the modification-journal stack without reverting anything.</summary>
+    public ToolResult<object> JournalList(int limit)
+    {
+        var journal = D365FO.Core.Journal.ModificationJournal.ForIndex();
+        var effectiveLimit = limit <= 0 ? 50 : limit;
+        var entries = journal.List(effectiveLimit);
+        return ToolResult<object>.Success(new
+        {
+            journalDirectory = journal.JournalDirectory,
+            count = entries.Count,
+            totalCount = journal.Count(),
+            entries = entries.Select(e => new
+            {
+                id = e.Id,
+                timestampUtc = e.TimestampUtc,
+                command = e.Command,
+                targetType = e.TargetType.ToString(),
+                kind = e.Kind,
+                name = e.ObjectName,
+                model = e.Model,
+                operation = e.Operation.ToString(),
+                writePath = e.WritePath.ToString(),
+                target = e.TargetPath,
+                hasPreImage = e.PreImage is not null,
+            }),
+        });
     }
 
     public ToolResult<object> IndexHistory(int limit, string? model)

--- a/tests/D365FO.Core.Tests/ExtractPipelineTests.cs
+++ b/tests/D365FO.Core.Tests/ExtractPipelineTests.cs
@@ -6,6 +6,10 @@ using Xunit;
 
 namespace D365FO.Core.Tests;
 
+// Shares a collection with ScaffoldFileWriterJournalTests: both call ScaffoldFileWriter.Write,
+// which (issue #113) journals via the process-wide D365FO_INDEX_DB env var that the journal
+// test overrides — running them in parallel would race on that global state.
+[Collection("ScaffoldFileWriter")]
 public class ExtractPipelineTests : IDisposable
 {
     private readonly string _dbPath = Path.Combine(Path.GetTempPath(), $"d365fo-extract-{Guid.NewGuid():N}.sqlite");

--- a/tests/D365FO.Core.Tests/ModificationJournalTests.cs
+++ b/tests/D365FO.Core.Tests/ModificationJournalTests.cs
@@ -1,0 +1,170 @@
+using D365FO.Core.Journal;
+using Xunit;
+
+namespace D365FO.Core.Tests;
+
+public sealed class ModificationJournalTests : IDisposable
+{
+    private readonly string _dir = Path.Combine(Path.GetTempPath(), $"journal-{Guid.NewGuid():N}");
+
+    public void Dispose()
+    {
+        try { Directory.Delete(_dir, recursive: true); } catch { }
+    }
+
+    private static JournalEntry Entry(string name, DateTimeOffset? ts = null) => new(
+        Id: Guid.NewGuid().ToString("N"),
+        TimestampUtc: ts ?? DateTimeOffset.UtcNow,
+        Command: "generate table",
+        TargetType: JournalTargetType.AotObject,
+        Kind: "table",
+        ObjectName: name,
+        SecondaryKey: null,
+        Model: "MyModel",
+        Operation: JournalOperation.Create,
+        WritePath: JournalWritePath.Disk,
+        TargetPath: $@"C:\pkg\MyModel\MyModel\AxTable\{name}.xml",
+        PreImage: null,
+        IsTombstone: true,
+        RnrProjDelta: null);
+
+    [Fact]
+    public void Append_then_List_returns_most_recent_first()
+    {
+        var journal = new ModificationJournal(_dir);
+        var now = DateTimeOffset.UtcNow;
+        journal.Append(Entry("First", now));
+        journal.Append(Entry("Second", now.AddMilliseconds(10)));
+        journal.Append(Entry("Third", now.AddMilliseconds(20)));
+
+        var list = journal.List();
+
+        Assert.Equal(3, list.Count);
+        Assert.Equal("Third", list[0].ObjectName);
+        Assert.Equal("Second", list[1].ObjectName);
+        Assert.Equal("First", list[2].ObjectName);
+    }
+
+    [Fact]
+    public void List_honours_limit()
+    {
+        var journal = new ModificationJournal(_dir);
+        for (var i = 0; i < 5; i++)
+            journal.Append(Entry($"T{i}", DateTimeOffset.UtcNow.AddMilliseconds(i)));
+
+        var list = journal.List(2);
+
+        Assert.Equal(2, list.Count);
+        Assert.Equal("T4", list[0].ObjectName);
+        Assert.Equal("T3", list[1].ObjectName);
+    }
+
+    [Fact]
+    public void Peek_returns_the_most_recent_entry_or_null_when_empty()
+    {
+        var journal = new ModificationJournal(_dir);
+        Assert.Null(journal.Peek());
+
+        journal.Append(Entry("Only"));
+        Assert.Equal("Only", journal.Peek()!.ObjectName);
+    }
+
+    [Fact]
+    public void Remove_deletes_the_entry_and_is_idempotent()
+    {
+        var journal = new ModificationJournal(_dir);
+        var appended = journal.Append(Entry("Gone"));
+
+        Assert.True(journal.Remove(appended.Id));
+        Assert.Empty(journal.List());
+        Assert.False(journal.Remove(appended.Id)); // already gone
+    }
+
+    [Fact]
+    public void Append_roundtrips_all_fields_including_preimage_and_rnrproj_delta()
+    {
+        var journal = new ModificationJournal(_dir);
+        var delta = new RnrProjDelta(@"C:\pkg\MyModel\MyModel.rnrproj", "Compile", @"AxTable\Foo.xml", WasAdded: true);
+        var entry = new JournalEntry(
+            Id: Guid.NewGuid().ToString("N"),
+            TimestampUtc: DateTimeOffset.UtcNow,
+            Command: "generate table",
+            TargetType: JournalTargetType.AotObject,
+            Kind: "table",
+            ObjectName: "Foo",
+            SecondaryKey: null,
+            Model: "MyModel",
+            Operation: JournalOperation.Update,
+            WritePath: JournalWritePath.Disk,
+            TargetPath: @"C:\pkg\MyModel\MyModel\AxTable\Foo.xml",
+            PreImage: "<AxTable><Name>Foo</Name></AxTable>",
+            IsTombstone: false,
+            RnrProjDelta: delta);
+
+        journal.Append(entry);
+        var read = Assert.Single(journal.List());
+
+        Assert.Equal(entry.ObjectName, read.ObjectName);
+        Assert.Equal(entry.PreImage, read.PreImage);
+        Assert.Equal(entry.Operation, read.Operation);
+        Assert.Equal(entry.WritePath, read.WritePath);
+        Assert.NotNull(read.RnrProjDelta);
+        Assert.Equal(delta.Include, read.RnrProjDelta!.Include);
+        Assert.True(read.RnrProjDelta.WasAdded);
+    }
+
+    [Fact]
+    public void FIFO_pruning_by_max_entries_drops_the_oldest_first()
+    {
+        var journal = new ModificationJournal(_dir, maxBytes: long.MaxValue, maxEntries: 3);
+        for (var i = 0; i < 5; i++)
+            journal.Append(Entry($"T{i}", DateTimeOffset.UtcNow.AddMilliseconds(i)));
+
+        var list = journal.List();
+
+        Assert.Equal(3, list.Count);
+        // Newest three survive; T0 and T1 were pruned.
+        Assert.Equal(new[] { "T4", "T3", "T2" }, list.Select(e => e.ObjectName));
+    }
+
+    [Fact]
+    public void FIFO_pruning_by_max_bytes_drops_the_oldest_first()
+    {
+        // Each entry's JSON is comfortably a few hundred bytes; cap tight enough that
+        // pruning must kick in well before 20 entries accumulate.
+        var journal = new ModificationJournal(_dir, maxBytes: 800, maxEntries: int.MaxValue);
+        for (var i = 0; i < 20; i++)
+            journal.Append(Entry($"T{i:D2}", DateTimeOffset.UtcNow.AddMilliseconds(i)));
+
+        var list = journal.List();
+
+        Assert.True(list.Count < 20, "expected size-based pruning to have removed older entries");
+        Assert.Equal("T19", list[0].ObjectName); // the newest entry always survives
+        var totalBytes = Directory.EnumerateFiles(_dir, "*.json").Sum(f => new FileInfo(f).Length);
+        Assert.True(totalBytes <= 800 + 512, $"journal directory grew past the cap: {totalBytes} bytes");
+    }
+
+    [Fact]
+    public void Corrupt_entry_file_is_skipped_not_thrown()
+    {
+        var journal = new ModificationJournal(_dir);
+        journal.Append(Entry("Good"));
+        Directory.CreateDirectory(_dir);
+        File.WriteAllText(Path.Combine(_dir, "0000000000000000001_corrupt.json"), "{ not valid json");
+
+        var list = journal.List();
+
+        Assert.Single(list);
+        Assert.Equal("Good", list[0].ObjectName);
+    }
+
+    [Fact]
+    public void Count_reflects_entries_on_disk()
+    {
+        var journal = new ModificationJournal(_dir);
+        Assert.Equal(0, journal.Count());
+        journal.Append(Entry("A"));
+        journal.Append(Entry("B"));
+        Assert.Equal(2, journal.Count());
+    }
+}

--- a/tests/D365FO.Core.Tests/RnrProjRegistryTests.cs
+++ b/tests/D365FO.Core.Tests/RnrProjRegistryTests.cs
@@ -30,7 +30,9 @@ public sealed class RnrProjRegistryTests : IDisposable
 
         Assert.NotNull(delta);
         Assert.True(delta!.WasAdded);
-        Assert.Equal(Path.Combine("AxTable", "NewTable.xml"), delta.Include);
+        // .rnrproj Include paths are always Windows/Visual-Studio-style (backslash), regardless
+        // of the host OS this test runs on — not Path.Combine, which would use '/' on Linux/macOS.
+        Assert.Equal(@"AxTable\NewTable.xml", delta.Include);
         var xml = File.ReadAllText(rnrproj);
         Assert.Contains("NewTable.xml", xml);
         Assert.Contains("Existing.xml", xml); // pre-existing entry untouched

--- a/tests/D365FO.Core.Tests/RnrProjRegistryTests.cs
+++ b/tests/D365FO.Core.Tests/RnrProjRegistryTests.cs
@@ -1,0 +1,123 @@
+using D365FO.Core.Journal;
+using Xunit;
+
+namespace D365FO.Core.Tests;
+
+public sealed class RnrProjRegistryTests : IDisposable
+{
+    private readonly string _dir = Path.Combine(Path.GetTempPath(), $"rnrproj-{Guid.NewGuid():N}");
+
+    public RnrProjRegistryTests() => Directory.CreateDirectory(_dir);
+
+    public void Dispose()
+    {
+        try { Directory.Delete(_dir, recursive: true); } catch { }
+    }
+
+    private const string ProjectXml =
+        "<Project xmlns=\"http://schemas.microsoft.com/developer/msbuild/2003\">" +
+        "<ItemGroup><Compile Include=\"AxTable\\Existing.xml\" /></ItemGroup></Project>";
+
+    [Fact]
+    public void TryRegisterCreate_adds_an_entry_when_project_file_has_an_item_list()
+    {
+        var modelFolder = Path.Combine(_dir, "MyModel", "MyModel");
+        Directory.CreateDirectory(modelFolder);
+        var rnrproj = Path.Combine(modelFolder, "MyModel.rnrproj");
+        File.WriteAllText(rnrproj, ProjectXml);
+
+        var delta = RnrProjRegistry.TryRegisterCreate(modelFolder, "AxTable", "NewTable");
+
+        Assert.NotNull(delta);
+        Assert.True(delta!.WasAdded);
+        Assert.Equal(Path.Combine("AxTable", "NewTable.xml"), delta.Include);
+        var xml = File.ReadAllText(rnrproj);
+        Assert.Contains("NewTable.xml", xml);
+        Assert.Contains("Existing.xml", xml); // pre-existing entry untouched
+    }
+
+    [Fact]
+    public void TryRegisterCreate_is_a_noop_when_entry_already_exists()
+    {
+        var modelFolder = Path.Combine(_dir, "MyModel", "MyModel");
+        Directory.CreateDirectory(modelFolder);
+        var rnrproj = Path.Combine(modelFolder, "MyModel.rnrproj");
+        File.WriteAllText(rnrproj, ProjectXml);
+
+        var delta = RnrProjRegistry.TryRegisterCreate(modelFolder, "AxTable", "Existing");
+
+        Assert.Null(delta);
+    }
+
+    [Fact]
+    public void TryRegisterCreate_is_a_noop_when_no_rnrproj_exists()
+    {
+        var modelFolder = Path.Combine(_dir, "Headless", "Headless");
+        Directory.CreateDirectory(modelFolder);
+
+        var delta = RnrProjRegistry.TryRegisterCreate(modelFolder, "AxTable", "NewTable");
+
+        Assert.Null(delta);
+    }
+
+    [Fact]
+    public void TryRegisterDelete_removes_an_existing_entry()
+    {
+        var modelFolder = Path.Combine(_dir, "MyModel", "MyModel");
+        Directory.CreateDirectory(modelFolder);
+        var rnrproj = Path.Combine(modelFolder, "MyModel.rnrproj");
+        File.WriteAllText(rnrproj, ProjectXml);
+
+        var delta = RnrProjRegistry.TryRegisterDelete(modelFolder, "AxTable", "Existing");
+
+        Assert.NotNull(delta);
+        Assert.False(delta!.WasAdded);
+        var xml = File.ReadAllText(rnrproj);
+        Assert.DoesNotContain("Existing.xml", xml);
+    }
+
+    [Fact]
+    public void Invert_of_a_create_delta_removes_the_entry_it_added()
+    {
+        var modelFolder = Path.Combine(_dir, "MyModel", "MyModel");
+        Directory.CreateDirectory(modelFolder);
+        var rnrproj = Path.Combine(modelFolder, "MyModel.rnrproj");
+        File.WriteAllText(rnrproj, ProjectXml);
+
+        var delta = RnrProjRegistry.TryRegisterCreate(modelFolder, "AxTable", "NewTable");
+        Assert.NotNull(delta);
+        Assert.Contains("NewTable.xml", File.ReadAllText(rnrproj));
+
+        Assert.True(RnrProjRegistry.Invert(delta!));
+        Assert.DoesNotContain("NewTable.xml", File.ReadAllText(rnrproj));
+    }
+
+    [Fact]
+    public void Invert_of_a_delete_delta_re_adds_the_entry_it_removed()
+    {
+        var modelFolder = Path.Combine(_dir, "MyModel", "MyModel");
+        Directory.CreateDirectory(modelFolder);
+        var rnrproj = Path.Combine(modelFolder, "MyModel.rnrproj");
+        File.WriteAllText(rnrproj, ProjectXml);
+
+        var delta = RnrProjRegistry.TryRegisterDelete(modelFolder, "AxTable", "Existing");
+        Assert.NotNull(delta);
+        Assert.DoesNotContain("Existing.xml", File.ReadAllText(rnrproj));
+
+        Assert.True(RnrProjRegistry.Invert(delta!));
+        Assert.Contains("Existing.xml", File.ReadAllText(rnrproj));
+    }
+
+    [Fact]
+    public void FindRnrProj_checks_the_model_folder_then_its_parent()
+    {
+        var modelFolder = Path.Combine(_dir, "MyModel", "MyModel");
+        Directory.CreateDirectory(modelFolder);
+        var rnrproj = Path.Combine(_dir, "MyModel", "MyModel.rnrproj"); // one level up
+        File.WriteAllText(rnrproj, ProjectXml);
+
+        var found = RnrProjRegistry.FindRnrProj(modelFolder);
+
+        Assert.Equal(rnrproj, found);
+    }
+}

--- a/tests/D365FO.Core.Tests/ScaffoldFileWriterJournalTests.cs
+++ b/tests/D365FO.Core.Tests/ScaffoldFileWriterJournalTests.cs
@@ -1,0 +1,87 @@
+using System.Xml.Linq;
+using D365FO.Core.Journal;
+using D365FO.Core.Scaffolding;
+using Xunit;
+
+namespace D365FO.Core.Tests;
+
+/// <summary>
+/// Verifies that <see cref="ScaffoldFileWriter"/> — the single choke point every
+/// <c>generate *</c> CLI command and the MCP <c>generate_object</c> tool funnel disk writes
+/// through — journals every write (issue #113) without the caller having to opt in.
+/// </summary>
+[Collection("ScaffoldFileWriter")]
+public sealed class ScaffoldFileWriterJournalTests : IDisposable
+{
+    private readonly string _dir = Path.Combine(Path.GetTempPath(), $"sfw-journal-{Guid.NewGuid():N}");
+    private readonly string _dbPath;
+    private readonly string? _prevIndexDb;
+
+    public ScaffoldFileWriterJournalTests()
+    {
+        Directory.CreateDirectory(_dir);
+        _dbPath = Path.Combine(_dir, "index", "d365fo-index.sqlite");
+        _prevIndexDb = Environment.GetEnvironmentVariable("D365FO_INDEX_DB");
+        Environment.SetEnvironmentVariable("D365FO_INDEX_DB", _dbPath);
+    }
+
+    public void Dispose()
+    {
+        Environment.SetEnvironmentVariable("D365FO_INDEX_DB", _prevIndexDb);
+        try { Directory.Delete(_dir, recursive: true); } catch { }
+    }
+
+    private ModificationJournal Journal() => ModificationJournal.ForIndex();
+
+    private static XDocument TableDoc(string name) => XDocument.Parse(
+        $"<AxTable xmlns:i=\"http://www.w3.org/2001/XMLSchema-instance\"><Name>{name}</Name></AxTable>");
+
+    [Fact]
+    public void Write_of_a_new_file_journals_a_tombstone_create()
+    {
+        var path = Path.Combine(_dir, "AxTable", "BrandNew.xml");
+        ScaffoldFileWriter.Write(TableDoc("BrandNew"), path);
+
+        var entry = Journal().Peek();
+
+        Assert.NotNull(entry);
+        Assert.Equal(JournalOperation.Create, entry!.Operation);
+        Assert.True(entry.IsTombstone);
+        Assert.Null(entry.PreImage);
+        Assert.Equal("BrandNew", entry.ObjectName);
+        Assert.Equal("Table", entry.Kind);
+        Assert.Equal(JournalWritePath.Disk, entry.WritePath);
+        Assert.Equal(Path.GetFullPath(path), entry.TargetPath);
+    }
+
+    [Fact]
+    public void Write_over_an_existing_file_journals_an_update_with_the_preimage()
+    {
+        var path = Path.Combine(_dir, "AxTable", "Existing.xml");
+        ScaffoldFileWriter.Write(TableDoc("Existing"), path);
+        var firstWriteText = File.ReadAllText(path);
+
+        ScaffoldFileWriter.Write(TableDoc("Existing"), path, overwrite: true);
+
+        var entry = Journal().Peek();
+
+        Assert.NotNull(entry);
+        Assert.Equal(JournalOperation.Update, entry!.Operation);
+        Assert.False(entry.IsTombstone);
+        Assert.Equal(firstWriteText, entry.PreImage);
+    }
+
+    [Fact]
+    public void Undo_of_a_generate_style_create_removes_the_file()
+    {
+        var path = Path.Combine(_dir, "AxTable", "Scratch.xml");
+        ScaffoldFileWriter.Write(TableDoc("Scratch"), path);
+        Assert.True(File.Exists(path));
+
+        var journal = Journal();
+        var result = UndoEngine.Undo(journal, 1, dryRun: false);
+
+        Assert.True(result.AllOk);
+        Assert.False(File.Exists(path));
+    }
+}

--- a/tests/D365FO.Core.Tests/UndoEngineTests.cs
+++ b/tests/D365FO.Core.Tests/UndoEngineTests.cs
@@ -1,0 +1,448 @@
+using System.Text.Json.Nodes;
+using D365FO.Core.Bridge;
+using D365FO.Core.Journal;
+using D365FO.Core.Labels;
+using Xunit;
+
+namespace D365FO.Core.Tests;
+
+/// <summary>
+/// Covers the acceptance criteria of issue #113: create→undo removes the file (+ .rnrproj
+/// entry), update→undo restores the exact pre-image, delete→undo restores the file, --dry-run
+/// makes no changes, and undo behaves identically whether the write went through disk or the
+/// bridge (faked via the same in-memory stdio harness <c>BridgeClientTests</c> uses).
+/// </summary>
+public sealed class UndoEngineTests : IDisposable
+{
+    private readonly string _dir = Path.Combine(Path.GetTempPath(), $"undo-{Guid.NewGuid():N}");
+
+    public UndoEngineTests() => Directory.CreateDirectory(_dir);
+
+    public void Dispose()
+    {
+        try { Directory.Delete(_dir, recursive: true); } catch { }
+    }
+
+    private ModificationJournal NewJournal() => new(Path.Combine(_dir, "journal"));
+
+    private string PathIn(string name) => Path.Combine(_dir, name);
+
+    // ---- disk: create -----------------------------------------------------
+
+    [Fact]
+    public void Disk_create_undo_deletes_the_file()
+    {
+        var target = PathIn("NewTable.xml");
+        File.WriteAllText(target, "<AxTable><Name>NewTable</Name></AxTable>");
+
+        var journal = NewJournal();
+        journal.Append(new JournalEntry(
+            Id: Guid.NewGuid().ToString("N"), TimestampUtc: DateTimeOffset.UtcNow, Command: "generate table",
+            TargetType: JournalTargetType.AotObject, Kind: "table", ObjectName: "NewTable", SecondaryKey: null,
+            Model: null, Operation: JournalOperation.Create, WritePath: JournalWritePath.Disk,
+            TargetPath: target, PreImage: null, IsTombstone: true, RnrProjDelta: null));
+
+        var result = UndoEngine.Undo(journal, 1, dryRun: false);
+
+        Assert.True(result.AllOk);
+        Assert.False(File.Exists(target));
+        Assert.Empty(journal.List()); // entry consumed
+    }
+
+    [Fact]
+    public void Disk_create_undo_also_removes_the_rnrproj_entry()
+    {
+        var modelFolder = Path.Combine(_dir, "MyModel", "MyModel");
+        var axSubfolder = Path.Combine(modelFolder, "AxTable");
+        Directory.CreateDirectory(axSubfolder);
+        var target = Path.Combine(axSubfolder, "NewTable.xml");
+        File.WriteAllText(target, "<AxTable><Name>NewTable</Name></AxTable>");
+
+        var rnrproj = Path.Combine(modelFolder, "MyModel.rnrproj");
+        File.WriteAllText(rnrproj,
+            "<Project xmlns=\"http://schemas.microsoft.com/developer/msbuild/2003\">" +
+            "<ItemGroup><Compile Include=\"AxTable\\NewTable.xml\" /></ItemGroup></Project>");
+
+        var delta = new RnrProjDelta(rnrproj, "Compile", @"AxTable\NewTable.xml", WasAdded: true);
+        var journal = NewJournal();
+        journal.Append(new JournalEntry(
+            Id: Guid.NewGuid().ToString("N"), TimestampUtc: DateTimeOffset.UtcNow, Command: "generate table",
+            TargetType: JournalTargetType.AotObject, Kind: "table", ObjectName: "NewTable", SecondaryKey: null,
+            Model: "MyModel", Operation: JournalOperation.Create, WritePath: JournalWritePath.Disk,
+            TargetPath: target, PreImage: null, IsTombstone: true, RnrProjDelta: delta));
+
+        var result = UndoEngine.Undo(journal, 1, dryRun: false);
+
+        Assert.True(result.AllOk);
+        Assert.False(File.Exists(target));
+        var projXml = File.ReadAllText(rnrproj);
+        Assert.DoesNotContain("NewTable.xml", projXml);
+    }
+
+    // ---- disk: update -------------------------------------------------------
+
+    [Fact]
+    public void Disk_update_undo_restores_the_exact_preimage_bytes()
+    {
+        var target = PathIn("CustTable.xml");
+        var originalBytes = "<AxTable><Name>CustTable</Name><SomeProp>Original\r\nMultiline\tValue</SomeProp></AxTable>";
+        File.WriteAllText(target, "<AxTable><Name>CustTable</Name><SomeProp>Changed</SomeProp></AxTable>");
+
+        var journal = NewJournal();
+        journal.Append(new JournalEntry(
+            Id: Guid.NewGuid().ToString("N"), TimestampUtc: DateTimeOffset.UtcNow, Command: "generate table",
+            TargetType: JournalTargetType.AotObject, Kind: "table", ObjectName: "CustTable", SecondaryKey: null,
+            Model: null, Operation: JournalOperation.Update, WritePath: JournalWritePath.Disk,
+            TargetPath: target, PreImage: originalBytes, IsTombstone: false, RnrProjDelta: null));
+
+        var result = UndoEngine.Undo(journal, 1, dryRun: false);
+
+        Assert.True(result.AllOk);
+        Assert.Equal(originalBytes, File.ReadAllText(target));
+    }
+
+    // ---- disk: delete -------------------------------------------------------
+
+    [Fact]
+    public void Disk_delete_undo_restores_the_file()
+    {
+        var target = PathIn("OldClass.xml");
+        var originalBytes = "<AxClass><Name>OldClass</Name></AxClass>";
+        // File does not exist — it was deleted by the original write.
+        Assert.False(File.Exists(target));
+
+        var journal = NewJournal();
+        journal.Append(new JournalEntry(
+            Id: Guid.NewGuid().ToString("N"), TimestampUtc: DateTimeOffset.UtcNow, Command: "delete",
+            TargetType: JournalTargetType.AotObject, Kind: "class", ObjectName: "OldClass", SecondaryKey: null,
+            Model: null, Operation: JournalOperation.Delete, WritePath: JournalWritePath.Disk,
+            TargetPath: target, PreImage: originalBytes, IsTombstone: false, RnrProjDelta: null));
+
+        var result = UndoEngine.Undo(journal, 1, dryRun: false);
+
+        Assert.True(result.AllOk);
+        Assert.True(File.Exists(target));
+        Assert.Equal(originalBytes, File.ReadAllText(target));
+    }
+
+    // ---- dry run --------------------------------------------------------------
+
+    [Fact]
+    public void DryRun_makes_no_changes_and_leaves_the_journal_intact()
+    {
+        var target = PathIn("Untouched.xml");
+        File.WriteAllText(target, "<AxTable><Name>Untouched</Name></AxTable>");
+
+        var journal = NewJournal();
+        journal.Append(new JournalEntry(
+            Id: Guid.NewGuid().ToString("N"), TimestampUtc: DateTimeOffset.UtcNow, Command: "generate table",
+            TargetType: JournalTargetType.AotObject, Kind: "table", ObjectName: "Untouched", SecondaryKey: null,
+            Model: null, Operation: JournalOperation.Create, WritePath: JournalWritePath.Disk,
+            TargetPath: target, PreImage: null, IsTombstone: true, RnrProjDelta: null));
+
+        var result = UndoEngine.Undo(journal, 1, dryRun: true);
+
+        Assert.True(result.DryRun);
+        Assert.True(result.AllOk);
+        Assert.True(File.Exists(target)); // untouched
+        Assert.Single(journal.List());    // entry NOT consumed
+        Assert.Contains("would delete", result.Steps[0].Detail);
+    }
+
+    // ---- fail-fast ------------------------------------------------------------
+
+    [Fact]
+    public void Undo_stops_at_first_failure_and_leaves_older_entries_in_the_journal()
+    {
+        var journal = NewJournal();
+        // Oldest first in append order; newest (broken) entry has no pre-image so it fails.
+        var goodTarget = PathIn("Good.xml");
+        File.WriteAllText(goodTarget, "<AxTable><Name>Good</Name></AxTable>");
+        journal.Append(new JournalEntry(
+            Id: Guid.NewGuid().ToString("N"), TimestampUtc: DateTimeOffset.UtcNow, Command: "generate table",
+            TargetType: JournalTargetType.AotObject, Kind: "table", ObjectName: "Good", SecondaryKey: null,
+            Model: null, Operation: JournalOperation.Create, WritePath: JournalWritePath.Disk,
+            TargetPath: goodTarget, PreImage: null, IsTombstone: true, RnrProjDelta: null));
+
+        journal.Append(new JournalEntry(
+            Id: Guid.NewGuid().ToString("N"), TimestampUtc: DateTimeOffset.UtcNow.AddMilliseconds(10), Command: "generate table",
+            TargetType: JournalTargetType.AotObject, Kind: "table", ObjectName: "Broken", SecondaryKey: null,
+            Model: null, Operation: JournalOperation.Update, WritePath: JournalWritePath.Disk,
+            TargetPath: PathIn("Broken.xml"), PreImage: null /* missing preimage -> fails */, IsTombstone: false, RnrProjDelta: null));
+
+        var result = UndoEngine.Undo(journal, 2, dryRun: false);
+
+        Assert.False(result.AllOk);
+        Assert.False(result.Steps[0].Ok);  // newest (Broken) attempted first, fails
+        Assert.Single(result.Steps);       // fail-fast: "Good" was never attempted
+        // Neither entry is consumed: "Broken" failed (left for retry), "Good" was never
+        // attempted (left untouched) — and its file was never deleted.
+        Assert.True(File.Exists(goodTarget));
+        Assert.Equal(2, journal.List().Count);
+        Assert.Equal("Broken", journal.List()[0].ObjectName);
+        Assert.Equal("Good", journal.List()[1].ObjectName);
+    }
+
+    // ---- labels -----------------------------------------------------------
+
+    [Fact]
+    public void Label_create_undo_removes_the_key()
+    {
+        var file = PathIn("Test.en-us.label.txt");
+        LabelFileWriter.CreateOrUpdate(file, "MyLabel", "Hello");
+
+        var journal = NewJournal();
+        journal.Append(new JournalEntry(
+            Id: Guid.NewGuid().ToString("N"), TimestampUtc: DateTimeOffset.UtcNow, Command: "labels create",
+            TargetType: JournalTargetType.Label, Kind: "label", ObjectName: "MyLabel", SecondaryKey: null,
+            Model: null, Operation: JournalOperation.Create, WritePath: JournalWritePath.Disk,
+            TargetPath: file, PreImage: null, IsTombstone: true, RnrProjDelta: null));
+
+        var result = UndoEngine.Undo(journal, 1, dryRun: false);
+
+        Assert.True(result.AllOk);
+        var lines = File.ReadAllLines(file);
+        Assert.DoesNotContain(lines, l => l.StartsWith("MyLabel="));
+    }
+
+    [Fact]
+    public void Label_update_undo_restores_the_old_value()
+    {
+        var file = PathIn("Test2.en-us.label.txt");
+        LabelFileWriter.CreateOrUpdate(file, "MyLabel", "Old value");
+        LabelFileWriter.CreateOrUpdate(file, "MyLabel", "New value", overwrite: true);
+
+        var journal = NewJournal();
+        journal.Append(new JournalEntry(
+            Id: Guid.NewGuid().ToString("N"), TimestampUtc: DateTimeOffset.UtcNow, Command: "labels create",
+            TargetType: JournalTargetType.Label, Kind: "label", ObjectName: "MyLabel", SecondaryKey: null,
+            Model: null, Operation: JournalOperation.Update, WritePath: JournalWritePath.Disk,
+            TargetPath: file, PreImage: "Old value", IsTombstone: false, RnrProjDelta: null));
+
+        var result = UndoEngine.Undo(journal, 1, dryRun: false);
+
+        Assert.True(result.AllOk);
+        var lines = File.ReadAllLines(file);
+        Assert.Contains("MyLabel=Old value", lines);
+    }
+
+    [Fact]
+    public void Label_delete_undo_recreates_the_key()
+    {
+        var file = PathIn("Test3.en-us.label.txt");
+        var journal = NewJournal();
+        journal.Append(new JournalEntry(
+            Id: Guid.NewGuid().ToString("N"), TimestampUtc: DateTimeOffset.UtcNow, Command: "labels delete",
+            TargetType: JournalTargetType.Label, Kind: "label", ObjectName: "Gone", SecondaryKey: null,
+            Model: null, Operation: JournalOperation.Delete, WritePath: JournalWritePath.Disk,
+            TargetPath: file, PreImage: "Recovered value", IsTombstone: false, RnrProjDelta: null));
+
+        var result = UndoEngine.Undo(journal, 1, dryRun: false);
+
+        Assert.True(result.AllOk);
+        var lines = File.ReadAllLines(file);
+        Assert.Contains("Gone=Recovered value", lines);
+    }
+
+    [Fact]
+    public void Label_rename_undo_renames_back()
+    {
+        var file = PathIn("Test4.en-us.label.txt");
+        LabelFileWriter.CreateOrUpdate(file, "NewKey", "Value");
+
+        var journal = NewJournal();
+        journal.Append(new JournalEntry(
+            Id: Guid.NewGuid().ToString("N"), TimestampUtc: DateTimeOffset.UtcNow, Command: "labels rename",
+            TargetType: JournalTargetType.Label, Kind: "label", ObjectName: "NewKey", SecondaryKey: "OldKey",
+            Model: null, Operation: JournalOperation.Rename, WritePath: JournalWritePath.Disk,
+            TargetPath: file, PreImage: null, IsTombstone: false, RnrProjDelta: null));
+
+        var result = UndoEngine.Undo(journal, 1, dryRun: false);
+
+        Assert.True(result.AllOk);
+        var lines = File.ReadAllLines(file);
+        Assert.Contains(lines, l => l.StartsWith("OldKey="));
+        Assert.DoesNotContain(lines, l => l.StartsWith("NewKey="));
+    }
+
+    // ---- bridge parity (faked, no real D365FO.Bridge.exe) ---------------------
+
+    [Fact]
+    public void Bridge_create_undo_calls_deleteObject()
+    {
+        string? calledMethod = null;
+        using var harness = FakeBridge.Create(req =>
+        {
+            calledMethod = (string?)req["method"];
+            Assert.Equal("Foo", (string?)req["params"]!["name"]);
+            return Ok(req, new JsonObject { ["ok"] = true });
+        });
+
+        var journal = NewJournal();
+        journal.Append(new JournalEntry(
+            Id: Guid.NewGuid().ToString("N"), TimestampUtc: DateTimeOffset.UtcNow, Command: "generate table --install-to",
+            TargetType: JournalTargetType.AotObject, Kind: "table", ObjectName: "Foo", SecondaryKey: null,
+            Model: "MyModel", Operation: JournalOperation.Create, WritePath: JournalWritePath.Bridge,
+            TargetPath: null, PreImage: null, IsTombstone: true, RnrProjDelta: null));
+
+        var result = UndoEngine.Undo(journal, 1, dryRun: false, bridgeClientFactory: () => harness.Client);
+
+        Assert.True(result.AllOk);
+        Assert.Equal("deleteObject", calledMethod);
+    }
+
+    [Fact]
+    public void Bridge_update_undo_calls_updateObject_with_preimage_xml()
+    {
+        string? calledMethod = null;
+        string? sentXml = null;
+        using var harness = FakeBridge.Create(req =>
+        {
+            calledMethod = (string?)req["method"];
+            sentXml = (string?)req["params"]!["xml"];
+            return Ok(req, new JsonObject { ["ok"] = true });
+        });
+
+        var journal = NewJournal();
+        journal.Append(new JournalEntry(
+            Id: Guid.NewGuid().ToString("N"), TimestampUtc: DateTimeOffset.UtcNow, Command: "generate table --install-to",
+            TargetType: JournalTargetType.AotObject, Kind: "table", ObjectName: "Foo", SecondaryKey: null,
+            Model: "MyModel", Operation: JournalOperation.Update, WritePath: JournalWritePath.Bridge,
+            TargetPath: null, PreImage: "<AxTable><Name>Foo</Name></AxTable>", IsTombstone: false, RnrProjDelta: null));
+
+        var result = UndoEngine.Undo(journal, 1, dryRun: false, bridgeClientFactory: () => harness.Client);
+
+        Assert.True(result.AllOk);
+        Assert.Equal("updateObject", calledMethod);
+        Assert.Equal("<AxTable><Name>Foo</Name></AxTable>", sentXml);
+    }
+
+    [Fact]
+    public void Bridge_delete_undo_calls_createObject_with_preimage_xml()
+    {
+        string? calledMethod = null;
+        using var harness = FakeBridge.Create(req =>
+        {
+            calledMethod = (string?)req["method"];
+            return Ok(req, new JsonObject { ["ok"] = true });
+        });
+
+        var journal = NewJournal();
+        journal.Append(new JournalEntry(
+            Id: Guid.NewGuid().ToString("N"), TimestampUtc: DateTimeOffset.UtcNow, Command: "delete --install-to",
+            TargetType: JournalTargetType.AotObject, Kind: "table", ObjectName: "Foo", SecondaryKey: null,
+            Model: "MyModel", Operation: JournalOperation.Delete, WritePath: JournalWritePath.Bridge,
+            TargetPath: null, PreImage: "<AxTable><Name>Foo</Name></AxTable>", IsTombstone: false, RnrProjDelta: null));
+
+        var result = UndoEngine.Undo(journal, 1, dryRun: false, bridgeClientFactory: () => harness.Client);
+
+        Assert.True(result.AllOk);
+        Assert.Equal("createObject", calledMethod);
+    }
+
+    [Fact]
+    public void Bridge_failure_response_fails_the_undo_step_and_keeps_the_entry()
+    {
+        using var harness = FakeBridge.Create(req => Ok(req, new JsonObject
+        {
+            ["ok"] = false,
+            ["error"] = "NOT_FOUND",
+            ["message"] = "boom",
+        }));
+
+        var journal = NewJournal();
+        journal.Append(new JournalEntry(
+            Id: Guid.NewGuid().ToString("N"), TimestampUtc: DateTimeOffset.UtcNow, Command: "generate table --install-to",
+            TargetType: JournalTargetType.AotObject, Kind: "table", ObjectName: "Foo", SecondaryKey: null,
+            Model: "MyModel", Operation: JournalOperation.Create, WritePath: JournalWritePath.Bridge,
+            TargetPath: null, PreImage: null, IsTombstone: true, RnrProjDelta: null));
+
+        var result = UndoEngine.Undo(journal, 1, dryRun: false, bridgeClientFactory: () => harness.Client);
+
+        Assert.False(result.AllOk);
+        Assert.Contains("NOT_FOUND", result.Steps[0].Error);
+        Assert.Single(journal.List()); // entry left in place for retry
+    }
+
+    private static JsonObject Ok(JsonObject request, JsonObject result) => new()
+    {
+        ["jsonrpc"] = "2.0",
+        ["id"] = request["id"]?.DeepClone(),
+        ["result"] = result,
+    };
+
+    /// <summary>
+    /// Stand-in for <c>D365FO.Bridge.exe</c> backed by in-memory readers/writers — same
+    /// technique as <c>BridgeClientTests.FakeBridge</c>, duplicated here (that one is a
+    /// private nested type) since <see cref="UndoEngine"/> needs its own harness instance
+    /// per test to assert on the specific verb/args it sends.
+    /// </summary>
+    private sealed class FakeBridge : IDisposable
+    {
+        public BridgeClient Client { get; }
+
+        private FakeBridge(BridgeClient client) => Client = client;
+
+        public static FakeBridge Create(Func<JsonObject, JsonObject> respondWith)
+        {
+            var reader = new DeferredResponseReader(respondWith);
+            var client = new BridgeClient(writer: new TeeWriter(reader), reader: reader);
+            return new FakeBridge(client);
+        }
+
+        public void Dispose() => Client.Dispose();
+    }
+
+    private sealed class TeeWriter : TextWriter
+    {
+        private readonly DeferredResponseReader signal;
+        private readonly System.Text.StringBuilder buffer = new();
+
+        public TeeWriter(DeferredResponseReader signal) => this.signal = signal;
+
+        public override System.Text.Encoding Encoding => System.Text.Encoding.UTF8;
+
+        public override void Write(char value)
+        {
+            if (value == '\n')
+            {
+                var line = buffer.ToString();
+                buffer.Clear();
+                signal.OnRequest(line);
+            }
+            else
+            {
+                buffer.Append(value);
+            }
+        }
+
+        public override void Write(string? value)
+        {
+            if (value is null) return;
+            foreach (var ch in value) Write(ch);
+        }
+
+        public override void WriteLine(string? value)
+        {
+            Write(value);
+            Write('\n');
+        }
+    }
+
+    private sealed class DeferredResponseReader : TextReader
+    {
+        private readonly Func<JsonObject, JsonObject> respondWith;
+        private readonly Queue<string> queued = new();
+
+        public DeferredResponseReader(Func<JsonObject, JsonObject> respondWith) => this.respondWith = respondWith;
+
+        public void OnRequest(string requestLine)
+        {
+            var parsed = JsonNode.Parse(requestLine) as JsonObject
+                ?? throw new InvalidOperationException("bad request JSON");
+            queued.Enqueue(respondWith(parsed).ToJsonString());
+        }
+
+        public override string? ReadLine() => queued.Count == 0 ? null : queued.Dequeue();
+    }
+}


### PR DESCRIPTION
## Summary

Adds a shared modification journal in `D365FO.Core` (`src/D365FO.Core/Journal/*`) that every
metadata write path appends to, plus `d365fo undo` / `d365fo journal list` and MCP parity tools,
closing the gap called out in the issue: `.bak` backups only hold the *latest* pre-image and only
for overwrites, and `git checkout` assumes a clean git worktree that `PackagesLocalDirectory`
rarely is.

**Journal format & storage**
- One JSON file per entry under `<index-dir>/journal/` (next to the SQLite index), filename =
  zero-padded UTC ticks + guid so lexical directory order is chronological order (`ModificationJournal`).
- Each entry: timestamp, command, object identity (kind/name/model), operation
  (create/update/delete/rename), write path (disk/bridge), target path, exact pre-image (or
  tombstone for creates), and an optional `.rnrproj` item-list delta.
- Size-capped + FIFO-pruned (`D365FO_JOURNAL_MAX_BYTES` / `D365FO_JOURNAL_MAX_ENTRIES`, defaults
  50 MB / 500 entries) — oldest entries drop first.

**Write-path integration** (shared by every write path, per the issue)
- `ScaffoldFileWriter.WriteCore` (the single choke point every `generate *` CLI command *and* the
  MCP `generate_object` tool funnel disk writes through) now captures the pre-image and journals
  every create/update automatically — no per-command wiring needed. Added `ScaffoldFileWriter.Delete`
  as its create/delete counterpart.
- Bridge-mediated create (`GenerateInstaller.PlanInstall`'s `createObject` path) journals a
  tombstone entry.
- `generate datasource-method` / `generate control-method` (bridge update + on-disk `AtomicSave`)
  journal an Update with the pre-injection XML as pre-image.
- Label `create`/`rename`/`delete` — both the CLI (`LabelWriteCommands.cs`) and the MCP `labels`
  tool (`ToolHandlers.cs`) call a shared `LabelJournalRecorder` so either surface's writes are
  undo-able the same way.
- New `d365fo delete --kind <K> --name <N> (--install-to <M> | --path <P>)` command — the CLI had
  no way to delete an AOT object at all before this, so "delete → undo" was untestable end-to-end.
  Captures the pre-image (via a new bridge `readObjectXml` verb, or a direct file read) before
  deleting, either through `BridgeGate.TryDeleteObject` (the bridge already had a `deleteObject`
  handler, just unwired at the CLI layer) or `ScaffoldFileWriter.Delete`.

**`d365fo undo [--steps N] [--dry-run]`**
- `UndoEngine.Undo` replays entries most-recent-first through the SAME write path that produced
  them: plain file I/O for disk entries, a `BridgeClient` round-trip (`deleteObject` /
  `updateObject` / `createObject`) for bridge entries — so behaviour is identical with the bridge
  enabled or disabled.
- Fail-fast: stops at the first failure so older entries are never silently skipped.
- `--dry-run` previews without touching anything.
- `d365fo journal list [--limit N]` inspects the stack.

**`.rnrproj` handling** — `RnrProjRegistry` is honest about scope: D365FO's build/sync tooling
discovers objects by directory convention, not an explicit project item list, so most headless/VM
installs have no `.rnrproj` with an item list to touch at all. When one *does* exist with explicit
`<Compile Include="..."/>` entries, create/delete keep it in sync and undo inverts the delta;
otherwise it's a documented no-op (tested both ways in `RnrProjRegistryTests`).

**MCP parity** — `undo_last_modification` (`steps`, `dryRun`) and `journal_list` (`limit`) added to
`ToolCatalog.cs`/`ToolHandlers.cs`, `undo_last_modification` flagged in `WriteTools`.

**Bridge changes** — added `readObjectXml` (Handlers.cs + Program.cs dispatch), the escape hatch
explicitly allowed for a "genuinely required" new verb: `deleteObject` already existed but there
was no way to get a re-serializable XML pre-image before an update/delete (the JSON read shapes are
lossy for that purpose). Wired `TryDeleteObject`/`TryReadObjectXml` into `BridgeGate.cs`.

**Docs** — `docs/MIGRATION_FROM_MCP.md` (`undo_last_modification` row + new journal section),
`docs/CAPABILITIES.md`, `docs/EXAMPLES.md`, `README.md` command table, `SchemaCommand.cs` manifest.

## Test plan

- [x] `dotnet build d365fo-cli.slnx` — clean.
- [x] `dotnet test d365fo-cli.slnx` — 581/581 passing (204 Cli.Tests + 377 Core.Tests; suite was
      ~548 before this PR, net +33 new tests here).
- [x] New tests: `ModificationJournalTests` (append/list ordering, peek, remove, FIFO pruning by
      bytes and by count, corrupt-file skip), `UndoEngineTests` (disk create/update/delete undo,
      dry-run, fail-fast, label create/update/delete/rename undo, bridge create/update/delete undo
      via an in-memory stdio fake — no real `D365FO.Bridge.exe` needed, bridge failure handling),
      `RnrProjRegistryTests` (add/remove/invert roundtrip + no-op when no project file),
      `ScaffoldFileWriterJournalTests` (auto-journal on every `Write`, undo round-trip).
- [x] Manual CLI smoke test: `generate table` → `journal list` → `undo --dry-run` → `undo` (file
      removed) → `labels create` → `undo` (key removed) → `delete --path` → `undo` (file restored).
- [x] create → undo removes the file *and* its `.rnrproj` entry when applicable.
- [x] update → undo restores the exact pre-image (byte-for-byte, verified with CRLF/tabs in the
      test fixture).
- [x] delete → undo restores the file.
- [x] Works with the bridge enabled (faked) and disabled (default).

Closes #113
