### PR TITLE
fix: undo byte-fidelity, undo path guard, and result-cap bypasses

### DIFF
--- a/src/D365FO.Cli/Commands/Journal/JournalCommands.cs
+++ b/src/D365FO.Cli/Commands/Journal/JournalCommands.cs
@@ -37,7 +37,15 @@ public sealed class UndoCommand : Command<UndoCommand.Settings>
                 "The modification journal is empty — nothing to undo.",
                 "Every write from `generate`, `labels create|rename|delete`, and `delete` appends an entry here."));
 
-        var steps = settings.Steps <= 0 ? 1 : settings.Steps;
+        // Undo is destructive. A caller that passes 0 or a negative count has made a mistake —
+        // silently rounding that up to 1 reverts a write nobody asked to revert, so fail loudly
+        // instead.
+        if (settings.Steps <= 0)
+            return RenderHelpers.Render(kind, ToolResult<object>.Fail(D365FoErrorCodes.InvalidArgs,
+                $"--steps must be 1 or greater; got {settings.Steps}.",
+                "Use `--steps 1` to revert the most recent entry, or `--dry-run` to preview first."));
+
+        var steps = settings.Steps;
         var result = UndoEngine.Undo(journal, steps, settings.DryRun);
 
         var touchedModels = result.Steps

--- a/src/D365FO.Core/Bridge/BridgeClient.cs
+++ b/src/D365FO.Core/Bridge/BridgeClient.cs
@@ -202,8 +202,16 @@ public sealed class BridgeClient : IDisposable
             var completed = Task.WhenAny(readTask, timeoutTask).GetAwaiter().GetResult();
             if (completed != readTask)
             {
+                // The abandoned ReadLine is still parked on the pipe and will consume
+                // whatever the bridge eventually writes. Leaving the process alive would
+                // hand that late reply to the NEXT request, silently shifting every
+                // subsequent response by one. Tear the child down instead so the next
+                // call starts a clean bridge.
+                cancel.ThrowIfCancellationRequested();
+                DiscardProcess();
                 throw new BridgeException(
-                    $"Bridge did not respond within {options.RequestTimeout.TotalSeconds:F0}s (method: {method}).");
+                    $"Bridge did not respond within {options.RequestTimeout.TotalSeconds:F0}s (method: {method}). " +
+                    "The bridge process was restarted; retry the call.");
             }
 
             responseLine = readTask.GetAwaiter().GetResult();
@@ -227,6 +235,19 @@ public sealed class BridgeClient : IDisposable
         if (parsed is not JsonObject response)
         {
             throw new BridgeException("Bridge returned a non-object response.");
+        }
+
+        // Correlate the reply with the request. The protocol is strictly one
+        // request/response at a time, so a mismatched id means the stream has
+        // drifted out of step and every later reply would be misattributed —
+        // surfacing stale data as if it answered the current call.
+        var responseId = (int?)response["id"];
+        if (responseId is not null && responseId != id)
+        {
+            DiscardProcess();
+            throw new BridgeException(
+                $"Bridge replied to request {responseId} while {id} was pending (method: {method}). " +
+                "The stream was out of sync; the bridge process was restarted.");
         }
 
         if (response["error"] is JsonObject err)
@@ -258,6 +279,36 @@ public sealed class BridgeClient : IDisposable
         if (!string.IsNullOrWhiteSpace(options.XrefConnectionString))
             env.Add(new("D365FO_XREF_CONNECTIONSTRING", options.XrefConnectionString!));
         return env;
+    }
+
+    /// <summary>
+    /// Kill and forget the current child process so the next <see cref="SendAsync"/> spawns a
+    /// fresh one. Called when the stdio stream can no longer be trusted to be in step with the
+    /// request sequence (timeout, mismatched response id). No-op in test-stream mode, where the
+    /// caller owns the streams and there is no process to replace.
+    /// </summary>
+    private void DiscardProcess()
+    {
+        if (options.UseInProcessStreams) return;
+
+        var dead = process;
+        process = null;
+        writer = null;
+        reader = null;
+
+        if (dead is null) return;
+        try
+        {
+            if (!dead.HasExited) dead.Kill(entireProcessTree: true);
+        }
+        catch
+        {
+            // Best-effort: the process may have exited on its own between the check and the kill.
+        }
+        finally
+        {
+            dead.Dispose();
+        }
     }
 
     private void EnsureStarted()

--- a/src/D365FO.Core/Guardrails/ProvenanceStore.cs
+++ b/src/D365FO.Core/Guardrails/ProvenanceStore.cs
@@ -90,6 +90,15 @@ public static class ProvenanceStore
     /// Tokens are object-bound: a token issued for CustTable does not authorize
     /// writes touching SalesTable.
     /// </summary>
