### PR TITLE
feat(eval): merge eval-catalog batch-2 (31 cases) into main

### DIFF
--- a/docs/AGENT_EVAL_LOOP.md
+++ b/docs/AGENT_EVAL_LOOP.md
@@ -1,6 +1,6 @@
 # Self-improving agent eval loop — design spec
 
-**Status:** implemented — a 22-case catalog (L0–L2) runs end-to-end. See
+**Status:** implemented — a 31-case catalog (L0–L2) runs end-to-end. See
 [eval/README.md](../eval/README.md) for day-to-day mechanics and the open
 work queue.
 
@@ -260,12 +260,14 @@ Tiers (unchanged from the source repo's convention):
 | L3 — composite | relation + generated form + datasource rebind |
 | L4 — feature slice | data entity + security chain, batch job, SSRS report |
 
-Current catalog: 22 cases, L0–L2 (`generate edt`, `enum`, `table`, `class`,
+Current catalog: 31 cases, L0–L2 (`generate edt`, `enum`, `table`, `class`,
 `coc`, `form`, `query`, `map`, `report`, `sysoperation`, `runbase`,
 `business-event`, `custom-service`, `workflow`, `systest`,
-`extension table/edt/enum`, `event-handler`, `number-sequence`, `entity`,
-`security-policy`). See [eval/README.md](../eval/README.md) for the standing
-"grow the catalog" queue.
+`extension table/edt/enum/form`, `event-handler`, `number-sequence`, `entity`,
+`security-policy`, `privilege`, `duty`, `role`, `menu-item`, `view`,
+`migration-script`, `datasource-method`, `control-method`) — every `generate`
+subcommand except the bridge-only `modify`/`test`/`bp` branches. See
+[eval/README.md](../eval/README.md) for the standing "grow the catalog" queue.
 
 ---
 

--- a/eval/README.md
+++ b/eval/README.md
@@ -113,13 +113,15 @@ lie in place while a deeper fix waits.
   an automated "cluster MODEL_ERROR runs into `skills/_source` proposals"
   step (`knowledgeFeedback.ts`); not built here yet. The rubric and agent
   roles already support adding it.
-- **Catalog breadth.** 22 cases across L0–L2 (`edt`, `enum`, `table`,
+- **Catalog breadth.** 31 cases across L0–L2 (`edt`, `enum`, `table`,
   `class`, `coc`, `form`, `query`, `map`, `report`, `sysoperation`,
   `runbase`, `business-event`, `custom-service`, `workflow`, `systest`,
-  `extension table/edt/enum`, `event-handler`, `number-sequence`, `entity`,
-  `security-policy`). L3/L4 (batch, workflow *runtime* submission, posting,
-  DMF, ER, SSRS rendering, …) need a live build/BP-check/SysTest oracle this
-  offline loop doesn't have — the natural next slice is either growing L0–L2
-  breadth further (forms/security/menu-items not yet covered) or adding that
-  oracle. See `d365fo-mcp-server`'s `eval/cases/` for the fuller L3/L4
-  catalog shape to port once a VM-backed oracle exists here.
+  `extension table/edt/enum/form`, `event-handler`, `number-sequence`,
+  `entity`, `security-policy`, `privilege`, `duty`, `role`, `menu-item`,
+  `view`, `migration-script`, `datasource-method`, `control-method`) — every
+  `generate` subcommand except the bridge-only `modify`/`test`/`bp` branches.
+  L3/L4 (batch, workflow *runtime* submission, posting, DMF, ER, SSRS
+  rendering, …) need a live build/BP-check/SysTest oracle this offline loop
+  doesn't have — the natural next slice is adding that oracle. See
+  `d365fo-mcp-server`'s `eval/cases/` for the fuller L3/L4 catalog shape to
+  port once a VM-backed oracle exists here.

--- a/eval/cases/L1-duty-basic.json
+++ b/eval/cases/L1-duty-basic.json
@@ -1,0 +1,13 @@
+{
+  "id": "L1-duty-basic",
+  "title": "Security duty aggregating a single privilege",
+  "tier": 1,
+  "instruction": "Create a security duty named ConFmVehicleMaintainDuty that aggregates the privilege ConFmVehicleMaintainPriv. Use only the d365fo CLI (search/get/generate/validate) — do not hand-write XML.",
+  "canonical_args": ["generate", "duty", "ConFmVehicleMaintainDuty", "--privilege", "ConFmVehicleMaintainPriv"],
+  "target_artifact_types": ["AxSecurityDuty"],
+  "golden_path": "L1-duty-basic",
+  "tags": ["duty", "security", "metadata"],
+  "ignore": [],
+  "requires_fixture_index": false,
+  "golden_pending": false
+}

--- a/eval/cases/L1-menu-item-basic.json
+++ b/eval/cases/L1-menu-item-basic.json
@@ -1,0 +1,13 @@
+{
+  "id": "L1-menu-item-basic",
+  "title": "Display menu item pointing at an AxForm",
+  "tier": 1,
+  "instruction": "Create a display menu item named ConFmVehicleListMenuItem pointing at the form ConFmVehicleList, labeled 'Fleet vehicles'. Use only the d365fo CLI (search/get/generate/validate) — do not hand-write XML.",
+  "canonical_args": ["generate", "menu-item", "ConFmVehicleListMenuItem", "--object", "ConFmVehicleList", "--object-type", "Form", "--kind", "Display", "--label", "Fleet vehicles"],
+  "target_artifact_types": ["AxMenuItemDisplay"],
+  "golden_path": "L1-menu-item-basic",
+  "tags": ["menu-item", "metadata"],
+  "ignore": [],
+  "requires_fixture_index": false,
+  "golden_pending": false
+}

--- a/eval/cases/L1-migration-script-basic.json
+++ b/eval/cases/L1-migration-script-basic.json
@@ -1,0 +1,13 @@
+{
+  "id": "L1-migration-script-basic",
+  "title": "SysRunnable data-migration script over an existing table",
+  "tier": 1,
+  "instruction": "Create a data-migration script class named ConFmVehicleMigration that upserts records from FmVehicle to FmVehicle (a self-migration, e.g. a re-key pass). Use `d365fo get table FmVehicle` first to confirm the table exists before generating. Use only the d365fo CLI (search/get/generate/validate) — do not hand-write XML.",
+  "canonical_args": ["generate", "migration-script", "ConFmVehicleMigration", "--source-table", "FmVehicle", "--target-table", "FmVehicle", "--mode", "Upsert"],
+  "target_artifact_types": ["AxClass"],
+  "golden_path": "L1-migration-script-basic",
+  "tags": ["migration-script", "data-migration"],
+  "ignore": [],
+  "requires_fixture_index": true,
+  "golden_pending": false
+}

--- a/eval/cases/L1-privilege-basic.json
+++ b/eval/cases/L1-privilege-basic.json
@@ -1,0 +1,13 @@
+{
+  "id": "L1-privilege-basic",
+  "title": "Security privilege granting Update on a display menu item",
+  "tier": 1,
+  "instruction": "Create a security privilege named ConFmVehicleMaintainPriv granting Update access to the display menu item ConFmVehicleListMenuItem. Use only the d365fo CLI (search/get/generate/validate) — do not hand-write XML.",
+  "canonical_args": ["generate", "privilege", "ConFmVehicleMaintainPriv", "--entry-point", "ConFmVehicleListMenuItem", "--entry-kind", "MenuItemDisplay", "--access", "Update"],
+  "target_artifact_types": ["AxSecurityPrivilege"],
+  "golden_path": "L1-privilege-basic",
+  "tags": ["privilege", "security", "metadata"],
+  "ignore": [],
+  "requires_fixture_index": false,
+  "golden_pending": false
+}

--- a/eval/cases/L1-role-basic.json
+++ b/eval/cases/L1-role-basic.json
@@ -1,0 +1,13 @@
+{
+  "id": "L1-role-basic",
+  "title": "Security role referencing a single duty",
+  "tier": 1,
+  "instruction": "Create a security role named ConFmVehicleOperatorRole labeled 'Fleet vehicle operator' that references the duty ConFmVehicleMaintainDuty. Use only the d365fo CLI (search/get/generate/validate) — do not hand-write XML.",
+  "canonical_args": ["generate", "role", "ConFmVehicleOperatorRole", "--duty", "ConFmVehicleMaintainDuty", "--label", "Fleet vehicle operator"],
+  "target_artifact_types": ["AxSecurityRole"],
+  "golden_path": "L1-role-basic",
+  "tags": ["role", "security", "metadata"],
+  "ignore": [],
+  "requires_fixture_index": false,
+  "golden_pending": false
+}

--- a/eval/cases/L1-view-basic.json
+++ b/eval/cases/L1-view-basic.json
@@ -1,0 +1,13 @@
+{
+  "id": "L1-view-basic",
+  "title": "Read-only AxView projecting an AxQuery",
+  "tier": 1,
+  "instruction": "Create an AxView named ConFmVehicleView projecting the query ConFmVehicleQuery, exposing bound fields VIN and Make from the FmVehicle datasource. Use only the d365fo CLI (search/get/generate/validate) — do not hand-write XML.",
+  "canonical_args": ["generate", "view", "ConFmVehicleView", "--query", "ConFmVehicleQuery", "--field", "VIN:FmVehicle", "--field", "Make:FmVehicle"],
+  "target_artifact_types": ["AxView"],
+  "golden_path": "L1-view-basic",
+  "tags": ["view", "metadata"],
+  "ignore": [],
+  "requires_fixture_index": false,
+  "golden_pending": false
+}

--- a/eval/cases/L2-control-method-basic.json
+++ b/eval/cases/L2-control-method-basic.json
@@ -1,0 +1,13 @@
+{
+  "id": "L2-control-method-basic",
+  "title": "Override clicked on an existing form's grid control",
+  "tier": 2,
+  "instruction": "On the existing form eval/goldens/L1-form-basic/ConFmVehicleList.xml, override the clicked method on its Grid_VIN control. First run `d365fo generate control-method eval/goldens/L1-form-basic/ConFmVehicleList.xml --list` to confirm clicked is a catalogued override. Use only the d365fo CLI (search/get/generate/validate) — do not hand-write XML.",
+  "canonical_args": ["generate", "control-method", "eval/goldens/L1-form-basic/ConFmVehicleList.xml", "--control", "Grid_VIN", "--method", "clicked"],
+  "target_artifact_types": ["AxForm"],
+  "golden_path": "L2-control-method-basic",
+  "tags": ["control-method", "form", "metadata"],
+  "ignore": [],
+  "requires_fixture_index": false,
+  "golden_pending": false
+}

--- a/eval/cases/L2-datasource-method-basic.json
+++ b/eval/cases/L2-datasource-method-basic.json
@@ -1,0 +1,13 @@
+{
+  "id": "L2-datasource-method-basic",
+  "title": "Override validateWrite on an existing form's datasource",
+  "tier": 2,
+  "instruction": "On the existing form eval/goldens/L1-form-basic/ConFmVehicleList.xml, override the validateWrite method on its FmVehicle datasource. First run `d365fo generate datasource-method eval/goldens/L1-form-basic/ConFmVehicleList.xml --list` to confirm validateWrite is a catalogued override. Use only the d365fo CLI (search/get/generate/validate) — do not hand-write XML.",
+  "canonical_args": ["generate", "datasource-method", "eval/goldens/L1-form-basic/ConFmVehicleList.xml", "--datasource", "FmVehicle", "--method", "validateWrite"],
+  "target_artifact_types": ["AxForm"],
+  "golden_path": "L2-datasource-method-basic",
+  "tags": ["datasource-method", "form", "metadata"],
+  "ignore": [],
+  "requires_fixture_index": false,
+  "golden_pending": false
+}

--- a/eval/cases/L2-form-extension-basic.json
+++ b/eval/cases/L2-form-extension-basic.json
@@ -1,0 +1,13 @@
+{
+  "id": "L2-form-extension-basic",
+  "title": "Form extension shell over the ConFmVehicleList list page",
+  "tier": 2,
+  "instruction": "Create a form extension over ConFmVehicleList (the fleet-vehicle list page generated earlier). Use only the d365fo CLI (search/get/generate/validate) — do not hand-write XML.",
+  "canonical_args": ["generate", "extension", "Form", "ConFmVehicleList", "--suffix", "ConDemo"],
+  "target_artifact_types": ["AxFormExtension"],
+  "golden_path": "L2-form-extension-basic",
+  "tags": ["extension", "form", "metadata"],
+  "ignore": [],
+  "requires_fixture_index": false,
+  "golden_pending": false
+}

--- a/eval/corpus/runs/20260805T144403788Z__L1-privilege-basic__c2c9a3600baa4c58b7d38d748165b8c9.json
+++ b/eval/corpus/runs/20260805T144403788Z__L1-privilege-basic__c2c9a3600baa4c58b7d38d748165b8c9.json
@@ -1,0 +1,20 @@
+{
+  "runId": "20260805T144403788Z__L1-privilege-basic__c2c9a3600baa4c58b7d38d748165b8c9",
+  "caseId": "L1-privilege-basic",
+  "tier": 1,
+  "timestampUtc": "2026-08-05T14:44:03.7902222+00:00",
+  "source": "replay",
+  "score": {
+    "xppClean": true,
+    "xppErrors": 0,
+    "referencesClean": true,
+    "referenceErrors": 0,
+    "goldenMatch": true,
+    "goldenDiff": {
+      "missing": [],
+      "extra": [],
+      "changed": [],
+      "isMatch": true
+    }
+  }
+}

--- a/eval/corpus/runs/20260805T144408829Z__L1-duty-basic__4f18da539f39495186f222d7137848b4.json
+++ b/eval/corpus/runs/20260805T144408829Z__L1-duty-basic__4f18da539f39495186f222d7137848b4.json
@@ -1,0 +1,20 @@
+{
+  "runId": "20260805T144408829Z__L1-duty-basic__4f18da539f39495186f222d7137848b4",
+  "caseId": "L1-duty-basic",
+  "tier": 1,
+  "timestampUtc": "2026-08-05T14:44:08.830985+00:00",
+  "source": "replay",
+  "score": {
+    "xppClean": true,
+    "xppErrors": 0,
+    "referencesClean": true,
+    "referenceErrors": 0,
+    "goldenMatch": true,
+    "goldenDiff": {
+      "missing": [],
+      "extra": [],
+      "changed": [],
+      "isMatch": true
+    }
+  }
+}

--- a/eval/corpus/runs/20260805T144413935Z__L1-role-basic__1c42a22d2a5341748db1687392143bc9.json
+++ b/eval/corpus/runs/20260805T144413935Z__L1-role-basic__1c42a22d2a5341748db1687392143bc9.json
@@ -1,0 +1,20 @@
+{
+  "runId": "20260805T144413935Z__L1-role-basic__1c42a22d2a5341748db1687392143bc9",
+  "caseId": "L1-role-basic",
+  "tier": 1,
+  "timestampUtc": "2026-08-05T14:44:13.936771+00:00",
+  "source": "replay",
+  "score": {
+    "xppClean": true,
+    "xppErrors": 0,
+    "referencesClean": true,
+    "referenceErrors": 0,
+    "goldenMatch": true,
+    "goldenDiff": {
+      "missing": [],
+      "extra": [],
+      "changed": [],
+      "isMatch": true
+    }
+  }
+}

--- a/eval/corpus/runs/20260805T144418899Z__L1-menu-item-basic__ddfd66bb887d457eb7bcb53d3b548104.json
+++ b/eval/corpus/runs/20260805T144418899Z__L1-menu-item-basic__ddfd66bb887d457eb7bcb53d3b548104.json
@@ -1,0 +1,20 @@
+{
+  "runId": "20260805T144418899Z__L1-menu-item-basic__ddfd66bb887d457eb7bcb53d3b548104",
+  "caseId": "L1-menu-item-basic",
+  "tier": 1,
+  "timestampUtc": "2026-08-05T14:44:18.9010798+00:00",
+  "source": "replay",
+  "score": {
+    "xppClean": true,
+    "xppErrors": 0,
+    "referencesClean": true,
+    "referenceErrors": 0,
+    "goldenMatch": true,
+    "goldenDiff": {
+      "missing": [],
+      "extra": [],
+      "changed": [],
+      "isMatch": true
+    }
+  }
+}

--- a/eval/corpus/runs/20260805T144423809Z__L1-view-basic__5b4b06ec70fb4093a658dd4a898c0770.json
+++ b/eval/corpus/runs/20260805T144423809Z__L1-view-basic__5b4b06ec70fb4093a658dd4a898c0770.json
@@ -1,0 +1,20 @@
+{
+  "runId": "20260805T144423809Z__L1-view-basic__5b4b06ec70fb4093a658dd4a898c0770",
+  "caseId": "L1-view-basic",
+  "tier": 1,
+  "timestampUtc": "2026-08-05T14:44:23.8110175+00:00",
+  "source": "replay",
+  "score": {
+    "xppClean": true,
+    "xppErrors": 0,
+    "referencesClean": true,
+    "referenceErrors": 0,
+    "goldenMatch": true,
+    "goldenDiff": {
+      "missing": [],
+      "extra": [],
+      "changed": [],
+      "isMatch": true
+    }
+  }
+}

--- a/eval/corpus/runs/20260805T144429005Z__L1-migration-script-basic__2e864490bcba47d68dd89ae757ca197a.json
+++ b/eval/corpus/runs/20260805T144429005Z__L1-migration-script-basic__2e864490bcba47d68dd89ae757ca197a.json
@@ -1,0 +1,20 @@
+{
+  "runId": "20260805T144429005Z__L1-migration-script-basic__2e864490bcba47d68dd89ae757ca197a",
+  "caseId": "L1-migration-script-basic",
+  "tier": 1,
+  "timestampUtc": "2026-08-05T14:44:29.0077285+00:00",
+  "source": "replay",
+  "score": {
+    "xppClean": true,
+    "xppErrors": 0,
+    "referencesClean": true,
+    "referenceErrors": 0,
+    "goldenMatch": true,
+    "goldenDiff": {
+      "missing": [],
+      "extra": [],
+      "changed": [],
+      "isMatch": true
+    }
+  }
+}

--- a/eval/corpus/runs/20260805T144434280Z__L2-form-extension-basic__f5f24195fa86429eb9d26c8e4be2ca7d.json
+++ b/eval/corpus/runs/20260805T144434280Z__L2-form-extension-basic__f5f24195fa86429eb9d26c8e4be2ca7d.json
@@ -1,0 +1,20 @@
+{
+  "runId": "20260805T144434280Z__L2-form-extension-basic__f5f24195fa86429eb9d26c8e4be2ca7d",
+  "caseId": "L2-form-extension-basic",
+  "tier": 2,
+  "timestampUtc": "2026-08-05T14:44:34.2826829+00:00",
+  "source": "replay",
+  "score": {
+    "xppClean": true,
+    "xppErrors": 0,
+    "referencesClean": true,
+    "referenceErrors": 0,
+    "goldenMatch": true,
+    "goldenDiff": {
+      "missing": [],
+      "extra": [],
+      "changed": [],
+      "isMatch": true
+    }
+  }
+}

--- a/eval/corpus/runs/20260805T144439239Z__L2-datasource-method-basic__8f70356d8e134eda83a5f3daa9f1d303.json
+++ b/eval/corpus/runs/20260805T144439239Z__L2-datasource-method-basic__8f70356d8e134eda83a5f3daa9f1d303.json
@@ -1,0 +1,20 @@
+{
+  "runId": "20260805T144439239Z__L2-datasource-method-basic__8f70356d8e134eda83a5f3daa9f1d303",
+  "caseId": "L2-datasource-method-basic",
+  "tier": 2,
+  "timestampUtc": "2026-08-05T14:44:39.2413546+00:00",
+  "source": "replay",
+  "score": {
+    "xppClean": true,
+    "xppErrors": 0,
+    "referencesClean": true,
+    "referenceErrors": 0,
+    "goldenMatch": true,
+    "goldenDiff": {
+      "missing": [],
+      "extra": [],
+      "changed": [],
+      "isMatch": true
+    }
+  }
+}

--- a/eval/corpus/runs/20260805T144444125Z__L2-control-method-basic__fd1d966bbf57433ca05eb63f75f0bce0.json
+++ b/eval/corpus/runs/20260805T144444125Z__L2-control-method-basic__fd1d966bbf57433ca05eb63f75f0bce0.json
@@ -1,0 +1,20 @@
+{
+  "runId": "20260805T144444125Z__L2-control-method-basic__fd1d966bbf57433ca05eb63f75f0bce0",
+  "caseId": "L2-control-method-basic",
+  "tier": 2,
+  "timestampUtc": "2026-08-05T14:44:44.1272349+00:00",
+  "source": "replay",
+  "score": {
+    "xppClean": true,
+    "xppErrors": 0,
+    "referencesClean": true,
+    "referenceErrors": 0,
+    "goldenMatch": true,
+    "goldenDiff": {
+      "missing": [],
+      "extra": [],
+      "changed": [],
+      "isMatch": true
+    }
+  }
+}

--- a/eval/goldens/L1-duty-basic/ConFmVehicleMaintainDuty.xml
+++ b/eval/goldens/L1-duty-basic/ConFmVehicleMaintainDuty.xml
@@ -1,0 +1,9 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<AxSecurityDuty>
+  <Name>ConFmVehicleMaintainDuty</Name>
+  <PrivilegeReferences>
+    <AxSecurityPrivilegeReference>
+      <Name>ConFmVehicleMaintainPriv</Name>
+    </AxSecurityPrivilegeReference>
+  </PrivilegeReferences>
+</AxSecurityDuty>

--- a/eval/goldens/L1-menu-item-basic/ConFmVehicleListMenuItem.xml
+++ b/eval/goldens/L1-menu-item-basic/ConFmVehicleListMenuItem.xml
@@ -1,0 +1,10 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<AxMenuItemDisplay>
+  <Name>ConFmVehicleListMenuItem</Name>
+  <Label>Fleet vehicles</Label>
+  <Image>
+    <ImageType>Symbol</ImageType>
+  </Image>
+  <Object>ConFmVehicleList</Object>
+  <ObjectType>Form</ObjectType>
+</AxMenuItemDisplay>

--- a/eval/goldens/L1-migration-script-basic/ConFmVehicleMigration.xml
+++ b/eval/goldens/L1-migration-script-basic/ConFmVehicleMigration.xml
@@ -1,0 +1,55 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<AxClass>
+  <Name>ConFmVehicleMigration</Name>
+  <Extends>SysRunnable</Extends>
+  <SourceCode>
+    <Declaration>/// &lt;summary&gt;
+/// Data migration: FmVehicle → FmVehicle.
+/// Run once via Batch or SysRunnable; uses doInsert/doUpdate (permitted exception).
+/// &lt;/summary&gt;
+public class ConFmVehicleMigration extends SysRunnable
+{
+    private static int BatchSize = 1000;
+}
+</Declaration>
+    <Methods>
+      <Method>
+        <Name>run</Name>
+        <Source>public void run()
+{
+    FmVehicle source;
+    FmVehicle target;
+    int count = 0;
+
+    ttsbegin;
+    while select source
+    {
+        // TODO: map fields from source to target
+        target.clear();
+        // target.Field = source.Field;
+        if (target.RecId) target.doUpdate(); else target.doInsert();
+        count++;
+        if (count mod BatchSize == 0)
+        {
+            ttscommit;
+            info(strFmt("Migrated %1 records", count));
+            ttsbegin;
+        }
+    }
+    ttscommit;
+    info(strFmt("Migration complete. Total: %1", count));
+}
+</Source>
+      </Method>
+      <Method>
+        <Name>main</Name>
+        <Source>public static void main(Args _args)
+{
+    ConFmVehicleMigration runObject = new ConFmVehicleMigration();
+    runObject.run();
+}
+</Source>
+      </Method>
+    </Methods>
+  </SourceCode>
+</AxClass>

--- a/eval/goldens/L1-privilege-basic/ConFmVehicleMaintainPriv.xml
+++ b/eval/goldens/L1-privilege-basic/ConFmVehicleMaintainPriv.xml
@@ -1,0 +1,12 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<AxSecurityPrivilege>
+  <Name>ConFmVehicleMaintainPriv</Name>
+  <EntryPoints>
+    <AxSecurityEntryPointReference>
+      <Name>ConFmVehicleListMenuItem</Name>
+      <ObjectName>ConFmVehicleListMenuItem</ObjectName>
+      <ObjectType>MenuItemDisplay</ObjectType>
+      <AccessLevel>Update</AccessLevel>
+    </AxSecurityEntryPointReference>
+  </EntryPoints>
+</AxSecurityPrivilege>

--- a/eval/goldens/L1-role-basic/ConFmVehicleOperatorRole.xml
+++ b/eval/goldens/L1-role-basic/ConFmVehicleOperatorRole.xml
@@ -1,0 +1,10 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<AxSecurityRole>
+  <Name>ConFmVehicleOperatorRole</Name>
+  <Label>Fleet vehicle operator</Label>
+  <Duties>
+    <AxSecurityDutyReference>
+      <Name>ConFmVehicleMaintainDuty</Name>
+    </AxSecurityDutyReference>
+  </Duties>
+</AxSecurityRole>

--- a/eval/goldens/L1-view-basic/ConFmVehicleView.xml
+++ b/eval/goldens/L1-view-basic/ConFmVehicleView.xml
@@ -1,0 +1,59 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<AxView xmlns:i="http://www.w3.org/2001/XMLSchema-instance">
+  <Name>ConFmVehicleView</Name>
+  <SourceCode>
+    <Declaration><![CDATA[
+public class ConFmVehicleView extends common
+{
+}
+]]></Declaration>
+    <Methods />
+  </SourceCode>
+  <Query>ConFmVehicleQuery</Query>
+  <FieldGroups>
+    <AxTableFieldGroup>
+      <Name>AutoReport</Name>
+      <Fields />
+    </AxTableFieldGroup>
+    <AxTableFieldGroup>
+      <Name>AutoLookup</Name>
+      <Fields />
+    </AxTableFieldGroup>
+    <AxTableFieldGroup>
+      <Name>AutoIdentification</Name>
+      <AutoPopulate>Yes</AutoPopulate>
+      <Fields />
+    </AxTableFieldGroup>
+    <AxTableFieldGroup>
+      <Name>AutoSummary</Name>
+      <Fields />
+    </AxTableFieldGroup>
+    <AxTableFieldGroup>
+      <Name>AutoBrowse</Name>
+      <Fields />
+    </AxTableFieldGroup>
+  </FieldGroups>
+  <Fields>
+    <AxViewField i:type="AxViewFieldBound">
+      <Name>VIN</Name>
+      <DataField>VIN</DataField>
+      <DataSource>FmVehicle</DataSource>
+    </AxViewField>
+    <AxViewField i:type="AxViewFieldBound">
+      <Name>Make</Name>
+      <DataField>Make</DataField>
+      <DataSource>FmVehicle</DataSource>
+    </AxViewField>
+  </Fields>
+  <Indexes />
+  <Mappings />
+  <Relations />
+  <StateMachines />
+  <ViewMetadata>
+    <Name>Metadata</Name>
+    <SourceCode>
+      <Methods />
+    </SourceCode>
+    <DataSources />
+  </ViewMetadata>
+</AxView>

--- a/eval/goldens/L2-control-method-basic/ConFmVehicleList.xml
+++ b/eval/goldens/L2-control-method-basic/ConFmVehicleList.xml
@@ -1,0 +1,143 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<AxForm xmlns:i="http://www.w3.org/2001/XMLSchema-instance" xmlns="Microsoft.Dynamics.AX.Metadata.V6">
+  <Name>ConFmVehicleList</Name>
+  <SourceCode>
+    <Methods xmlns="">
+      <Method>
+        <Name>classDeclaration</Name>
+        <Source><![CDATA[
+[Form]
+public class ConFmVehicleList extends FormRun
+{
+}
+
+]]></Source>
+      </Method>
+    </Methods>
+    <DataSources xmlns="" />
+    <DataControls xmlns=""><DataControl><Name>Grid_VIN</Name><Methods><Method><Name>clicked</Name><Source><![CDATA[
+    public void clicked()
+    {
+        super();
+    }
+]]></Source></Method></Methods></DataControl></DataControls>
+    <Members xmlns="" />
+  </SourceCode>
+  <DataSources>
+    <AxFormDataSource xmlns="">
+      <Name>FmVehicle</Name>
+      <Table>FmVehicle</Table>
+      <Fields>
+        <AxFormDataSourceField>
+          <DataField>VIN</DataField>
+        </AxFormDataSourceField>
+        <AxFormDataSourceField>
+          <DataField>Make</DataField>
+        </AxFormDataSourceField>
+      </Fields>
+      <ReferencedDataSources />
+      <InsertIfEmpty>No</InsertIfEmpty>
+      <DataSourceLinks />
+      <DerivedDataSources />
+    </AxFormDataSource>
+  </DataSources>
+  <Design>
+    <Caption xmlns="">Fleet vehicles</Caption>
+    <DataSource xmlns="">FmVehicle</DataSource>
+    <HideIfEmpty xmlns="">No</HideIfEmpty>
+    <Pattern xmlns="">SimpleList</Pattern>
+    <PatternVersion xmlns="">1.1</PatternVersion>
+    <Style xmlns="">SimpleList</Style>
+    <TitleDataSource xmlns="">FmVehicle</TitleDataSource>
+    <Controls xmlns="">
+      <AxFormControl xmlns="" i:type="AxFormActionPaneControl">
+        <Name>ActionPane</Name>
+        <ElementPosition>134217727</ElementPosition>
+        <FilterExpression>%1</FilterExpression>
+        <Type>ActionPane</Type>
+        <VerticalSpacing>-1</VerticalSpacing>
+        <FormControlExtension i:nil="true" />
+        <Controls>
+          <AxFormControl xmlns="" i:type="AxFormButtonGroupControl">
+            <Name>ButtonGroup</Name>
+            <Type>ButtonGroup</Type>
+            <FormControlExtension i:nil="true" />
+            <Controls />
+            <ArrangeMethod>Vertical</ArrangeMethod>
+          </AxFormControl>
+        </Controls>
+        <AlignChild>No</AlignChild>
+        <AlignChildren>No</AlignChildren>
+        <ArrangeMethod>Vertical</ArrangeMethod>
+      </AxFormControl>
+      <AxFormControl xmlns="" i:type="AxFormGroupControl">
+        <Name>CustomFilterGroup</Name>
+        <Pattern>CustomAndQuickFilters</Pattern>
+        <PatternVersion>1.1</PatternVersion>
+        <Type>Group</Type>
+        <WidthMode>SizeToAvailable</WidthMode>
+        <FormControlExtension i:nil="true" />
+        <Controls>
+          <AxFormControl>
+            <Name>QuickFilterControl</Name>
+            <FormControlExtension>
+              <Name>QuickFilterControl</Name>
+              <ExtensionComponents />
+              <ExtensionProperties>
+                <AxFormControlExtensionProperty>
+                  <Name>targetControlName</Name>
+                  <Type>String</Type>
+                  <Value>Grid</Value>
+                </AxFormControlExtensionProperty>
+                <AxFormControlExtensionProperty>
+                  <Name>defaultColumnName</Name>
+                  <Type>String</Type>
+                  <Value>Grid_VIN</Value>
+                </AxFormControlExtensionProperty>
+                <AxFormControlExtensionProperty>
+                  <Name>placeholderText</Name>
+                  <Type>String</Type>
+                </AxFormControlExtensionProperty>
+              </ExtensionProperties>
+            </FormControlExtension>
+          </AxFormControl>
+        </Controls>
+        <ArrangeMethod>HorizontalLeft</ArrangeMethod>
+        <FrameType>None</FrameType>
+        <Style>CustomFilter</Style>
+        <ViewEditMode>Edit</ViewEditMode>
+      </AxFormControl>
+      <AxFormControl xmlns="" i:type="AxFormGridControl">
+        <Name>Grid</Name>
+        <ElementPosition>1431655764</ElementPosition>
+        <FilterExpression>%1</FilterExpression>
+        <Type>Grid</Type>
+        <VerticalSpacing>-1</VerticalSpacing>
+        <FormControlExtension i:nil="true" />
+        <Controls>
+          <AxFormControl xmlns="" i:type="AxFormStringControl">
+            <Name>Grid_VIN</Name>
+            <Type>String</Type>
+            <FormControlExtension i:nil="true" />
+            <DataField>VIN</DataField>
+            <DataSource>FmVehicle</DataSource>
+          </AxFormControl>
+          <AxFormControl xmlns="" i:type="AxFormStringControl">
+            <Name>Grid_Make</Name>
+            <Type>String</Type>
+            <FormControlExtension i:nil="true" />
+            <DataField>Make</DataField>
+            <DataSource>FmVehicle</DataSource>
+          </AxFormControl>
+        </Controls>
+        <AlternateRowShading>No</AlternateRowShading>
+        <DataGroup>Overview</DataGroup>
+        <DataSource>FmVehicle</DataSource>
+        <MultiSelect>No</MultiSelect>
+        <ShowRowLabels>No</ShowRowLabels>
+        <Style>Tabular</Style>
+      </AxFormControl>
+    </Controls>
+  </Design>
+  <Parts />
+</AxForm>

--- a/eval/goldens/L2-datasource-method-basic/ConFmVehicleList.xml
+++ b/eval/goldens/L2-datasource-method-basic/ConFmVehicleList.xml
@@ -1,0 +1,147 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<AxForm xmlns:i="http://www.w3.org/2001/XMLSchema-instance" xmlns="Microsoft.Dynamics.AX.Metadata.V6">
+  <Name>ConFmVehicleList</Name>
+  <SourceCode>
+    <Methods xmlns="">
+      <Method>
+        <Name>classDeclaration</Name>
+        <Source><![CDATA[
+[Form]
+public class ConFmVehicleList extends FormRun
+{
+}
+
+]]></Source>
+      </Method>
+    </Methods>
+    <DataSources xmlns=""><DataSource><Name>FmVehicle</Name><Methods><Method><Name>validateWrite</Name><Source><![CDATA[
+    public boolean validateWrite()
+    {
+        boolean ret;
+
+        ret = super();
+
+        return ret;
+    }
+]]></Source></Method></Methods><Fields /></DataSource></DataSources>
+    <DataControls xmlns="" />
+    <Members xmlns="" />
+  </SourceCode>
+  <DataSources>
+    <AxFormDataSource xmlns="">
+      <Name>FmVehicle</Name>
+      <Table>FmVehicle</Table>
+      <Fields>
+        <AxFormDataSourceField>
+          <DataField>VIN</DataField>
+        </AxFormDataSourceField>
+        <AxFormDataSourceField>
+          <DataField>Make</DataField>
+        </AxFormDataSourceField>
+      </Fields>
+      <ReferencedDataSources />
+      <InsertIfEmpty>No</InsertIfEmpty>
+      <DataSourceLinks />
+      <DerivedDataSources />
+    </AxFormDataSource>
+  </DataSources>
+  <Design>
+    <Caption xmlns="">Fleet vehicles</Caption>
+    <DataSource xmlns="">FmVehicle</DataSource>
+    <HideIfEmpty xmlns="">No</HideIfEmpty>
+    <Pattern xmlns="">SimpleList</Pattern>
+    <PatternVersion xmlns="">1.1</PatternVersion>
+    <Style xmlns="">SimpleList</Style>
+    <TitleDataSource xmlns="">FmVehicle</TitleDataSource>
+    <Controls xmlns="">
+      <AxFormControl xmlns="" i:type="AxFormActionPaneControl">
+        <Name>ActionPane</Name>
+        <ElementPosition>134217727</ElementPosition>
+        <FilterExpression>%1</FilterExpression>
+        <Type>ActionPane</Type>
+        <VerticalSpacing>-1</VerticalSpacing>
+        <FormControlExtension i:nil="true" />
+        <Controls>
+          <AxFormControl xmlns="" i:type="AxFormButtonGroupControl">
+            <Name>ButtonGroup</Name>
+            <Type>ButtonGroup</Type>
+            <FormControlExtension i:nil="true" />
+            <Controls />
+            <ArrangeMethod>Vertical</ArrangeMethod>
+          </AxFormControl>
+        </Controls>
+        <AlignChild>No</AlignChild>
+        <AlignChildren>No</AlignChildren>
+        <ArrangeMethod>Vertical</ArrangeMethod>
+      </AxFormControl>
+      <AxFormControl xmlns="" i:type="AxFormGroupControl">
+        <Name>CustomFilterGroup</Name>
+        <Pattern>CustomAndQuickFilters</Pattern>
+        <PatternVersion>1.1</PatternVersion>
+        <Type>Group</Type>
+        <WidthMode>SizeToAvailable</WidthMode>
+        <FormControlExtension i:nil="true" />
+        <Controls>
+          <AxFormControl>
+            <Name>QuickFilterControl</Name>
+            <FormControlExtension>
+              <Name>QuickFilterControl</Name>
+              <ExtensionComponents />
+              <ExtensionProperties>
+                <AxFormControlExtensionProperty>
+                  <Name>targetControlName</Name>
+                  <Type>String</Type>
+                  <Value>Grid</Value>
+                </AxFormControlExtensionProperty>
+                <AxFormControlExtensionProperty>
+                  <Name>defaultColumnName</Name>
+                  <Type>String</Type>
+                  <Value>Grid_VIN</Value>
+                </AxFormControlExtensionProperty>
+                <AxFormControlExtensionProperty>
+                  <Name>placeholderText</Name>
+                  <Type>String</Type>
+                </AxFormControlExtensionProperty>
+              </ExtensionProperties>
+            </FormControlExtension>
+          </AxFormControl>
+        </Controls>
+        <ArrangeMethod>HorizontalLeft</ArrangeMethod>
+        <FrameType>None</FrameType>
+        <Style>CustomFilter</Style>
+        <ViewEditMode>Edit</ViewEditMode>
+      </AxFormControl>
+      <AxFormControl xmlns="" i:type="AxFormGridControl">
+        <Name>Grid</Name>
+        <ElementPosition>1431655764</ElementPosition>
+        <FilterExpression>%1</FilterExpression>
+        <Type>Grid</Type>
+        <VerticalSpacing>-1</VerticalSpacing>
+        <FormControlExtension i:nil="true" />
+        <Controls>
+          <AxFormControl xmlns="" i:type="AxFormStringControl">
+            <Name>Grid_VIN</Name>
+            <Type>String</Type>
+            <FormControlExtension i:nil="true" />
+            <DataField>VIN</DataField>
+            <DataSource>FmVehicle</DataSource>
+          </AxFormControl>
+          <AxFormControl xmlns="" i:type="AxFormStringControl">
+            <Name>Grid_Make</Name>
+            <Type>String</Type>
+            <FormControlExtension i:nil="true" />
+            <DataField>Make</DataField>
+            <DataSource>FmVehicle</DataSource>
+          </AxFormControl>
+        </Controls>
+        <AlternateRowShading>No</AlternateRowShading>
+        <DataGroup>Overview</DataGroup>
+        <DataSource>FmVehicle</DataSource>
+        <MultiSelect>No</MultiSelect>
+        <ShowRowLabels>No</ShowRowLabels>
+        <Style>Tabular</Style>
+      </AxFormControl>
+    </Controls>
+  </Design>
+  <Parts />
+</AxForm>

--- a/eval/goldens/L2-form-extension-basic/ConFmVehicleList.ConDemo.xml
+++ b/eval/goldens/L2-form-extension-basic/ConFmVehicleList.ConDemo.xml
@@ -1,0 +1,4 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<AxFormExtension>
+  <Name>ConFmVehicleList.ConDemo</Name>
+</AxFormExtension>

--- a/tests/D365FO.Cli.Tests/Eval/EvalListCommandTests.cs
+++ b/tests/D365FO.Cli.Tests/Eval/EvalListCommandTests.cs
@@ -33,7 +33,7 @@ public class EvalListCommandTests
 
         Assert.Equal(0, exit);
         Assert.Contains("\"ok\":true", stdout);
-        Assert.Contains("\"count\":22", stdout);
+        Assert.Contains("\"count\":31", stdout);
         Assert.Contains("L0-edt-basic", stdout);
         Assert.Contains("L2-coc-extension", stdout);
     }

