### PR TITLE
feat: one-line installer + interactive d365fo init wizard

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,29 +76,49 @@ Structural violations (wrong order, missing container, disallowed control, misap
 
 ### Install
 
+One line in PowerShell checks for the .NET SDK, clones the repo, publishes a self-contained `d365fo` binary onto `PATH`, and hands off to `d365fo init` — an interactive wizard that detects your `PackagesLocalDirectory` and asks the rest. Safe to re-run — an existing checkout is updated in place.
+
+```powershell
+irm https://raw.githubusercontent.com/dynamics365ninja/d365fo-cli/main/install.ps1 | iex
+```
+
+macOS / Linux (read · search · scaffold only — `build`/`sync`/`test`/`bp` need a Windows D365FO VM):
+
+```sh
+curl -fsSL https://raw.githubusercontent.com/dynamics365ninja/d365fo-cli/main/install.sh | bash
+```
+
+<details>
+<summary>Prefer to run the steps yourself</summary>
+
 ```sh
 git clone https://github.com/dynamics365ninja/d365fo-cli.git
 cd d365fo-cli
 dotnet build d365fo-cli.slnx -c Release
+d365fo init --persist-profile
 ```
 
-**PowerShell alias (fastest for dev):**
+**PowerShell alias (fastest for dev, no publish step):**
 
 ```powershell
 function d365fo { dotnet run --project C:\path\to\d365fo-cli\src\D365FO.Cli -- @args }
 ```
 
-**Self-contained binary (for distribution):**
+**Self-contained binary (what the installer does):**
 
 ```sh
 dotnet publish src/D365FO.Cli -c Release -r win-x64 --self-contained
-# also: linux-x64, osx-arm64
+# also: linux-x64, osx-x64, osx-arm64
 ```
+
+</details>
 
 ### First run
 
+The installer above already ran `d365fo init` for you. What's left is populating the index:
+
 ```sh
-# Point at your packages folder
+# Point at your packages folder (skip if 'd365fo init' found it already)
 $env:D365FO_PACKAGES_PATH = "K:\AosService\PackagesLocalDirectory"
 
 # Build + populate the index
@@ -117,38 +137,7 @@ d365fo find coc SalesTable::insert --output json
 d365fo labels resolve @SYS12345 --lang en-us,cs
 ```
 
-### Scaffold your first object
-
-```sh
-# New table
-d365fo generate table FmVehicle \
-  --label "@Fleet:Vehicle" \
-  --field VIN:VinEdt:mandatory \
-  --field Make:Name \
-  --field Year:YearEdt \
-  --out src/MyModel/AxTable/FmVehicle.xml
-
-# Chain-of-Command extension
-d365fo generate coc SalesTable --method insert --out src/MyModel/AxClass/SalesTable_MyExt.xml
-
-# Form — consult the pattern spec, scaffold, and the write is pattern-gated
-d365fo form-pattern spec SimpleList --output json
-d365fo generate form FmVehicles \
-  --pattern SimpleList \
-  --table FmVehicle \
-  --field VIN --field Make --field Year \
-  --out src/MyModel/AxForm/FmVehicles.xml
-
-# Form datasource / control override methods (mutates the existing AxForm)
-d365fo generate datasource-method FmVehicles --datasource FmVehicle --list      # show overridable methods
-d365fo generate datasource-method FmVehicles --datasource FmVehicle --method active
-d365fo generate control-method    FmVehicles --control VIN --method modified
-
-# Replace an existing method's body on a live class/table/edt/form (Windows VM, D365FO_BRIDGE_ENABLED=1)
-d365fo modify method class CustBalance calc --body "return 2;"
-```
-
-Full walkthrough: **[docs/SETUP.md](docs/SETUP.md)**
+Ready to scaffold your first table, form, and CoC extension? Full walkthrough with every command: **[docs/SETUP.md — Step 6](docs/SETUP.md#step-6--scaffold-your-first-object)**.
 
 ---
 

--- a/docs/CAPABILITIES.md
+++ b/docs/CAPABILITIES.md
@@ -452,3 +452,11 @@ The same 19 topics are also emitted as `skills/copilot/*.instructions.md` (legac
 | `src/D365FO.Mcp/ToolCatalog.cs` | MCP tool descriptors |
 | `src/D365FO.Mcp/ToolHandlers.cs` | MCP handler methods |
 | `skills/_source/` | Skill source files (emitted to `skills/d365fo-cli/references/`, `skills/copilot/`, `skills/anthropic/`) |
+
+---
+
+## See also
+
+- [SETUP.md](SETUP.md) — install, configure, connect an AI agent.
+- [EXAMPLES.md](EXAMPLES.md) — one worked example per command.
+- [ARCHITECTURE.md](ARCHITECTURE.md) — internals behind every feature above.

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -1,5 +1,7 @@
 # Configuration
 
+Run `d365fo init` — in a terminal it's a wizard that asks for what you need and writes `settings.json` (`--persist-profile`); nothing below has to be edited by hand. The tables in this page document what it can write and what every setting does.
+
 `d365fo` resolves settings in the following priority order — first match wins:
 
 1. **Explicit CLI flags** (`--packages`, `--db`, …) — highest priority
@@ -19,8 +21,6 @@
 | `D365FO_INDEX_DB` | Path to the SQLite index file | `%LOCALAPPDATA%\d365fo-cli\d365fo-index.sqlite` |
 | `D365FO_WORKSPACE_PATH` | Root of your X++ solution (enables scaffold output) | — |
 | `D365FO_CUSTOM_MODELS` | Comma-separated list of custom model names | — |
-
-> ⚠️ **`D365FO_WORKSPACE_PATH` is not the same thing as your editor's "workspace".** This variable only tells the `d365fo` CLI where scaffolded X++ output should be written. It has **no effect** on where Visual Studio or VS Code loads GitHub Copilot instruction files from — that is determined purely by the folder/`.sln` you have open in the editor (see [SETUP.md — Connect your AI agent](SETUP.md#step-5--connect-your-ai-agent)). Setting `D365FO_WORKSPACE_PATH` does **not** make Copilot pick up `.github/copilot-instructions.md` from that path.
 | `D365FO_BRIDGE_ENABLED` | `1`/`true` enables the metadata bridge (required for `generate --install-to` and `find refs --xref`) | `false` |
 | `D365FO_BRIDGE_PATH` | Path to `D365FO.Bridge.exe` (auto-detected next to `d365fo.exe` when unset) | *(auto)* |
 | `D365FO_BIN_PATH` | Folder containing `Microsoft.Dynamics.AX.Metadata.*.dll` (usually `<PackagesLocalDirectory>\bin`) | — |
@@ -29,6 +29,8 @@
 | `D365FO_HOME` | Root for the provenance/grounding token store | `%USERPROFILE%\.d365fo` |
 | `D365FO_GROUNDING_ENFORCE` | `true` = `generate` rejects writes without a valid grounding token or with unresolved references / BP errors | `false` (warn only) |
 | `D365FO_FORM_PATTERN_ENFORCE` | `false` = disable the form-pattern write gate; by default `generate form` rejects structural pattern violations (FP001–FP005, FP007) | `true` |
+
+> ⚠️ **`D365FO_WORKSPACE_PATH` is not the same thing as your editor's "workspace".** This variable only tells the `d365fo` CLI where scaffolded X++ output should be written. It has **no effect** on where Visual Studio or VS Code loads GitHub Copilot instruction files from — that is determined purely by the folder/`.sln` you have open in the editor (see [SETUP.md — Connect your AI agent](SETUP.md#step-5--connect-your-ai-agent)). Setting `D365FO_WORKSPACE_PATH` does **not** make Copilot pick up `.github/copilot-instructions.md` from that path.
 
 ### `d365fo-mcp`-only variables
 
@@ -98,3 +100,11 @@ Alternatively, set variables at **machine scope** so they are inherited by every
     "K:\AosService\PackagesLocalDirectory",
     [System.EnvironmentVariableTarget]::Machine)
 ```
+
+---
+
+## See also
+
+- [SETUP.md](SETUP.md) — install and the `d365fo init` wizard.
+- [TROUBLESHOOTING.md](TROUBLESHOOTING.md) — env var / profile disagreements and other failure modes.
+- [ARCHITECTURE.md](ARCHITECTURE.md) — where the bridge and MCP variables plug in.

--- a/docs/EXAMPLES.md
+++ b/docs/EXAMPLES.md
@@ -188,12 +188,15 @@ Static naming-rule check (publisher prefix, PascalCase, suffix conventions). Ret
 ### `init` — quickstart
 
 ```sh
+d365fo init                            # in a terminal: interactive wizard
 d365fo init --run-extract
 d365fo init --dry-run                  # show what would be done
 d365fo init --persist-profile          # append env vars to $PROFILE / ~/.profile
 ```
 
-Auto-detects the Windows `PackagesLocalDirectory`, prepares the SQLite schema, and (with `--run-extract`) drives the full extract pipeline. `--persist-profile` writes `D365FO_PACKAGES_PATH` / `D365FO_INDEX_DB` to the user's shell profile.
+Auto-detects the Windows `PackagesLocalDirectory`, prepares the SQLite schema, and (with `--run-extract`) drives the full extract pipeline. `--persist-profile` writes `D365FO_PACKAGES_PATH` / `D365FO_INDEX_DB` (and, if set, `D365FO_LABEL_LANGUAGES`) to the user's shell profile.
+
+In a real terminal, `init` is a wizard unless `--packages`, `--output`, `--dry-run`, or `--no-wizard` is given (or output is piped/non-TTY, as it always is for an agent's shell tool calls) — it asks for the packages path, an optional UDE extra root, label languages, and whether to persist / build the index now. `--persist-profile` and `--run-extract` still work as pre-answers to those last two questions when the wizard does run, so `d365fo init --persist-profile` above launches the wizard interactively but skips asking whether to persist.
 
 ---
 
@@ -772,8 +775,6 @@ After `dotnet publish src/D365FO.Mcp -c Release -r osx-arm64` you get a standalo
 
 ---
 
----
-
 ## Daemon (warm cache)
 
 For latency-sensitive integrations, run the CLI as a daemon so the SQLite handle and read caches stay hot:
@@ -810,3 +811,12 @@ Every command is scriptable: exit codes are reliable, output is JSON by default 
     d365fo review diff --base origin/main --head HEAD --output json \
       | jq -e '.data.violationCount == 0'
 ```
+
+---
+
+## See also
+
+- [SETUP.md](SETUP.md) — install, configure, connect an AI agent.
+- [CAPABILITIES.md](CAPABILITIES.md) — full command reference and the built-in-editor-vs-`d365fo` decision table.
+- [ARCHITECTURE.md](ARCHITECTURE.md) — index schema, lint rules, form pattern engine, the daemon.
+- [TROUBLESHOOTING.md](TROUBLESHOOTING.md) — common failure modes and fixes.

--- a/docs/SETUP.md
+++ b/docs/SETUP.md
@@ -1,9 +1,31 @@
 # Setup
 
-Five steps from a fresh clone to a working index that any AI agent can query.
+Five steps from a fresh clone to a working index that any AI agent can query — or one line that does steps 1–3 for you.
 
-> **TL;DR** — install .NET 10 · build the CLI · `d365fo init --persist-profile` · `d365fo index extract` · point your AI agent at it. Done.
+> **TL;DR** — `irm .../install.ps1 | iex` (installs .NET, builds, runs `d365fo init`) · `d365fo index extract` · point your AI agent at it. Done.
 > Day-to-day commands: [EXAMPLES.md](EXAMPLES.md) · env vars: [CONFIGURATION.md](CONFIGURATION.md) · architecture: [ARCHITECTURE.md](ARCHITECTURE.md).
+
+## One-line install
+
+```powershell
+irm https://raw.githubusercontent.com/dynamics365ninja/d365fo-cli/main/install.ps1 | iex
+```
+
+```sh
+# macOS / Linux
+curl -fsSL https://raw.githubusercontent.com/dynamics365ninja/d365fo-cli/main/install.sh | bash
+```
+
+Checks for the .NET SDK (installs it if missing, no elevation needed), clones or updates the repo, publishes a self-contained `d365fo` binary onto `PATH`, and hands off to the `d365fo init` wizard, then `d365fo doctor`. Safe to re-run. Env vars instead of flags, since the script is piped through `iex`/`bash`:
+
+| Variable | Effect |
+|---|---|
+| `D365FO_CLI_DIR` | Where to clone / look for an existing checkout (default `K:\d365fo-cli` or `~/d365fo-cli`) |
+| `D365FO_CLI_YES=1` | Non-interactive: pass `--no-wizard` to `d365fo init` instead of prompting |
+| `D365FO_CLI_NO_WIZARD=1` | Install only, skip `d365fo init` entirely |
+| `D365FO_CLI_RUN_EXTRACT=1` | Also run `index build` + `index extract` during install (can take minutes for `ApplicationSuite`) |
+
+What's left after either installer: **Step 4** below to populate the index (unless `D365FO_CLI_RUN_EXTRACT` was set), then **Step 5** to connect your AI agent. The steps below are what the installer automates — read them if you want to run each one yourself, understand what happened, or install on a machine you don't want to pipe a remote script into.
 
 ---
 
@@ -81,11 +103,19 @@ Supported RIDs: `win-x64`, `linux-x64`, `osx-x64`, `osx-arm64`. Output lands in 
 
 ## Step 3 — Configure (one command)
 
+Run it bare in a terminal and it's a wizard — confirms the detected packages path (or asks for one), an optional UDE extra root, label languages, and whether to build the index now, then writes everything:
+
+```powershell
+d365fo init
+```
+
+Or skip the prompts with explicit flags (what the wizard itself ends up writing) — this is also what runs unattended in CI/scripts, since piped/non-TTY output never shows prompts regardless of flags:
+
 ```powershell
 d365fo init --packages K:\AosService\PackagesLocalDirectory --persist-profile
 ```
 
-`init` writes both the JSON config (`%LOCALAPPDATA%\d365fo-cli\settings.json`) **and** every `$PROFILE` it finds (Windows PowerShell 5.1, PowerShell 7, VS Developer PowerShell). Subsequent shells inherit the settings automatically; you never have to remember which `$PROFILE` you edited.
+Either way, `init` writes both the JSON config (`%LOCALAPPDATA%\d365fo-cli\settings.json`) **and** every `$PROFILE` it finds (Windows PowerShell 5.1, PowerShell 7, VS Developer PowerShell). Subsequent shells inherit the settings automatically; you never have to remember which `$PROFILE` you edited. Add `--no-wizard` to force the flag-driven path even in a terminal.
 
 **UDE / dual packages roots:**
 
@@ -218,57 +248,44 @@ A `d365fo search` call returning results from your codebase = you are connected.
 
 ---
 
-## Quickstart scripts
-
-Copy-paste to go from a fresh clone to a working index in one shot.
-
-### PowerShell (Windows D365FO VM)
-
-```powershell
-# Edit the first three lines, then run the rest as-is.
-$Repo  = "C:\source\d365fo-cli"
-$Pkg   = "K:\AosService\PackagesLocalDirectory"
-$Langs = "en-us"          # add languages you actually use, e.g. "en-us,cs,de"
-
-# 1. Build
-Push-Location $Repo
-dotnet build d365fo-cli.slnx -c Release
-Pop-Location
-
-# 2. Alias + env + JSON config in one shot
-Add-Content -Path $PROFILE -Value "function d365fo { dotnet run --project $Repo\src\D365FO.Cli -- @args }"
-Add-Content -Path $PROFILE -Value "`$env:D365FO_LABEL_LANGUAGES = '$Langs'"
-. $PROFILE
-d365fo init --packages $Pkg --persist-profile
-
-# 3. Populate the index
-d365fo index build
-d365fo index extract
-d365fo doctor
-```
-
-### bash / zsh (macOS / Linux)
+## Step 6 — Scaffold your first object
 
 ```sh
-REPO=$HOME/source/d365fo-cli
-PKG=/mnt/d365fo/PackagesLocalDirectory
-LANGS="en-us"
+# New table
+d365fo generate table FmVehicle \
+  --label "@Fleet:Vehicle" \
+  --field VIN:VinEdt:mandatory \
+  --field Make:Name \
+  --field Year:YearEdt \
+  --out src/MyModel/AxTable/FmVehicle.xml
 
-cd "$REPO" && dotnet build d365fo-cli.slnx -c Release
+# Chain-of-Command extension
+d365fo generate coc SalesTable --method insert --out src/MyModel/AxClass/SalesTable_MyExt.xml
 
-{
-  echo ""
-  echo "# d365fo-cli"
-  echo "alias d365fo='dotnet run --project $REPO/src/D365FO.Cli --'"
-  echo "export D365FO_LABEL_LANGUAGES=\"$LANGS\""
-} >> "$HOME/.zshrc"
-source "$HOME/.zshrc"
+# Form — consult the pattern spec, scaffold, and the write is pattern-gated
+d365fo form-pattern spec SimpleList --output json
+d365fo generate form FmVehicles \
+  --pattern SimpleList \
+  --table FmVehicle \
+  --field VIN --field Make --field Year \
+  --out src/MyModel/AxForm/FmVehicles.xml
 
-d365fo init --packages "$PKG" --persist-profile
-d365fo index build
-d365fo index extract
-d365fo doctor
+# Form datasource / control override methods (mutates the existing AxForm)
+d365fo generate datasource-method FmVehicles --datasource FmVehicle --list      # show overridable methods
+d365fo generate datasource-method FmVehicles --datasource FmVehicle --method active
+d365fo generate control-method    FmVehicles --control VIN --method modified
+
+# Replace an existing method's body on a live class/table/edt/form (Windows VM, D365FO_BRIDGE_ENABLED=1)
+d365fo modify method class CustBalance calc --body "return 2;"
 ```
+
+One example per `generate` sub-command (25 more object types, security, reports, workflows, …): **[EXAMPLES.md § Scaffold](EXAMPLES.md#scaffold)**.
+
+---
+
+## Quickstart scripts
+
+The [one-line install](#one-line-install) at the top of this page **is** the quickstart script — `install.ps1` / `install.sh` in the repo root do exactly steps 1–3 (build, publish onto `PATH`, `d365fo init`) and then run `doctor`. Set `D365FO_CLI_RUN_EXTRACT=1` first if you also want step 4 done for you. Reading the steps above is only needed if you want to run them by hand instead.
 
 ---
 

--- a/docs/TROUBLESHOOTING.md
+++ b/docs/TROUBLESHOOTING.md
@@ -4,6 +4,26 @@ Common failure modes and their fixes. For installation details see [SETUP.md](SE
 
 ---
 
+## Installer (`install.ps1` / `install.sh`)
+
+### `d365fo` not recognized after the installer finishes
+
+The installer adds its publish directory to the **User** `PATH` via the registry / shell profile, but the *current* shell process doesn't reread that until you open a new one. Open a new PowerShell/terminal window, or `Refresh-Path`-equivalent: `$env:Path = [Environment]::GetEnvironmentVariable('Path','Machine') + ';' + [Environment]::GetEnvironmentVariable('Path','User')` (bash: `source ~/.bashrc` / `~/.zshrc` / `~/.profile`, whichever the script appended to).
+
+### `.NET SDK still not on PATH` / winget unavailable
+
+D365FO VMs are Windows Server, where `winget` is often missing. The installer falls back to the official `dotnet-install.ps1`/`.sh` script (no admin rights needed, installs under `%LOCALAPPDATA%\Microsoft\dotnet` / `~/.dotnet`). If it still isn't found afterward, open a new shell first (see above) before assuming the install failed.
+
+### Picked up the wrong existing checkout
+
+The installer probes `$env:D365FO_CLI_DIR` / `$D365FO_CLI_DIR`, then `K:\d365fo-cli` (Windows) or `~/d365fo-cli`, and updates in place (`git pull --ff-only`) whichever it finds first. If you have a checkout elsewhere, set that env var before running the installer so it targets the right directory instead of cloning a second copy.
+
+### `git pull --ff-only` failed
+
+Local commits or a detached `HEAD` in the install directory diverge from `origin/main`. The installer won't merge or discard anything for you — resolve it yourself (`git status` in that directory), then re-run the installer.
+
+---
+
 ## Package path patterns
 
 The `D365FO_PACKAGES_PATH` environment variable (or `--packages <PATH>`) must point to the root of `PackagesLocalDirectory`. Common locations:
@@ -147,20 +167,23 @@ Common message: `Assembly not found: Microsoft.Dynamics.Ax.Xpp.Support`. Fix: en
 
 Label files follow the pattern `<File>.<lang-tag>.label.txt` (e.g. `ApplicationCommon.en-US.label.txt`, `ApplicationCommon.cs-CZ.label.txt`). Language codes use IETF BCP 47 format (`en-US`, `cs-CZ`, `de-DE`, not `en`, `cs`, `de`).
 
-### `--languages` flag
+### Limiting which languages get indexed
 
-When running `index extract`, the extractor indexes all `.label.txt` files it finds. To limit extraction to specific languages (faster, smaller index):
+There is no `--languages` flag on `index extract` — the language list comes from `D365FO_LABEL_LANGUAGES` (default `en-us`), read the same way as every other setting: env var → `settings.json` → default. Extraction indexes only the languages named there (faster, smaller index than indexing every `.label.txt` file found):
 
 ```sh
-d365fo index extract --languages en-US,cs-CZ
+d365fo init --label-languages en-us,cs-CZ --persist-profile   # writes D365FO_LABEL_LANGUAGES + reruns nothing
+d365fo index extract                                          # picks it up; extract always re-populates, no --force
 ```
+
+Or set it directly for one session: `$env:D365FO_LABEL_LANGUAGES = "en-us,cs-CZ"` before running `index extract`.
 
 ### Label not found after extraction
 
 If `d365fo labels resolve @SYS12345 --lang cs-CZ` returns `LABEL_NOT_FOUND`:
 
 1. Check the language code is correct: `d365fo index status --output json` lists indexed languages under `data.languages`.
-2. Re-run extraction with the language included: `d365fo index extract --languages cs-CZ --force`.
+2. Add it to `D365FO_LABEL_LANGUAGES` (see above) and re-run `d365fo index extract` — extraction is idempotent and always reprocesses every model, so no `--force` is needed (that flag exists only on `index refresh`).
 3. Verify the label file exists on disk: `Get-ChildItem $env:D365FO_PACKAGES_PATH -Recurse -Filter "*.cs-CZ.label.txt"`.
 
 ---
@@ -178,16 +201,16 @@ The migration is applied automatically on first connection and is always additiv
 - New virtual tables (e.g. the `MethodSourceFts` method-body index) are created empty.
 - Lint flag columns (`HasInsertInLoop`, `HasNestedSelect`, etc.) default to `0` in existing rows.
 
-After migration, newly added columns are empty until you re-extract:
+After migration, newly added columns are empty until you re-extract — `index extract` has no `--force` flag (that's `index refresh` only), but it doesn't need one: every run reprocesses every model and replaces its rows:
 
 ```sh
-d365fo index extract --force    # re-populate all models with new columns
+d365fo index extract    # re-populate all models with new columns
 ```
 
-The opt-in method-body index stays empty until you re-extract *with the flag* — a plain `--force` does not populate it:
+The opt-in method-body index stays empty until you re-extract *with the flag*:
 
 ```sh
-d365fo index extract --force --index-source   # backfill MethodSourceFts too
+d365fo index extract --index-source   # backfill MethodSourceFts too
 ```
 
 ### When to use `index build` vs `index extract`
@@ -288,3 +311,12 @@ d365fo search batch CustTable SalesTable CustAccount --output json
 ```
 
 `--limit N` (default 25) caps result set size on every search command.
+
+---
+
+## See also
+
+- [SETUP.md](SETUP.md) — install, configure, connect an AI agent.
+- [EXAMPLES.md](EXAMPLES.md) — one worked example per command.
+- [ARCHITECTURE.md](ARCHITECTURE.md) — index schema, lint rules, the daemon.
+- [CONFIGURATION.md](CONFIGURATION.md) — every env var and the JSON config file.

--- a/install.ps1
+++ b/install.ps1
@@ -1,0 +1,210 @@
+# d365fo CLI - one-line installer (Windows PowerShell 5.1+ / PowerShell 7+)
+#
+#   irm https://raw.githubusercontent.com/dynamics365ninja/d365fo-cli/main/install.ps1 | iex
+#
+# Bootstraps a full installation from source and hands off to 'd365fo init',
+# which detects your PackagesLocalDirectory, writes the config, and reports
+# what's left to do. Safe to re-run — an existing checkout is updated in
+# place instead of re-cloned.
+#
+# There is no package registry yet (see docs/MIGRATION_FROM_MCP.md) — this
+# script clones the repo, builds a self-contained binary with 'dotnet
+# publish', and puts it on PATH. That's the "compilation" step; 'd365fo init'
+# is the setup wizard.
+#
+# Piped through Invoke-Expression, so configuration is env vars, not params:
+#
+#   $env:D365FO_CLI_DIR = 'D:\tools\d365fo-cli'   # where to clone / look for an existing checkout
+#   $env:D365FO_CLI_YES = '1'                     # non-interactive: accept all defaults
+#   $env:D365FO_CLI_NO_WIZARD = '1'                # install only, skip 'd365fo init'
+#   $env:D365FO_CLI_RUN_EXTRACT = '1'              # also run 'index build' + 'index extract' (can take minutes)
+#
+# D365FO VMs are Windows Server, where winget is usually unavailable - the
+# .NET SDK and Git both fall back to portable/official installers that need
+# no elevation.
+
+$ErrorActionPreference = 'Stop'
+$ProgressPreference = 'SilentlyContinue'
+
+$MinDotnetMajor = 10
+$RepoUrl = 'https://github.com/dynamics365ninja/d365fo-cli.git'
+# Pinned MinGit fallback for machines without winget (Windows Server). Portable,
+# extracted under %LOCALAPPDATA% - used only when git is not already installed.
+$MinGitUrl = 'https://github.com/git-for-windows/git/releases/download/v2.47.1.windows.1/MinGit-2.47.1-64-bit.zip'
+
+function Write-Step([string]$msg)  { Write-Host "==> $msg" -ForegroundColor Cyan }
+function Write-Ok([string]$msg)    { Write-Host "  + $msg" -ForegroundColor Green }
+function Write-Note([string]$msg)  { Write-Host "  * $msg" -ForegroundColor Yellow }
+function Fail([string]$msg) { Write-Host "  x $msg" -ForegroundColor Red; exit 1 }
+
+$NonInteractive = $env:D365FO_CLI_YES -and $env:D365FO_CLI_YES -ne '0' -and $env:D365FO_CLI_YES -ne 'false'
+
+# Re-read PATH from the registry so tools installed a moment ago resolve
+# without opening a new shell.
+function Refresh-Path {
+    $machine = [Environment]::GetEnvironmentVariable('Path', 'Machine')
+    $user = [Environment]::GetEnvironmentVariable('Path', 'User')
+    $env:Path = "$machine;$user"
+}
+
+function Test-Cmd([string]$name) {
+    return [bool](Get-Command $name -ErrorAction SilentlyContinue)
+}
+
+function Ensure-DotNet {
+    if (Test-Cmd dotnet) {
+        $major = [int]((dotnet --version) -replace '^(\d+)\..*', '$1')
+        if ($major -ge $MinDotnetMajor) { Write-Ok ".NET SDK $(dotnet --version)"; return }
+        Write-Note ".NET SDK $(dotnet --version) found, but $MinDotnetMajor+ is required"
+    }
+    if (Test-Cmd winget) {
+        Write-Step 'Installing .NET SDK via winget'
+        winget install --id Microsoft.DotNet.SDK.$MinDotnetMajor --accept-source-agreements --accept-package-agreements
+        Refresh-Path
+    } else {
+        # Official install script - no elevation needed, installs under %LOCALAPPDATA%\dotnet.
+        Write-Step "Downloading the .NET SDK $MinDotnetMajor install script from dot.net"
+        $installer = Join-Path $env:TEMP 'dotnet-install.ps1'
+        Invoke-WebRequest 'https://dot.net/v1/dotnet-install.ps1' -OutFile $installer
+        & $installer -Channel "$MinDotnetMajor.0" -InstallDir "$env:LOCALAPPDATA\Microsoft\dotnet"
+        $dotnetDir = "$env:LOCALAPPDATA\Microsoft\dotnet"
+        $env:Path = "$dotnetDir;$env:Path"
+        $userPath = [Environment]::GetEnvironmentVariable('Path', 'User')
+        if ($userPath -notlike "*$dotnetDir*") {
+            [Environment]::SetEnvironmentVariable('Path', "$userPath;$dotnetDir", 'User')
+        }
+    }
+    if (-not (Test-Cmd dotnet)) { Fail '.NET SDK still not on PATH - open a new PowerShell window and re-run this script.' }
+    $major = [int]((dotnet --version) -replace '^(\d+)\..*', '$1')
+    if ($major -lt $MinDotnetMajor) { Fail ".NET SDK $(dotnet --version) is still below $MinDotnetMajor - install it from https://dotnet.microsoft.com/download and re-run." }
+    Write-Ok ".NET SDK $(dotnet --version)"
+}
+
+function Ensure-Git {
+    if (Test-Cmd git) { Write-Ok "$(git --version)"; return }
+    if (Test-Cmd winget) {
+        Write-Step 'Installing Git via winget'
+        winget install --id Git.Git --accept-source-agreements --accept-package-agreements
+        Refresh-Path
+        if (Test-Cmd git) { Write-Ok "$(git --version)"; return }
+    }
+    Write-Step 'Installing portable MinGit (no winget on this machine)'
+    $minGitDir = Join-Path $env:LOCALAPPDATA 'd365fo-cli\MinGit'
+    $zip = Join-Path $env:TEMP 'MinGit.zip'
+    Invoke-WebRequest $MinGitUrl -OutFile $zip
+    Expand-Archive $zip -DestinationPath $minGitDir -Force
+    $gitCmd = Join-Path $minGitDir 'cmd'
+    $env:Path = "$gitCmd;$env:Path"
+    $userPath = [Environment]::GetEnvironmentVariable('Path', 'User')
+    if ($userPath -notlike "*$gitCmd*") {
+        [Environment]::SetEnvironmentVariable('Path', "$userPath;$gitCmd", 'User')
+    }
+    if (-not (Test-Cmd git)) { Fail 'Git installation failed - install Git from https://git-scm.com and re-run.' }
+    Write-Ok "$(git --version) (portable)"
+}
+
+# Probed rather than asked, same reasoning as a fresh npm install has nowhere
+# to name: a directory only matters once something is already there.
+function Find-Checkout {
+    $candidates = @()
+    if ($env:D365FO_CLI_DIR) { $candidates += $env:D365FO_CLI_DIR }
+    $candidates += 'K:\d365fo-cli'
+    $candidates += (Join-Path $env:USERPROFILE 'd365fo-cli')
+
+    foreach ($dir in $candidates) {
+        if (Test-Path (Join-Path $dir '.git')) { return $dir }
+    }
+    if ($env:D365FO_CLI_DIR -and (Test-Path $env:D365FO_CLI_DIR) -and (Get-ChildItem $env:D365FO_CLI_DIR -Force | Select-Object -First 1)) {
+        Fail "$($env:D365FO_CLI_DIR) exists, is not empty, and is not a git checkout. Empty it or point `$env:D365FO_CLI_DIR elsewhere."
+    }
+    return $null
+}
+
+function Get-InstallDir {
+    if ($env:D365FO_CLI_DIR) { return $env:D365FO_CLI_DIR }
+    return (Join-Path $env:USERPROFILE 'd365fo-cli')
+}
+
+# Publishes a self-contained single-file binary and puts it on the user PATH,
+# so 'd365fo' resolves from any shell the way a global npm/dotnet-tool install
+# would - without needing a package registry.
+function Build-And-Install([string]$dir) {
+    Push-Location $dir
+    try {
+        Write-Step 'Publishing d365fo (dotnet publish -c Release)'
+        $binDir = Join-Path $env:LOCALAPPDATA 'd365fo-cli\bin'
+        dotnet publish src\D365FO.Cli -c Release -r win-x64 --self-contained `
+            -p:PublishSingleFile=true -p:PublishTrimmed=true -o $binDir
+        if ($LASTEXITCODE -ne 0) { Fail 'dotnet publish failed - see the error above.' }
+
+        $userPath = [Environment]::GetEnvironmentVariable('Path', 'User')
+        if ($userPath -notlike "*$binDir*") {
+            [Environment]::SetEnvironmentVariable('Path', "$userPath;$binDir", 'User')
+        }
+        $env:Path = "$env:Path;$binDir"
+        Write-Ok "Installed to $binDir"
+    } finally {
+        Pop-Location
+    }
+
+    if (-not (Test-Cmd 'd365fo')) {
+        Fail 'd365fo built but is not on PATH - open a new PowerShell window and run: d365fo doctor'
+    }
+
+    if ($env:D365FO_CLI_NO_WIZARD) {
+        Write-Note 'Skipping the setup wizard (D365FO_CLI_NO_WIZARD set).'
+        Write-Host ''
+        Write-Host 'Next: d365fo init --persist-profile' -ForegroundColor Magenta
+        return
+    }
+
+    Write-Step "Running 'd365fo init' (interactive wizard in a real terminal; detects PackagesLocalDirectory)"
+    $initArgs = @('--persist-profile')
+    if ($env:D365FO_CLI_RUN_EXTRACT) { $initArgs += '--run-extract' }
+    # D365FO_CLI_YES means "accept defaults, don't ask" - 'd365fo init' has its
+    # own wizard now, so honor that env var by skipping straight to it instead
+    # of leaving the promise in the header comment unfulfilled.
+    if ($NonInteractive) { $initArgs += '--no-wizard' }
+    d365fo init @initArgs
+
+    Write-Step "Running 'd365fo doctor'"
+    d365fo doctor
+
+    Write-Host ''
+    Write-Host 'Useful commands (from anywhere):' -ForegroundColor Magenta
+    Write-Host '  d365fo doctor                    health check'
+    Write-Host '  d365fo index build; d365fo index extract   populate the index (skip if D365FO_CLI_RUN_EXTRACT was set)'
+    Write-Host '  d365fo --help                    command list'
+    Write-Host ''
+    Write-Host 'Connect an AI agent: docs/SETUP.md#step-5--connect-your-ai-agent' -ForegroundColor Magenta
+}
+
+# --- main -------------------------------------------------------------------
+
+if ($env:OS -ne 'Windows_NT') {
+    Fail 'This installer targets Windows (D365FO development VMs). On other platforms: git clone, then dotnet publish - see docs/SETUP.md, or run install.sh.'
+}
+[Net.ServicePointManager]::SecurityProtocol = [Net.ServicePointManager]::SecurityProtocol -bor [Net.SecurityProtocolType]::Tls12
+
+Write-Host ''
+Write-Host 'd365fo CLI - installer' -ForegroundColor Magenta
+Write-Host ''
+
+Write-Step 'Checking prerequisites'
+Ensure-DotNet
+Ensure-Git
+
+$checkout = Find-Checkout
+if ($checkout) {
+    Write-Note "Existing checkout found at $checkout - updating it in place."
+    Write-Step "Updating $checkout"
+    git -C $checkout pull --ff-only
+    if ($LASTEXITCODE -ne 0) { Fail 'git pull failed - resolve the conflict in the install directory and re-run.' }
+    Build-And-Install $checkout
+} else {
+    $installDir = Get-InstallDir
+    Write-Step "Cloning into $installDir"
+    git clone $RepoUrl $installDir
+    if ($LASTEXITCODE -ne 0) { Fail 'git clone failed - see the error above.' }
+    Build-And-Install $installDir
+}

--- a/install.sh
+++ b/install.sh
@@ -1,0 +1,143 @@
+#!/usr/bin/env bash
+# d365fo CLI - one-line installer (macOS / Linux)
+#
+#   curl -fsSL https://raw.githubusercontent.com/dynamics365ninja/d365fo-cli/main/install.sh | bash
+#
+# Off-platform (scenario B in docs/SETUP.md): read / search / scaffold work
+# everywhere; build/sync/test/bp need a Windows D365FO VM regardless of how
+# the CLI got installed. There is no package registry yet (see
+# docs/MIGRATION_FROM_MCP.md) - this script clones the repo, publishes a
+# self-contained binary with 'dotnet publish', and puts it on PATH.
+# 'd365fo init' is the setup wizard. Safe to re-run.
+#
+# Env vars (no flags - this is piped through bash):
+#   D365FO_CLI_DIR=/path             where to clone / look for an existing checkout
+#   D365FO_CLI_YES=1                 non-interactive: pass --no-wizard to 'd365fo init'
+#   D365FO_CLI_NO_WIZARD=1           install only, skip 'd365fo init' entirely
+#   D365FO_CLI_RUN_EXTRACT=1         also run 'index build' + 'index extract' (can take minutes)
+
+set -euo pipefail
+
+MIN_DOTNET_MAJOR=10
+REPO_URL='https://github.com/dynamics365ninja/d365fo-cli.git'
+
+step() { printf '\033[36m==> %s\033[0m\n' "$1"; }
+ok()   { printf '\033[32m  + %s\033[0m\n' "$1"; }
+note() { printf '\033[33m  * %s\033[0m\n' "$1"; }
+fail() { printf '\033[31m  x %s\033[0m\n' "$1"; exit 1; }
+
+case "$(uname -s)" in
+  Darwin) OS=osx ;;
+  Linux)  OS=linux ;;
+  *) fail "Unsupported OS: $(uname -s). See docs/SETUP.md for manual steps." ;;
+esac
+case "$(uname -m)" in
+  x86_64|amd64) ARCH=x64 ;;
+  arm64|aarch64) ARCH=arm64 ;;
+  *) fail "Unsupported architecture: $(uname -m)." ;;
+esac
+RID="${OS}-${ARCH}"
+# Published RIDs (see docs/SETUP.md): win-x64, linux-x64, osx-x64, osx-arm64 - no linux-arm64.
+case "$RID" in
+  linux-x64|osx-x64|osx-arm64) ;;
+  *) fail "Unsupported platform: $RID. Supported: linux-x64, osx-x64, osx-arm64." ;;
+esac
+
+ensure_dotnet() {
+  if command -v dotnet >/dev/null 2>&1; then
+    local major
+    major="$(dotnet --version | cut -d. -f1)"
+    if [ "$major" -ge "$MIN_DOTNET_MAJOR" ]; then ok ".NET SDK $(dotnet --version)"; return; fi
+    note ".NET SDK $(dotnet --version) found, but $MIN_DOTNET_MAJOR+ is required"
+  fi
+  step "Installing .NET SDK $MIN_DOTNET_MAJOR (official dotnet-install.sh, no root needed)"
+  curl -fsSL https://dot.net/v1/dotnet-install.sh -o /tmp/dotnet-install.sh
+  bash /tmp/dotnet-install.sh --channel "${MIN_DOTNET_MAJOR}.0" --install-dir "$HOME/.dotnet"
+  export PATH="$HOME/.dotnet:$PATH"
+  if ! command -v dotnet >/dev/null 2>&1; then
+    fail ".NET SDK still not on PATH - add \$HOME/.dotnet to PATH and re-run, or install from https://dotnet.microsoft.com/download."
+  fi
+  ok ".NET SDK $(dotnet --version)"
+}
+
+ensure_git() {
+  command -v git >/dev/null 2>&1 || fail 'git is required - install it (apt/brew/yum) and re-run.'
+  ok "$(git --version)"
+}
+
+find_checkout() {
+  local candidates=()
+  [ -n "${D365FO_CLI_DIR:-}" ] && candidates+=("$D365FO_CLI_DIR")
+  candidates+=("$HOME/d365fo-cli")
+  for dir in "${candidates[@]}"; do
+    [ -d "$dir/.git" ] && { echo "$dir"; return; }
+  done
+  if [ -n "${D365FO_CLI_DIR:-}" ] && [ -d "$D365FO_CLI_DIR" ] && [ -n "$(ls -A "$D365FO_CLI_DIR" 2>/dev/null)" ]; then
+    fail "$D365FO_CLI_DIR exists, is not empty, and is not a git checkout. Empty it or point \$D365FO_CLI_DIR elsewhere."
+  fi
+  echo ""
+}
+
+build_and_install() {
+  local dir="$1"
+  local bin_dir="$HOME/.local/share/d365fo-cli/bin"
+  step 'Publishing d365fo (dotnet publish -c Release)'
+  (cd "$dir" && dotnet publish src/D365FO.Cli -c Release -r "$RID" --self-contained \
+    -p:PublishSingleFile=true -p:PublishTrimmed=true -o "$bin_dir")
+  chmod +x "$bin_dir/d365fo"
+  ok "Installed to $bin_dir"
+
+  local profile="$HOME/.profile"
+  [ -n "${ZSH_VERSION:-}" ] && profile="$HOME/.zshrc"
+  [ -n "${BASH_VERSION:-}" ] && [ -f "$HOME/.bashrc" ] && profile="$HOME/.bashrc"
+  if ! grep -qs "d365fo-cli/bin" "$profile" 2>/dev/null; then
+    { echo ''; echo '# d365fo-cli'; echo "export PATH=\"$bin_dir:\$PATH\""; } >> "$profile"
+    note "Added $bin_dir to PATH in $profile - restart your shell, or run: export PATH=\"$bin_dir:\$PATH\""
+  fi
+  export PATH="$bin_dir:$PATH"
+
+  if [ -n "${D365FO_CLI_NO_WIZARD:-}" ]; then
+    note 'Skipping the setup wizard (D365FO_CLI_NO_WIZARD set).'
+    echo ''
+    echo "Next: $bin_dir/d365fo init --persist-profile"
+    return
+  fi
+
+  step "Running 'd365fo init' (interactive wizard in a real terminal; detects PackagesLocalDirectory)"
+  init_args=(--persist-profile)
+  [ -n "${D365FO_CLI_RUN_EXTRACT:-}" ] && init_args+=(--run-extract)
+  [ -n "${D365FO_CLI_YES:-}" ] && init_args+=(--no-wizard)
+  "$bin_dir/d365fo" init "${init_args[@]}"
+
+  step "Running 'd365fo doctor'"
+  "$bin_dir/d365fo" doctor
+
+  echo ''
+  echo 'Useful commands (after restarting your shell, or from $bin_dir):'
+  echo '  d365fo doctor                              health check'
+  echo '  d365fo index build; d365fo index extract   populate the index'
+  echo '  d365fo --help                               command list'
+  echo ''
+  echo 'build/sync/test/bp still need a Windows D365FO VM - see docs/SETUP.md.'
+}
+
+echo ''
+echo 'd365fo CLI - installer'
+echo ''
+
+step 'Checking prerequisites'
+ensure_dotnet
+ensure_git
+
+checkout="$(find_checkout)"
+if [ -n "$checkout" ]; then
+  note "Existing checkout found at $checkout - updating it in place."
+  step "Updating $checkout"
+  git -C "$checkout" pull --ff-only
+  build_and_install "$checkout"
+else
+  install_dir="${D365FO_CLI_DIR:-$HOME/d365fo-cli}"
+  step "Cloning into $install_dir"
+  git clone "$REPO_URL" "$install_dir"
+  build_and_install "$install_dir"
+fi

--- a/src/D365FO.Cli/Commands/Ops/InitCommand.cs
+++ b/src/D365FO.Cli/Commands/Ops/InitCommand.cs
@@ -37,6 +37,14 @@ public sealed class InitCommand : Command<InitCommand.Settings>
         [CommandOption("--persist-profile")]
         [System.ComponentModel.Description("Append D365FO_PACKAGES_PATH / D365FO_INDEX_DB to the user's shell profile (PowerShell $PROFILE on Windows, ~/.profile otherwise).")]
         public bool PersistProfile { get; init; }
+
+        [CommandOption("--label-languages <LANGS>")]
+        [System.ComponentModel.Description("Comma-separated label languages to persist as D365FO_LABEL_LANGUAGES, e.g. en-us,cs. Only written with --persist-profile.")]
+        public string? LabelLanguages { get; init; }
+
+        [CommandOption("--no-wizard")]
+        [System.ComponentModel.Description("Skip the interactive setup wizard even in a terminal; use flags/auto-detect only. Non-interactive runs (piped, CI, --output json) never show the wizard regardless of this flag.")]
+        public bool NoWizard { get; init; }
     }
 
     private static readonly string[] CandidateRoots =
@@ -52,10 +60,45 @@ public sealed class InitCommand : Command<InitCommand.Settings>
         var kind = OutputMode.Resolve(settings.Output);
         var cfg = D365FoSettings.FromEnvironment(settings.DatabasePath);
 
-        var packages = settings.PackagesPath ?? cfg.PackagesPath ?? AutoDetectPackages();
-        var extraPackages = D365FO.Cli.Commands.Index.IndexExtractCommand.MergeExtraPaths(
+        var extraFromFlags = D365FO.Cli.Commands.Index.IndexExtractCommand.MergeExtraPaths(
             settings.ExtraPackagesPaths,
-            cfg.CustomPackagesPaths);
+            cfg.CustomPackagesPaths) ?? Array.Empty<string>();
+
+        // Bare 'd365fo init' in a real terminal walks the user through it
+        // instead of just reporting what auto-detect found — same job as
+        // `npm run setup` upstream. Any explicit --packages, --output, or
+        // --dry-run means the caller already knows what they want, so those
+        // (and non-TTY / --no-wizard) skip straight to the flag-driven path.
+        var runWizard = !settings.NoWizard
+            && OutputMode.IsTty
+            && string.IsNullOrEmpty(settings.Output)
+            && !settings.DryRun
+            && settings.PackagesPath is null;
+
+        string? packages;
+        List<string> extraPackages;
+        bool persistProfile;
+        bool runExtractNow;
+        string? labelLanguages;
+
+        if (runWizard)
+        {
+            var answers = RunWizard(settings, cfg, extraFromFlags);
+            packages = answers.Packages;
+            extraPackages = answers.ExtraPackages;
+            persistProfile = answers.PersistProfile;
+            runExtractNow = answers.RunExtract;
+            labelLanguages = answers.LabelLanguages;
+        }
+        else
+        {
+            packages = settings.PackagesPath ?? cfg.PackagesPath ?? AutoDetectPackages();
+            extraPackages = extraFromFlags.ToList();
+            persistProfile = settings.PersistProfile;
+            runExtractNow = settings.RunExtract;
+            labelLanguages = settings.LabelLanguages;
+        }
+
         var workspace = cfg.WorkspacePath ?? (packages is null ? null : Path.GetFullPath(Path.Combine(packages, "..")));
         var steps = new List<object>();
 
@@ -85,7 +128,7 @@ public sealed class InitCommand : Command<InitCommand.Settings>
         }
 
         int extractExit = 0;
-        if (settings.RunExtract && packages is not null && !settings.DryRun)
+        if (runExtractNow && packages is not null && !settings.DryRun)
         {
             try
             {
@@ -100,7 +143,7 @@ public sealed class InitCommand : Command<InitCommand.Settings>
             }
         }
 
-        if (settings.PersistProfile && packages is not null)
+        if (persistProfile && packages is not null)
         {
             var vars = new Dictionary<string, string>
             {
@@ -111,6 +154,8 @@ public sealed class InitCommand : Command<InitCommand.Settings>
                 vars["D365FO_WORKSPACE_PATH"] = workspace;
             if (extraPackages is { Count: > 0 })
                 vars["D365FO_CUSTOM_PACKAGES_PATH"] = string.Join(";", extraPackages);
+            if (!string.IsNullOrWhiteSpace(labelLanguages))
+                vars["D365FO_LABEL_LANGUAGES"] = labelLanguages;
 
             // --- JSON config file (shell-agnostic, solves Developer PowerShell issue) ---
             try
@@ -166,7 +211,7 @@ public sealed class InitCommand : Command<InitCommand.Settings>
                 workspace,
                 database = cfg.DatabasePath,
                 dryRun = settings.DryRun,
-                extracted = settings.RunExtract && !settings.DryRun && extractExit == 0,
+                extracted = runExtractNow && !settings.DryRun && extractExit == 0,
                 nextSteps = new[]
                 {
                     "Set D365FO_PACKAGES_PATH to persist the discovered path.",
@@ -189,6 +234,61 @@ public sealed class InitCommand : Command<InitCommand.Settings>
             if (ok)
                 AnsiConsole.MarkupLine("[green]Init complete.[/] Run 'd365fo doctor' to verify.");
         });
+    }
+
+    private readonly record struct WizardAnswers(
+        string? Packages,
+        List<string> ExtraPackages,
+        bool PersistProfile,
+        bool RunExtract,
+        string? LabelLanguages);
+
+    /// <summary>
+    /// Interactive first-run walkthrough for a bare <c>d365fo init</c> in a
+    /// terminal — confirms/asks for the packages path, an optional UDE extra
+    /// root, label languages, whether to persist, and whether to build the
+    /// index now. Mirrors <c>npm run setup</c> upstream, scoped to what this
+    /// CLI actually needs (no scenario picker, no secrets — it has neither).
+    /// </summary>
+    private static WizardAnswers RunWizard(Settings settings, D365FoSettings cfg, IReadOnlyList<string> extraFromFlags)
+    {
+        AnsiConsole.Write(new Rule("[bold]d365fo init — setup wizard[/]").LeftJustified());
+        AnsiConsole.MarkupLine("[grey]Enter accepts the default shown. Nothing is written until the end. Pass --no-wizard to skip this.[/]");
+        AnsiConsole.WriteLine();
+
+        var detected = AutoDetectPackages() ?? cfg.PackagesPath;
+        string? packages;
+        if (detected is not null && AnsiConsole.Confirm($"Found PackagesLocalDirectory at [green]{RenderHelpers.Escape(detected)}[/] — use it?"))
+        {
+            packages = detected;
+        }
+        else
+        {
+            packages = AnsiConsole.Prompt(
+                new TextPrompt<string>("Path to [bold]PackagesLocalDirectory[/]:")
+                    .Validate(p => Directory.Exists(p)
+                        ? ValidationResult.Success()
+                        : ValidationResult.Error("[red]Directory not found[/]")));
+        }
+
+        var extraPackages = new List<string>(extraFromFlags);
+        if (AnsiConsole.Confirm("Second (UDE) packages root for local custom-model XML?", false))
+        {
+            var raw = AnsiConsole.Ask<string>("Extra path(s), semicolon-separated:");
+            extraPackages.AddRange(raw.Split(';', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries));
+        }
+
+        var defaultLanguages = settings.LabelLanguages ?? D365FoSettings.Resolve("D365FO_LABEL_LANGUAGES") ?? "en-us";
+        var labelLanguages = AnsiConsole.Ask("Label languages (comma-separated):", defaultLanguages);
+
+        var persistProfile = settings.PersistProfile
+            || AnsiConsole.Confirm("Persist these settings to your shell profile so new shells pick them up?");
+
+        var runExtract = settings.RunExtract
+            || AnsiConsole.Confirm("Build the metadata index now? (minutes for one model, longer for ApplicationSuite)", false);
+
+        AnsiConsole.WriteLine();
+        return new WizardAnswers(packages, extraPackages, persistProfile, runExtract, labelLanguages);
     }
 
     private static string? AutoDetectPackages()


### PR DESCRIPTION
## What

- `install.ps1` / `install.sh` at the repo root: check for the .NET SDK, clone-or-update the repo, `dotnet publish` a self-contained `d365fo` binary onto `PATH`, then hand off to `d365fo init` and `d365fo doctor`. Safe to re-run.
- `d365fo init` gains an interactive wizard: invoked bare in a real terminal (TTY, no `--output`, no `--dry-run`, no explicit `--packages`) it confirms the detected `PackagesLocalDirectory` (or asks for one), an optional UDE extra root, label languages, and whether to build the index now — then writes the same config the flag-driven path would. Any explicit flag, non-TTY, or the new `--no-wizard` skips straight to the existing behavior, so CI/scripted `d365fo init --packages ... --persist-profile` calls are unaffected.
- New `--label-languages` and `--no-wizard` options on `InitCommand`.

## Why

Today's only install path is `git clone` + `dotnet build`, then a hand-run `d365fo init --packages ... --persist-profile`. This closes that gap with a single piped command, mirroring the ergonomics of upstream `d365fo-mcp-server`'s own setup wizard but adapted to this repo's actual distribution story (git-clone-and-publish, not npm/NuGet — there is no package registry yet).

## Docs

README/SETUP/CONFIGURATION/EXAMPLES/TROUBLESHOOTING updated to lead with the one-line install, with the existing manual steps kept as a documented fallback (`<details>` in README, "Prefer to run the steps yourself") for anyone who doesn't want to pipe a remote script.

## Scope note

This branch is deliberately installer-only. A separate, unrelated architecture-doc/diagram drift audit (stale tool counts, missing HTTP-transport/journal/undo/connect sections) is in #135 — kept apart so each PR reviews cleanly on its own.

## Test plan

- [ ] `pwsh -File install.ps1` on a clean machine / fresh checkout — verify SDK check, publish, and `d365fo init` handoff
- [ ] `bash install.sh` on macOS/Linux — verify read/search/scaffold path only, no build/sync/test/bp claims
- [ ] `d365fo init` bare in an interactive terminal — wizard prompts appear, writes settings.json + \$PROFILE
- [ ] `d365fo init --packages ... --persist-profile` (flag-driven) and `d365fo init --output json` (piped/non-TTY) — wizard does NOT trigger, existing behavior unchanged
- [ ] `d365fo init --no-wizard` in a terminal — flag-driven path forced even with a TTY

🤖 Generated with [Claude Code](https://claude.com/claude-code)