### PR TITLE
fix: close remaining d365fo-cli skill audit items (#10, #12)

### DIFF
--- a/docs/SETUP.md
+++ b/docs/SETUP.md
@@ -166,6 +166,14 @@ flowchart LR
 3. **Agent mode (recommended).** Open Copilot Chat → mode dropdown (top-right) → **Agent**. Copilot now calls `d365fo` directly via its terminal tool — no copy-paste.
 4. **Chat mode (fallback).** Without agent tools, Copilot asks you to run `d365fo` commands in Developer PowerShell and paste the JSON back. The skill teaches Copilot to ask first — if it skips that step the `.github/skills/d365fo-cli/SKILL.md` file is missing from the parent folder.
 
+> **How the skill decides to activate — and what to do when it doesn't.**
+>
+> The skill replaces what used to be 19 separate `.github/instructions/*.instructions.md` files, each scoped by an `applyTo` glob. Those applied deterministically: edit a file matching the glob, get the instructions. A skill works differently — the agent sees only its `name` and `description` and decides for itself whether the task is relevant. That's what makes it cheap (see [TOKEN_ECONOMICS.md](TOKEN_ECONOMICS.md)), but it also means activation is a judgement call, not a rule.
+>
+> In practice it fires reliably on D365FO work, because the `description` enumerates the artifact types. If it doesn't, name it in your prompt — *"use the d365fo-cli skill"* — or reference the topic file directly, e.g. *"follow references/coc-extension-authoring"*. Visual Studio shows which skills were applied in the chat reply; VS Code lists them under **References**.
+>
+> If you need the old deterministic behaviour, `skills/copilot/*.instructions.md` is still emitted — copy it to `.github/instructions/` as before. The two layouts coexist; the skill does not clobber them.
+
 > ⚠️ **Never** use `@workspace` or built-in code search on AOT XML. It always fails. Copilot must use `d365fo` exclusively for codebase queries; the Skills enforce this.
 
 > ⚠️ **"Workspace" means two unrelated things here — don't conflate them.**

--- a/scripts/Install-D365FoCopilotSkills.ps1
+++ b/scripts/Install-D365FoCopilotSkills.ps1
@@ -29,7 +29,7 @@
 
 .PARAMETER XppRepo
     Absolute path to the root of your X++ project repository (the folder that
-    contains — or will contain — the .github/ directory).
+    contains - or will contain - the .github/ directory).
 
 .EXAMPLE
     .\Install-D365FoCopilotSkills.ps1 `
@@ -37,7 +37,7 @@
         -XppRepo  "K:\D365FO\MyProject"
 
 .EXAMPLE
-    # Run from inside the d365fo-cli scripts folder — CliRepo is auto-detected
+    # Run from inside the d365fo-cli scripts folder - CliRepo is auto-detected
     .\Install-D365FoCopilotSkills.ps1 -XppRepo "K:\D365FO\MyProject"
 
 .NOTES
@@ -56,7 +56,7 @@ param(
 Set-StrictMode -Version Latest
 $ErrorActionPreference = 'Stop'
 
-# ── Resolve paths ──────────────────────────────────────────────────────────────
+# -- Resolve paths --------------------------------------------------------------
 $skillSrc    = Join-Path $CliRepo 'skills\d365fo-cli'
 $referenceSrc = Join-Path $skillSrc 'references'
 $dstSkill    = Join-Path $XppRepo '.github\skills\d365fo-cli'
@@ -65,7 +65,7 @@ Write-Host "d365fo-cli repo : $CliRepo"
 Write-Host "X++ project repo: $XppRepo"
 Write-Host ""
 
-# ── Validate source ────────────────────────────────────────────────────────────
+# -- Validate source ------------------------------------------------------------
 if (-not (Test-Path $CliRepo)) {
     Write-Error "CliRepo not found: $CliRepo"
 }
@@ -73,7 +73,7 @@ if (-not (Test-Path $XppRepo)) {
     Write-Error "XppRepo not found: $XppRepo"
 }
 
-# ── Regenerate references if the folder is empty (first run / clean clone) ─────
+# -- Regenerate references if the folder is empty (first run / clean clone) -----
 # Note: @(...) keeps .Count valid under Set-StrictMode when the folder is absent.
 $referenceFiles = @(Get-ChildItem -Path $referenceSrc -Filter '*.md' -ErrorAction SilentlyContinue)
 if ($referenceFiles.Count -eq 0) {
@@ -111,11 +111,11 @@ if ($referenceFiles.Count -eq 0) {
     }
 }
 
-# ── Create target directories ─────────────────────────────────────────────────
+# -- Create target directories -------------------------------------------------
 New-Item -ItemType Directory -Force -Path $dstSkill | Out-Null
 New-Item -ItemType Directory -Force -Path (Join-Path $dstSkill 'references') | Out-Null
 
-# ── Copy SKILL.md ─────────────────────────────────────────────────────────────
+# -- Copy SKILL.md -------------------------------------------------------------
 $skillMd = Join-Path $skillSrc 'SKILL.md'
 if (Test-Path $skillMd) {
     Copy-Item -Path $skillMd -Destination $dstSkill -Force
@@ -124,7 +124,7 @@ if (Test-Path $skillMd) {
     Write-Warning "SKILL.md not found at: $skillMd"
 }
 
-# ── Copy references ────────────────────────────────────────────────────────────
+# -- Copy references ------------------------------------------------------------
 $dstReferences = Join-Path $dstSkill 'references'
 $copied = 0
 foreach ($f in $referenceFiles) {
@@ -133,7 +133,7 @@ foreach ($f in $referenceFiles) {
     $copied++
 }
 
-# ── Prune references that no longer exist upstream ────────────────────────────
+# -- Prune references that no longer exist upstream ----------------------------
 # Renamed or retired topics would otherwise linger in the target repo forever
 # and keep feeding Copilot guidance this version of the skill has dropped.
 $expected = @($referenceFiles | ForEach-Object { $_.Name })
@@ -144,7 +144,7 @@ foreach ($f in $stale) {
     Write-Host "[--] removed stale references\$($f.Name)"
 }
 
-# ── Migration notice ──────────────────────────────────────────────────────────
+# -- Migration notice ----------------------------------------------------------
 $legacyCanon   = Join-Path $XppRepo '.github\copilot-instructions.md'
 $legacyInstrDir = Join-Path $XppRepo '.github\instructions'
 if ((Test-Path $legacyCanon) -or (Test-Path $legacyInstrDir)) {
@@ -152,12 +152,14 @@ if ((Test-Path $legacyCanon) -or (Test-Path $legacyInstrDir)) {
     Write-Host "!  Legacy files detected in your X++ repo:"
     if (Test-Path $legacyCanon)   { Write-Host "     .github\copilot-instructions.md" }
     if (Test-Path $legacyInstrDir) { Write-Host "     .github\instructions\" }
-    Write-Host "   These are superseded by the d365fo-cli skill and can be safely deleted:"
-    Write-Host "     Remove-Item -Recurse '$legacyCanon' -ErrorAction SilentlyContinue"
-    Write-Host "     Remove-Item -Recurse '$legacyInstrDir' -ErrorAction SilentlyContinue"
+    Write-Host "   The skill supersedes them and does not conflict with them. Delete them"
+    Write-Host "   unless you deliberately want the deterministic applyTo scoping of the"
+    Write-Host "   legacy instruction files (see docs/SETUP.md):"
+    if (Test-Path $legacyCanon)    { Write-Host "     Remove-Item '$legacyCanon'" }
+    if (Test-Path $legacyInstrDir) { Write-Host "     Remove-Item -Recurse '$legacyInstrDir'" }
 }
 
-# ── Summary ───────────────────────────────────────────────────────────────────
+# -- Summary -------------------------------------------------------------------
 Write-Host ""
 $summary = "Deployed SKILL.md + $copied reference(s)"
 if ($stale.Count -gt 0) { $summary += ", removed $($stale.Count) stale reference(s)" }


### PR DESCRIPTION
Closes the last two open items from the [PR #127 audit](https://github.com/dynamics365ninja/d365fo-cli/pull/127#issuecomment-5188416959). Nothing from that review is left after this.

### #10 — non-ASCII in `Install-D365FoCopilotSkills.ps1`

I filed this as cosmetic. It isn't: the em dashes sit in `.PARAMETER` and `.EXAMPLE` blocks, and the file has no BOM, so Windows PowerShell 5.1 reads it as ANSI and `Get-Help` renders them broken.

```
contains â€” or will contain â€” the .github/ directory
```

Em dashes and box-drawing characters are now ASCII. A BOM would have been the other fix, but not for these two scripts — `emit-skills.ps1` carries a `#!/usr/bin/env pwsh` shebang that a BOM breaks, and it's worth more to keep both scripts encoded the same way than to keep the typography.