--- a/tests/D365FO.Core.Tests/Eval/EvalCaseCatalogTests.cs
+++ b/tests/D365FO.Core.Tests/Eval/EvalCaseCatalogTests.cs
@@ -14,13 +14,15 @@ public class EvalCaseCatalogTests
         var (cases, errors) = EvalCaseCatalog.LoadAll(EvalPaths.CasesDir(RepoRoot));
 
         Assert.Empty(errors);
-        Assert.Equal(22, cases.Count);
+        Assert.Equal(31, cases.Count);
         Assert.Contains(cases, c => c.Id == "L0-edt-basic");
         Assert.Contains(cases, c => c.Id == "L0-enum-basic");
         Assert.Contains(cases, c => c.Id == "L1-table-basic");
         Assert.Contains(cases, c => c.Id == "L1-class-basic");
         Assert.Contains(cases, c => c.Id == "L2-coc-extension");
         Assert.Contains(cases, c => c.Id == "L2-security-policy-basic");
+        Assert.Contains(cases, c => c.Id == "L1-view-basic");
+        Assert.Contains(cases, c => c.Id == "L2-datasource-method-basic");
     }
 
     [Fact]
@@ -46,9 +48,9 @@ public class EvalCaseCatalogTests
         Assert.Equal(
             new[]
             {
-                "L1-form-basic", "L1-map-basic", "L1-query-basic", "L1-systest-basic", "L1-workflow-basic",
-                "L2-coc-extension", "L2-event-handler-basic", "L2-security-policy-basic", "L2-table-extension",
-                "L2-virtual-entity-basic",
+                "L1-form-basic", "L1-map-basic", "L1-migration-script-basic", "L1-query-basic", "L1-systest-basic",
+                "L1-workflow-basic", "L2-coc-extension", "L2-event-handler-basic", "L2-security-policy-basic",
+                "L2-table-extension", "L2-virtual-entity-basic",
             },
             fixtureCases);
     }


### PR DESCRIPTION
## Summary
PR #143 was stacked with base `fix/ci-eval-list-count-and-help-markup` (to keep it scoped cleanly on top of the #142 hotfix) and got merged into that branch rather than `main`. #142 had already merged into `main` by that point, so `main` is missing #143's content (the eval catalog batch-2 expansion, 22 → 31 cases). This PR is just that gap: `fix/ci-eval-list-count-and-help-markup` → `main`, no new changes.

## Test plan
- [x] `dotnet test` — 817/817 passing on this branch (confirmed before #143 merged)
- [x] `git diff main origin/fix/ci-eval-list-count-and-help-markup` — only the expected 31 files from #143

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>

https://claude.ai/code/session_01C6X7iPu1AXRectkHUQf7GC