### PR TITLE
fix(ci): repair main's broken build-test gate (count mismatch + Spectre markup crash)

### DIFF
--- a/src/D365FO.Cli/CliApp.cs
+++ b/src/D365FO.Cli/CliApp.cs
@@ -32,7 +32,13 @@ namespace D365FO.Cli;
 /// </summary>
 public static class CliApp
 {
-    public static CommandApp Build()
+    /// <param name="console">
+    /// Optional scoped console to render through instead of the global
+    /// <see cref="Spectre.Console.AnsiConsole.Console"/> singleton — lets tests
+    /// capture output without mutating process-wide static state (which would
+    /// race against other tests capturing console output in parallel).
+    /// </param>
+    public static CommandApp Build(Spectre.Console.IAnsiConsole? console = null)
     {
         var app = new CommandApp();
         app.Configure(cfg =>
@@ -41,6 +47,7 @@ public static class CliApp
             cfg.SetApplicationVersion("0.1.0-dev");
             cfg.CaseSensitivity(CaseSensitivity.None);
             cfg.PropagateExceptions();
+            if (console is not null) cfg.ConfigureConsole(console);
 
             cfg.AddBranch("search", b =>
             {

--- a/src/D365FO.Cli/Commands/Generate/GenerateSysTestCommand.cs
+++ b/src/D365FO.Cli/Commands/Generate/GenerateSysTestCommand.cs
@@ -22,7 +22,7 @@ public sealed class GenerateSysTestCommand : Command<GenerateSysTestCommand.Sett
         public string Name { get; init; } = "";
 
         [CommandOption("--data-area-id <COMPANY>")]
-        [System.ComponentModel.Description("Company emitted as [SysTestCaseDataDependency('<Company>')]. Omitted entirely when not set.")]
+        [System.ComponentModel.Description("Company emitted as [[SysTestCaseDataDependency('<Company>')]]. Omitted entirely when not set.")]
         public string? DataAreaId { get; init; }
 
         [CommandOption("--atl")]

--- a/src/D365FO.Cli/Commands/Generate/GenerateViewMapCommands.cs
+++ b/src/D365FO.Cli/Commands/Generate/GenerateViewMapCommands.cs
@@ -19,7 +19,7 @@ public sealed class GenerateViewCommand : Command<GenerateViewCommand.Settings>
         public string? Query { get; init; }
 
         [CommandOption("--field <SPEC>")]
-        [System.ComponentModel.Description("Repeatable bound field: <name>:<dataSource>[:<dataField>]. dataField defaults to <name>. Example: --field AccountNum:CustTable")]
+        [System.ComponentModel.Description("Repeatable bound field: <name>:<dataSource>[[:<dataField>]]. dataField defaults to <name>. Example: --field AccountNum:CustTable")]
         public string[] Fields { get; init; } = Array.Empty<string>();
 
         [CommandOption("--computed <SPEC>")]
@@ -154,11 +154,11 @@ public sealed class GenerateMapCommand : Command<GenerateMapCommand.Settings>
         public string Name { get; init; } = "";
 
         [CommandOption("--field <SPEC>")]
-        [System.ComponentModel.Description("Repeatable: <name>:<edt>[:<label>]. The EDT determines the field's concrete type. Example: --field AccountNum:CustAccount")]
+        [System.ComponentModel.Description("Repeatable: <name>:<edt>[[:<label>]]. The EDT determines the field's concrete type. Example: --field AccountNum:CustAccount")]
         public string[] Fields { get; init; } = Array.Empty<string>();
 
         [CommandOption("--map-to <SPEC>")]
-        [System.ComponentModel.Description("Repeatable: <table>[:<mapField>=<tableField>,…]. Omit the pairs to map every field by identical name. Example: --map-to CustTable:AccountNum=AccountNum")]
+        [System.ComponentModel.Description("Repeatable: <table>[[:<mapField>=<tableField>,…]]. Omit the pairs to map every field by identical name. Example: --map-to CustTable:AccountNum=AccountNum")]
         public string[] MapTo { get; init; } = Array.Empty<string>();
 
         [CommandOption("--label <KEY>")]

--- a/tests/D365FO.Cli.Tests/Eval/EvalListCommandTests.cs
+++ b/tests/D365FO.Cli.Tests/Eval/EvalListCommandTests.cs
@@ -33,7 +33,7 @@ public class EvalListCommandTests
 
         Assert.Equal(0, exit);
         Assert.Contains("\"ok\":true", stdout);
-        Assert.Contains("\"count\":5", stdout);
+        Assert.Contains("\"count\":22", stdout);
         Assert.Contains("L0-edt-basic", stdout);
         Assert.Contains("L2-coc-extension", stdout);
     }

--- a/tests/D365FO.Cli.Tests/GenerateHelpRenderTests.cs
+++ b/tests/D365FO.Cli.Tests/GenerateHelpRenderTests.cs
@@ -1,0 +1,45 @@
+using Spectre.Console;
+
+namespace D365FO.Cli.Tests;
+
+/// <summary>
+/// `--help` renders every [CommandOption]/[CommandArgument] Description through
+/// Spectre.Console markup, where a bare '[' or ']' is parsed as a style tag
+/// rather than literal text. A description like "&lt;name&gt;[:&lt;label&gt;]" (unescaped)
+/// crashes with "Could not find color or style" instead of printing help —
+/// found via `generate view --help` while authoring further eval cases.
+/// Literal brackets must be doubled ("[[:&lt;label&gt;]]").
+/// </summary>
+public class GenerateHelpRenderTests
+{
+    public static IEnumerable<object[]> GenerateSubcommands => new[]
+    {
+        "table", "class", "coc", "form", "datasource-method", "control-method", "simple-list",
+        "entity", "extension", "event-handler", "privilege", "duty", "role", "report",
+        "sysoperation", "number-sequence", "workflow", "menu-item", "edt", "enum", "query",
+        "view", "map", "business-event", "custom-service", "migration-script", "runbase",
+        "security-policy", "systest",
+    }.Select(name => new object[] { name });
+
+    [Theory]
+    [MemberData(nameof(GenerateSubcommands))]
+    public void Help_renders_without_a_markup_exception(string subcommand)
+    {
+        // Route through a scoped IAnsiConsole (ConfigureConsole) rather than the
+        // global AnsiConsole.Console static — this test class is not the only one
+        // that captures console output, and xUnit runs different test classes in
+        // parallel by default, so mutating global state here would race with them.
+        var writer = new StringWriter();
+        var scopedConsole = AnsiConsole.Create(new AnsiConsoleSettings
+        {
+            Ansi = AnsiSupport.No,
+            ColorSystem = ColorSystemSupport.NoColors,
+            Out = new AnsiConsoleOutput(writer),
+        });
+        var app = CliApp.Build(scopedConsole);
+
+        var exitCode = app.Run(new[] { "generate", subcommand, "--help" });
+
+        Assert.Equal(0, exitCode);
+    }
+}


### PR DESCRIPTION
## Summary
- `main`'s `build-test` CI job has been red on all three platforms since PR #141 merged: `EvalListCommandTests.Lists_every_authored_case` still asserted the pre-expansion `"count":5`, but the catalog grew to 22 cases in that PR. `EvalCaseCatalogTests.cs` (Core.Tests) was updated at the time; this sibling assertion in `D365FO.Cli.Tests` was missed.
- While exploring `generate` subcommands not yet covered by an eval case (in prep for the next catalog batch), found `generate view --help`, `generate map --help`, and `generate systest --help` all crash with `Could not find color or style ':<dataField>'` — three `[CommandOption] Description` strings had unescaped single `[...]` brackets, which Spectre.Console's markup renderer parses as a style tag. The correct doubled-bracket escaping (`[[...]]`) was already used correctly elsewhere in the same files.
- Added `GenerateHelpRenderTests`, a regression test that renders `--help` for every `generate` subcommand and asserts it doesn't throw — reverting any one of the three fixes reproduces the crash under this test. To capture console output without racing other tests that also redirect console state (xUnit parallelizes across test classes by default), `CliApp.Build()` gained an optional `IAnsiConsole` parameter wired through Spectre's `ConfigureConsole`, rather than mutating the global `AnsiConsole.Console` singleton (a hazard `EvalRunCommand.cs` already documents from an earlier design).

## Test plan
- [x] `dotnet test` — 817/817 passing locally (306 D365FO.Cli.Tests + 511 D365FO.Core.Tests)
- [x] Confirmed `GenerateHelpRenderTests` catches the regression: reverting the `GenerateViewMapCommands.cs` fix reproduces the exact CI-style crash and fails the test
- [x] Confirmed the `EvalListCommandTests` fix alone was insufficient without the parallel-safety fix — an earlier version of `GenerateHelpRenderTests` that mutated `AnsiConsole.Console` directly caused an unrelated test (`IndexExtractOutputModeTests`) to intermittently fail when run as part of the full suite

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>

https://claude.ai/code/session_01C6X7iPu1AXRectkHUQf7GC