+    /// <remarks>
+    /// The target must either BE the bound object, be an artefact DERIVED from it (D365FO names
+    /// extensions and handlers by prefixing the base object — <c>CustTable_MyExt_Extension</c>,
+    /// <c>CustTableEventHandler</c>), or match the name <c>prepare create</c> proposed.
+    /// Deliberately a prefix test rather than a substring one in either direction: a plain
+    /// "contains" match let a token issued for <c>Cust</c> authorize writes to every object with
+    /// "Cust" anywhere in its name, and a token for <c>CustTable</c> authorize a write to the
+    /// unrelated shorter <c>Cust</c> — which defeats the point of binding the token to an object.
+    /// </remarks>
     public static (bool Ok, string Reason) Validate(string? token, string objectName)
     {
         if (string.IsNullOrWhiteSpace(token))
@@ -99,9 +108,13 @@ public static class ProvenanceStore
             return (false, "Grounding token not found or expired (30-min TTL). Re-run `d365fo prepare change`/`prepare create`.");
         var bound = bundle.Context.ObjectName;
         var proposed = bundle.Context.ProposedName;
-        if (!objectName.Contains(bound, StringComparison.OrdinalIgnoreCase)
-            && !bound.Contains(objectName, StringComparison.OrdinalIgnoreCase)
-            && !string.Equals(proposed, objectName, StringComparison.OrdinalIgnoreCase))
+
+        var authorized =
+            string.Equals(objectName, bound, StringComparison.OrdinalIgnoreCase)
+            || (!string.IsNullOrEmpty(bound) && objectName.StartsWith(bound, StringComparison.OrdinalIgnoreCase))
+            || (!string.IsNullOrWhiteSpace(proposed) && string.Equals(proposed, objectName, StringComparison.OrdinalIgnoreCase));
+
+        if (!authorized)
         {
             return (false, $"Grounding token is bound to \"{bound}\" — it does not authorize writes to \"{objectName}\". " +
                            "Run `d365fo prepare change`/`prepare create` for this object.");

--- a/src/D365FO.Core/Index/MetadataRepository.Validation.cs
+++ b/src/D365FO.Core/Index/MetadataRepository.Validation.cs
@@ -1,4 +1,4 @@
-using D365FO.Core.Validation;
+﻿using D365FO.Core.Validation;
 using Dapper;
 
 namespace D365FO.Core.Index;
@@ -161,6 +161,7 @@ public sealed partial class MetadataRepository : IReferenceIndex, IPropertyStats
     /// <inheritdoc />
     public IReadOnlyList<(string Value, long Count)> GetPropertyValueDistribution(string nodeType, string property, int limit = 5)
     {
+        limit = ClampLimit(limit, 5);
         using var conn = OpenReadOnly();
         return conn.Query<(string Value, long Count)>(@"
             SELECT Value, SUM(Count) AS Count FROM PropertyStats
@@ -211,6 +212,7 @@ public sealed partial class MetadataRepository : IReferenceIndex, IPropertyStats
     /// </summary>
     public IReadOnlyList<(string Name, string Model)> FindSimilarObjects(string kind, string needle, int limit = 5)
     {
+        limit = ClampLimit(limit, 5);
         var table = kind.ToLowerInvariant() switch
         {
             "table" => "Tables",

--- a/src/D365FO.Core/Index/MetadataRepository.cs
+++ b/src/D365FO.Core/Index/MetadataRepository.cs
@@ -291,6 +291,7 @@ public sealed partial class MetadataRepository
     /// </remarks>
     public IReadOnlyList<ClassInfo> SearchClasses(string query, string? model = null, int limit = 50)
     {
+        limit = ClampLimit(limit, 50);
         using var conn = OpenReadOnly();
         var like = $"%{EscapeLike(query)}%";
         var sql = @"
@@ -462,6 +463,7 @@ public sealed partial class MetadataRepository
 
     public IReadOnlyList<LabelMatch> SearchLabels(string query, IReadOnlyCollection<string>? languages = null, int limit = 100)
     {
+        limit = ClampLimit(limit, 100);
         using var conn = OpenReadOnly();
         var like = $"%{EscapeLike(query)}%";
         var langsLower = languages?.Select(l => l.ToLowerInvariant()).ToList();
@@ -497,6 +499,7 @@ public sealed partial class MetadataRepository
     /// </summary>
     public IReadOnlyList<LabelMatch> SearchLabelsFts(string query, IReadOnlyCollection<string>? languages = null, int limit = 100)
     {
+        limit = ClampLimit(limit, 100);
         using var conn = OpenReadOnly();
         var langsLower = languages?.Select(l => l.ToLowerInvariant()).ToList();
         try
@@ -587,6 +590,7 @@ public sealed partial class MetadataRepository
     /// </summary>
     public IReadOnlyList<MethodSourceMatch> SearchMethodSource(string query, int limit = 100, string? model = null, string? kind = null)
     {
+        limit = ClampLimit(limit, 100);
         using var conn = OpenReadOnly();
         try
         {
@@ -730,6 +734,7 @@ public sealed partial class MetadataRepository
         string? model = null,
         int limit = 50)
     {
+        limit = ClampLimit(limit, 50);
         using var conn = OpenReadOnly();
         // Driving datasource = OrderIndex 0 (or any when none populated yet).
         var sql = @"
@@ -740,14 +745,16 @@ public sealed partial class MetadataRepository
                      ORDER BY d.OrderIndex, d.Id LIMIT 1) AS PrimaryTable,
                    (SELECT COUNT(*) FROM FormDataSources d WHERE d.FormId = f.FormId) AS DataSourceCount
             FROM Forms f JOIN Models m ON m.ModelId = f.ModelId
-            WHERE (@pat IS NULL OR f.Pattern LIKE @patLike)
+            WHERE (@pat IS NULL OR f.Pattern LIKE @patLike ESCAPE '!')
               AND (@tbl IS NULL OR EXISTS (
                     SELECT 1 FROM FormDataSources d
                     WHERE d.FormId = f.FormId AND d.TableName = @tbl))
               AND (@mdl IS NULL OR m.Name = @mdl)
             ORDER BY f.Pattern, f.Name
             LIMIT @lim";
-        var patLike = pattern is null ? null : pattern + "%";
+        // Prefix match on a caller-supplied pattern name — escape the wildcards so that
+        // e.g. "Simple_List" matches that literal name and not "SimpleXList".
+        var patLike = pattern is null ? null : EscapeLike(pattern) + "%";
         return conn.Query<FormPatternRow>(sql, new
         {
             pat = pattern,
@@ -1228,6 +1235,7 @@ public sealed partial class MetadataRepository
 
     public IReadOnlyList<QueryInfo> SearchQueries(string query, int limit = 50)
     {
+        limit = ClampLimit(limit, 50);
         using var conn = OpenReadOnly();
         var like = $"%{EscapeLike(query)}%";
         return conn.Query<QueryInfo>(@"
@@ -1253,6 +1261,7 @@ public sealed partial class MetadataRepository
 
     public IReadOnlyList<ViewInfo> SearchViews(string query, int limit = 50)
     {
+        limit = ClampLimit(limit, 50);
         using var conn = OpenReadOnly();
         var like = $"%{EscapeLike(query)}%";
         return conn.Query<ViewInfo>(@"
@@ -1278,6 +1287,7 @@ public sealed partial class MetadataRepository
 
     public IReadOnlyList<DataEntityInfo> SearchDataEntities(string query, int limit = 50)
     {
+        limit = ClampLimit(limit, 50);
         using var conn = OpenReadOnly();
         var like = $"%{EscapeLike(query)}%";
         return conn.Query<DataEntityInfo>(@"
@@ -1306,6 +1316,7 @@ public sealed partial class MetadataRepository
 
     public IReadOnlyList<ReportInfo> SearchReports(string query, int limit = 50)
     {
+        limit = ClampLimit(limit, 50);
         using var conn = OpenReadOnly();
         var like = $"%{EscapeLike(query)}%";
         return conn.Query<ReportInfo>(@"
@@ -1331,6 +1342,7 @@ public sealed partial class MetadataRepository
 
     public IReadOnlyList<ServiceInfo> SearchServices(string query, int limit = 50)
     {
+        limit = ClampLimit(limit, 50);
         using var conn = OpenReadOnly();
         var like = $"%{EscapeLike(query)}%";
         return conn.Query<ServiceInfo>(@"
@@ -1370,6 +1382,7 @@ public sealed partial class MetadataRepository
 
     public IReadOnlyList<WorkflowTypeInfo> SearchWorkflowTypes(string query, int limit = 50)
     {
+        limit = ClampLimit(limit, 50);
         using var conn = OpenReadOnly();
         var like = $"%{EscapeLike(query)}%";
         return conn.Query<WorkflowTypeInfo>(@"
@@ -1385,6 +1398,7 @@ public sealed partial class MetadataRepository
     /// <summary>Search for AxMap objects by name (LIKE wildcard).</summary>
     public IReadOnlyList<MapInfo> SearchMaps(string query, int limit = 50)
     {
+        limit = ClampLimit(limit, 50);
         using var conn = OpenReadOnly();
         var like = $"%{EscapeLike(query)}%";
         return conn.Query<MapInfo>(@"
@@ -1420,6 +1434,7 @@ public sealed partial class MetadataRepository
 
     public IReadOnlyList<BusinessEventInfo> SearchBusinessEvents(string query, string? category = null, int limit = 50)
     {
+        limit = ClampLimit(limit, 50);
         using var conn = OpenReadOnly();
         var like = $"%{EscapeLike(query)}%";
         return conn.Query<BusinessEventInfo>(@"
@@ -1442,6 +1457,7 @@ public sealed partial class MetadataRepository
 
     public IReadOnlyList<SecurityPolicyInfo> SearchSecurityPolicies(string query, int limit = 50)
     {
+        limit = ClampLimit(limit, 50);
         using var conn = OpenReadOnly();
         var like = $"%{EscapeLike(query)}%";
         return conn.Query<SecurityPolicyInfo>(@"
@@ -1465,6 +1481,7 @@ public sealed partial class MetadataRepository
 
     public IReadOnlyList<ConfigurationKeyInfo> SearchConfigurationKeys(string query, int limit = 50)
     {
+        limit = ClampLimit(limit, 50);
         using var conn = OpenReadOnly();
         var like = $"%{EscapeLike(query)}%";
         return conn.Query<ConfigurationKeyInfo>(@"
@@ -1477,6 +1494,7 @@ public sealed partial class MetadataRepository
 
     public IReadOnlyList<TileInfo> SearchTiles(string query, int limit = 50)
     {
+        limit = ClampLimit(limit, 50);
         using var conn = OpenReadOnly();
         var like = $"%{EscapeLike(query)}%";
         return conn.Query<TileInfo>(@"
@@ -1489,6 +1507,7 @@ public sealed partial class MetadataRepository
 
     public IReadOnlyList<WorkspaceInfo> SearchWorkspaces(string query, int limit = 50)
     {
+        limit = ClampLimit(limit, 50);
         using var conn = OpenReadOnly();
         var like = $"%{EscapeLike(query)}%";
         return conn.Query<WorkspaceInfo>(@"
@@ -1552,6 +1571,7 @@ public sealed partial class MetadataRepository
     public IReadOnlyList<(string Kind, string Name, string Model)> FindUsagesFiltered(
         string needle, IReadOnlyList<string>? kinds, int limit = 100)
     {
+        limit = ClampLimit(limit, 100);
         if (kinds is null || kinds.Count == 0)
             return FindUsages(needle, limit);
 
@@ -1637,6 +1657,7 @@ public sealed partial class MetadataRepository
 
     public IReadOnlyList<CommandTimingRow> GetCommandTimings(int limit = 50)
     {
+        limit = ClampLimit(limit, 50);
         using var conn = OpenReadOnly();
         return conn.Query<CommandTimingRow>(@"
             SELECT Command,
@@ -1832,6 +1853,7 @@ public sealed partial class MetadataRepository
     /// </summary>
     public IReadOnlyList<TableFieldMatch> FindTablesByField(string name, string? model = null, int limit = 200)
     {
+        limit = ClampLimit(limit, 200);
         using var conn = OpenReadOnly();
 
         // Base-table fields (TableFields). Queried as real columns so the SQLite
@@ -1886,6 +1908,7 @@ public sealed partial class MetadataRepository
 
     public IReadOnlyList<TableInfo> SearchTables(string query, string? model = null, int limit = 50)
     {
+        limit = ClampLimit(limit, 50);
         using var conn = OpenReadOnly();
         var like = $"%{EscapeLike(query)}%";
         return conn.Query<TableInfo>(@"
@@ -1901,6 +1924,7 @@ public sealed partial class MetadataRepository
 
     public IReadOnlyList<EdtInfo> SearchEdts(string query, int limit = 50)
     {
+        limit = ClampLimit(limit, 50);
         using var conn = OpenReadOnly();
         var like = $"%{EscapeLike(query)}%";
         return conn.Query<EdtInfo>(@"
@@ -1915,6 +1939,7 @@ public sealed partial class MetadataRepository
 
     public IReadOnlyList<EnumInfo> SearchEnums(string query, int limit = 50)
     {
+        limit = ClampLimit(limit, 50);
         using var conn = OpenReadOnly();
         var like = $"%{EscapeLike(query)}%";
         return conn.Query<EnumInfo>(@"
@@ -2034,6 +2059,7 @@ public sealed partial class MetadataRepository
     /// </summary>
     public IReadOnlyList<(string Kind, string Name, string Model)> FindUsages(string needle, int limit = 100)
     {
+        limit = ClampLimit(limit, 100);
         using var conn = OpenReadOnly();
         var like = $"%{EscapeLike(needle)}%";
         var rows = conn.Query<UsageRow>(@"
@@ -2148,6 +2174,7 @@ public sealed partial class MetadataRepository
     /// <summary>Recent <c>ExtractionRuns</c>, newest first.</summary>
     public IReadOnlyList<ExtractionRunRow> GetExtractionRuns(int limit = 200, string? model = null)
     {
+        limit = ClampLimit(limit, 200);
         using var conn = OpenReadOnly();
         var sql = @"SELECT RunId, StartedUtc, Model, ElapsedMs, Tables, Classes, Edts, Enums, Labels, IsCustom
                     FROM ExtractionRuns
@@ -2924,14 +2951,6 @@ public sealed partial class MetadataRepository
     }
 
     /// <summary>
-    /// Opens a read-only connection to the index database. Used by all pure
-    /// query methods to avoid acquiring a write-capable lock unnecessarily.
-    /// Falls back to <see cref="Open"/> when the database does not yet exist
-    /// (i.e. during <see cref="EnsureSchema"/> bootstrapping) — callers of
-    /// this method must therefore have previously called EnsureSchema().
-    /// </summary>
-
-    /// <summary>
     /// Escapes SQLite LIKE wildcard characters (<c>%</c>, <c>_</c>, and the
     /// chosen escape character <c>!</c>) in a user-supplied query fragment so
     /// that they are treated as literals.
@@ -2940,6 +2959,26 @@ public sealed partial class MetadataRepository
     private static string EscapeLike(string value) =>
         value.Replace("!", "!!").Replace("%", "!%").Replace("_", "!_");
 
+    /// <summary>
+    /// Clamps a caller-supplied row limit into a sane range. SQLite treats a
+    /// NEGATIVE <c>LIMIT</c> as "no limit at all", so passing <c>--limit -1</c>
+    /// through unchecked turns a bounded lookup into a full-index dump — the
+    /// exact token blow-up the result caps exist to prevent. Zero and negative
+    /// values fall back to <paramref name="fallback"/>; anything above
+    /// <see cref="MaxRowLimit"/> is capped.
+    /// </summary>
+    internal static int ClampLimit(int limit, int fallback = 50) =>
+        limit <= 0 ? fallback : Math.Min(limit, MaxRowLimit);
+
+    /// <summary>Hard ceiling on rows any single query may return.</summary>
+    public const int MaxRowLimit = 1000;
+
+    /// <summary>
+    /// Opens a read-only connection to the index database. Used by all pure
+    /// query methods to avoid acquiring a write-capable lock unnecessarily.
+    /// The database must already exist — callers reach this only after
+    /// <see cref="EnsureSchema"/> has created it.
+    /// </summary>
     private SqliteConnection OpenReadOnly()
     {
         var conn = new SqliteConnection(_readOnlyConnectionString);

--- a/src/D365FO.Core/Journal/JournalEntry.cs
+++ b/src/D365FO.Core/Journal/JournalEntry.cs
@@ -52,6 +52,14 @@ public sealed record RnrProjDelta(string RnrProjPath, string ItemElementName, st
 /// A single reversible write, captured by every write path that funnels through
 /// <c>ScaffoldFileWriter</c>, <c>LabelFileWriter</c>, or the bridge create/update/delete verbs.
 /// </summary>
+/// <remarks>
+/// <c>PreImageHadBom</c> records whether the pre-image file started with a UTF-8 BOM.
+/// <c>PreImage</c> is captured as a decoded string and the decoder strips the BOM — without this
+/// flag undo would rewrite AOT XML three bytes shorter than the original, which is a real diff to
+/// D365FO and Visual Studio (both write these files WITH a BOM). <c>null</c> means "not recorded"
+/// (entries written by an older build); undo then falls back to the BOM state of the file
+/// currently on disk.
+/// </remarks>
 public sealed record JournalEntry(
     string Id,
     DateTimeOffset TimestampUtc,
@@ -66,4 +74,5 @@ public sealed record JournalEntry(
     string? TargetPath,
     string? PreImage,
     bool IsTombstone,
-    RnrProjDelta? RnrProjDelta);
+    RnrProjDelta? RnrProjDelta,
+    bool? PreImageHadBom = null);

--- a/src/D365FO.Core/Journal/UndoEngine.cs
+++ b/src/D365FO.Core/Journal/UndoEngine.cs
@@ -1,5 +1,6 @@
 using System.Text.Json.Nodes;
 using D365FO.Core.Bridge;
+using D365FO.Core.Guardrails;
 using D365FO.Core.Labels;
 
 namespace D365FO.Core.Journal;
@@ -26,6 +27,12 @@ public static class UndoEngine
     /// stack. In <paramref name="dryRun"/> mode nothing is written or removed; each step is
     /// previewed only.
     /// </summary>
+    /// <param name="journal">Journal to pop entries from; successfully replayed entries are removed.</param>
+    /// <param name="steps">
+    /// How many entries to revert, most-recent-first. Zero or negative reverts nothing — a caller
+    /// asking for no steps must not silently get one.
+    /// </param>
+    /// <param name="dryRun">Preview only: nothing is written and no entry is removed.</param>
     /// <param name="bridgeClientFactory">
     /// Test seam: when supplied, its return value is used for every bridge-written entry
     /// instead of spawning a real <c>D365FO.Bridge.exe</c> — the caller owns disposal (see
@@ -40,7 +47,12 @@ public static class UndoEngine
         Func<BridgeClient>? bridgeClientFactory = null)
     {
         ArgumentNullException.ThrowIfNull(journal);
-        var entries = journal.List(Math.Max(1, steps));
+        if (steps <= 0)
+        {
+            return new UndoResult(Array.Empty<UndoStepResult>(), dryRun);
+        }
+
+        var entries = journal.List(steps);
         var results = new List<UndoStepResult>(entries.Count);
 
         BridgeClient? ownedClient = null;
@@ -132,6 +144,16 @@ public static class UndoEngine
         if (string.IsNullOrWhiteSpace(entry.TargetPath))
             return (false, "Journal entry has no target path.", null, null);
 
+        // Same boundary the forward write paths enforce (XppScaffolder.Write / LabelFileWriter).
+        // The target path comes out of the journal store, not from the current command line, so
+        // undo must re-check it rather than trust it: a journal carried over from a different
+        // D365FO_PACKAGES_PATH — or hand-edited — would otherwise let `undo` delete or rewrite
+        // files anywhere on disk.
+        var cfg = D365FoSettings.FromEnvironment();
+        PathGuard.EnsureWithinBoundary(
+            entry.TargetPath,
+            new[] { cfg.PackagesPath, cfg.WorkspacePath }.Concat(cfg.CustomPackagesPaths).ToArray());
+
         string? rnrWarn = null;
         switch (entry.Operation)
         {
@@ -147,13 +169,13 @@ public static class UndoEngine
             case JournalOperation.Update:
                 if (entry.PreImage is null)
                     return (false, "No pre-image recorded for this update — cannot restore exact bytes.", null, null);
-                AtomicWriteText(entry.TargetPath, entry.PreImage);
+                AtomicWriteText(entry.TargetPath, entry.PreImage, entry.PreImageHadBom);
                 return (true, null, $"restored pre-image of {entry.TargetPath}", null);
 
             case JournalOperation.Delete:
                 if (entry.PreImage is null)
                     return (false, "No pre-image recorded for this delete — cannot restore the file.", null, null);
-                AtomicWriteText(entry.TargetPath, entry.PreImage);
+                AtomicWriteText(entry.TargetPath, entry.PreImage, entry.PreImageHadBom);
                 if (entry.RnrProjDelta is not null && !RnrProjRegistry.Invert(entry.RnrProjDelta))
                     rnrWarn = $".rnrproj entry for '{entry.ObjectName}' could not be restored automatically — check {entry.RnrProjDelta.RnrProjPath}.";
                 return (true, null, $"recreated {entry.TargetPath}", rnrWarn);
@@ -163,13 +185,27 @@ public static class UndoEngine
         }
     }
 
-    private static void AtomicWriteText(string path, string content)
+    /// <summary>
+    /// Restore <paramref name="content"/> to <paramref name="path"/> via tmp+move.
+    /// </summary>
+    /// <remarks>
+    /// <c>preImageHadBom</c> is the BOM state of the original file, recorded at write time.
+    /// <see cref="JournalEntry.PreImage"/> is a decoded string, so the UTF-8 BOM the original
+    /// carried is not in it — writing without re-emitting it would leave the "restored" AOT XML
+    /// three bytes shorter than what D365FO and Visual Studio wrote, which shows up as a real
+    /// change in git. <c>null</c> (entry written by an older build) falls back to the BOM state
+    /// of the file currently on disk, and to "no BOM" when there is no file to inspect.
+    /// </remarks>
+    private static void AtomicWriteText(string path, string content, bool? preImageHadBom = null)
     {
         var full = Path.GetFullPath(path);
         var dir = Path.GetDirectoryName(full);
         if (!string.IsNullOrEmpty(dir)) Directory.CreateDirectory(dir);
+
+        var emitBom = preImageHadBom ?? (File.Exists(full) && Scaffolding.ScaffoldFileWriter.DetectUtf8Bom(full) == true);
+
         var tmp = full + ".undo.tmp";
-        File.WriteAllText(tmp, content);
+        File.WriteAllText(tmp, content, new System.Text.UTF8Encoding(encoderShouldEmitUTF8Identifier: emitBom));
         File.Move(tmp, full, overwrite: true);
     }
 

--- a/src/D365FO.Core/Scaffolding/XppScaffolder.cs
+++ b/src/D365FO.Core/Scaffolding/XppScaffolder.cs
@@ -1224,6 +1224,7 @@ public static class ScaffoldFileWriter
             throw new FileNotFoundException($"Target does not exist: {full}", full);
 
         var preImage = SafeReadAllText(full);
+        var preImageHadBom = DetectUtf8Bom(full);
         var (kind, objectName) = InferKindAndName(full);
         var effectiveModel = model ?? InferModel(full);
 
@@ -1254,7 +1255,8 @@ public static class ScaffoldFileWriter
                 TargetPath: full,
                 PreImage: preImage,
                 IsTombstone: false,
-                RnrProjDelta: delta);
+                RnrProjDelta: delta,
+                PreImageHadBom: preImageHadBom);
             ModificationJournal.ForIndex().Append(entry);
         }
         catch { /* best-effort */ }
@@ -1377,6 +1379,7 @@ public static class ScaffoldFileWriter
         // independent of the .bak file below, which the write path keeps for immediate manual
         // recovery but is not itself part of the journal's reversible-write contract.
         string? preImage = File.Exists(full) ? SafeReadAllText(full) : null;
+        bool? preImageHadBom = File.Exists(full) ? DetectUtf8Bom(full) : null;
 
         string? backup = null;
         if (File.Exists(full))
@@ -1420,7 +1423,7 @@ public static class ScaffoldFileWriter
         }
 
         var bytes = new FileInfo(full).Length;
-        RecordJournalEntry(full, preImage);
+        RecordJournalEntry(full, preImage, preImageHadBom);
         return new WriteResult(full, bytes, backup);
     }
 
@@ -1435,7 +1438,7 @@ public static class ScaffoldFileWriter
     /// best-effort: when the path doesn't match that convention, Model is left null and the
     /// entry is still recorded (disk replay only needs the path + pre-image, not the model).
     /// </summary>
-    private static void RecordJournalEntry(string fullPath, string? preImage)
+    private static void RecordJournalEntry(string fullPath, string? preImage, bool? preImageHadBom = null)
     {
         try
         {
@@ -1464,7 +1467,8 @@ public static class ScaffoldFileWriter
                 TargetPath: fullPath,
                 PreImage: preImage,
                 IsTombstone: preImage is null,
-                RnrProjDelta: delta);
+                RnrProjDelta: delta,
+                PreImageHadBom: preImageHadBom);
 
             ModificationJournal.ForIndex().Append(entry);
         }
@@ -1479,6 +1483,24 @@ public static class ScaffoldFileWriter
     {
         try { return File.ReadAllText(path); }
         catch { return string.Empty; }
+    }
+
+    /// <summary>
+    /// Whether <paramref name="path"/> starts with a UTF-8 BOM. Recorded alongside the pre-image
+    /// so <c>d365fo undo</c> can restore the file byte-for-byte: the pre-image is a decoded string
+    /// and the decoder swallows the BOM, so without this the restored AOT XML would be three bytes
+    /// shorter than the original that D365FO and Visual Studio wrote.
+    /// </summary>
+    internal static bool? DetectUtf8Bom(string path)
+    {
+        try
+        {
+            using var fs = File.OpenRead(path);
+            Span<byte> head = stackalloc byte[3];
+            return fs.ReadAtLeast(head, 3, throwOnEndOfStream: false) == 3
+                   && head[0] == 0xEF && head[1] == 0xBB && head[2] == 0xBF;
+        }
+        catch { return null; }
     }
 
     /// <summary>

--- a/tests/D365FO.Core.Tests/MetadataRepositoryTests.cs
+++ b/tests/D365FO.Core.Tests/MetadataRepositoryTests.cs
@@ -58,6 +58,38 @@ public class MetadataRepositoryTests : IDisposable
     }
 
     [Fact]
+    public void Negative_limit_does_not_disable_the_row_cap()
+    {
+        // SQLite reads a NEGATIVE LIMIT as "no limit", so an unchecked `--limit -1`
+        // turns a bounded search into a full-index dump.
+        var repo = new MetadataRepository(_dbPath);
+        repo.EnsureSchema();
+
+        using var conn = new Microsoft.Data.Sqlite.SqliteConnection(repo.ConnectionString);
+        conn.Open();
+        using var cmd = conn.CreateCommand();
+        cmd.CommandText = "INSERT INTO Models(Name,IsCustom) VALUES('AppFound',0);";
+        for (var i = 0; i < 60; i++)
+            cmd.CommandText += $"INSERT INTO Classes(Name,ModelId,IsAbstract,IsFinal,SourcePath) VALUES('CustCls{i:D3}',1,0,0,'/x');";
+        cmd.ExecuteNonQuery();
+
+        // -1 and 0 both fall back to the method's documented default (50), not "everything".
+        Assert.Equal(50, repo.SearchClasses("CustCls", limit: -1).Count);
+        Assert.Equal(50, repo.SearchClasses("CustCls", limit: 0).Count);
+        Assert.Equal(5, repo.SearchClasses("CustCls", limit: 5).Count);
+    }
+
+    [Fact]
+    public void Limit_is_capped_at_the_hard_ceiling()
+    {
+        Assert.Equal(MetadataRepository.MaxRowLimit, MetadataRepository.ClampLimit(int.MaxValue));
+        Assert.Equal(MetadataRepository.MaxRowLimit, MetadataRepository.ClampLimit(5000));
+        Assert.Equal(50, MetadataRepository.ClampLimit(-1));
+        Assert.Equal(100, MetadataRepository.ClampLimit(0, fallback: 100));
+        Assert.Equal(7, MetadataRepository.ClampLimit(7));
+    }
+
+    [Fact]
     public void Search_ranks_custom_models_above_Microsoft_models()
     {
         var repo = new MetadataRepository(_dbPath);

--- a/tests/D365FO.Core.Tests/ProvenanceStoreTests.cs
+++ b/tests/D365FO.Core.Tests/ProvenanceStoreTests.cs
@@ -47,6 +47,36 @@ public class ProvenanceStoreTests : IDisposable
     }
 
     [Fact]
+    public void Validate_rejects_object_that_merely_contains_the_bound_name()
+    {
+        // A token issued for the short name "Cust" must not become a wildcard over every
+        // object with "Cust" somewhere inside it.
+        var token = ProvenanceStore.CreateToken(new ProvenanceContext("goal", "Cust"));
+        var (ok, reason) = ProvenanceStore.Validate(token, "SalesCustTable");
+        Assert.False(ok);
+        Assert.Contains("bound", reason);
+    }
+
+    [Fact]
+    public void Validate_rejects_shorter_object_the_bound_name_contains()
+    {
+        // The reverse direction: a token for CustTable does not authorize the unrelated "Cust".
+        var token = ProvenanceStore.CreateToken(new ProvenanceContext("goal", "CustTable"));
+        var (ok, _) = ProvenanceStore.Validate(token, "Cust");
+        Assert.False(ok);
+    }
+
+    [Fact]
+    public void Validate_accepts_derived_name_without_a_proposed_name()
+    {
+        // Extensions/handlers are named by prefixing the base object; that stays authorized
+        // even when prepare did not propose the exact name up front.
+        var token = ProvenanceStore.CreateToken(new ProvenanceContext("goal", "CustTable"));
+        var (ok, _) = ProvenanceStore.Validate(token, "CustTableEventHandler");
+        Assert.True(ok);
+    }
+
+    [Fact]
     public void Validate_rejects_other_object()
     {
         var token = ProvenanceStore.CreateToken(new ProvenanceContext("goal", "CustTable"));

--- a/tests/D365FO.Core.Tests/UndoEngineTests.cs
+++ b/tests/D365FO.Core.Tests/UndoEngineTests.cs
@@ -101,6 +101,98 @@ public sealed class UndoEngineTests : IDisposable
         Assert.Equal(originalBytes, File.ReadAllText(target));
     }
 
+    [Fact]
+    public void Disk_update_undo_restores_the_utf8_bom()
+    {
+        // AOT XML is written WITH a BOM by D365FO, Visual Studio, and this tool's own
+        // scaffolder. PreImage is a decoded string, so the BOM is not in it — undo has to
+        // re-emit it from the recorded flag or the "restored" file is three bytes short.
+        var target = PathIn("BomTable.xml");
+        var body = "<AxTable><Name>BomTable</Name></AxTable>";
+        File.WriteAllText(target, "<AxTable><Name>BomTable</Name><Changed /></AxTable>",
+            new System.Text.UTF8Encoding(encoderShouldEmitUTF8Identifier: true));
+
+        var journal = NewJournal();
+        journal.Append(new JournalEntry(
+            Id: Guid.NewGuid().ToString("N"), TimestampUtc: DateTimeOffset.UtcNow, Command: "generate table",
+            TargetType: JournalTargetType.AotObject, Kind: "table", ObjectName: "BomTable", SecondaryKey: null,
+            Model: null, Operation: JournalOperation.Update, WritePath: JournalWritePath.Disk,
+            TargetPath: target, PreImage: body, IsTombstone: false, RnrProjDelta: null,
+            PreImageHadBom: true));
+
+        var result = UndoEngine.Undo(journal, 1, dryRun: false);
+
+        Assert.True(result.AllOk);
+        var bytes = File.ReadAllBytes(target);
+        Assert.Equal(new byte[] { 0xEF, 0xBB, 0xBF }, bytes.Take(3).ToArray());
+        Assert.Equal(body, File.ReadAllText(target));
+    }
+
+    [Fact]
+    public void Disk_update_undo_does_not_add_a_bom_the_original_lacked()
+    {
+        var target = PathIn("NoBomTable.xml");
+        var body = "<AxTable><Name>NoBomTable</Name></AxTable>";
+        File.WriteAllText(target, "<AxTable><Name>NoBomTable</Name><Changed /></AxTable>",
+            new System.Text.UTF8Encoding(encoderShouldEmitUTF8Identifier: false));
+
+        var journal = NewJournal();
+        journal.Append(new JournalEntry(
+            Id: Guid.NewGuid().ToString("N"), TimestampUtc: DateTimeOffset.UtcNow, Command: "generate table",
+            TargetType: JournalTargetType.AotObject, Kind: "table", ObjectName: "NoBomTable", SecondaryKey: null,
+            Model: null, Operation: JournalOperation.Update, WritePath: JournalWritePath.Disk,
+            TargetPath: target, PreImage: body, IsTombstone: false, RnrProjDelta: null,
+            PreImageHadBom: false));
+
+        Assert.True(UndoEngine.Undo(journal, 1, dryRun: false).AllOk);
+        Assert.Equal(System.Text.Encoding.UTF8.GetBytes(body), File.ReadAllBytes(target));
+    }
+
+    [Fact]
+    public void Undo_with_zero_or_negative_steps_reverts_nothing()
+    {
+        var target = PathIn("Untouched.xml");
+        File.WriteAllText(target, "<AxTable><Name>Untouched</Name></AxTable>");
+
+        var journal = NewJournal();
+        journal.Append(new JournalEntry(
+            Id: Guid.NewGuid().ToString("N"), TimestampUtc: DateTimeOffset.UtcNow, Command: "generate table",
+            TargetType: JournalTargetType.AotObject, Kind: "table", ObjectName: "Untouched", SecondaryKey: null,
+            Model: null, Operation: JournalOperation.Create, WritePath: JournalWritePath.Disk,
+            TargetPath: target, PreImage: null, IsTombstone: true, RnrProjDelta: null));
+
+        foreach (var steps in new[] { 0, -1 })
+        {
+            var result = UndoEngine.Undo(journal, steps, dryRun: false);
+            Assert.Empty(result.Steps);
+            Assert.True(File.Exists(target));   // the write was NOT reverted
+            Assert.Single(journal.List());      // the entry is still on the stack
+        }
+    }
+
+    [Fact]
+    public void Disk_replay_refuses_a_target_outside_the_allowed_roots()
+    {
+        // A journal entry pointing outside packages/workspace/temp must not be replayed —
+        // the path comes from the journal store, not from the command line.
+        var outside = OperatingSystem.IsWindows()
+            ? @"C:\d365fo-undo-boundary-probe.xml"
+            : "/d365fo-undo-boundary-probe.xml";
+
+        var journal = NewJournal();
+        journal.Append(new JournalEntry(
+            Id: Guid.NewGuid().ToString("N"), TimestampUtc: DateTimeOffset.UtcNow, Command: "generate table",
+            TargetType: JournalTargetType.AotObject, Kind: "table", ObjectName: "Probe", SecondaryKey: null,
+            Model: null, Operation: JournalOperation.Update, WritePath: JournalWritePath.Disk,
+            TargetPath: outside, PreImage: "<AxTable/>", IsTombstone: false, RnrProjDelta: null));
+
+        var result = UndoEngine.Undo(journal, 1, dryRun: false);
+
+        Assert.False(result.AllOk);
+        Assert.Contains("Path traversal blocked", result.Steps[0].Error);
+        Assert.False(File.Exists(outside));
+    }
+
     // ---- disk: delete -------------------------------------------------------
 
     [Fact]


### PR DESCRIPTION
Full-repo audit of the CLI, Core, MCP, and Bridge projects. Eight defects, each with a regression test. Build is warning-free; **657 tests pass** (648 existing + 9 new).

## Bugs fixed

### `undo` did not restore the exact bytes it promises

The journal's contract is "restoring the exact pre-image bytes", but `PreImage` is stored as a *decoded string* and the decoder swallows the UTF-8 BOM. `AtomicWriteText` then rewrote the file without one. Reproduced end-to-end:

```
before undo:  ef bb bf 3c   ("<" behind a BOM)
after  undo:  3c 3f 78 6d   ("<?xm" — BOM gone)
```

D365FO and Visual Studio both write AOT XML **with** a BOM, so every `undo` left a spurious change in `git diff`. `JournalEntry` gains an optional `PreImageHadBom` flag — backward compatible, since entries from older builds deserialize to `null` and fall back to the BOM state of the file on disk. After the fix the restored file is byte-identical to the original.

### `undo` bypassed `PathGuard`

`ReplayDisk` called `File.Delete` and wrote files with no boundary check, unlike every other write path in the codebase. The target path comes out of the journal store rather than the current command line, so a journal carried over from a different `D365FO_PACKAGES_PATH` — or hand-edited — could reach anywhere on disk.

### A negative `--limit` disabled the row cap

SQLite reads a **negative** `LIMIT` as "no limit at all", so `--limit -1` turned a bounded lookup into a full-index dump — the exact token blow-up the result caps exist to prevent. The MCP layer already guarded this (`limit <= 0 ? 50`); the CLI and Core did not. Adds `ClampLimit` across all 27 query methods, plus a hard `MaxRowLimit = 1000` ceiling.

### `BridgeClient` desynchronised after a timeout

On timeout the abandoned `ReadLine` stayed parked on the pipe and consumed the bridge's late reply — which was then handed to the **next** request, shifting every subsequent response by one. Replies were never correlated by JSON-RPC `id` either. The child process is now discarded on timeout so the next call starts clean, and a mismatched `id` is a hard error rather than silently misattributed data.

### `undo --steps 0` reverted an entry

Both `UndoEngine` (`Math.Max(1, steps)`) and the CLI (`settings.Steps <= 0 ? 1`) silently rounded 0 up to 1. Undo is destructive, so a caller asking for no steps now gets `INVALID_ARGS` instead of an unrequested revert.

### Three smaller ones

- **Unescaped LIKE wildcards** in `FindFormsByPattern` — `--pattern "Simple_List"` also matched `SimpleXList`.
- **Grounding-token binding was too loose** — the bidirectional substring match meant a token issued for `Cust` authorized writes to *anything* containing "Cust", and a token for `CustTable` authorized the unrelated shorter `Cust`. Now a prefix match, which still allows derived names like `CustTable_MyExt_Extension` and `CustTableEventHandler`.
- **Build hygiene** — 3× CS1573, and a doc comment on `OpenReadOnly` promising an `EnsureSchema` fallback that does not exist in the code.

## Verification

`dotnet build -c Release` is clean, and the fixes were exercised against the `MiniAot` sample through the real CLI, not only through unit tests: BOM round-trip, `--steps 0`/`-3`, `--limit -1`, and `--pattern "Simple_List"`.

## Deliberately not changed

Three findings alter operational behavior and are left as follow-ups:

- `HttpServerHost` binds `0.0.0.0` even with no `API_KEY` (log warning only). A loopback default would be safer but breaks Azure App Service deployments, which require `0.0.0.0`.
- `CallDedup` is a static cache shared across all HTTP clients — in a shared team deployment client B can be served client A's cached answer. Read-only metadata from the same index, so not a leak, but it is cross-session state.
- `PathGuard` always allows the whole `%TEMP%` tree. Intentional for tests, but it widens the boundary for production writes too.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