While in there: the migration notice suggested `Remove-Item -Recurse` on a *file*, and printed hints for paths that don't exist. Each hint now appears only when its target is actually present, with `-Recurse` only on the directory.

### #12 — skill activation is a judgement call, not a glob

The skill replaced 19 `.instructions.md` files that applied deterministically through `applyTo`. A skill exposes only `name` + `description`, and the agent decides relevance for itself. That's exactly what makes it cheap — but it's a real behaviour change and it was nowhere in the docs.

`docs/SETUP.md` now covers it at the point users hit it: how to force activation (`use the d365fo-cli skill`, or naming a `references/` file), where each IDE shows which skills were applied, and that `skills/copilot/*.instructions.md` is still emitted for anyone who wants deterministic scoping back.

That last point contradicted the installer, which flatly called the legacy files safe to delete — it now says the skill supersedes and doesn't conflict with them, and points at SETUP.md.

### Verified on Windows PowerShell 5.1

- `Get-Help` renders clean ASCII.
- Installer deploys `SKILL.md` + 19 references, prunes a planted stale one, and the legacy notice only offers commands for paths that exist.
- Emitters remain drift-free (`git diff` clean after `emit-skills.py`).

No code changes — scripts and docs only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FfAAnxQDnPHRB1ne5H724n
