### PR TITLE
fix(validator): XML001 no longer flags an empty AxTableExtension

### DIFF
--- a/eval/cases/L2-table-extension.json
+++ b/eval/cases/L2-table-extension.json
@@ -6,7 +6,7 @@
   "canonical_args": ["generate", "extension", "Table", "FmVehicle"],
   "target_artifact_types": ["AxTableExtension"],
   "golden_path": "L2-table-extension",
-  "tags": ["extension", "table", "metadata", "known-xpp-gap"],
+  "tags": ["extension", "table", "metadata"],
   "ignore": [],
   "requires_fixture_index": true,
   "golden_pending": false

--- a/src/D365FO.Core/Validation/XppValidator.cs
+++ b/src/D365FO.Core/Validation/XppValidator.cs
@@ -339,7 +339,22 @@ public static class XppValidator
 
     private static void CheckMissingAlternateKey(string code, List<XppViolation> v)
     {
-        if (!Regex.IsMatch(code, @"<AxTable(Extension)?[\s>]", RegexOptions.IgnoreCase)) return;
+        var isExtension = Regex.IsMatch(code, @"<AxTableExtension[\s>]", RegexOptions.IgnoreCase);
+        var isBaseTable = Regex.IsMatch(code, @"<AxTable[\s>]", RegexOptions.IgnoreCase);
+        if (!isExtension && !isBaseTable) return;
+
+        // A table extension merges into the base table it targets — it does not
+        // define a new physical table, and D365FO's extension model already gives
+        // it the base table's alternate key automatically. `d365fo generate
+        // extension Table <target>` legitimately emits a field-less, index-less
+        // shell (a placeholder, or purely a CoC/event-handler target) as a normal,
+        // common pattern, and there is nothing in that extension's own delta that
+        // needs an alternate key. The real BPCheckAlternateKeyAbsent's documented
+        // precondition (Microsoft Learn's Customization Analysis Report reference)
+        // is "tables that have a unique index" — only hold the extension to this
+        // rule once it actually introduces an index of its own.
+        if (isExtension && !Regex.IsMatch(code, @"<AxTableIndex[\s>]", RegexOptions.IgnoreCase)) return;
+
         if (!Regex.IsMatch(code, @"<AlternateKey>\s*Yes\s*</AlternateKey>", RegexOptions.IgnoreCase))
         {
             v.Add(new XppViolation("XML001", "error", null,

--- a/tests/D365FO.Cli.Tests/Eval/EvalRunCommandTests.cs
+++ b/tests/D365FO.Cli.Tests/Eval/EvalRunCommandTests.cs
@@ -42,6 +42,7 @@ public class EvalRunCommandTests
     [InlineData("L1-table-basic")]
     [InlineData("L1-class-basic")]
     [InlineData("L2-coc-extension")]
+    [InlineData("L2-table-extension")]
     public void Every_authored_case_replays_clean_against_its_golden(string caseId)
     {
         var exit = Run(caseId, out var stdout);

--- a/tests/D365FO.Core.Tests/XppValidatorTests.cs
+++ b/tests/D365FO.Core.Tests/XppValidatorTests.cs
@@ -266,6 +266,35 @@ public class XppValidatorTests
     }
 
     [Fact]
+    public void Xml001_quiet_for_empty_table_extension()
+    {
+        // `d365fo generate extension Table <target>` always emits this exact
+        // shell — a table extension that adds zero fields/indexes of its own
+        // (a common, valid pattern: placeholder shell, CoC/event-handler
+        // target, etc.). It inherits the base table's alternate key
+        // automatically; there is nothing in the extension's own delta to
+        // require one. Real BPCheckAlternateKeyAbsent's documented
+        // precondition (Customization Analysis Report docs) is "tables that
+        // have a unique index" — an index-less extension never meets it.
+        var xml = "<AxTableExtension><Name>FmVehicle.Extension</Name></AxTableExtension>";
+        var v = Run(xml, "xml-any");
+        Assert.DoesNotContain(v, x => x.Rule == "XML001");
+    }
+
+    [Fact]
+    public void Xml001_flags_table_extension_that_adds_an_index_without_alternate_key()
+    {
+        // Once the extension actually introduces its own AxTableIndex, the
+        // real rule's precondition ("has a unique index") is met for that
+        // delta — an extension-added index without an alternate key should
+        // still be flagged.
+        var xml = "<AxTableExtension><Name>FmVehicle.Extension</Name>" +
+                   "<Indexes><AxTableIndex><Name>NewIdx</Name></AxTableIndex></Indexes></AxTableExtension>";
+        var v = Run(xml, "xml-any");
+        Assert.Contains(v, x => x.Rule == "XML001" && x.Severity == "error");
+    }
+
+    [Fact]
     public void Xml002_and_003_fire_with_static_defaults()
     {
         var xml = "<AxTable><Name>MyTable</Name><Fields/></AxTable>";


### PR DESCRIPTION
## Summary

- `d365fo generate extension Table <target>` always produces a field-less, index-less shell (only `<Name>`) — there's no `--field`/`--index` option on that command at all, so this is the *only* shape it can ever emit. `CheckMissingAlternateKey` in `src/D365FO.Core/Validation/XppValidator.cs` ran the same "must have an `<AlternateKey>Yes</AlternateKey>` index" rule against `AxTableExtension` as against `AxTable`, so every `generate extension Table` invocation unconditionally tripped `XML001`.
- Evidence: corpus record `eval/corpus/runs/20260805T125746944Z__L2-table-extension__1d9c1c3c07ea414c8a98434d87558083.json` (`xppClean:false`, 1 XML001 error, `referencesClean:true`, `goldenMatch:true`). The case (`eval/cases/L2-table-extension.json`) was tagged `known-xpp-gap` by a prior session without confirming real `xppbp` semantics.
- Re-derived the real rule: Microsoft Learn's Customization Analysis Report reference documents `BPCheckAlternateKeyAbsent`'s precondition as *"tables that have a unique index"* — not "every table". A table extension merges into its base table (it isn't a new physical table) and inherits the base table's alternate key automatically; an index-less extension's own delta never meets that precondition. Field-less extension shells (placeholders, CoC/event-handler targets) are a normal, common pattern, and this CLI's own generator can only ever emit that shape for `generate extension Table` today.
- Fix is narrowly scoped: `CheckMissingAlternateKey` now only requires an alternate-key index on `AxTableExtension` once the extension itself introduces at least one `<AxTableIndex>` — base `AxTable` behavior is untouched (still fires XML001 unconditionally, per the CLI's existing defensive "never ship a table without an alternate key" stance).

## Evidence / before-after

- Before (this PR's base, matching the committed corpus record): `d365fo validate xpp` on the golden `eval/goldens/L2-table-extension/FmVehicle.Extension.xml` → `errors:1`, `XML001`.
- After this fix, same file → `{"errors":0,"warnings":0,"violations":[],"verdict":"No violations found."}`.
- Base `AxTable` with zero indexes still correctly fires `XML001` (unchanged) — verified manually against `<AxTable><Name>Bare</Name></AxTable>`.
- An `AxTableExtension` that *does* introduce its own `<AxTableIndex>` without an alternate key still correctly fires `XML001` (unchanged behavior for that shape) — covered by a new regression test.
- Dropped the `known-xpp-gap` tag from `eval/cases/L2-table-extension.json` (no longer a known gap) and added `L2-table-extension` to `EvalRunCommandTests`' golden-replay theory (`tests/D365FO.Cli.Tests/Eval/EvalRunCommandTests.cs`) — this drives the real CLI child-process replay path end to end and now asserts `goldenMatch:true` / `xppClean` not-false for this case permanently in CI.

## New regression tests

- `tests/D365FO.Core.Tests/XppValidatorTests.cs`: `Xml001_quiet_for_empty_table_extension` (fails before this fix — confirmed) and `Xml001_flags_table_extension_that_adds_an_index_without_alternate_key` (guards against overcorrecting to "never fire on extensions at all").
- `tests/D365FO.Cli.Tests/Eval/EvalRunCommandTests.cs`: `L2-table-extension` added to `Every_authored_case_replays_clean_against_its_golden`.

## Test plan

- [x] `dotnet test d365fo-cli.slnx` — full suite green (307 D365FO.Cli.Tests + 513 D365FO.Core.Tests = 820 total, 0 failures).
- [x] New `XppValidatorTests` case reproduced the gap as a failing test before the fix, passes after.
- [x] Manually re-validated `eval/goldens/L1-table-basic/ConVehicleLog.xml`, `L1-view-basic/ConFmVehicleView.xml`, `L1-map-basic/ConFmVehicleMap.xml` (the only other goldens containing `AxTable`) via `d365fo validate xpp` — all still clean, no regression.
- [x] Manually re-validated a bare base `AxTable` (`<AxTable><Name>Bare</Name></AxTable>`) — still fires `XML001` as before (base-table behavior intentionally untouched).

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01C6X7iPu1AXRectkHUQf7GC