### PR TITLE
feat(eval): expand catalog to 22 cases, fix 3 real generator/validator bugs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,6 +20,3 @@ memory/
 
 # Agent workflow scratch worktrees
 .claude/worktrees/
-
-# Agent eval loop corpus — VM-free but still local run evidence, not committed (docs/AGENT_EVAL_LOOP.md)
-eval/corpus/runs/*.json

--- a/docs/AGENT_EVAL_LOOP.md
+++ b/docs/AGENT_EVAL_LOOP.md
@@ -1,6 +1,6 @@
 # Self-improving agent eval loop — design spec
 
-**Status:** implemented — a 5-case catalog (L0–L2) runs clean end-to-end. See
+**Status:** implemented — a 22-case catalog (L0–L2) runs end-to-end. See
 [eval/README.md](../eval/README.md) for day-to-day mechanics and the open
 work queue.
 
@@ -260,9 +260,12 @@ Tiers (unchanged from the source repo's convention):
 | L3 — composite | relation + generated form + datasource rebind |
 | L4 — feature slice | data entity + security chain, batch job, SSRS report |
 
-Current catalog: 5 cases, L0–L2 (`generate edt`, `enum`, `table`, `class`,
-`coc`). See [eval/README.md](../eval/README.md) for the standing "grow the
-catalog" queue.
+Current catalog: 22 cases, L0–L2 (`generate edt`, `enum`, `table`, `class`,
+`coc`, `form`, `query`, `map`, `report`, `sysoperation`, `runbase`,
+`business-event`, `custom-service`, `workflow`, `systest`,
+`extension table/edt/enum`, `event-handler`, `number-sequence`, `entity`,
+`security-policy`). See [eval/README.md](../eval/README.md) for the standing
+"grow the catalog" queue.
 
 ---
 

--- a/eval/README.md
+++ b/eval/README.md
@@ -23,7 +23,7 @@ eval/
 │   └── <case-id>/*.xml     ← committed, human-reviewed golden output (exactly one file per v1 case)
 └── corpus/
     ├── schema.json          ← documented run-record shape
-    └── runs/                ← one *.json run record per run (gitignored — local/CI evidence)
+    └── runs/                ← one *.json run record per run (committed, matching d365fo-mcp-server's eval/corpus/runs/)
 ```
 
 ## Running a case
@@ -98,15 +98,28 @@ lie in place while a deeper fix waits.
 
 ## Explicitly out of scope (for now)
 
-- **CI wiring.** `eval run` for all 5 cases is not yet a gate in
-  `.github/workflows/ci.yml`. Natural follow-up once the catalog has grown
-  past the initial 5.
+- **CI wiring.** `eval run` for all cases is not yet a gate in
+  `.github/workflows/ci.yml`.
 - **No runtime/SysTest oracle.** No `SysTestRunner` integration exists in
   this offline loop — only the golden-diff and static-validator dimensions.
+  A handful of cases (tagged `known-reference-gap`) generate a class or
+  extension whose body legitimately references a *sibling* artifact or a
+  standard system object that a minimal offline index can't contain (e.g.
+  the SysOperation controller's own Service class, or a CoC extension over a
+  standard `NumberSeqApplicationModule_*` class) — `referencesClean: false`
+  there is the expected, honest result of scoring one artifact in isolation,
+  not a defect.
 - **`MODEL_ERROR` → knowledge-base feedback tooling.** The sibling repo has
   an automated "cluster MODEL_ERROR runs into `skills/_source` proposals"
   step (`knowledgeFeedback.ts`); not built here yet. The rubric and agent
   roles already support adding it.
-- **Catalog breadth.** 5 cases across L0–L2 today (`generate edt`, `enum`,
-  `table`, `class`, `coc`). Wider `generate` coverage (forms, extensions,
-  security, entities, …) is the natural next slice — use `eval-author`.
+- **Catalog breadth.** 22 cases across L0–L2 (`edt`, `enum`, `table`,
+  `class`, `coc`, `form`, `query`, `map`, `report`, `sysoperation`,
+  `runbase`, `business-event`, `custom-service`, `workflow`, `systest`,
+  `extension table/edt/enum`, `event-handler`, `number-sequence`, `entity`,
+  `security-policy`). L3/L4 (batch, workflow *runtime* submission, posting,
+  DMF, ER, SSRS rendering, …) need a live build/BP-check/SysTest oracle this
+  offline loop doesn't have — the natural next slice is either growing L0–L2
+  breadth further (forms/security/menu-items not yet covered) or adding that
+  oracle. See `d365fo-mcp-server`'s `eval/cases/` for the fuller L3/L4
+  catalog shape to port once a VM-backed oracle exists here.

--- a/eval/cases/L1-business-event-basic.json
+++ b/eval/cases/L1-business-event-basic.json
@@ -1,0 +1,13 @@
+{
+  "id": "L1-business-event-basic",
+  "title": "Business event class + contract scaffold",
+  "tier": 1,
+  "instruction": "Create a business event named ConFmVehicleNoteAdded with a single payload field NoteId (EDT Name). Use only the d365fo CLI (search/get/generate/validate) — do not hand-write XML.",
+  "canonical_args": ["generate", "business-event", "ConFmVehicleNoteAdded", "--payload", "NoteId:Name"],
+  "target_artifact_types": ["AxClass"],
+  "golden_path": "L1-business-event-basic",
+  "tags": ["business-event", "class", "metadata", "known-reference-gap"],
+  "ignore": [],
+  "requires_fixture_index": false,
+  "golden_pending": false
+}

--- a/eval/cases/L1-custom-service-basic.json
+++ b/eval/cases/L1-custom-service-basic.json
@@ -1,0 +1,13 @@
+{
+  "id": "L1-custom-service-basic",
+  "title": "AxService descriptor with a single operation",
+  "tier": 1,
+  "instruction": "Create a custom AOT service named ConFmVehicleQueryService with a single operation 'lookup' returning str. Use only the d365fo CLI (search/get/generate/validate) — do not hand-write XML.",
+  "canonical_args": ["generate", "custom-service", "ConFmVehicleQueryService", "--operation", "lookup:str"],
+  "target_artifact_types": ["AxService"],
+  "golden_path": "L1-custom-service-basic",
+  "tags": ["custom-service", "metadata"],
+  "ignore": [],
+  "requires_fixture_index": false,
+  "golden_pending": false
+}

--- a/eval/cases/L1-form-basic.json
+++ b/eval/cases/L1-form-basic.json
@@ -1,0 +1,13 @@
+{
+  "id": "L1-form-basic",
+  "title": "SimpleList form bound to an existing table",
+  "tier": 1,
+  "instruction": "Create a SimpleList form named ConFmVehicleList bound to the FmVehicle table, with grid columns for VIN and Make, captioned 'Fleet vehicles'. Use `d365fo get table FmVehicle` first to confirm the field names before generating. Use only the d365fo CLI (search/get/generate/validate) — do not hand-write XML.",
+  "canonical_args": ["generate", "form", "ConFmVehicleList", "--pattern", "SimpleList", "--table", "FmVehicle", "--field", "VIN", "--field", "Make", "--caption", "Fleet vehicles"],
+  "target_artifact_types": ["AxForm"],
+  "golden_path": "L1-form-basic",
+  "tags": ["form", "simplelist", "metadata"],
+  "ignore": [],
+  "requires_fixture_index": true,
+  "golden_pending": false
+}

--- a/eval/cases/L1-map-basic.json
+++ b/eval/cases/L1-map-basic.json
@@ -1,0 +1,13 @@
+{
+  "id": "L1-map-basic",
+  "title": "Shared field map onto an existing table",
+  "tier": 1,
+  "instruction": "Create an AxMap named ConFmVehicleMap with a single field Make (EDT Name), mapped onto the FmVehicle table's own Make field by identical name. Use `d365fo get table FmVehicle` first to confirm the field exists before generating. Use only the d365fo CLI (search/get/generate/validate) — do not hand-write XML.",
+  "canonical_args": ["generate", "map", "ConFmVehicleMap", "--field", "Make:Name", "--map-to", "FmVehicle:Make=Make"],
+  "target_artifact_types": ["AxMap"],
+  "golden_path": "L1-map-basic",
+  "tags": ["map", "metadata"],
+  "ignore": [],
+  "requires_fixture_index": true,
+  "golden_pending": false
+}

--- a/eval/cases/L1-query-basic.json
+++ b/eval/cases/L1-query-basic.json
@@ -1,0 +1,13 @@
+{
+  "id": "L1-query-basic",
+  "title": "Single-datasource AOT query over an existing table",
+  "tier": 1,
+  "instruction": "Create an AOT query named ConFmVehicleQuery with FmVehicle as its single root data source. Use `d365fo get table FmVehicle` first to confirm the table exists before generating. Use only the d365fo CLI (search/get/generate/validate) — do not hand-write XML.",
+  "canonical_args": ["generate", "query", "ConFmVehicleQuery", "--ds", "FmVehicle"],
+  "target_artifact_types": ["AxQuery"],
+  "golden_path": "L1-query-basic",
+  "tags": ["query", "metadata"],
+  "ignore": [],
+  "requires_fixture_index": true,
+  "golden_pending": false
+}

--- a/eval/cases/L1-report-basic.json
+++ b/eval/cases/L1-report-basic.json
@@ -1,0 +1,13 @@
+{
+  "id": "L1-report-basic",
+  "title": "SRS report with a two-column tablix",
+  "tier": 1,
+  "instruction": "Create an SSRS report named ConFmVehicleReport with a tablix showing columns VIN and Make, captioned 'Fleet vehicle report'. Use only the d365fo CLI (search/get/generate/validate) — do not hand-write XML.",
+  "canonical_args": ["generate", "report", "ConFmVehicleReport", "--field", "VIN", "--field", "Make", "--caption", "Fleet vehicle report"],
+  "target_artifact_types": ["AxReport"],
+  "golden_path": "L1-report-basic",
+  "tags": ["report", "srs", "metadata"],
+  "ignore": [],
+  "requires_fixture_index": false,
+  "golden_pending": false
+}

--- a/eval/cases/L1-runbase-basic.json
+++ b/eval/cases/L1-runbase-basic.json
@@ -1,0 +1,13 @@
+{
+  "id": "L1-runbase-basic",
+  "title": "RunBase batch-ready class skeleton",
+  "tier": 1,
+  "instruction": "Create a RunBase-derived class named ConFmVehicleRun with the standard dialog/pack/unpack/run skeleton. Use only the d365fo CLI (search/get/generate/validate) — do not hand-write XML.",
+  "canonical_args": ["generate", "runbase", "ConFmVehicleRun"],
+  "target_artifact_types": ["AxClass"],
+  "golden_path": "L1-runbase-basic",
+  "tags": ["runbase", "class", "metadata"],
+  "ignore": [],
+  "requires_fixture_index": false,
+  "golden_pending": false
+}

--- a/eval/cases/L1-sysoperation-basic.json
+++ b/eval/cases/L1-sysoperation-basic.json
@@ -1,0 +1,13 @@
+{
+  "id": "L1-sysoperation-basic",
+  "title": "SysOperation DataContract + Service + Controller triplet",
+  "tier": 1,
+  "instruction": "Create a synchronous SysOperation framework triplet named ConFmVehicleImport with a single contract parameter VehicleNote (EDT Name). Use only the d365fo CLI (search/get/generate/validate) — do not hand-write XML.",
+  "canonical_args": ["generate", "sysoperation", "ConFmVehicleImport", "--param", "VehicleNote:Name"],
+  "target_artifact_types": ["AxClass"],
+  "golden_path": "L1-sysoperation-basic",
+  "tags": ["sysoperation", "class", "metadata", "known-reference-gap"],
+  "ignore": [],
+  "requires_fixture_index": false,
+  "golden_pending": false
+}

--- a/eval/cases/L1-systest-basic.json
+++ b/eval/cases/L1-systest-basic.json
@@ -1,0 +1,13 @@
+{
+  "id": "L1-systest-basic",
+  "title": "ATL-ready SysTestCase skeleton over an existing class method",
+  "tier": 1,
+  "instruction": "Create an ATL-ready SysTest class named ConFmVehicleServiceTest exercising FmVehicleService.run(). Use `d365fo get class FmVehicleService` first to confirm the method exists before generating. Use only the d365fo CLI (search/get/generate/validate) — do not hand-write XML.",
+  "canonical_args": ["generate", "systest", "ConFmVehicleServiceTest", "--class", "FmVehicleService", "--method", "run"],
+  "target_artifact_types": ["AxClass"],
+  "golden_path": "L1-systest-basic",
+  "tags": ["systest", "class", "metadata"],
+  "ignore": [],
+  "requires_fixture_index": true,
+  "golden_pending": false
+}

--- a/eval/cases/L1-workflow-basic.json
+++ b/eval/cases/L1-workflow-basic.json
@@ -1,0 +1,13 @@
+{
+  "id": "L1-workflow-basic",
+  "title": "AxWorkflow type driven by an existing table",
+  "tier": 1,
+  "instruction": "Create an approval workflow type named ConFmVehicleNoteWorkflow driven by the FmVehicle table. Use `d365fo get table FmVehicle` first to confirm the table exists before generating. Use only the d365fo CLI (search/get/generate/validate) — do not hand-write XML.",
+  "canonical_args": ["generate", "workflow", "ConFmVehicleNoteWorkflow", "--table", "FmVehicle"],
+  "target_artifact_types": ["AxWorkflow"],
+  "golden_path": "L1-workflow-basic",
+  "tags": ["workflow", "metadata"],
+  "ignore": [],
+  "requires_fixture_index": true,
+  "golden_pending": false
+}

--- a/eval/cases/L2-edt-extension.json
+++ b/eval/cases/L2-edt-extension.json
@@ -1,0 +1,13 @@
+{
+  "id": "L2-edt-extension",
+  "title": "EDT extension shell over a standard EDT",
+  "tier": 2,
+  "instruction": "Create an EDT extension over the standard EDT AccountNum. Use only the d365fo CLI (search/get/generate/validate) — do not hand-write XML.",
+  "canonical_args": ["generate", "extension", "Edt", "AccountNum"],
+  "target_artifact_types": ["AxEdtExtension"],
+  "golden_path": "L2-edt-extension",
+  "tags": ["extension", "edt", "metadata"],
+  "ignore": [],
+  "requires_fixture_index": false,
+  "golden_pending": false
+}

--- a/eval/cases/L2-enum-extension.json
+++ b/eval/cases/L2-enum-extension.json
@@ -1,0 +1,13 @@
+{
+  "id": "L2-enum-extension",
+  "title": "Enum extension shell over a standard base enum",
+  "tier": 2,
+  "instruction": "Create an enum extension over the standard base enum NoYes. Use only the d365fo CLI (search/get/generate/validate) — do not hand-write XML.",
+  "canonical_args": ["generate", "extension", "Enum", "NoYes"],
+  "target_artifact_types": ["AxEnumExtension"],
+  "golden_path": "L2-enum-extension",
+  "tags": ["extension", "enum", "metadata"],
+  "ignore": [],
+  "requires_fixture_index": false,
+  "golden_pending": false
+}

--- a/eval/cases/L2-event-handler-basic.json
+++ b/eval/cases/L2-event-handler-basic.json
@@ -1,0 +1,13 @@
+{
+  "id": "L2-event-handler-basic",
+  "title": "Class-delegate event subscriber over an existing class",
+  "tier": 2,
+  "instruction": "Create an event subscriber class named ConFmVehicleServiceRunHandler subscribing to the FmVehicleService class's run event. Use `d365fo get class FmVehicleService` first to confirm the method exists before generating. Use only the d365fo CLI (search/get/generate/validate) — do not hand-write XML.",
+  "canonical_args": ["generate", "event-handler", "ConFmVehicleServiceRunHandler", "--source-kind", "Class", "--source-object", "FmVehicleService", "--method", "run"],
+  "target_artifact_types": ["AxClass"],
+  "golden_path": "L2-event-handler-basic",
+  "tags": ["event-handler", "class", "metadata"],
+  "ignore": [],
+  "requires_fixture_index": true,
+  "golden_pending": false
+}

--- a/eval/cases/L2-numberseq-basic.json
+++ b/eval/cases/L2-numberseq-basic.json
@@ -1,0 +1,13 @@
+{
+  "id": "L2-numberseq-basic",
+  "title": "Number sequence module registration (EDT + CoC module extension)",
+  "tier": 2,
+  "instruction": "Register a new number-sequence module named ConDemo: a CoC extension of NumberSeqApplicationModule_ConDemo that registers a NumberSeqDatatype for a new EDT ConDemoNum in loadModule(). Use only the d365fo CLI (search/get/generate/validate) — do not hand-write XML.",
+  "canonical_args": ["generate", "number-sequence", "ConDemo"],
+  "target_artifact_types": ["AxClass"],
+  "golden_path": "L2-numberseq-basic",
+  "tags": ["numbersequence", "class", "coc", "metadata", "known-reference-gap"],
+  "ignore": [],
+  "requires_fixture_index": false,
+  "golden_pending": false
+}

--- a/eval/cases/L2-security-policy-basic.json
+++ b/eval/cases/L2-security-policy-basic.json
@@ -1,0 +1,13 @@
+{
+  "id": "L2-security-policy-basic",
+  "title": "XDS security policy constraining an existing table",
+  "tier": 2,
+  "instruction": "Create a security policy named ConFmVehicleOwnerPolicy constraining the FmVehicle table via a policy query ConFmVehicleOwnerQuery. Use `d365fo get table FmVehicle` first to confirm the table exists before generating. Use only the d365fo CLI (search/get/generate/validate) — do not hand-write XML.",
+  "canonical_args": ["generate", "security-policy", "ConFmVehicleOwnerPolicy", "--constrained-table", "FmVehicle", "--policy-query", "ConFmVehicleOwnerQuery"],
+  "target_artifact_types": ["AxSecurityPolicy"],
+  "golden_path": "L2-security-policy-basic",
+  "tags": ["security-policy", "xds", "metadata"],
+  "ignore": [],
+  "requires_fixture_index": true,
+  "golden_pending": false
+}

--- a/eval/cases/L2-table-extension.json
+++ b/eval/cases/L2-table-extension.json
@@ -1,0 +1,13 @@
+{
+  "id": "L2-table-extension",
+  "title": "Table extension shell over an existing table",
+  "tier": 2,
+  "instruction": "Create a Table extension over FmVehicle. Use `d365fo get table FmVehicle` first to confirm the table exists before generating. Use only the d365fo CLI (search/get/generate/validate) — do not hand-write XML.",
+  "canonical_args": ["generate", "extension", "Table", "FmVehicle"],
+  "target_artifact_types": ["AxTableExtension"],
+  "golden_path": "L2-table-extension",
+  "tags": ["extension", "table", "metadata", "known-xpp-gap"],
+  "ignore": [],
+  "requires_fixture_index": true,
+  "golden_pending": false
+}

--- a/eval/cases/L2-virtual-entity-basic.json
+++ b/eval/cases/L2-virtual-entity-basic.json
@@ -1,0 +1,13 @@
+{
+  "id": "L2-virtual-entity-basic",
+  "title": "Public data entity view over an existing table",
+  "tier": 2,
+  "instruction": "Create a public data entity named ConFmVehicleEntity over the FmVehicle table, exposing VIN and Make, with public collection name ConFmVehicleEntities. Use `d365fo get table FmVehicle` first to confirm the field names before generating. Use only the d365fo CLI (search/get/generate/validate) — do not hand-write XML.",
+  "canonical_args": ["generate", "entity", "ConFmVehicleEntity", "--table", "FmVehicle", "--public-entity", "ConFmVehicleEntity", "--public-collection", "ConFmVehicleEntities", "--field", "VIN", "--field", "Make"],
+  "target_artifact_types": ["AxDataEntityView"],
+  "golden_path": "L2-virtual-entity-basic",
+  "tags": ["entity", "data-entity", "metadata"],
+  "ignore": [],
+  "requires_fixture_index": true,
+  "golden_pending": false
+}

--- a/eval/corpus/runs/20260805T113909858Z__L0-edt-basic__75b2211595184508ba968b88863682b4.json
+++ b/eval/corpus/runs/20260805T113909858Z__L0-edt-basic__75b2211595184508ba968b88863682b4.json
@@ -1,0 +1,20 @@
+{
+  "runId": "20260805T113909858Z__L0-edt-basic__75b2211595184508ba968b88863682b4",
+  "caseId": "L0-edt-basic",
+  "tier": 0,
+  "timestampUtc": "2026-08-05T11:39:09.8602359+00:00",
+  "source": "replay",
+  "score": {
+    "xppClean": true,
+    "xppErrors": 0,
+    "referencesClean": true,
+    "referenceErrors": 0,
+    "goldenMatch": true,
+    "goldenDiff": {
+      "missing": [],
+      "extra": [],
+      "changed": [],
+      "isMatch": true
+    }
+  }
+}

--- a/eval/corpus/runs/20260805T113920642Z__L0-enum-basic__32e906fb1952422681c10069b6f0c150.json
+++ b/eval/corpus/runs/20260805T113920642Z__L0-enum-basic__32e906fb1952422681c10069b6f0c150.json
@@ -1,0 +1,20 @@
+{
+  "runId": "20260805T113920642Z__L0-enum-basic__32e906fb1952422681c10069b6f0c150",
+  "caseId": "L0-enum-basic",
+  "tier": 0,
+  "timestampUtc": "2026-08-05T11:39:20.6441582+00:00",
+  "source": "replay",
+  "score": {
+    "xppClean": true,
+    "xppErrors": 0,
+    "referencesClean": true,
+    "referenceErrors": 0,
+    "goldenMatch": true,
+    "goldenDiff": {
+      "missing": [],
+      "extra": [],
+      "changed": [],
+      "isMatch": true
+    }
+  }
+}

--- a/eval/corpus/runs/20260805T113925675Z__L1-class-basic__52adf99a9d8d4369890cfd619594ade2.json
+++ b/eval/corpus/runs/20260805T113925675Z__L1-class-basic__52adf99a9d8d4369890cfd619594ade2.json
@@ -1,0 +1,20 @@
+{
+  "runId": "20260805T113925675Z__L1-class-basic__52adf99a9d8d4369890cfd619594ade2",
+  "caseId": "L1-class-basic",
+  "tier": 1,
+  "timestampUtc": "2026-08-05T11:39:25.6767983+00:00",
+  "source": "replay",
+  "score": {
+    "xppClean": true,
+    "xppErrors": 0,
+    "referencesClean": true,
+    "referenceErrors": 0,
+    "goldenMatch": true,
+    "goldenDiff": {
+      "missing": [],
+      "extra": [],
+      "changed": [],
+      "isMatch": true
+    }
+  }
+}

--- a/eval/corpus/runs/20260805T113930771Z__L1-table-basic__0204500c96e74421983cf2b7e67003d9.json
+++ b/eval/corpus/runs/20260805T113930771Z__L1-table-basic__0204500c96e74421983cf2b7e67003d9.json
@@ -1,0 +1,20 @@
+{
+  "runId": "20260805T113930771Z__L1-table-basic__0204500c96e74421983cf2b7e67003d9",
+  "caseId": "L1-table-basic",
+  "tier": 1,
+  "timestampUtc": "2026-08-05T11:39:30.7732815+00:00",
+  "source": "replay",
+  "score": {
+    "xppClean": true,
+    "xppErrors": 0,
+    "referencesClean": true,
+    "referenceErrors": 0,
+    "goldenMatch": true,
+    "goldenDiff": {
+      "missing": [],
+      "extra": [],
+      "changed": [],
+      "isMatch": true
+    }
+  }
+}

--- a/eval/corpus/runs/20260805T113936180Z__L2-coc-extension__814cca39e88c46e78b6a281c0a030125.json
+++ b/eval/corpus/runs/20260805T113936180Z__L2-coc-extension__814cca39e88c46e78b6a281c0a030125.json
@@ -1,0 +1,20 @@
+{
+  "runId": "20260805T113936180Z__L2-coc-extension__814cca39e88c46e78b6a281c0a030125",
+  "caseId": "L2-coc-extension",
+  "tier": 2,
+  "timestampUtc": "2026-08-05T11:39:36.1821108+00:00",
+  "source": "replay",
+  "score": {
+    "xppClean": true,
+    "xppErrors": 0,
+    "referencesClean": true,
+    "referenceErrors": 0,
+    "goldenMatch": true,
+    "goldenDiff": {
+      "missing": [],
+      "extra": [],
+      "changed": [],
+      "isMatch": true
+    }
+  }
+}

--- a/eval/corpus/runs/20260805T125629230Z__L0-edt-basic__52c88f72c9db4f4e919b426305426fb8.json
+++ b/eval/corpus/runs/20260805T125629230Z__L0-edt-basic__52c88f72c9db4f4e919b426305426fb8.json
@@ -1,0 +1,20 @@
+{
+  "runId": "20260805T125629230Z__L0-edt-basic__52c88f72c9db4f4e919b426305426fb8",
+  "caseId": "L0-edt-basic",
+  "tier": 0,
+  "timestampUtc": "2026-08-05T12:56:29.2319183+00:00",
+  "source": "replay",
+  "score": {
+    "xppClean": true,
+    "xppErrors": 0,
+    "referencesClean": true,
+    "referenceErrors": 0,
+    "goldenMatch": true,
+    "goldenDiff": {
+      "missing": [],
+      "extra": [],
+      "changed": [],
+      "isMatch": true
+    }
+  }
+}

--- a/eval/corpus/runs/20260805T125634162Z__L0-enum-basic__b790b79ef2eb478c9190fbbd8dcaa562.json
+++ b/eval/corpus/runs/20260805T125634162Z__L0-enum-basic__b790b79ef2eb478c9190fbbd8dcaa562.json
@@ -1,0 +1,20 @@
+{
+  "runId": "20260805T125634162Z__L0-enum-basic__b790b79ef2eb478c9190fbbd8dcaa562",
+  "caseId": "L0-enum-basic",
+  "tier": 0,
+  "timestampUtc": "2026-08-05T12:56:34.1642399+00:00",
+  "source": "replay",
+  "score": {
+    "xppClean": true,
+    "xppErrors": 0,
+    "referencesClean": true,
+    "referenceErrors": 0,
+    "goldenMatch": true,
+    "goldenDiff": {
+      "missing": [],
+      "extra": [],
+      "changed": [],
+      "isMatch": true
+    }
+  }
+}

--- a/eval/corpus/runs/20260805T125639283Z__L1-class-basic__531ebe9dbbff42249d89e2fed5c7366b.json
+++ b/eval/corpus/runs/20260805T125639283Z__L1-class-basic__531ebe9dbbff42249d89e2fed5c7366b.json
@@ -1,0 +1,20 @@
+{
+  "runId": "20260805T125639283Z__L1-class-basic__531ebe9dbbff42249d89e2fed5c7366b",
+  "caseId": "L1-class-basic",
+  "tier": 1,
+  "timestampUtc": "2026-08-05T12:56:39.2849794+00:00",
+  "source": "replay",
+  "score": {
+    "xppClean": true,
+    "xppErrors": 0,
+    "referencesClean": true,
+    "referenceErrors": 0,
+    "goldenMatch": true,
+    "goldenDiff": {
+      "missing": [],
+      "extra": [],
+      "changed": [],
+      "isMatch": true
+    }
+  }
+}

--- a/eval/corpus/runs/20260805T125644609Z__L1-table-basic__691cf2c6fda64a1f9f175229c2dd81e6.json
+++ b/eval/corpus/runs/20260805T125644609Z__L1-table-basic__691cf2c6fda64a1f9f175229c2dd81e6.json
@@ -1,0 +1,20 @@
+{
+  "runId": "20260805T125644609Z__L1-table-basic__691cf2c6fda64a1f9f175229c2dd81e6",
+  "caseId": "L1-table-basic",
+  "tier": 1,
+  "timestampUtc": "2026-08-05T12:56:44.6112505+00:00",
+  "source": "replay",
+  "score": {
+    "xppClean": true,
+    "xppErrors": 0,
+    "referencesClean": true,
+    "referenceErrors": 0,
+    "goldenMatch": true,
+    "goldenDiff": {
+      "missing": [],
+      "extra": [],
+      "changed": [],
+      "isMatch": true
+    }
+  }
+}

--- a/eval/corpus/runs/20260805T125650135Z__L1-form-basic__f3d7376be3d94baaad4b2d363e6a1095.json
+++ b/eval/corpus/runs/20260805T125650135Z__L1-form-basic__f3d7376be3d94baaad4b2d363e6a1095.json
@@ -1,0 +1,20 @@
+{
+  "runId": "20260805T125650135Z__L1-form-basic__f3d7376be3d94baaad4b2d363e6a1095",
+  "caseId": "L1-form-basic",
+  "tier": 1,
+  "timestampUtc": "2026-08-05T12:56:50.137471+00:00",
+  "source": "replay",
+  "score": {
+    "xppClean": true,
+    "xppErrors": 0,
+    "referencesClean": true,
+    "referenceErrors": 0,
+    "goldenMatch": true,
+    "goldenDiff": {
+      "missing": [],
+      "extra": [],
+      "changed": [],
+      "isMatch": true
+    }
+  }
+}

--- a/eval/corpus/runs/20260805T125655393Z__L1-query-basic__65abcd1cfc9f45cfbbdd54008b0f6176.json
+++ b/eval/corpus/runs/20260805T125655393Z__L1-query-basic__65abcd1cfc9f45cfbbdd54008b0f6176.json
@@ -1,0 +1,20 @@
+{
+  "runId": "20260805T125655393Z__L1-query-basic__65abcd1cfc9f45cfbbdd54008b0f6176",
+  "caseId": "L1-query-basic",
+  "tier": 1,
+  "timestampUtc": "2026-08-05T12:56:55.3948752+00:00",
+  "source": "replay",
+  "score": {
+    "xppClean": true,
+    "xppErrors": 0,
+    "referencesClean": true,
+    "referenceErrors": 0,
+    "goldenMatch": true,
+    "goldenDiff": {
+      "missing": [],
+      "extra": [],
+      "changed": [],
+      "isMatch": true
+    }
+  }
+}

--- a/eval/corpus/runs/20260805T125700589Z__L1-map-basic__80631d86a7b64d45be2a23af5dd1f76f.json
+++ b/eval/corpus/runs/20260805T125700589Z__L1-map-basic__80631d86a7b64d45be2a23af5dd1f76f.json
@@ -1,0 +1,20 @@
+{
+  "runId": "20260805T125700589Z__L1-map-basic__80631d86a7b64d45be2a23af5dd1f76f",
+  "caseId": "L1-map-basic",
+  "tier": 1,
+  "timestampUtc": "2026-08-05T12:57:00.5915122+00:00",
+  "source": "replay",
+  "score": {
+    "xppClean": true,
+    "xppErrors": 0,
+    "referencesClean": true,
+    "referenceErrors": 0,
+    "goldenMatch": true,
+    "goldenDiff": {
+      "missing": [],
+      "extra": [],
+      "changed": [],
+      "isMatch": true
+    }
+  }
+}

--- a/eval/corpus/runs/20260805T125705546Z__L1-report-basic__f0ff3fde1ed14f949392fafd1bca69c6.json
+++ b/eval/corpus/runs/20260805T125705546Z__L1-report-basic__f0ff3fde1ed14f949392fafd1bca69c6.json
@@ -1,0 +1,20 @@
+{
+  "runId": "20260805T125705546Z__L1-report-basic__f0ff3fde1ed14f949392fafd1bca69c6",
+  "caseId": "L1-report-basic",
+  "tier": 1,
+  "timestampUtc": "2026-08-05T12:57:05.5480805+00:00",
+  "source": "replay",
+  "score": {
+    "xppClean": true,
+    "xppErrors": 0,
+    "referencesClean": true,
+    "referenceErrors": 0,
+    "goldenMatch": true,
+    "goldenDiff": {
+      "missing": [],
+      "extra": [],
+      "changed": [],
+      "isMatch": true
+    }
+  }
+}

--- a/eval/corpus/runs/20260805T125710673Z__L1-sysoperation-basic__f9e18f02966144198aed7317812c0291.json
+++ b/eval/corpus/runs/20260805T125710673Z__L1-sysoperation-basic__f9e18f02966144198aed7317812c0291.json
@@ -1,0 +1,20 @@
+{
+  "runId": "20260805T125710673Z__L1-sysoperation-basic__f9e18f02966144198aed7317812c0291",
+  "caseId": "L1-sysoperation-basic",
+  "tier": 1,
+  "timestampUtc": "2026-08-05T12:57:10.6752903+00:00",
+  "source": "replay",
+  "score": {
+    "xppClean": true,
+    "xppErrors": 0,
+    "referencesClean": false,
+    "referenceErrors": 3,
+    "goldenMatch": true,
+    "goldenDiff": {
+      "missing": [],
+      "extra": [],
+      "changed": [],
+      "isMatch": true
+    }
+  }
+}

--- a/eval/corpus/runs/20260805T125715574Z__L1-runbase-basic__ffcbe1944a5b4d8a9b3a6e8ea74ccfa6.json
+++ b/eval/corpus/runs/20260805T125715574Z__L1-runbase-basic__ffcbe1944a5b4d8a9b3a6e8ea74ccfa6.json
@@ -1,0 +1,20 @@
+{
+  "runId": "20260805T125715574Z__L1-runbase-basic__ffcbe1944a5b4d8a9b3a6e8ea74ccfa6",
+  "caseId": "L1-runbase-basic",
+  "tier": 1,
+  "timestampUtc": "2026-08-05T12:57:15.5765379+00:00",
+  "source": "replay",
+  "score": {
+    "xppClean": true,
+    "xppErrors": 0,
+    "referencesClean": true,
+    "referenceErrors": 0,
+    "goldenMatch": true,
+    "goldenDiff": {
+      "missing": [],
+      "extra": [],
+      "changed": [],
+      "isMatch": true
+    }
+  }
+}

--- a/eval/corpus/runs/20260805T125720671Z__L1-business-event-basic__02af13beb5a947f8a28f1af760b7c347.json
+++ b/eval/corpus/runs/20260805T125720671Z__L1-business-event-basic__02af13beb5a947f8a28f1af760b7c347.json
@@ -1,0 +1,20 @@
+{
+  "runId": "20260805T125720671Z__L1-business-event-basic__02af13beb5a947f8a28f1af760b7c347",
+  "caseId": "L1-business-event-basic",
+  "tier": 1,
+  "timestampUtc": "2026-08-05T12:57:20.6732747+00:00",
+  "source": "replay",
+  "score": {
+    "xppClean": true,
+    "xppErrors": 0,
+    "referencesClean": false,
+    "referenceErrors": 1,
+    "goldenMatch": true,
+    "goldenDiff": {
+      "missing": [],
+      "extra": [],
+      "changed": [],
+      "isMatch": true
+    }
+  }
+}

--- a/eval/corpus/runs/20260805T125725622Z__L1-custom-service-basic__eb92fca449274acdb597c6087c791541.json
+++ b/eval/corpus/runs/20260805T125725622Z__L1-custom-service-basic__eb92fca449274acdb597c6087c791541.json
@@ -1,0 +1,20 @@
+{
+  "runId": "20260805T125725622Z__L1-custom-service-basic__eb92fca449274acdb597c6087c791541",
+  "caseId": "L1-custom-service-basic",
+  "tier": 1,
+  "timestampUtc": "2026-08-05T12:57:25.6240997+00:00",
+  "source": "replay",
+  "score": {
+    "xppClean": true,
+    "xppErrors": 0,
+    "referencesClean": true,
+    "referenceErrors": 0,
+    "goldenMatch": true,
+    "goldenDiff": {
+      "missing": [],
+      "extra": [],
+      "changed": [],
+      "isMatch": true
+    }
+  }
+}

--- a/eval/corpus/runs/20260805T125730958Z__L1-workflow-basic__efbf3ae8cdc94867adb19a594137dfbc.json
+++ b/eval/corpus/runs/20260805T125730958Z__L1-workflow-basic__efbf3ae8cdc94867adb19a594137dfbc.json
@@ -1,0 +1,20 @@
+{
+  "runId": "20260805T125730958Z__L1-workflow-basic__efbf3ae8cdc94867adb19a594137dfbc",
+  "caseId": "L1-workflow-basic",
+  "tier": 1,
+  "timestampUtc": "2026-08-05T12:57:30.9610558+00:00",
+  "source": "replay",
+  "score": {
+    "xppClean": true,
+    "xppErrors": 0,
+    "referencesClean": true,
+    "referenceErrors": 0,
+    "goldenMatch": true,
+    "goldenDiff": {
+      "missing": [],
+      "extra": [],
+      "changed": [],
+      "isMatch": true
+    }
+  }
+}

--- a/eval/corpus/runs/20260805T125736263Z__L1-systest-basic__03b4007bab2b4eab9c62b1440cc84ae7.json
+++ b/eval/corpus/runs/20260805T125736263Z__L1-systest-basic__03b4007bab2b4eab9c62b1440cc84ae7.json
@@ -1,0 +1,20 @@
+{
+  "runId": "20260805T125736263Z__L1-systest-basic__03b4007bab2b4eab9c62b1440cc84ae7",
+  "caseId": "L1-systest-basic",
+  "tier": 1,
+  "timestampUtc": "2026-08-05T12:57:36.2649325+00:00",
+  "source": "replay",
+  "score": {
+    "xppClean": true,
+    "xppErrors": 0,
+    "referencesClean": true,
+    "referenceErrors": 0,
+    "goldenMatch": true,
+    "goldenDiff": {
+      "missing": [],
+      "extra": [],
+      "changed": [],
+      "isMatch": true
+    }
+  }
+}

--- a/eval/corpus/runs/20260805T125741627Z__L2-coc-extension__66d5e3c8dd1140a79b82a25b6a5c6505.json
+++ b/eval/corpus/runs/20260805T125741627Z__L2-coc-extension__66d5e3c8dd1140a79b82a25b6a5c6505.json
@@ -1,0 +1,20 @@
+{
+  "runId": "20260805T125741627Z__L2-coc-extension__66d5e3c8dd1140a79b82a25b6a5c6505",
+  "caseId": "L2-coc-extension",
+  "tier": 2,
+  "timestampUtc": "2026-08-05T12:57:41.6292722+00:00",
+  "source": "replay",
+  "score": {
+    "xppClean": true,
+    "xppErrors": 0,
+    "referencesClean": true,
+    "referenceErrors": 0,
+    "goldenMatch": true,
+    "goldenDiff": {
+      "missing": [],
+      "extra": [],
+      "changed": [],
+      "isMatch": true
+    }
+  }
+}

--- a/eval/corpus/runs/20260805T125746944Z__L2-table-extension__1d9c1c3c07ea414c8a98434d87558083.json
+++ b/eval/corpus/runs/20260805T125746944Z__L2-table-extension__1d9c1c3c07ea414c8a98434d87558083.json
@@ -1,0 +1,20 @@
+{
+  "runId": "20260805T125746944Z__L2-table-extension__1d9c1c3c07ea414c8a98434d87558083",
+  "caseId": "L2-table-extension",
+  "tier": 2,
+  "timestampUtc": "2026-08-05T12:57:46.9465053+00:00",
+  "source": "replay",
+  "score": {
+    "xppClean": false,
+    "xppErrors": 1,
+    "referencesClean": true,
+    "referenceErrors": 0,
+    "goldenMatch": true,
+    "goldenDiff": {
+      "missing": [],
+      "extra": [],
+      "changed": [],
+      "isMatch": true
+    }
+  }
+}

--- a/eval/corpus/runs/20260805T125752193Z__L2-edt-extension__dc2ca7782d114c969611dc4d341ec3bf.json
+++ b/eval/corpus/runs/20260805T125752193Z__L2-edt-extension__dc2ca7782d114c969611dc4d341ec3bf.json
@@ -1,0 +1,20 @@
+{
+  "runId": "20260805T125752193Z__L2-edt-extension__dc2ca7782d114c969611dc4d341ec3bf",
+  "caseId": "L2-edt-extension",
+  "tier": 2,
+  "timestampUtc": "2026-08-05T12:57:52.1956991+00:00",
+  "source": "replay",
+  "score": {
+    "xppClean": true,
+    "xppErrors": 0,
+    "referencesClean": true,
+    "referenceErrors": 0,
+    "goldenMatch": true,
+    "goldenDiff": {
+      "missing": [],
+      "extra": [],
+      "changed": [],
+      "isMatch": true
+    }
+  }
+}

--- a/eval/corpus/runs/20260805T125757338Z__L2-enum-extension__098fd0d8199d4ca1a6c3f8db8711f0fd.json
+++ b/eval/corpus/runs/20260805T125757338Z__L2-enum-extension__098fd0d8199d4ca1a6c3f8db8711f0fd.json
@@ -1,0 +1,20 @@
+{
+  "runId": "20260805T125757338Z__L2-enum-extension__098fd0d8199d4ca1a6c3f8db8711f0fd",
+  "caseId": "L2-enum-extension",
+  "tier": 2,
+  "timestampUtc": "2026-08-05T12:57:57.3402194+00:00",
+  "source": "replay",
+  "score": {
+    "xppClean": true,
+    "xppErrors": 0,
+    "referencesClean": true,
+    "referenceErrors": 0,
+    "goldenMatch": true,
+    "goldenDiff": {
+      "missing": [],
+      "extra": [],
+      "changed": [],
+      "isMatch": true
+    }
+  }
+}

--- a/eval/corpus/runs/20260805T125802776Z__L2-event-handler-basic__e01e1c3b216e494bbf2cc18762b2a059.json
+++ b/eval/corpus/runs/20260805T125802776Z__L2-event-handler-basic__e01e1c3b216e494bbf2cc18762b2a059.json
@@ -1,0 +1,20 @@
+{
+  "runId": "20260805T125802776Z__L2-event-handler-basic__e01e1c3b216e494bbf2cc18762b2a059",
+  "caseId": "L2-event-handler-basic",
+  "tier": 2,
+  "timestampUtc": "2026-08-05T12:58:02.7782864+00:00",
+  "source": "replay",
+  "score": {
+    "xppClean": true,
+    "xppErrors": 0,
+    "referencesClean": true,
+    "referenceErrors": 0,
+    "goldenMatch": true,
+    "goldenDiff": {
+      "missing": [],
+      "extra": [],
+      "changed": [],
+      "isMatch": true
+    }
+  }
+}

--- a/eval/corpus/runs/20260805T125807969Z__L2-numberseq-basic__f37292c7c6bb41f6b4b0c87bca85a75b.json
+++ b/eval/corpus/runs/20260805T125807969Z__L2-numberseq-basic__f37292c7c6bb41f6b4b0c87bca85a75b.json
@@ -1,0 +1,20 @@
+{
+  "runId": "20260805T125807969Z__L2-numberseq-basic__f37292c7c6bb41f6b4b0c87bca85a75b",
+  "caseId": "L2-numberseq-basic",
+  "tier": 2,
+  "timestampUtc": "2026-08-05T12:58:07.9716909+00:00",
+  "source": "replay",
+  "score": {
+    "xppClean": true,
+    "xppErrors": 0,
+    "referencesClean": false,
+    "referenceErrors": 4,
+    "goldenMatch": true,
+    "goldenDiff": {
+      "missing": [],
+      "extra": [],
+      "changed": [],
+      "isMatch": true
+    }
+  }
+}

--- a/eval/corpus/runs/20260805T125813157Z__L2-virtual-entity-basic__edb13a2cc9e84ca18c717ebb5cde78c1.json
+++ b/eval/corpus/runs/20260805T125813157Z__L2-virtual-entity-basic__edb13a2cc9e84ca18c717ebb5cde78c1.json
@@ -1,0 +1,20 @@
+{
+  "runId": "20260805T125813157Z__L2-virtual-entity-basic__edb13a2cc9e84ca18c717ebb5cde78c1",
+  "caseId": "L2-virtual-entity-basic",
+  "tier": 2,
+  "timestampUtc": "2026-08-05T12:58:13.1592196+00:00",
+  "source": "replay",
+  "score": {
+    "xppClean": true,
+    "xppErrors": 0,
+    "referencesClean": true,
+    "referenceErrors": 0,
+    "goldenMatch": true,
+    "goldenDiff": {
+      "missing": [],
+      "extra": [],
+      "changed": [],
+      "isMatch": true
+    }
+  }
+}

--- a/eval/corpus/runs/20260805T125818235Z__L2-security-policy-basic__323bc0096cfa4eccab8e2ee8a28a3f5a.json
+++ b/eval/corpus/runs/20260805T125818235Z__L2-security-policy-basic__323bc0096cfa4eccab8e2ee8a28a3f5a.json
@@ -1,0 +1,20 @@
+{
+  "runId": "20260805T125818235Z__L2-security-policy-basic__323bc0096cfa4eccab8e2ee8a28a3f5a",
+  "caseId": "L2-security-policy-basic",
+  "tier": 2,
+  "timestampUtc": "2026-08-05T12:58:18.2375437+00:00",
+  "source": "replay",
+  "score": {
+    "xppClean": true,
+    "xppErrors": 0,
+    "referencesClean": true,
+    "referenceErrors": 0,
+    "goldenMatch": true,
+    "goldenDiff": {
+      "missing": [],
+      "extra": [],
+      "changed": [],
+      "isMatch": true
+    }
+  }
+}

--- a/eval/corpus/runs/20260805T130220902Z__L1-form-basic__227fae0222ba4d06b42eab99f85b79c1.json
+++ b/eval/corpus/runs/20260805T130220902Z__L1-form-basic__227fae0222ba4d06b42eab99f85b79c1.json
@@ -1,0 +1,46 @@
+{
+  "runId": "20260805T130220902Z__L1-form-basic__227fae0222ba4d06b42eab99f85b79c1",
+  "caseId": "L1-form-basic",
+  "tier": 1,
+  "timestampUtc": "2026-08-05T13:02:20.9048094+00:00",
+  "source": "agent",
+  "score": {
+    "xppClean": true,
+    "xppErrors": 0,
+    "referencesClean": true,
+    "referenceErrors": 0,
+    "goldenMatch": false,
+    "goldenDiff": {
+      "missing": [
+        "AxForm/DataSources/AxFormDataSource/Fields/AxFormDataSourceField[Make]/DataField",
+        "AxForm/DataSources/AxFormDataSource/Fields/AxFormDataSourceField[VIN]/DataField",
+        "AxForm/Design/Controls/AxFormControl[Grid]/Controls/AxFormControl[Grid_Make]/@type",
+        "AxForm/Design/Controls/AxFormControl[Grid]/Controls/AxFormControl[Grid_Make]/DataField",
+        "AxForm/Design/Controls/AxFormControl[Grid]/Controls/AxFormControl[Grid_Make]/DataSource",
+        "AxForm/Design/Controls/AxFormControl[Grid]/Controls/AxFormControl[Grid_Make]/FormControlExtension/@nil",
+        "AxForm/Design/Controls/AxFormControl[Grid]/Controls/AxFormControl[Grid_Make]/Name",
+        "AxForm/Design/Controls/AxFormControl[Grid]/Controls/AxFormControl[Grid_Make]/Type",
+        "AxForm/Design/Controls/AxFormControl[Grid]/Controls/AxFormControl[Grid_VIN]/@type",
+        "AxForm/Design/Controls/AxFormControl[Grid]/Controls/AxFormControl[Grid_VIN]/DataField",
+        "AxForm/Design/Controls/AxFormControl[Grid]/Controls/AxFormControl[Grid_VIN]/DataSource",
+        "AxForm/Design/Controls/AxFormControl[Grid]/Controls/AxFormControl[Grid_VIN]/FormControlExtension/@nil",
+        "AxForm/Design/Controls/AxFormControl[Grid]/Controls/AxFormControl[Grid_VIN]/Name",
+        "AxForm/Design/Controls/AxFormControl[Grid]/Controls/AxFormControl[Grid_VIN]/Type"
+      ],
+      "extra": [],
+      "changed": [
+        {
+          "path": "AxForm/Design/Caption",
+          "expected": "Fleet vehicles",
+          "actual": "@Fleet:Vehicle"
+        },
+        {
+          "path": "AxForm/Design/Controls/AxFormControl[CustomFilterGroup]/Controls/AxFormControl/FormControlExtension/ExtensionProperties/AxFormControlExtensionProperty[defaultColumnName]/Value",
+          "expected": "Grid_VIN",
+          "actual": "Grid_FmVehicle"
+        }
+      ],
+      "isMatch": false
+    }
+  }
+}

--- a/eval/corpus/runs/20260805T130448016Z__L1-form-basic__5d2afe09312e40aca18315d5042bfa24.json
+++ b/eval/corpus/runs/20260805T130448016Z__L1-form-basic__5d2afe09312e40aca18315d5042bfa24.json
@@ -1,0 +1,27 @@
+{
+  "runId": "20260805T130448016Z__L1-form-basic__5d2afe09312e40aca18315d5042bfa24",
+  "caseId": "L1-form-basic",
+  "tier": 1,
+  "timestampUtc": "2026-08-05T13:04:48.0187602+00:00",
+  "source": "agent",
+  "score": {
+    "xppClean": true,
+    "xppErrors": 0,
+    "referencesClean": true,
+    "referenceErrors": 0,
+    "goldenMatch": false,
+    "goldenDiff": {
+      "missing": [],
+      "extra": [],
+      "changed": [
+        {
+          "path": "AxForm/Design/Caption",
+          "expected": "Fleet vehicles",
+          "actual": "@Fleet:Vehicle"
+        }
+      ],
+      "isMatch": false
+    }
+  },
+  "note": "Agent-driven, instruction-only run. First draft omitted --field, matching the tool\u0027s own empty-grid warning; adding --field VIN --field Make (from prior \u0027get table FmVehicle\u0027 output) closes every diff except Design/Caption (golden literal \u0027Fleet vehicles\u0027 vs tool default \u0027@Fleet:Vehicle\u0027 inherited from the table label) \u2014 that string is not derivable from the instruction text, likely a case-authoring detail baked into canonical_args rather than a CLI defect."
+}

--- a/eval/corpus/runs/20260805T130458135Z__L1-form-basic__20d6ff185c0e4d1eb49ee5c9a5c35dea.json
+++ b/eval/corpus/runs/20260805T130458135Z__L1-form-basic__20d6ff185c0e4d1eb49ee5c9a5c35dea.json
@@ -1,0 +1,20 @@
+{
+  "runId": "20260805T130458135Z__L1-form-basic__20d6ff185c0e4d1eb49ee5c9a5c35dea",
+  "caseId": "L1-form-basic",
+  "tier": 1,
+  "timestampUtc": "2026-08-05T13:04:58.1368993+00:00",
+  "source": "replay",
+  "score": {
+    "xppClean": true,
+    "xppErrors": 0,
+    "referencesClean": true,
+    "referenceErrors": 0,
+    "goldenMatch": true,
+    "goldenDiff": {
+      "missing": [],
+      "extra": [],
+      "changed": [],
+      "isMatch": true
+    }
+  }
+}

--- a/eval/goldens/L1-business-event-basic/ConFmVehicleNoteAdded.xml
+++ b/eval/goldens/L1-business-event-basic/ConFmVehicleNoteAdded.xml
@@ -1,0 +1,33 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<AxClass>
+  <Name>ConFmVehicleNoteAdded</Name>
+  <Extends>BusinessEventsBase</Extends>
+  <SourceCode>
+    <Declaration>[BusinessEvents(classStr(ConFmVehicleNoteAdded), classStr(ConFmVehicleNoteAddedContract), "Custom", "Custom")]
+public final class ConFmVehicleNoteAdded extends BusinessEventsBase
+{
+}
+</Declaration>
+    <Methods>
+      <Method>
+        <Name>newFromTable</Name>
+        <Source>public static ConFmVehicleNoteAdded newFromTable(Common _table)
+{
+    ConFmVehicleNoteAdded event = new ConFmVehicleNoteAdded();
+    event.parmId(classStr(ConFmVehicleNoteAdded));
+    return event;
+}
+</Source>
+      </Method>
+      <Method>
+        <Name>buildContract</Name>
+        <Source>[Wrappable(false), Replaceable(false)]
+public BusinessEventsContract buildContract()
+{
+    return new ConFmVehicleNoteAddedContract();
+}
+</Source>
+      </Method>
+    </Methods>
+  </SourceCode>
+</AxClass>

--- a/eval/goldens/L1-custom-service-basic/ConFmVehicleQueryService.xml
+++ b/eval/goldens/L1-custom-service-basic/ConFmVehicleQueryService.xml
@@ -1,0 +1,11 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<AxService>
+  <Name>ConFmVehicleQueryService</Name>
+  <Class>ConFmVehicleQueryServiceService</Class>
+  <ServiceOperations>
+    <AxServiceOperation>
+      <Name>lookup</Name>
+      <Method>lookup</Method>
+    </AxServiceOperation>
+  </ServiceOperations>
+</AxService>

--- a/eval/goldens/L1-form-basic/ConFmVehicleList.xml
+++ b/eval/goldens/L1-form-basic/ConFmVehicleList.xml
@@ -1,0 +1,138 @@
+<?xml version="1.0" encoding="utf-8"?>
+<AxForm xmlns:i="http://www.w3.org/2001/XMLSchema-instance" xmlns="Microsoft.Dynamics.AX.Metadata.V6">
+  <Name>ConFmVehicleList</Name>
+  <SourceCode>
+    <Methods xmlns="">
+      <Method>
+        <Name>classDeclaration</Name>
+        <Source><![CDATA[
+[Form]
+public class ConFmVehicleList extends FormRun
+{
+}
+
+]]></Source>
+      </Method>
+    </Methods>
+    <DataSources xmlns="" />
+    <DataControls xmlns="" />
+    <Members xmlns="" />
+  </SourceCode>
+  <DataSources>
+    <AxFormDataSource xmlns="">
+      <Name>FmVehicle</Name>
+      <Table>FmVehicle</Table>
+      <Fields>
+        <AxFormDataSourceField>
+          <DataField>VIN</DataField>
+        </AxFormDataSourceField>
+        <AxFormDataSourceField>
+          <DataField>Make</DataField>
+        </AxFormDataSourceField>
+      </Fields>
+      <ReferencedDataSources />
+      <InsertIfEmpty>No</InsertIfEmpty>
+      <DataSourceLinks />
+      <DerivedDataSources />
+    </AxFormDataSource>
+  </DataSources>
+  <Design>
+    <Caption xmlns="">Fleet vehicles</Caption>
+    <DataSource xmlns="">FmVehicle</DataSource>
+    <HideIfEmpty xmlns="">No</HideIfEmpty>
+    <Pattern xmlns="">SimpleList</Pattern>
+    <PatternVersion xmlns="">1.1</PatternVersion>
+    <Style xmlns="">SimpleList</Style>
+    <TitleDataSource xmlns="">FmVehicle</TitleDataSource>
+    <Controls xmlns="">
+      <AxFormControl xmlns="" i:type="AxFormActionPaneControl">
+        <Name>ActionPane</Name>
+        <ElementPosition>134217727</ElementPosition>
+        <FilterExpression>%1</FilterExpression>
+        <Type>ActionPane</Type>
+        <VerticalSpacing>-1</VerticalSpacing>
+        <FormControlExtension i:nil="true" />
+        <Controls>
+          <AxFormControl xmlns="" i:type="AxFormButtonGroupControl">
+            <Name>ButtonGroup</Name>
+            <Type>ButtonGroup</Type>
+            <FormControlExtension i:nil="true" />
+            <Controls />
+            <ArrangeMethod>Vertical</ArrangeMethod>
+          </AxFormControl>
+        </Controls>
+        <AlignChild>No</AlignChild>
+        <AlignChildren>No</AlignChildren>
+        <ArrangeMethod>Vertical</ArrangeMethod>
+      </AxFormControl>
+      <AxFormControl xmlns="" i:type="AxFormGroupControl">
+        <Name>CustomFilterGroup</Name>
+        <Pattern>CustomAndQuickFilters</Pattern>
+        <PatternVersion>1.1</PatternVersion>
+        <Type>Group</Type>
+        <WidthMode>SizeToAvailable</WidthMode>
+        <FormControlExtension i:nil="true" />
+        <Controls>
+          <AxFormControl>
+            <Name>QuickFilterControl</Name>
+            <FormControlExtension>
+              <Name>QuickFilterControl</Name>
+              <ExtensionComponents />
+              <ExtensionProperties>
+                <AxFormControlExtensionProperty>
+                  <Name>targetControlName</Name>
+                  <Type>String</Type>
+                  <Value>Grid</Value>
+                </AxFormControlExtensionProperty>
+                <AxFormControlExtensionProperty>
+                  <Name>defaultColumnName</Name>
+                  <Type>String</Type>
+                  <Value>Grid_VIN</Value>
+                </AxFormControlExtensionProperty>
+                <AxFormControlExtensionProperty>
+                  <Name>placeholderText</Name>
+                  <Type>String</Type>
+                </AxFormControlExtensionProperty>
+              </ExtensionProperties>
+            </FormControlExtension>
+          </AxFormControl>
+        </Controls>
+        <ArrangeMethod>HorizontalLeft</ArrangeMethod>
+        <FrameType>None</FrameType>
+        <Style>CustomFilter</Style>
+        <ViewEditMode>Edit</ViewEditMode>
+      </AxFormControl>
+      <AxFormControl xmlns="" i:type="AxFormGridControl">
+        <Name>Grid</Name>
+        <ElementPosition>1431655764</ElementPosition>
+        <FilterExpression>%1</FilterExpression>
+        <Type>Grid</Type>
+        <VerticalSpacing>-1</VerticalSpacing>
+        <FormControlExtension i:nil="true" />
+        <Controls>
+          <AxFormControl xmlns="" i:type="AxFormStringControl">
+            <Name>Grid_VIN</Name>
+            <Type>String</Type>
+            <FormControlExtension i:nil="true" />
+            <DataField>VIN</DataField>
+            <DataSource>FmVehicle</DataSource>
+          </AxFormControl>
+          <AxFormControl xmlns="" i:type="AxFormStringControl">
+            <Name>Grid_Make</Name>
+            <Type>String</Type>
+            <FormControlExtension i:nil="true" />
+            <DataField>Make</DataField>
+            <DataSource>FmVehicle</DataSource>
+          </AxFormControl>
+        </Controls>
+        <AlternateRowShading>No</AlternateRowShading>
+        <DataGroup>Overview</DataGroup>
+        <DataSource>FmVehicle</DataSource>
+        <MultiSelect>No</MultiSelect>
+        <ShowRowLabels>No</ShowRowLabels>
+        <Style>Tabular</Style>
+      </AxFormControl>
+    </Controls>
+  </Design>
+  <Parts />
+</AxForm>

--- a/eval/goldens/L1-map-basic/ConFmVehicleMap.xml
+++ b/eval/goldens/L1-map-basic/ConFmVehicleMap.xml
@@ -1,0 +1,30 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<AxMap xmlns:i="http://www.w3.org/2001/XMLSchema-instance">
+  <Name>ConFmVehicleMap</Name>
+  <SourceCode>
+    <Declaration><![CDATA[
+public class ConFmVehicleMap extends common
+{
+}
+]]></Declaration>
+    <Methods />
+  </SourceCode>
+  <FieldGroups />
+  <Fields>
+    <AxMapBaseField i:type="AxMapFieldString">
+      <Name>Make</Name>
+      <ExtendedDataType>Name</ExtendedDataType>
+    </AxMapBaseField>
+  </Fields>
+  <Mappings>
+    <AxTableMapping>
+      <MappingTable>FmVehicle</MappingTable>
+      <Connections>
+        <AxTableMappingConnection>
+          <MapField>Make</MapField>
+          <MapFieldTo>Make</MapFieldTo>
+        </AxTableMappingConnection>
+      </Connections>
+    </AxTableMapping>
+  </Mappings>
+</AxMap>

--- a/eval/goldens/L1-query-basic/ConFmVehicleQuery.xml
+++ b/eval/goldens/L1-query-basic/ConFmVehicleQuery.xml
@@ -1,0 +1,10 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<AxQuery>
+  <Name>ConFmVehicleQuery</Name>
+  <DataSources>
+    <AxQuerySimpleRootDataSource>
+      <Name>FmVehicle</Name>
+      <Table>FmVehicle</Table>
+    </AxQuerySimpleRootDataSource>
+  </DataSources>
+</AxQuery>

--- a/eval/goldens/L1-report-basic/ConFmVehicleReport.xml
+++ b/eval/goldens/L1-report-basic/ConFmVehicleReport.xml
@@ -1,0 +1,109 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<AxReport>
+  <Name>ConFmVehicleReport</Name>
+  <Datasets>
+    <AxReportDataset>
+      <Name>ConFmVehicleReportDS</Name>
+      <DataProvider>ConFmVehicleReportDP</DataProvider>
+      <QueryType>DataProvider</QueryType>
+      <DynamicFilters>Yes</DynamicFilters>
+    </AxReportDataset>
+  </Datasets>
+  <Designs>
+    <AxReportDesign>
+      <Name>Report</Name>
+      <Caption>Fleet vehicle report</Caption>
+      <AutoDesignSpecs>
+        <AxReportAutoDesignNode>
+          <Name>AutoDesign</Name>
+          <DataSet>ConFmVehicleReportDS</DataSet>
+          <ReportAutoDesignItems>
+            <AxReportAutoDesignDataSet>
+              <Name>AutoDesignDataSet1</Name>
+              <DataSet>ConFmVehicleReportDS</DataSet>
+              <AutoFields>Yes</AutoFields>
+            </AxReportAutoDesignDataSet>
+          </ReportAutoDesignItems>
+        </AxReportAutoDesignNode>
+      </AutoDesignSpecs>
+      <ReportDesignItems>
+        <AxReportTablix>
+          <Name>Tablix1</Name>
+          <DataSetName>ConFmVehicleReportDS</DataSetName>
+          <TablixBody>
+            <TablixColumns>
+              <TablixColumn>
+                <Width>2in</Width>
+              </TablixColumn>
+              <TablixColumn>
+                <Width>2in</Width>
+              </TablixColumn>
+            </TablixColumns>
+            <TablixRows>
+              <TablixRow>
+                <Height>0.25in</Height>
+                <TablixCells>
+                  <TablixCell>
+                    <CellContents>
+                      <Textbox Name="Tablix1_VIN_Header">
+                        <Value>VIN</Value>
+                        <Style>
+                          <FontWeight>Bold</FontWeight>
+                          <BackgroundColor>#e0e0e0</BackgroundColor>
+                        </Style>
+                      </Textbox>
+                    </CellContents>
+                  </TablixCell>
+                  <TablixCell>
+                    <CellContents>
+                      <Textbox Name="Tablix1_Make_Header">
+                        <Value>Make</Value>
+                        <Style>
+                          <FontWeight>Bold</FontWeight>
+                          <BackgroundColor>#e0e0e0</BackgroundColor>
+                        </Style>
+                      </Textbox>
+                    </CellContents>
+                  </TablixCell>
+                </TablixCells>
+              </TablixRow>
+              <TablixRow>
+                <Height>0.25in</Height>
+                <TablixCells>
+                  <TablixCell>
+                    <CellContents>
+                      <Textbox Name="Tablix1_VIN">
+                        <Value>=Fields!VIN.Value</Value>
+                      </Textbox>
+                    </CellContents>
+                  </TablixCell>
+                  <TablixCell>
+                    <CellContents>
+                      <Textbox Name="Tablix1_Make">
+                        <Value>=Fields!Make.Value</Value>
+                      </Textbox>
+                    </CellContents>
+                  </TablixCell>
+                </TablixCells>
+              </TablixRow>
+            </TablixRows>
+          </TablixBody>
+          <TablixColumnHierarchy>
+            <TablixMembers>
+              <TablixMember />
+              <TablixMember />
+            </TablixMembers>
+          </TablixColumnHierarchy>
+          <TablixRowHierarchy>
+            <TablixMembers>
+              <TablixMember />
+              <TablixMember>
+                <Group Name="Detail" />
+              </TablixMember>
+            </TablixMembers>
+          </TablixRowHierarchy>
+        </AxReportTablix>
+      </ReportDesignItems>
+    </AxReportDesign>
+  </Designs>
+</AxReport>

--- a/eval/goldens/L1-runbase-basic/ConFmVehicleRun.xml
+++ b/eval/goldens/L1-runbase-basic/ConFmVehicleRun.xml
@@ -1,0 +1,72 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<AxClass>
+  <Name>ConFmVehicleRun</Name>
+  <Extends>RunBase</Extends>
+  <SourceCode>
+    <Declaration>public class ConFmVehicleRun extends RunBase
+{
+        // Packing version constant
+    private static int currentVersion = 1;
+}
+</Declaration>
+    <Methods>
+      <Method>
+        <Name>dialog</Name>
+        <Source>public Object dialog()
+{
+    DialogRunbase dialog = super();
+    return dialog;
+}
+</Source>
+      </Method>
+      <Method>
+        <Name>getFromDialog</Name>
+        <Source>public boolean getFromDialog()
+{
+    return super();
+}
+</Source>
+      </Method>
+      <Method>
+        <Name>pack</Name>
+        <Source>public container pack()
+{
+    return [currentVersion];
+}
+</Source>
+      </Method>
+      <Method>
+        <Name>unpack</Name>
+        <Source>public boolean unpack(container _packedClass)
+{
+    int version = RunBase::getVersion(_packedClass);
+    if (version == currentVersion)
+    {
+        [version] = _packedClass;
+        return true;
+    }
+    return false;
+}
+</Source>
+      </Method>
+      <Method>
+        <Name>run</Name>
+        <Source>public void run()
+{
+    // TODO: implement
+}
+</Source>
+      </Method>
+      <Method>
+        <Name>main</Name>
+        <Source>public static void main(Args _args)
+{
+    ConFmVehicleRun runObject = new ConFmVehicleRun();
+    if (runObject.prompt())
+        runObject.runOperationNow();
+}
+</Source>
+      </Method>
+    </Methods>
+  </SourceCode>
+</AxClass>

--- a/eval/goldens/L1-sysoperation-basic/ConFmVehicleImportController.xml
+++ b/eval/goldens/L1-sysoperation-basic/ConFmVehicleImportController.xml
@@ -1,0 +1,30 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<AxClass>
+  <Name>ConFmVehicleImportController</Name>
+  <Extends>SysOperationServiceController</Extends>
+  <SourceCode>
+    <Declaration>class ConFmVehicleImportController extends SysOperationServiceController
+{
+}
+</Declaration>
+    <Methods>
+      <Method>
+        <Name>new</Name>
+        <Source>public void new()
+{
+    super(classStr(ConFmVehicleImportService), methodStr(ConFmVehicleImportService, process), SysOperationExecutionMode::Synchronous);
+}
+</Source>
+      </Method>
+      <Method>
+        <Name>main</Name>
+        <Source>public static void main(Args _args)
+{
+    ConFmVehicleImportController controller = new ConFmVehicleImportController();
+    controller.startOperation();
+}
+</Source>
+      </Method>
+    </Methods>
+  </SourceCode>
+</AxClass>

--- a/eval/goldens/L1-systest-basic/ConFmVehicleServiceTest.xml
+++ b/eval/goldens/L1-systest-basic/ConFmVehicleServiceTest.xml
@@ -1,0 +1,26 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<AxClass>
+  <Name>ConFmVehicleServiceTest</Name>
+  <Extends>SysTestCase</Extends>
+  <SourceCode>
+    <Declaration>public class ConFmVehicleServiceTest extends SysTestCase
+{
+}
+</Declaration>
+    <Methods>
+      <Method>
+        <Name>run_scenario_expectedResult</Name>
+        <Source>[SysTestMethod]
+public void run_scenario_expectedResult()
+{
+    // Arrange
+
+    // Act
+
+    // Assert
+}
+</Source>
+      </Method>
+    </Methods>
+  </SourceCode>
+</AxClass>

--- a/eval/goldens/L1-workflow-basic/ConFmVehicleNoteWorkflow.xml
+++ b/eval/goldens/L1-workflow-basic/ConFmVehicleNoteWorkflow.xml
@@ -1,0 +1,10 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<AxWorkflow>
+  <Name>ConFmVehicleNoteWorkflow</Name>
+  <DocumentTableName>FmVehicle</DocumentTableName>
+  <DocumentMenuItemName>ConFmVehicleNoteWorkflowMenuItem</DocumentMenuItemName>
+  <DocumentMenuItemType>Display</DocumentMenuItemType>
+  <SubmitToWorkflowMenuItem>ConFmVehicleNoteWorkflowSubmit</SubmitToWorkflowMenuItem>
+  <SubmitToWorkflowMenuItemType>Action</SubmitToWorkflowMenuItemType>
+  <WorkflowDocumentClass>ConFmVehicleNoteWorkflowDocument</WorkflowDocumentClass>
+</AxWorkflow>

--- a/eval/goldens/L2-edt-extension/AccountNum.Extension.xml
+++ b/eval/goldens/L2-edt-extension/AccountNum.Extension.xml
@@ -1,0 +1,4 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<AxEdtExtension xmlns:i="http://www.w3.org/2001/XMLSchema-instance" i:type="AxEdtStringExtension">
+  <Name>AccountNum.Extension</Name>
+</AxEdtExtension>

--- a/eval/goldens/L2-enum-extension/NoYes.Extension.xml
+++ b/eval/goldens/L2-enum-extension/NoYes.Extension.xml
@@ -1,0 +1,4 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<AxEnumExtension>
+  <Name>NoYes.Extension</Name>
+</AxEnumExtension>

--- a/eval/goldens/L2-event-handler-basic/ConFmVehicleServiceRunHandler.xml
+++ b/eval/goldens/L2-event-handler-basic/ConFmVehicleServiceRunHandler.xml
@@ -1,0 +1,15 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<AxClass>
+  <Name>ConFmVehicleServiceRunHandler</Name>
+  <SourceCode>
+    <Declaration>public static class ConFmVehicleServiceRunHandler
+{
+    [SubscribesTo(classStr(FmVehicleService), delegateStr(FmVehicleService, OnInitialized))]
+    public static void run(XppPrePostArgs args)
+    {
+        // handler logic here
+    }
+}
+</Declaration>
+  </SourceCode>
+</AxClass>

--- a/eval/goldens/L2-numberseq-basic/NumberSeqApplicationModule_ConDemo_Extension.xml
+++ b/eval/goldens/L2-numberseq-basic/NumberSeqApplicationModule_ConDemo_Extension.xml
@@ -1,0 +1,32 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<AxClass>
+  <Name>NumberSeqApplicationModule_ConDemo_Extension</Name>
+  <SourceCode>
+    <Declaration>[ExtensionOf(classStr(NumberSeqApplicationModule_ConDemo))]
+final class NumberSeqApplicationModule_ConDemo_Extension
+{
+}
+</Declaration>
+    <Methods>
+      <Method>
+        <Name>loadModule</Name>
+        <Source>public void loadModule()
+{
+    next loadModule();
+
+    NumberSeqDatatype datatype = NumberSeqDatatype::construct();
+    datatype.parmDatatypeId(extendedTypeNum(ConDemoNum));
+    datatype.parmReferenceHelp(literalStr("ConDemoNum"));
+    datatype.parmWizardIsContinuous(false);
+    datatype.parmWizardIsManual(false);
+    datatype.parmWizardIsChangeDownAllowed(false);
+    datatype.parmWizardIsChangeUpAllowed(false);
+    datatype.parmWizardHighest(999999);
+    datatype.addParameterType(NumberSeqParameterType::DataArea, true, false);
+    this.create(datatype);
+}
+</Source>
+      </Method>
+    </Methods>
+  </SourceCode>
+</AxClass>

--- a/eval/goldens/L2-security-policy-basic/ConFmVehicleOwnerPolicy.xml
+++ b/eval/goldens/L2-security-policy-basic/ConFmVehicleOwnerPolicy.xml
@@ -1,0 +1,10 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<AxSecurityPolicy>
+  <Name>ConFmVehicleOwnerPolicy</Name>
+  <ConstrainedTable>FmVehicle</ConstrainedTable>
+  <Query>ConFmVehicleOwnerQuery</Query>
+  <Operation>Select</Operation>
+  <ContextType>RoleName</ContextType>
+  <ContextString></ContextString>
+  <Enabled>Yes</Enabled>
+</AxSecurityPolicy>

--- a/eval/goldens/L2-table-extension/FmVehicle.Extension.xml
+++ b/eval/goldens/L2-table-extension/FmVehicle.Extension.xml
@@ -1,0 +1,4 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<AxTableExtension>
+  <Name>FmVehicle.Extension</Name>
+</AxTableExtension>

--- a/eval/goldens/L2-virtual-entity-basic/ConFmVehicleEntity.xml
+++ b/eval/goldens/L2-virtual-entity-basic/ConFmVehicleEntity.xml
@@ -1,0 +1,27 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<AxDataEntityView>
+  <Name>ConFmVehicleEntity</Name>
+  <PublicEntityName>ConFmVehicleEntity</PublicEntityName>
+  <PublicCollectionName>ConFmVehicleEntities</PublicCollectionName>
+  <DataManagementEnabled>No</DataManagementEnabled>
+  <DataManagementStagingTable />
+  <IsPublic>Yes</IsPublic>
+  <DataSources>
+    <AxQuerySimpleRootDataSource>
+      <Name>FmVehicle</Name>
+      <Table>FmVehicle</Table>
+    </AxQuerySimpleRootDataSource>
+  </DataSources>
+  <Fields>
+    <AxDataEntityViewField>
+      <Name>VIN</Name>
+      <DataField>VIN</DataField>
+      <DataSource>FmVehicle</DataSource>
+    </AxDataEntityViewField>
+    <AxDataEntityViewField>
+      <Name>Make</Name>
+      <DataField>Make</DataField>
+      <DataSource>FmVehicle</DataSource>
+    </AxDataEntityViewField>
+  </Fields>
+</AxDataEntityView>

--- a/src/D365FO.Cli/Commands/Validate/ValidateXppCommand.cs
+++ b/src/D365FO.Cli/Commands/Validate/ValidateXppCommand.cs
@@ -1,3 +1,4 @@
+using System.Text.RegularExpressions;
 using D365FO.Core;
 using D365FO.Core.Validation;
 using Spectre.Console;
@@ -95,7 +96,9 @@ public sealed class ValidateXppCommand : Command<ValidateXppCommand.Settings>
 
     private static string DetectCodeType(string? file, string code)
     {
-        if (code.Contains("<AxTable", StringComparison.OrdinalIgnoreCase)) return XppValidator.CodeTypeXmlTable;
+        // Match the exact <AxTable> root tag, not other elements that merely start with
+        // that prefix (e.g. <AxTableMapping> inside an AxMap, <AxTableExtension>).
+        if (Regex.IsMatch(code, @"<AxTable[\s>]", RegexOptions.IgnoreCase)) return XppValidator.CodeTypeXmlTable;
         var trimmed = code.TrimStart();
         if (trimmed.StartsWith("<?xml") || trimmed.StartsWith('<')) return XppValidator.CodeTypeXmlAny;
         if (file is not null && file.EndsWith(".xml", StringComparison.OrdinalIgnoreCase)) return XppValidator.CodeTypeXmlAny;

--- a/src/D365FO.Core/Eval/EvalScorer.cs
+++ b/src/D365FO.Core/Eval/EvalScorer.cs
@@ -1,3 +1,4 @@
+using System.Text.RegularExpressions;
 using System.Xml.Linq;
 using D365FO.Core.Index;
 using D365FO.Core.Validation;
@@ -53,7 +54,9 @@ public static class EvalScorer
     /// <summary>Same heuristic as <c>ValidateXppCommand.DetectCodeType</c> (Cli project) — duplicated rather than shared across the Core/Cli boundary for a 3-line check.</summary>
     internal static string DetectCodeType(string xml)
     {
-        if (xml.Contains("<AxTable", StringComparison.OrdinalIgnoreCase)) return XppValidator.CodeTypeXmlTable;
+        // Match the exact <AxTable> root tag, not other elements that merely start with
+        // that prefix (e.g. <AxTableMapping> inside an AxMap, <AxTableExtension>).
+        if (Regex.IsMatch(xml, @"<AxTable[\s>]", RegexOptions.IgnoreCase)) return XppValidator.CodeTypeXmlTable;
         var trimmed = xml.TrimStart();
         if (trimmed.StartsWith("<?xml") || trimmed.StartsWith('<')) return XppValidator.CodeTypeXmlAny;
         return XppValidator.CodeTypeXpp;

--- a/src/D365FO.Core/Scaffolding/NumberSequenceScaffolder.cs
+++ b/src/D365FO.Core/Scaffolding/NumberSequenceScaffolder.cs
@@ -60,15 +60,24 @@ public static class NumberSequenceScaffolder
                             new XElement("Source", loadModuleSrc))))));
     }
 
-    /// <summary>Scaffolds an EDT that is backed by a number sequence.</summary>
+    /// <summary>
+    /// Scaffolds an EDT that is backed by a number sequence. Carries the same
+    /// <c>xmlns:i</c> / <c>i:type="AxEdtString"</c> root discriminator as
+    /// <see cref="XppScaffolder.Edt"/> — D365FO's metadata reader (and
+    /// <see cref="ScaffoldFileWriter"/>'s own write-time gate) reject an
+    /// <c>AxEdtString</c> root without it.
+    /// </summary>
     public static XDocument Edt(
         string edtName,
         string moduleName,
         NumberSequenceScope scope = NumberSequenceScope.Company,
         string? label = null)
     {
+        XNamespace xsi = "http://www.w3.org/2001/XMLSchema-instance";
         return new XDocument(
             new XElement("AxEdtString",
+                new XAttribute(XNamespace.Xmlns + "i", xsi.NamespaceName),
+                new XAttribute(XName.Get("type", xsi.NamespaceName), "AxEdtString"),
                 new XElement("Name", edtName),
                 new XElement("Extends", "Num"),
                 string.IsNullOrEmpty(label) ? null : new XElement("Label", label),

--- a/src/D365FO.Core/Scaffolding/XppScaffolder.cs
+++ b/src/D365FO.Core/Scaffolding/XppScaffolder.cs
@@ -456,7 +456,7 @@ public static class XppScaffolder
             $"public static class {className}\n{{\n" +
             $"    [{attr}]\n" +
             $"    public static void {handlerMethod}(XppPrePostArgs args)\n" +
-            "    {\n        // handler logic here\n    }\n}}\n";
+            "    {\n        // handler logic here\n    }\n}\n";
 
         return new XDocument(
             new XElement("AxClass",

--- a/src/D365FO.Core/Validation/XppValidator.cs
+++ b/src/D365FO.Core/Validation/XppValidator.cs
@@ -339,7 +339,7 @@ public static class XppValidator
 
     private static void CheckMissingAlternateKey(string code, List<XppViolation> v)
     {
-        if (!code.Contains("<AxTable") && !code.Contains("<AxTableExtension")) return;
+        if (!Regex.IsMatch(code, @"<AxTable(Extension)?[\s>]", RegexOptions.IgnoreCase)) return;
         if (!Regex.IsMatch(code, @"<AlternateKey>\s*Yes\s*</AlternateKey>", RegexOptions.IgnoreCase))
         {
             v.Add(new XppViolation("XML001", "error", null,

--- a/tests/D365FO.Core.Tests/Eval/EvalCaseCatalogTests.cs
+++ b/tests/D365FO.Core.Tests/Eval/EvalCaseCatalogTests.cs
@@ -14,12 +14,13 @@ public class EvalCaseCatalogTests
         var (cases, errors) = EvalCaseCatalog.LoadAll(EvalPaths.CasesDir(RepoRoot));
 
         Assert.Empty(errors);
-        Assert.Equal(5, cases.Count);
+        Assert.Equal(22, cases.Count);
         Assert.Contains(cases, c => c.Id == "L0-edt-basic");
         Assert.Contains(cases, c => c.Id == "L0-enum-basic");
         Assert.Contains(cases, c => c.Id == "L1-table-basic");
         Assert.Contains(cases, c => c.Id == "L1-class-basic");
         Assert.Contains(cases, c => c.Id == "L2-coc-extension");
+        Assert.Contains(cases, c => c.Id == "L2-security-policy-basic");
     }
 
     [Fact]
@@ -37,12 +38,19 @@ public class EvalCaseCatalogTests
     }
 
     [Fact]
-    public void Only_L2_coc_extension_requires_the_fixture_index()
+    public void Only_cases_grounded_against_the_FmVehicle_fixture_require_the_fixture_index()
     {
         var (cases, _) = EvalCaseCatalog.LoadAll(EvalPaths.CasesDir(RepoRoot));
 
-        var fixtureCases = cases.Where(c => c.RequiresFixtureIndex).Select(c => c.Id).ToList();
-        Assert.Equal(new[] { "L2-coc-extension" }, fixtureCases);
+        var fixtureCases = cases.Where(c => c.RequiresFixtureIndex).Select(c => c.Id).OrderBy(id => id).ToList();
+        Assert.Equal(
+            new[]
+            {
+                "L1-form-basic", "L1-map-basic", "L1-query-basic", "L1-systest-basic", "L1-workflow-basic",
+                "L2-coc-extension", "L2-event-handler-basic", "L2-security-policy-basic", "L2-table-extension",
+                "L2-virtual-entity-basic",
+            },
+            fixtureCases);
     }
 
     [Fact]

--- a/tests/D365FO.Core.Tests/XppScaffolderTests.cs
+++ b/tests/D365FO.Core.Tests/XppScaffolderTests.cs
@@ -1,0 +1,61 @@
+using System.Linq;
+using System.Xml.Linq;
+using D365FO.Core.Scaffolding;
+using Xunit;
+
+namespace D365FO.Core.Tests;
+
+/// <summary>
+/// Regression coverage for <see cref="XppScaffolder"/> emitters whose output is
+/// raw X++ source text, not just XML shape — a hand-authored string literal can
+/// silently drift out of brace-balance without any XML validator catching it.
+/// </summary>
+public class XppScaffolderTests
+{
+    /// <summary>
+    /// Found via the eval catalog (L2-event-handler-basic): the Declaration
+    /// literal ended in "}}\n" (method-close + a stray extra class-close) instead
+    /// of "}\n", producing an unbalanced-brace class body for every
+    /// `generate event-handler` call.
+    /// </summary>
+    [Theory]
+    [InlineData("Form")]
+    [InlineData("FormDataSource")]
+    [InlineData("Table")]
+    [InlineData("Class")]
+    public void EventHandler_DeclarationBracesAreBalanced(string sourceKind)
+    {
+        var doc = XppScaffolder.EventHandler("ConTestHandler", sourceKind, "TestSource", "OnInitialized", "run");
+        var src = doc.Descendants("Declaration").Single().Value;
+
+        var opens = src.Count(c => c == '{');
+        var closes = src.Count(c => c == '}');
+        Assert.Equal(opens, closes);
+        Assert.EndsWith("}\n", src);
+        Assert.DoesNotContain("}}", src);
+    }
+}
+
+/// <summary>
+/// Regression coverage for <see cref="NumberSequenceScaffolder"/>.
+/// </summary>
+public class NumberSequenceScaffolderTests
+{
+    /// <summary>
+    /// Found via the eval catalog (L2-numberseq-basic): the scaffolded EDT root
+    /// was a bare &lt;AxEdtString&gt; with no xmlns:i / i:type discriminator,
+    /// which <see cref="ScaffoldFileWriter"/>'s own write-time gate rejects
+    /// (WRITE_FAILED) — every `generate number-sequence` call failed after
+    /// already having written the module-extension class to disk.
+    /// </summary>
+    [Fact]
+    public void Edt_HasXsiNamespaceAndTypeDiscriminator()
+    {
+        var doc = NumberSequenceScaffolder.Edt("ConDemoNum", "ConDemo");
+        var root = doc.Root!;
+
+        XNamespace xsi = "http://www.w3.org/2001/XMLSchema-instance";
+        Assert.Equal("AxEdtString", root.Attribute(xsi + "type")?.Value);
+        Assert.Equal(xsi.NamespaceName, root.Attribute(XNamespace.Xmlns + "i")?.Value);
+    }
+}


### PR DESCRIPTION
## Summary
- Grows the offline agent-eval catalog from 5 to 22 cases (L0-L2), covering 20 of the 22 `generate` subcommands (form, query, map, report, sysoperation, runbase, business-event, custom-service, workflow, systest, extension table/edt/enum, event-handler, number-sequence, entity, security-policy, on top of the existing edt/enum/table/class/coc).
- A literal 1:1 port of `d365fo-mcp-server`'s 80-case catalog wasn't possible: ~59 of those cases need a live VM/BP-check/SysTest oracle or a shared Contoso fixture this offline, `canonical_args`-driven harness doesn't have. Documented the triage and the remaining gap in `eval/README.md`.
- Authoring the new cases surfaced three real generator/validator defects, each pinned with a regression test:
  - `DetectCodeType` (CLI `validate xpp` + eval scorer) substring-matched `"<AxTable"`, false-positiving on `<AxTableMapping>`/`<AxTableExtension>` and misapplying table-only BP rules to `AxMap` output. Now tag-boundary aware via regex.
  - `XppScaffolder.EventHandler` emitted an unbalanced closing brace (`"}}"`), producing syntactically invalid X++ for every `generate event-handler` call.
  - `NumberSequenceScaffolder.Edt` omitted the `xmlns:i`/`i:type` discriminator that `ScaffoldFileWriter`'s own write-time gate requires, so `generate number-sequence` always failed with `WRITE_FAILED` — after already having written its sibling module-extension class to disk.
- Three cases (sysoperation, business-event, number-sequence) legitimately score `referencesClean:false` / `xppClean:false` in isolation — their primary artifact references a sibling artifact or a standard system class outside the minimal `FmVehicle`/`FmVehicleService` fixture. Tagged `known-reference-gap` / `known-xpp-gap` and documented rather than faked clean.
- `eval/corpus/runs/*.json` is now committed (dropped from `.gitignore`) to match `d365fo-mcp-server`'s convention instead of being local/CI-only evidence.

## Test plan
- [x] `dotnet test tests/D365FO.Core.Tests/D365FO.Core.Tests.csproj` — 511 tests pass (includes new `XppScaffolderTests`/`NumberSequenceScaffolderTests` regression coverage and updated `EvalCaseCatalogTests` catalog-size assertions)
- [x] `dotnet run --project src/D365FO.Cli -- eval run <id> --write` for all 22 cases — 22/22 `goldenMatch: true`
- [x] `dotnet run --project src/D365FO.Cli -- eval report` — `goldenPassRate: 1`
- [x] `eval-runner` agent-driven check (natural-language `instruction` only, no `canonical_args`) on `L1-form-basic` — confirms the deterministic replay path is sound; surfaced a `MODEL_ERROR`-class finding (agent omitted the caption flag despite the instruction stating it) rather than a tool defect

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>

https://claude.ai/code/session_01C6X7iPu1AXRectkHUQf7GC