### PR TITLE
feat(eval): cover every generate branch, fixing 3 scaffolder defects found doing it

### DIFF
--- a/docs/AGENT_EVAL_LOOP.md
+++ b/docs/AGENT_EVAL_LOOP.md
@@ -57,10 +57,12 @@ d365fo-cli's core path is different: `generate` → `validate xpp` →
 - needs **no rollback/undo machinery** — each case runs `generate` against a
   disposable temp SQLite index and writes to a temp file; the whole
   workspace is deleted after scoring, so there is nothing to roll back;
-- needs **no shared-fixture problem** (source repo §4a) — the one case that
-  extends an existing object (`L2-coc-extension`) reads from the
-  already-checked-in `tests/Samples/MiniAot/TestModel` fixture, rebuilt
-  fresh into a temp index at the start of every run.
+- needs **no shared-fixture problem** (source repo §4a) — the cases that
+  extend or bind to an existing object (`L2-coc-extension`, the form-pattern
+  cases, `L1-query-join`, …) read from the already-checked-in
+  `tests/Samples/MiniAot/TestModel` fixture — two related tables
+  (`FmVehicle`, `FmVehicleLine`) plus one class — rebuilt fresh into a temp
+  index at the start of every run.
 
 What's missing relative to the source repo, honestly: no compiler
 round-trip (`build`/`bp check` are Windows-VM-only and out of scope here) and
@@ -260,13 +262,21 @@ Tiers (unchanged from the source repo's convention):
 | L3 — composite | relation + generated form + datasource rebind |
 | L4 — feature slice | data entity + security chain, batch job, SSRS report |
 
-Current catalog: 31 cases, L0–L2 (`generate edt`, `enum`, `table`, `class`,
-`coc`, `form`, `query`, `map`, `report`, `sysoperation`, `runbase`,
-`business-event`, `custom-service`, `workflow`, `systest`,
+Current catalog: 51 cases, L0–L2. Every `generate` subcommand except the
+bridge-only `modify`/`test`/`bp` branches has at least one case (`edt`, `enum`,
+`table`, `class`, `coc`, `form`, `query`, `map`, `report`, `sysoperation`,
+`runbase`, `business-event`, `custom-service`, `workflow`, `systest`,
 `extension table/edt/enum/form`, `event-handler`, `number-sequence`, `entity`,
 `security-policy`, `privilege`, `duty`, `role`, `menu-item`, `view`,
-`migration-script`, `datasource-method`, `control-method`) — every `generate`
-subcommand except the bridge-only `modify`/`test`/`bp` branches. See
+`migration-script`, `datasource-method`, `control-method`), and the option axes
+that select a *different code path* inside a subcommand are covered too: all
+nine `form --pattern` templates, `extension SecurityDuty`/`SecurityRole`,
+`edt --extends` vs `--base-type`, `enum --non-extensible`,
+`table --table-type TempDB`, `query --join`, `view --computed`,
+`report --parameter`/`--extra-dataset`, `privilege --data-entity`,
+`menu-item --kind Action`/`Output`, and `map --map-to` across two tables.
+Three of those axes were added after they were found to be *broken*, not merely
+untested — see the regression tags in the case files. See
 [eval/README.md](../eval/README.md) for the standing "grow the catalog" queue.
 
 ---

--- a/eval/README.md
+++ b/eval/README.md
@@ -105,21 +105,24 @@ lie in place while a deeper fix waits.
   A handful of cases (tagged `known-reference-gap`) generate a class or
   extension whose body legitimately references a *sibling* artifact or a
   standard system object that a minimal offline index can't contain (e.g.
-  the SysOperation controller's own Service class, or a CoC extension over a
-  standard `NumberSeqApplicationModule_*` class) — `referencesClean: false`
-  there is the expected, honest result of scoring one artifact in isolation,
-  not a defect.
+  the SysOperation controller's own Service class, a CoC extension over a
+  standard `NumberSeqApplicationModule_*` class, or a computed view's
+  `SysComputedColumn` call) — `referencesClean: false` there is the expected,
+  honest result of scoring one artifact in isolation, not a defect.
 - **`MODEL_ERROR` → knowledge-base feedback tooling.** The sibling repo has
   an automated "cluster MODEL_ERROR runs into `skills/_source` proposals"
   step (`knowledgeFeedback.ts`); not built here yet. The rubric and agent
   roles already support adding it.
-- **Catalog breadth.** 31 cases across L0–L2 (`edt`, `enum`, `table`,
-  `class`, `coc`, `form`, `query`, `map`, `report`, `sysoperation`,
-  `runbase`, `business-event`, `custom-service`, `workflow`, `systest`,
-  `extension table/edt/enum/form`, `event-handler`, `number-sequence`,
-  `entity`, `security-policy`, `privilege`, `duty`, `role`, `menu-item`,
-  `view`, `migration-script`, `datasource-method`, `control-method`) — every
-  `generate` subcommand except the bridge-only `modify`/`test`/`bp` branches.
+- **Catalog breadth.** 51 cases across L0–L2. Every `generate` subcommand
+  except the bridge-only `modify`/`test`/`bp` branches has a case, and so does
+  every *option axis that selects a different code path* inside one: all nine
+  `form --pattern` templates, `extension SecurityDuty`/`SecurityRole`,
+  `edt --extends`, `enum --non-extensible`, `table --table-type TempDB`,
+  `query --join`, `view --computed`, `report --parameter`/`--extra-dataset`,
+  `privilege --data-entity`, `menu-item --kind Action`/`Output`, and
+  `map --map-to` over two tables. Option axes that only vary a literal
+  (a different `--label`, another `--field`) are deliberately *not* separate
+  cases — they exercise no new branch.
   L3/L4 (batch, workflow *runtime* submission, posting, DMF, ER, SSRS
   rendering, …) need a live build/BP-check/SysTest oracle this offline loop
   doesn't have — the natural next slice is adding that oracle. See

--- a/eval/cases/L0-edt-extends.json
+++ b/eval/cases/L0-edt-extends.json
@@ -1,0 +1,27 @@
+{
+  "id": "L0-edt-extends",
+  "title": "EDT derived from a parent EDT rather than a primitive",
+  "tier": 0,
+  "instruction": "Create an Extended Data Type named ConFmVehicleName that extends the standard Name EDT (do not give it a primitive base type), labelled 'Vehicle name'. Use only the d365fo CLI (search/get/generate/validate) — do not hand-write XML.",
+  "canonical_args": [
+    "generate",
+    "edt",
+    "ConFmVehicleName",
+    "--extends",
+    "Name",
+    "--label",
+    "Vehicle name"
+  ],
+  "target_artifact_types": [
+    "AxEdt"
+  ],
+  "golden_path": "L0-edt-extends",
+  "tags": [
+    "edt",
+    "extends",
+    "metadata"
+  ],
+  "ignore": [],
+  "requires_fixture_index": false,
+  "golden_pending": false
+}

--- a/eval/cases/L0-enum-non-extensible.json
+++ b/eval/cases/L0-enum-non-extensible.json
@@ -1,0 +1,30 @@
+{
+  "id": "L0-enum-non-extensible",
+  "title": "Non-extensible base enum",
+  "tier": 0,
+  "instruction": "Create a base enum named ConFmVehicleKind with values Car=0 and Truck=1, labelled 'Vehicle kind', and mark it non-extensible. Use only the d365fo CLI (search/get/generate/validate) — do not hand-write XML.",
+  "canonical_args": [
+    "generate",
+    "enum",
+    "ConFmVehicleKind",
+    "--value",
+    "Car:0",
+    "--value",
+    "Truck:1",
+    "--non-extensible",
+    "--label",
+    "Vehicle kind"
+  ],
+  "target_artifact_types": [
+    "AxEnum"
+  ],
+  "golden_path": "L0-enum-non-extensible",
+  "tags": [
+    "enum",
+    "extensibility",
+    "metadata"
+  ],
+  "ignore": [],
+  "requires_fixture_index": false,
+  "golden_pending": false
+}

--- a/eval/cases/L1-form-details-master.json
+++ b/eval/cases/L1-form-details-master.json
@@ -1,0 +1,33 @@
+{
+  "id": "L1-form-details-master",
+  "title": "DetailsMaster form over an existing table",
+  "tier": 1,
+  "instruction": "Create a DetailsMaster form named ConFmVehicleDetails bound to the FmVehicle table, with VIN and Make on the Overview tab, captioned 'Fleet vehicle details'. Use `d365fo get table FmVehicle` first to confirm the field names before generating. Use only the d365fo CLI (search/get/generate/validate) — do not hand-write XML.",
+  "canonical_args": [
+    "generate",
+    "form",
+    "ConFmVehicleDetails",
+    "--pattern",
+    "DetailsMaster",
+    "--table",
+    "FmVehicle",
+    "--field",
+    "VIN",
+    "--field",
+    "Make",
+    "--caption",
+    "Fleet vehicle details"
+  ],
+  "target_artifact_types": [
+    "AxForm"
+  ],
+  "golden_path": "L1-form-details-master",
+  "tags": [
+    "form",
+    "detailsmaster",
+    "metadata"
+  ],
+  "ignore": [],
+  "requires_fixture_index": true,
+  "golden_pending": false
+}

--- a/eval/cases/L1-form-details-transaction.json
+++ b/eval/cases/L1-form-details-transaction.json
@@ -1,0 +1,34 @@
+{
+  "id": "L1-form-details-transaction",
+  "title": "DetailsTransaction form with a header and a lines datasource",
+  "tier": 1,
+  "instruction": "Create a DetailsTransaction (header/lines) form named ConFmVehicleServiceOrder with FmVehicle as the header table and FmVehicleLine as the lines table, showing VIN in the header, captioned 'Vehicle service order'. Use `d365fo get table FmVehicle` and `d365fo get table FmVehicleLine` first to confirm both tables exist. Use only the d365fo CLI (search/get/generate/validate) — do not hand-write XML.",
+  "canonical_args": [
+    "generate",
+    "form",
+    "ConFmVehicleServiceOrder",
+    "--pattern",
+    "DetailsTransaction",
+    "--table",
+    "FmVehicle",
+    "--lines-table",
+    "FmVehicleLine",
+    "--field",
+    "VIN",
+    "--caption",
+    "Vehicle service order"
+  ],
+  "target_artifact_types": [
+    "AxForm"
+  ],
+  "golden_path": "L1-form-details-transaction",
+  "tags": [
+    "form",
+    "detailstransaction",
+    "header-lines",
+    "metadata"
+  ],
+  "ignore": [],
+  "requires_fixture_index": true,
+  "golden_pending": false
+}

--- a/eval/cases/L1-form-dialog.json
+++ b/eval/cases/L1-form-dialog.json
@@ -1,0 +1,33 @@
+{
+  "id": "L1-form-dialog",
+  "title": "Dialog form with OK/Cancel over an existing table",
+  "tier": 1,
+  "instruction": "Create a Dialog form named ConFmVehicleCreateDialog bound to the FmVehicle table, prompting for VIN and Make, captioned 'Create vehicle'. Use `d365fo get table FmVehicle` first to confirm the field names before generating. Use only the d365fo CLI (search/get/generate/validate) — do not hand-write XML.",
+  "canonical_args": [
+    "generate",
+    "form",
+    "ConFmVehicleCreateDialog",
+    "--pattern",
+    "Dialog",
+    "--table",
+    "FmVehicle",
+    "--field",
+    "VIN",
+    "--field",
+    "Make",
+    "--caption",
+    "Create vehicle"
+  ],
+  "target_artifact_types": [
+    "AxForm"
+  ],
+  "golden_path": "L1-form-dialog",
+  "tags": [
+    "form",
+    "dialog",
+    "metadata"
+  ],
+  "ignore": [],
+  "requires_fixture_index": true,
+  "golden_pending": false
+}

--- a/eval/cases/L1-form-list-page.json
+++ b/eval/cases/L1-form-list-page.json
@@ -1,0 +1,33 @@
+{
+  "id": "L1-form-list-page",
+  "title": "ListPage form (read-only datasource) over an existing table",
+  "tier": 1,
+  "instruction": "Create a ListPage form named ConFmVehicleListPage bound to the FmVehicle table, showing VIN and Make, captioned 'Fleet vehicles'. Use `d365fo get table FmVehicle` first to confirm the field names before generating. Use only the d365fo CLI (search/get/generate/validate) — do not hand-write XML.",
+  "canonical_args": [
+    "generate",
+    "form",
+    "ConFmVehicleListPage",
+    "--pattern",
+    "ListPage",
+    "--table",
+    "FmVehicle",
+    "--field",
+    "VIN",
+    "--field",
+    "Make",
+    "--caption",
+    "Fleet vehicles"
+  ],
+  "target_artifact_types": [
+    "AxForm"
+  ],
+  "golden_path": "L1-form-list-page",
+  "tags": [
+    "form",
+    "listpage",
+    "metadata"
+  ],
+  "ignore": [],
+  "requires_fixture_index": true,
+  "golden_pending": false
+}

--- a/eval/cases/L1-form-lookup.json
+++ b/eval/cases/L1-form-lookup.json
@@ -1,0 +1,33 @@
+{
+  "id": "L1-form-lookup",
+  "title": "Lookup form over an existing table",
+  "tier": 1,
+  "instruction": "Create a Lookup form named ConFmVehicleLookupForm bound to the FmVehicle table, showing VIN and Make, captioned 'Vehicle lookup'. Use `d365fo get table FmVehicle` first to confirm the field names before generating. Use only the d365fo CLI (search/get/generate/validate) — do not hand-write XML.",
+  "canonical_args": [
+    "generate",
+    "form",
+    "ConFmVehicleLookupForm",
+    "--pattern",
+    "Lookup",
+    "--table",
+    "FmVehicle",
+    "--field",
+    "VIN",
+    "--field",
+    "Make",
+    "--caption",
+    "Vehicle lookup"
+  ],
+  "target_artifact_types": [
+    "AxForm"
+  ],
+  "golden_path": "L1-form-lookup",
+  "tags": [
+    "form",
+    "lookup",
+    "metadata"
+  ],
+  "ignore": [],
+  "requires_fixture_index": true,
+  "golden_pending": false
+}

--- a/eval/cases/L1-form-simplelist-details.json
+++ b/eval/cases/L1-form-simplelist-details.json
@@ -1,0 +1,33 @@
+{
+  "id": "L1-form-simplelist-details",
+  "title": "SimpleListDetails form over an existing table",
+  "tier": 1,
+  "instruction": "Create a SimpleListDetails form named ConFmVehicleListDetails bound to the FmVehicle table, showing VIN and Make in both the list and the details panel, captioned 'Fleet vehicles'. Use `d365fo get table FmVehicle` first to confirm the field names before generating. Use only the d365fo CLI (search/get/generate/validate) — do not hand-write XML.",
+  "canonical_args": [
+    "generate",
+    "form",
+    "ConFmVehicleListDetails",
+    "--pattern",
+    "SimpleListDetails",
+    "--table",
+    "FmVehicle",
+    "--field",
+    "VIN",
+    "--field",
+    "Make",
+    "--caption",
+    "Fleet vehicles"
+  ],
+  "target_artifact_types": [
+    "AxForm"
+  ],
+  "golden_path": "L1-form-simplelist-details",
+  "tags": [
+    "form",
+    "simplelistdetails",
+    "metadata"
+  ],
+  "ignore": [],
+  "requires_fixture_index": true,
+  "golden_pending": false
+}

--- a/eval/cases/L1-form-table-of-contents.json
+++ b/eval/cases/L1-form-table-of-contents.json
@@ -1,0 +1,34 @@
+{
+  "id": "L1-form-table-of-contents",
+  "title": "TableOfContents parameters form binding its fields",
+  "tier": 1,
+  "instruction": "Create a TableOfContents (parameters) form named ConFmVehicleParametersForm bound to the FmVehicle table, exposing VIN and Make, captioned 'Fleet parameters'. Use `d365fo get table FmVehicle` first to confirm the field names before generating. Use only the d365fo CLI (search/get/generate/validate) — do not hand-write XML.",
+  "canonical_args": [
+    "generate",
+    "form",
+    "ConFmVehicleParametersForm",
+    "--pattern",
+    "TableOfContents",
+    "--table",
+    "FmVehicle",
+    "--field",
+    "VIN",
+    "--field",
+    "Make",
+    "--caption",
+    "Fleet parameters"
+  ],
+  "target_artifact_types": [
+    "AxForm"
+  ],
+  "golden_path": "L1-form-table-of-contents",
+  "tags": [
+    "form",
+    "tableofcontents",
+    "metadata",
+    "regression"
+  ],
+  "ignore": [],
+  "requires_fixture_index": true,
+  "golden_pending": false
+}

--- a/eval/cases/L1-form-workspace.json
+++ b/eval/cases/L1-form-workspace.json
@@ -1,0 +1,34 @@
+{
+  "id": "L1-form-workspace",
+  "title": "Workspace (panorama) form binding its fields into a list section",
+  "tier": 1,
+  "instruction": "Create a Workspace form named ConFmVehicleWorkspace over the FmVehicle table, listing VIN and Make, captioned 'Fleet management'. Use `d365fo get table FmVehicle` first to confirm the field names before generating. Use only the d365fo CLI (search/get/generate/validate) — do not hand-write XML.",
+  "canonical_args": [
+    "generate",
+    "form",
+    "ConFmVehicleWorkspace",
+    "--pattern",
+    "Workspace",
+    "--table",
+    "FmVehicle",
+    "--field",
+    "VIN",
+    "--field",
+    "Make",
+    "--caption",
+    "Fleet management"
+  ],
+  "target_artifact_types": [
+    "AxForm"
+  ],
+  "golden_path": "L1-form-workspace",
+  "tags": [
+    "form",
+    "workspace",
+    "metadata",
+    "regression"
+  ],
+  "ignore": [],
+  "requires_fixture_index": true,
+  "golden_pending": false
+}

--- a/eval/cases/L1-map-multi-table.json
+++ b/eval/cases/L1-map-multi-table.json
@@ -1,0 +1,29 @@
+{
+  "id": "L1-map-multi-table",
+  "title": "Map whose field template is mapped onto two tables",
+  "tier": 1,
+  "instruction": "Create an AOT map named ConFmVehicleSharedMap with one field VIN of type VinEdt, mapped by identical name onto both FmVehicle and FmVehicleLine. Use only the d365fo CLI (search/get/generate/validate) — do not hand-write XML.",
+  "canonical_args": [
+    "generate",
+    "map",
+    "ConFmVehicleSharedMap",
+    "--field",
+    "VIN:VinEdt",
+    "--map-to",
+    "FmVehicle",
+    "--map-to",
+    "FmVehicleLine"
+  ],
+  "target_artifact_types": [
+    "AxMap"
+  ],
+  "golden_path": "L1-map-multi-table",
+  "tags": [
+    "map",
+    "mapping",
+    "metadata"
+  ],
+  "ignore": [],
+  "requires_fixture_index": true,
+  "golden_pending": false
+}

--- a/eval/cases/L1-menu-item-action.json
+++ b/eval/cases/L1-menu-item-action.json
@@ -1,0 +1,31 @@
+{
+  "id": "L1-menu-item-action",
+  "title": "Action menu item pointing at a class",
+  "tier": 1,
+  "instruction": "Create an Action menu item named ConFmVehicleServiceMenuItem that runs the FmVehicleService class, labelled 'Run vehicle service'. Use `d365fo get class FmVehicleService` first to confirm the class exists. Use only the d365fo CLI (search/get/generate/validate) — do not hand-write XML.",
+  "canonical_args": [
+    "generate",
+    "menu-item",
+    "ConFmVehicleServiceMenuItem",
+    "--object",
+    "FmVehicleService",
+    "--object-type",
+    "Class",
+    "--kind",
+    "Action",
+    "--label",
+    "Run vehicle service"
+  ],
+  "target_artifact_types": [
+    "AxMenuItemAction"
+  ],
+  "golden_path": "L1-menu-item-action",
+  "tags": [
+    "menu-item",
+    "action",
+    "metadata"
+  ],
+  "ignore": [],
+  "requires_fixture_index": true,
+  "golden_pending": false
+}

--- a/eval/cases/L1-menu-item-output.json
+++ b/eval/cases/L1-menu-item-output.json
@@ -1,0 +1,32 @@
+{
+  "id": "L1-menu-item-output",
+  "title": "Output menu item pointing at an SSRS report",
+  "tier": 1,
+  "instruction": "Create an Output menu item named ConFmVehicleReportMenuItem that runs the report ConFmVehicleParamReport, labelled 'Fleet vehicle report'. Use only the d365fo CLI (search/get/generate/validate) — do not hand-write XML.",
+  "canonical_args": [
+    "generate",
+    "menu-item",
+    "ConFmVehicleReportMenuItem",
+    "--object",
+    "ConFmVehicleParamReport",
+    "--object-type",
+    "Report",
+    "--kind",
+    "Output",
+    "--label",
+    "Fleet vehicle report"
+  ],
+  "target_artifact_types": [
+    "AxMenuItemOutput"
+  ],
+  "golden_path": "L1-menu-item-output",
+  "tags": [
+    "menu-item",
+    "output",
+    "report",
+    "metadata"
+  ],
+  "ignore": [],
+  "requires_fixture_index": false,
+  "golden_pending": false
+}

--- a/eval/cases/L1-privilege-data-entity.json
+++ b/eval/cases/L1-privilege-data-entity.json
@@ -1,0 +1,29 @@
+{
+  "id": "L1-privilege-data-entity",
+  "title": "Privilege granting maintain access on a data entity",
+  "tier": 1,
+  "instruction": "Create a security privilege named ConFmVehicleEntityPriv that grants maintain (create/read/update/delete/correct) access on the data entity ConFmVehicleEntity, labelled 'Fleet vehicle entity maintain'. It grants no menu-item entry point. Use only the d365fo CLI (search/get/generate/validate) — do not hand-write XML.",
+  "canonical_args": [
+    "generate",
+    "privilege",
+    "ConFmVehicleEntityPriv",
+    "--data-entity",
+    "ConFmVehicleEntity",
+    "--data-entity-access",
+    "maintain",
+    "--label",
+    "Fleet vehicle entity maintain"
+  ],
+  "target_artifact_types": [
+    "AxSecurityPrivilege"
+  ],
+  "golden_path": "L1-privilege-data-entity",
+  "tags": [
+    "security",
+    "privilege",
+    "data-entity"
+  ],
+  "ignore": [],
+  "requires_fixture_index": false,
+  "golden_pending": false
+}

--- a/eval/cases/L1-query-join.json
+++ b/eval/cases/L1-query-join.json
@@ -1,0 +1,27 @@
+{
+  "id": "L1-query-join",
+  "title": "Query joining a child table onto its root data source",
+  "tier": 1,
+  "instruction": "Create an AOT query named ConFmVehicleLineQuery rooted on FmVehicle with FmVehicleLine inner-joined to it. Use `d365fo get table FmVehicleLine` first to confirm the relation exists. Use only the d365fo CLI (search/get/generate/validate) — do not hand-write XML.",
+  "canonical_args": [
+    "generate",
+    "query",
+    "ConFmVehicleLineQuery",
+    "--ds",
+    "FmVehicle",
+    "--join",
+    "FmVehicleLine:InnerJoin:FmVehicle"
+  ],
+  "target_artifact_types": [
+    "AxQuery"
+  ],
+  "golden_path": "L1-query-join",
+  "tags": [
+    "query",
+    "join",
+    "metadata"
+  ],
+  "ignore": [],
+  "requires_fixture_index": true,
+  "golden_pending": false
+}

--- a/eval/cases/L1-report-parameters.json
+++ b/eval/cases/L1-report-parameters.json
@@ -1,0 +1,34 @@
+{
+  "id": "L1-report-parameters",
+  "title": "Report with a prompted parameter and a second dataset",
+  "tier": 1,
+  "instruction": "Create an SSRS report named ConFmVehicleParamReport with VIN and Make as tablix columns, a prompted FromDate parameter of type DateTime, and a second dataset ConFmVehicleSummaryDS fed by the data provider class ConFmVehicleSummaryDP, captioned 'Fleet vehicle parameter report'. Use only the d365fo CLI (search/get/generate/validate) — do not hand-write XML.",
+  "canonical_args": [
+    "generate",
+    "report",
+    "ConFmVehicleParamReport",
+    "--field",
+    "VIN",
+    "--field",
+    "Make",
+    "--parameter",
+    "FromDate:DateTime",
+    "--extra-dataset",
+    "ConFmVehicleSummaryDS:ConFmVehicleSummaryDP",
+    "--caption",
+    "Fleet vehicle parameter report"
+  ],
+  "target_artifact_types": [
+    "AxReport"
+  ],
+  "golden_path": "L1-report-parameters",
+  "tags": [
+    "report",
+    "parameters",
+    "dataset",
+    "metadata"
+  ],
+  "ignore": [],
+  "requires_fixture_index": false,
+  "golden_pending": false
+}

--- a/eval/cases/L1-table-tempdb.json
+++ b/eval/cases/L1-table-tempdb.json
@@ -1,0 +1,34 @@
+{
+  "id": "L1-table-tempdb",
+  "title": "TempDB table (storage kind, not table group)",
+  "tier": 1,
+  "instruction": "Create a TempDB (temporary, session-scoped) table named ConFmVehicleTmp with a mandatory VIN field using the VinEdt EDT and a ServiceNote field using the Notes EDT, labelled 'Vehicle scratch table'. It carries no business role, so give it the Miscellaneous table group. Use only the d365fo CLI (search/get/generate/validate) — do not hand-write XML.",
+  "canonical_args": [
+    "generate",
+    "table",
+    "ConFmVehicleTmp",
+    "--table-type",
+    "TempDB",
+    "--pattern",
+    "miscellaneous",
+    "--field",
+    "VIN:VinEdt:mandatory",
+    "--field",
+    "ServiceNote:Notes",
+    "--label",
+    "Vehicle scratch table"
+  ],
+  "target_artifact_types": [
+    "AxTable"
+  ],
+  "golden_path": "L1-table-tempdb",
+  "tags": [
+    "table",
+    "tempdb",
+    "storage",
+    "metadata"
+  ],
+  "ignore": [],
+  "requires_fixture_index": false,
+  "golden_pending": false
+}

--- a/eval/cases/L1-view-computed.json
+++ b/eval/cases/L1-view-computed.json
@@ -1,0 +1,31 @@
+{
+  "id": "L1-view-computed",
+  "title": "View with a computed column and its backing view method",
+  "tier": 1,
+  "instruction": "Create a view named ConFmVehicleAgeView over the query ConFmVehicleLineQuery, projecting VIN from the FmVehicle data source plus a computed integer column ServiceCount backed by a view method named computeServiceCount. Use only the d365fo CLI (search/get/generate/validate) — do not hand-write XML.",
+  "canonical_args": [
+    "generate",
+    "view",
+    "ConFmVehicleAgeView",
+    "--query",
+    "ConFmVehicleLineQuery",
+    "--field",
+    "VIN:FmVehicle",
+    "--computed",
+    "ServiceCount:computeServiceCount:Int"
+  ],
+  "target_artifact_types": [
+    "AxView"
+  ],
+  "golden_path": "L1-view-computed",
+  "tags": [
+    "view",
+    "computed-column",
+    "metadata",
+    "regression",
+    "known-reference-gap"
+  ],
+  "ignore": [],
+  "requires_fixture_index": true,
+  "golden_pending": false
+}

--- a/eval/cases/L2-security-duty-extension.json
+++ b/eval/cases/L2-security-duty-extension.json
@@ -1,0 +1,26 @@
+{
+  "id": "L2-security-duty-extension",
+  "title": "Security duty extension adding a privilege",
+  "tier": 2,
+  "instruction": "Extend the existing security duty ConFmVehicleMaintainDuty so it also grants the privilege ConFmVehicleMaintainPriv, without editing the duty itself. Use only the d365fo CLI (search/get/generate/validate) — do not hand-write XML.",
+  "canonical_args": [
+    "generate",
+    "extension",
+    "SecurityDuty",
+    "ConFmVehicleMaintainDuty",
+    "--privilege",
+    "ConFmVehicleMaintainPriv"
+  ],
+  "target_artifact_types": [
+    "AxSecurityDutyExtension"
+  ],
+  "golden_path": "L2-security-duty-extension",
+  "tags": [
+    "extension",
+    "security",
+    "duty"
+  ],
+  "ignore": [],
+  "requires_fixture_index": false,
+  "golden_pending": false
+}

--- a/eval/cases/L2-security-role-extension.json
+++ b/eval/cases/L2-security-role-extension.json
@@ -1,0 +1,26 @@
+{
+  "id": "L2-security-role-extension",
+  "title": "Security role extension adding a privilege",
+  "tier": 2,
+  "instruction": "Extend the existing security role ConFmVehicleOperatorRole so it also grants the privilege ConFmVehicleMaintainPriv, without editing the role itself. Use only the d365fo CLI (search/get/generate/validate) — do not hand-write XML.",
+  "canonical_args": [
+    "generate",
+    "extension",
+    "SecurityRole",
+    "ConFmVehicleOperatorRole",
+    "--privilege",
+    "ConFmVehicleMaintainPriv"
+  ],
+  "target_artifact_types": [
+    "AxSecurityRoleExtension"
+  ],
+  "golden_path": "L2-security-role-extension",
+  "tags": [
+    "extension",
+    "security",
+    "role"
+  ],
+  "ignore": [],
+  "requires_fixture_index": false,
+  "golden_pending": false
+}

--- a/eval/corpus/runs/20260805T162956034Z__L0-edt-basic__adabe4294b0640ba85fad0e979f4af63.json
+++ b/eval/corpus/runs/20260805T162956034Z__L0-edt-basic__adabe4294b0640ba85fad0e979f4af63.json
@@ -1,0 +1,20 @@
+{
+  "runId": "20260805T162956034Z__L0-edt-basic__adabe4294b0640ba85fad0e979f4af63",
+  "caseId": "L0-edt-basic",
+  "tier": 0,
+  "timestampUtc": "2026-08-05T16:29:56.0362641+00:00",
+  "source": "replay",
+  "score": {
+    "xppClean": true,
+    "xppErrors": 0,
+    "referencesClean": true,
+    "referenceErrors": 0,
+    "goldenMatch": true,
+    "goldenDiff": {
+      "missing": [],
+      "extra": [],
+      "changed": [],
+      "isMatch": true
+    }
+  }
+}

--- a/eval/corpus/runs/20260805T162958652Z__L0-edt-extends__61d48934ef6e4ce18caa09a4b1b184ee.json
+++ b/eval/corpus/runs/20260805T162958652Z__L0-edt-extends__61d48934ef6e4ce18caa09a4b1b184ee.json
@@ -1,0 +1,20 @@
+{
+  "runId": "20260805T162958652Z__L0-edt-extends__61d48934ef6e4ce18caa09a4b1b184ee",
+  "caseId": "L0-edt-extends",
+  "tier": 0,
+  "timestampUtc": "2026-08-05T16:29:58.6537281+00:00",
+  "source": "replay",
+  "score": {
+    "xppClean": true,
+    "xppErrors": 0,
+    "referencesClean": true,
+    "referenceErrors": 0,
+    "goldenMatch": true,
+    "goldenDiff": {
+      "missing": [],
+      "extra": [],
+      "changed": [],
+      "isMatch": true
+    }
+  }
+}

--- a/eval/corpus/runs/20260805T163001286Z__L0-enum-basic__56788dc9946b4dc2878b53a2ca6b651f.json
+++ b/eval/corpus/runs/20260805T163001286Z__L0-enum-basic__56788dc9946b4dc2878b53a2ca6b651f.json
@@ -1,0 +1,20 @@
+{
+  "runId": "20260805T163001286Z__L0-enum-basic__56788dc9946b4dc2878b53a2ca6b651f",
+  "caseId": "L0-enum-basic",
+  "tier": 0,
+  "timestampUtc": "2026-08-05T16:30:01.2878749+00:00",
+  "source": "replay",
+  "score": {
+    "xppClean": true,
+    "xppErrors": 0,
+    "referencesClean": true,
+    "referenceErrors": 0,
+    "goldenMatch": true,
+    "goldenDiff": {
+      "missing": [],
+      "extra": [],
+      "changed": [],
+      "isMatch": true
+    }
+  }
+}

--- a/eval/corpus/runs/20260805T163003952Z__L0-enum-non-extensible__29d9693321e1491785138b2fd228d58a.json
+++ b/eval/corpus/runs/20260805T163003952Z__L0-enum-non-extensible__29d9693321e1491785138b2fd228d58a.json
@@ -1,0 +1,20 @@
+{
+  "runId": "20260805T163003952Z__L0-enum-non-extensible__29d9693321e1491785138b2fd228d58a",
+  "caseId": "L0-enum-non-extensible",
+  "tier": 0,
+  "timestampUtc": "2026-08-05T16:30:03.954105+00:00",
+  "source": "replay",
+  "score": {
+    "xppClean": true,
+    "xppErrors": 0,
+    "referencesClean": true,
+    "referenceErrors": 0,
+    "goldenMatch": true,
+    "goldenDiff": {
+      "missing": [],
+      "extra": [],
+      "changed": [],
+      "isMatch": true
+    }
+  }
+}

--- a/eval/corpus/runs/20260805T163006628Z__L1-business-event-basic__687bac5469a74117ace85a80bd44ea9f.json
+++ b/eval/corpus/runs/20260805T163006628Z__L1-business-event-basic__687bac5469a74117ace85a80bd44ea9f.json
@@ -1,0 +1,20 @@
+{
+  "runId": "20260805T163006628Z__L1-business-event-basic__687bac5469a74117ace85a80bd44ea9f",
+  "caseId": "L1-business-event-basic",
+  "tier": 1,
+  "timestampUtc": "2026-08-05T16:30:06.630288+00:00",
+  "source": "replay",
+  "score": {
+    "xppClean": true,
+    "xppErrors": 0,
+    "referencesClean": false,
+    "referenceErrors": 1,
+    "goldenMatch": true,
+    "goldenDiff": {
+      "missing": [],
+      "extra": [],
+      "changed": [],
+      "isMatch": true
+    }
+  }
+}

--- a/eval/corpus/runs/20260805T163009233Z__L1-class-basic__a1365e61885a44658642bc62c4796fd8.json
+++ b/eval/corpus/runs/20260805T163009233Z__L1-class-basic__a1365e61885a44658642bc62c4796fd8.json
@@ -1,0 +1,20 @@
+{
+  "runId": "20260805T163009233Z__L1-class-basic__a1365e61885a44658642bc62c4796fd8",
+  "caseId": "L1-class-basic",
+  "tier": 1,
+  "timestampUtc": "2026-08-05T16:30:09.235396+00:00",
+  "source": "replay",
+  "score": {
+    "xppClean": true,
+    "xppErrors": 0,
+    "referencesClean": true,
+    "referenceErrors": 0,
+    "goldenMatch": true,
+    "goldenDiff": {
+      "missing": [],
+      "extra": [],
+      "changed": [],
+      "isMatch": true
+    }
+  }
+}

--- a/eval/corpus/runs/20260805T163011819Z__L1-custom-service-basic__343eca84798d46588da57a6812f6e173.json
+++ b/eval/corpus/runs/20260805T163011819Z__L1-custom-service-basic__343eca84798d46588da57a6812f6e173.json
@@ -1,0 +1,20 @@
+{
+  "runId": "20260805T163011819Z__L1-custom-service-basic__343eca84798d46588da57a6812f6e173",
+  "caseId": "L1-custom-service-basic",
+  "tier": 1,
+  "timestampUtc": "2026-08-05T16:30:11.8213858+00:00",
+  "source": "replay",
+  "score": {
+    "xppClean": true,
+    "xppErrors": 0,
+    "referencesClean": true,
+    "referenceErrors": 0,
+    "goldenMatch": true,
+    "goldenDiff": {
+      "missing": [],
+      "extra": [],
+      "changed": [],
+      "isMatch": true
+    }
+  }
+}

--- a/eval/corpus/runs/20260805T163014458Z__L1-duty-basic__05feaff71df84187bc7d59c30ef01070.json
+++ b/eval/corpus/runs/20260805T163014458Z__L1-duty-basic__05feaff71df84187bc7d59c30ef01070.json
@@ -1,0 +1,20 @@
+{
+  "runId": "20260805T163014458Z__L1-duty-basic__05feaff71df84187bc7d59c30ef01070",
+  "caseId": "L1-duty-basic",
+  "tier": 1,
+  "timestampUtc": "2026-08-05T16:30:14.4600177+00:00",
+  "source": "replay",
+  "score": {
+    "xppClean": true,
+    "xppErrors": 0,
+    "referencesClean": true,
+    "referenceErrors": 0,
+    "goldenMatch": true,
+    "goldenDiff": {
+      "missing": [],
+      "extra": [],
+      "changed": [],
+      "isMatch": true
+    }
+  }
+}

--- a/eval/corpus/runs/20260805T163017476Z__L1-form-basic__dea024365df44aa78359b7e3a9656a78.json
+++ b/eval/corpus/runs/20260805T163017476Z__L1-form-basic__dea024365df44aa78359b7e3a9656a78.json
@@ -1,0 +1,20 @@
+{
+  "runId": "20260805T163017476Z__L1-form-basic__dea024365df44aa78359b7e3a9656a78",
+  "caseId": "L1-form-basic",
+  "tier": 1,
+  "timestampUtc": "2026-08-05T16:30:17.4784067+00:00",
+  "source": "replay",
+  "score": {
+    "xppClean": true,
+    "xppErrors": 0,
+    "referencesClean": true,
+    "referenceErrors": 0,
+    "goldenMatch": true,
+    "goldenDiff": {
+      "missing": [],
+      "extra": [],
+      "changed": [],
+      "isMatch": true
+    }
+  }
+}

--- a/eval/corpus/runs/20260805T163020529Z__L1-form-details-master__0cec44e4cf934900a8e19fb1e5e2e94f.json
+++ b/eval/corpus/runs/20260805T163020529Z__L1-form-details-master__0cec44e4cf934900a8e19fb1e5e2e94f.json
@@ -1,0 +1,20 @@
+{
+  "runId": "20260805T163020529Z__L1-form-details-master__0cec44e4cf934900a8e19fb1e5e2e94f",
+  "caseId": "L1-form-details-master",
+  "tier": 1,
+  "timestampUtc": "2026-08-05T16:30:20.5314311+00:00",
+  "source": "replay",
+  "score": {
+    "xppClean": true,
+    "xppErrors": 0,
+    "referencesClean": true,
+    "referenceErrors": 0,
+    "goldenMatch": true,
+    "goldenDiff": {
+      "missing": [],
+      "extra": [],
+      "changed": [],
+      "isMatch": true
+    }
+  }
+}

--- a/eval/corpus/runs/20260805T163023578Z__L1-form-details-transaction__addcd86ef31541a4b34edfca53e27e18.json
+++ b/eval/corpus/runs/20260805T163023578Z__L1-form-details-transaction__addcd86ef31541a4b34edfca53e27e18.json
@@ -1,0 +1,20 @@
+{
+  "runId": "20260805T163023578Z__L1-form-details-transaction__addcd86ef31541a4b34edfca53e27e18",
+  "caseId": "L1-form-details-transaction",
+  "tier": 1,
+  "timestampUtc": "2026-08-05T16:30:23.5798997+00:00",
+  "source": "replay",
+  "score": {
+    "xppClean": true,
+    "xppErrors": 0,
+    "referencesClean": true,
+    "referenceErrors": 0,
+    "goldenMatch": true,
+    "goldenDiff": {
+      "missing": [],
+      "extra": [],
+      "changed": [],
+      "isMatch": true
+    }
+  }
+}

--- a/eval/corpus/runs/20260805T163026678Z__L1-form-dialog__c64427eada3b42a1b9c760664551cb82.json
+++ b/eval/corpus/runs/20260805T163026678Z__L1-form-dialog__c64427eada3b42a1b9c760664551cb82.json
@@ -1,0 +1,20 @@
+{
+  "runId": "20260805T163026678Z__L1-form-dialog__c64427eada3b42a1b9c760664551cb82",
+  "caseId": "L1-form-dialog",
+  "tier": 1,
+  "timestampUtc": "2026-08-05T16:30:26.6808234+00:00",
+  "source": "replay",
+  "score": {
+    "xppClean": true,
+    "xppErrors": 0,
+    "referencesClean": true,
+    "referenceErrors": 0,
+    "goldenMatch": true,
+    "goldenDiff": {
+      "missing": [],
+      "extra": [],
+      "changed": [],
+      "isMatch": true
+    }
+  }
+}

--- a/eval/corpus/runs/20260805T163029741Z__L1-form-list-page__390cfb9df89e4386baf525b79326097f.json
+++ b/eval/corpus/runs/20260805T163029741Z__L1-form-list-page__390cfb9df89e4386baf525b79326097f.json
@@ -1,0 +1,20 @@
+{
+  "runId": "20260805T163029741Z__L1-form-list-page__390cfb9df89e4386baf525b79326097f",
+  "caseId": "L1-form-list-page",
+  "tier": 1,
+  "timestampUtc": "2026-08-05T16:30:29.7437804+00:00",
+  "source": "replay",
+  "score": {
+    "xppClean": true,
+    "xppErrors": 0,
+    "referencesClean": true,
+    "referenceErrors": 0,
+    "goldenMatch": true,
+    "goldenDiff": {
+      "missing": [],
+      "extra": [],
+      "changed": [],
+      "isMatch": true
+    }
+  }
+}

--- a/eval/corpus/runs/20260805T163032783Z__L1-form-lookup__b3a7a61251d9477ba6aba4c66a8847f4.json
+++ b/eval/corpus/runs/20260805T163032783Z__L1-form-lookup__b3a7a61251d9477ba6aba4c66a8847f4.json
@@ -1,0 +1,20 @@
+{
+  "runId": "20260805T163032783Z__L1-form-lookup__b3a7a61251d9477ba6aba4c66a8847f4",
+  "caseId": "L1-form-lookup",
+  "tier": 1,
+  "timestampUtc": "2026-08-05T16:30:32.7857044+00:00",
+  "source": "replay",
+  "score": {
+    "xppClean": true,
+    "xppErrors": 0,
+    "referencesClean": true,
+    "referenceErrors": 0,
+    "goldenMatch": true,
+    "goldenDiff": {
+      "missing": [],
+      "extra": [],
+      "changed": [],
+      "isMatch": true
+    }
+  }
+}

--- a/eval/corpus/runs/20260805T163035807Z__L1-form-simplelist-details__10351b58556c4f9db20724d9b0c20602.json
+++ b/eval/corpus/runs/20260805T163035807Z__L1-form-simplelist-details__10351b58556c4f9db20724d9b0c20602.json
@@ -1,0 +1,20 @@
+{
+  "runId": "20260805T163035807Z__L1-form-simplelist-details__10351b58556c4f9db20724d9b0c20602",
+  "caseId": "L1-form-simplelist-details",
+  "tier": 1,
+  "timestampUtc": "2026-08-05T16:30:35.8088453+00:00",
+  "source": "replay",
+  "score": {
+    "xppClean": true,
+    "xppErrors": 0,
+    "referencesClean": true,
+    "referenceErrors": 0,
+    "goldenMatch": true,
+    "goldenDiff": {
+      "missing": [],
+      "extra": [],
+      "changed": [],
+      "isMatch": true
+    }
+  }
+}

--- a/eval/corpus/runs/20260805T163038948Z__L1-form-table-of-contents__341ac2c6b38a472a84889e97f540a2a4.json
+++ b/eval/corpus/runs/20260805T163038948Z__L1-form-table-of-contents__341ac2c6b38a472a84889e97f540a2a4.json
@@ -1,0 +1,20 @@
+{
+  "runId": "20260805T163038948Z__L1-form-table-of-contents__341ac2c6b38a472a84889e97f540a2a4",
+  "caseId": "L1-form-table-of-contents",
+  "tier": 1,
+  "timestampUtc": "2026-08-05T16:30:38.9508288+00:00",
+  "source": "replay",
+  "score": {
+    "xppClean": true,
+    "xppErrors": 0,
+    "referencesClean": true,
+    "referenceErrors": 0,
+    "goldenMatch": true,
+    "goldenDiff": {
+      "missing": [],
+      "extra": [],
+      "changed": [],
+      "isMatch": true
+    }
+  }
+}

--- a/eval/corpus/runs/20260805T163041951Z__L1-form-workspace__30de7adc649d4a35bea5d47fffaac924.json
+++ b/eval/corpus/runs/20260805T163041951Z__L1-form-workspace__30de7adc649d4a35bea5d47fffaac924.json
@@ -1,0 +1,20 @@
+{
+  "runId": "20260805T163041951Z__L1-form-workspace__30de7adc649d4a35bea5d47fffaac924",
+  "caseId": "L1-form-workspace",
+  "tier": 1,
+  "timestampUtc": "2026-08-05T16:30:41.9530022+00:00",
+  "source": "replay",
+  "score": {
+    "xppClean": true,
+    "xppErrors": 0,
+    "referencesClean": true,
+    "referenceErrors": 0,
+    "goldenMatch": true,
+    "goldenDiff": {
+      "missing": [],
+      "extra": [],
+      "changed": [],
+      "isMatch": true
+    }
+  }
+}

--- a/eval/corpus/runs/20260805T163044844Z__L1-map-basic__9f425577db914d939d6aeb13b4d03490.json
+++ b/eval/corpus/runs/20260805T163044844Z__L1-map-basic__9f425577db914d939d6aeb13b4d03490.json
@@ -1,0 +1,20 @@
+{
+  "runId": "20260805T163044844Z__L1-map-basic__9f425577db914d939d6aeb13b4d03490",
+  "caseId": "L1-map-basic",
+  "tier": 1,
+  "timestampUtc": "2026-08-05T16:30:44.8462187+00:00",
+  "source": "replay",
+  "score": {
+    "xppClean": true,
+    "xppErrors": 0,
+    "referencesClean": true,
+    "referenceErrors": 0,
+    "goldenMatch": true,
+    "goldenDiff": {
+      "missing": [],
+      "extra": [],
+      "changed": [],
+      "isMatch": true
+    }
+  }
+}

--- a/eval/corpus/runs/20260805T163047719Z__L1-map-multi-table__636cc5e0d6f24a6692e265d317a9226c.json
+++ b/eval/corpus/runs/20260805T163047719Z__L1-map-multi-table__636cc5e0d6f24a6692e265d317a9226c.json
@@ -1,0 +1,20 @@
+{
+  "runId": "20260805T163047719Z__L1-map-multi-table__636cc5e0d6f24a6692e265d317a9226c",
+  "caseId": "L1-map-multi-table",
+  "tier": 1,
+  "timestampUtc": "2026-08-05T16:30:47.7217646+00:00",
+  "source": "replay",
+  "score": {
+    "xppClean": true,
+    "xppErrors": 0,
+    "referencesClean": true,
+    "referenceErrors": 0,
+    "goldenMatch": true,
+    "goldenDiff": {
+      "missing": [],
+      "extra": [],
+      "changed": [],
+      "isMatch": true
+    }
+  }
+}

--- a/eval/corpus/runs/20260805T163050429Z__L1-menu-item-action__ef6c25b0de4e40ac9dd0dd2782eddcf8.json
+++ b/eval/corpus/runs/20260805T163050429Z__L1-menu-item-action__ef6c25b0de4e40ac9dd0dd2782eddcf8.json
@@ -1,0 +1,20 @@
+{
+  "runId": "20260805T163050429Z__L1-menu-item-action__ef6c25b0de4e40ac9dd0dd2782eddcf8",
+  "caseId": "L1-menu-item-action",
+  "tier": 1,
+  "timestampUtc": "2026-08-05T16:30:50.4313904+00:00",
+  "source": "replay",
+  "score": {
+    "xppClean": true,
+    "xppErrors": 0,
+    "referencesClean": true,
+    "referenceErrors": 0,
+    "goldenMatch": true,
+    "goldenDiff": {
+      "missing": [],
+      "extra": [],
+      "changed": [],
+      "isMatch": true
+    }
+  }
+}

--- a/eval/corpus/runs/20260805T163053069Z__L1-menu-item-basic__99d4d1b1d82547569b8a95b9e730c710.json
+++ b/eval/corpus/runs/20260805T163053069Z__L1-menu-item-basic__99d4d1b1d82547569b8a95b9e730c710.json
@@ -1,0 +1,20 @@
+{
+  "runId": "20260805T163053069Z__L1-menu-item-basic__99d4d1b1d82547569b8a95b9e730c710",
+  "caseId": "L1-menu-item-basic",
+  "tier": 1,
+  "timestampUtc": "2026-08-05T16:30:53.0707274+00:00",
+  "source": "replay",
+  "score": {
+    "xppClean": true,
+    "xppErrors": 0,
+    "referencesClean": true,
+    "referenceErrors": 0,
+    "goldenMatch": true,
+    "goldenDiff": {
+      "missing": [],
+      "extra": [],
+      "changed": [],
+      "isMatch": true
+    }
+  }
+}

--- a/eval/corpus/runs/20260805T163055671Z__L1-menu-item-output__ad843a289ccf4885b3fce05976787634.json
+++ b/eval/corpus/runs/20260805T163055671Z__L1-menu-item-output__ad843a289ccf4885b3fce05976787634.json
@@ -1,0 +1,20 @@
+{
+  "runId": "20260805T163055671Z__L1-menu-item-output__ad843a289ccf4885b3fce05976787634",
+  "caseId": "L1-menu-item-output",
+  "tier": 1,
+  "timestampUtc": "2026-08-05T16:30:55.6732754+00:00",
+  "source": "replay",
+  "score": {
+    "xppClean": true,
+    "xppErrors": 0,
+    "referencesClean": true,
+    "referenceErrors": 0,
+    "goldenMatch": true,
+    "goldenDiff": {
+      "missing": [],
+      "extra": [],
+      "changed": [],
+      "isMatch": true
+    }
+  }
+}

--- a/eval/corpus/runs/20260805T163058475Z__L1-migration-script-basic__11e185537be4427b84fdd69513f558f4.json
+++ b/eval/corpus/runs/20260805T163058475Z__L1-migration-script-basic__11e185537be4427b84fdd69513f558f4.json
@@ -1,0 +1,20 @@
+{
+  "runId": "20260805T163058475Z__L1-migration-script-basic__11e185537be4427b84fdd69513f558f4",
+  "caseId": "L1-migration-script-basic",
+  "tier": 1,
+  "timestampUtc": "2026-08-05T16:30:58.4774758+00:00",
+  "source": "replay",
+  "score": {
+    "xppClean": true,
+    "xppErrors": 0,
+    "referencesClean": true,
+    "referenceErrors": 0,
+    "goldenMatch": true,
+    "goldenDiff": {
+      "missing": [],
+      "extra": [],
+      "changed": [],
+      "isMatch": true
+    }
+  }
+}

--- a/eval/corpus/runs/20260805T163101081Z__L1-privilege-basic__dc93a17b59fb49bfaa6d9d0595358e4f.json
+++ b/eval/corpus/runs/20260805T163101081Z__L1-privilege-basic__dc93a17b59fb49bfaa6d9d0595358e4f.json
@@ -1,0 +1,20 @@
+{
+  "runId": "20260805T163101081Z__L1-privilege-basic__dc93a17b59fb49bfaa6d9d0595358e4f",
+  "caseId": "L1-privilege-basic",
+  "tier": 1,
+  "timestampUtc": "2026-08-05T16:31:01.0830838+00:00",
+  "source": "replay",
+  "score": {
+    "xppClean": true,
+    "xppErrors": 0,
+    "referencesClean": true,
+    "referenceErrors": 0,
+    "goldenMatch": true,
+    "goldenDiff": {
+      "missing": [],
+      "extra": [],
+      "changed": [],
+      "isMatch": true
+    }
+  }
+}

--- a/eval/corpus/runs/20260805T163103785Z__L1-privilege-data-entity__1b3a7bc5d5164d80ab80f6a1563e9713.json
+++ b/eval/corpus/runs/20260805T163103785Z__L1-privilege-data-entity__1b3a7bc5d5164d80ab80f6a1563e9713.json
@@ -1,0 +1,20 @@
+{
+  "runId": "20260805T163103785Z__L1-privilege-data-entity__1b3a7bc5d5164d80ab80f6a1563e9713",
+  "caseId": "L1-privilege-data-entity",
+  "tier": 1,
+  "timestampUtc": "2026-08-05T16:31:03.7873712+00:00",
+  "source": "replay",
+  "score": {
+    "xppClean": true,
+    "xppErrors": 0,
+    "referencesClean": true,
+    "referenceErrors": 0,
+    "goldenMatch": true,
+    "goldenDiff": {
+      "missing": [],
+      "extra": [],
+      "changed": [],
+      "isMatch": true
+    }
+  }
+}

--- a/eval/corpus/runs/20260805T163106654Z__L1-query-basic__05a6cbba5c2b40539844021df4e23ae3.json
+++ b/eval/corpus/runs/20260805T163106654Z__L1-query-basic__05a6cbba5c2b40539844021df4e23ae3.json
@@ -1,0 +1,20 @@
+{
+  "runId": "20260805T163106654Z__L1-query-basic__05a6cbba5c2b40539844021df4e23ae3",
+  "caseId": "L1-query-basic",
+  "tier": 1,
+  "timestampUtc": "2026-08-05T16:31:06.6570094+00:00",
+  "source": "replay",
+  "score": {
+    "xppClean": true,
+    "xppErrors": 0,
+    "referencesClean": true,
+    "referenceErrors": 0,
+    "goldenMatch": true,
+    "goldenDiff": {
+      "missing": [],
+      "extra": [],
+      "changed": [],
+      "isMatch": true
+    }
+  }
+}

--- a/eval/corpus/runs/20260805T163109463Z__L1-query-join__a90f6e9ab98b4e0eb91b1f2de0b5b75e.json
+++ b/eval/corpus/runs/20260805T163109463Z__L1-query-join__a90f6e9ab98b4e0eb91b1f2de0b5b75e.json
@@ -1,0 +1,20 @@
+{
+  "runId": "20260805T163109463Z__L1-query-join__a90f6e9ab98b4e0eb91b1f2de0b5b75e",
+  "caseId": "L1-query-join",
+  "tier": 1,
+  "timestampUtc": "2026-08-05T16:31:09.4657667+00:00",
+  "source": "replay",
+  "score": {
+    "xppClean": true,
+    "xppErrors": 0,
+    "referencesClean": true,
+    "referenceErrors": 0,
+    "goldenMatch": true,
+    "goldenDiff": {
+      "missing": [],
+      "extra": [],
+      "changed": [],
+      "isMatch": true
+    }
+  }
+}

--- a/eval/corpus/runs/20260805T163112147Z__L1-report-basic__e8f673d9ee814e66bf937a1c943e8ad6.json
+++ b/eval/corpus/runs/20260805T163112147Z__L1-report-basic__e8f673d9ee814e66bf937a1c943e8ad6.json
@@ -1,0 +1,20 @@
+{
+  "runId": "20260805T163112147Z__L1-report-basic__e8f673d9ee814e66bf937a1c943e8ad6",
+  "caseId": "L1-report-basic",
+  "tier": 1,
+  "timestampUtc": "2026-08-05T16:31:12.1496348+00:00",
+  "source": "replay",
+  "score": {
+    "xppClean": true,
+    "xppErrors": 0,
+    "referencesClean": true,
+    "referenceErrors": 0,
+    "goldenMatch": true,
+    "goldenDiff": {
+      "missing": [],
+      "extra": [],
+      "changed": [],
+      "isMatch": true
+    }
+  }
+}

--- a/eval/corpus/runs/20260805T163114902Z__L1-report-parameters__936384aa1caa43daab6416202773a3d7.json
+++ b/eval/corpus/runs/20260805T163114902Z__L1-report-parameters__936384aa1caa43daab6416202773a3d7.json
@@ -1,0 +1,20 @@
+{
+  "runId": "20260805T163114902Z__L1-report-parameters__936384aa1caa43daab6416202773a3d7",
+  "caseId": "L1-report-parameters",
+  "tier": 1,
+  "timestampUtc": "2026-08-05T16:31:14.9050684+00:00",
+  "source": "replay",
+  "score": {
+    "xppClean": true,
+    "xppErrors": 0,
+    "referencesClean": true,
+    "referenceErrors": 0,
+    "goldenMatch": true,
+    "goldenDiff": {
+      "missing": [],
+      "extra": [],
+      "changed": [],
+      "isMatch": true
+    }
+  }
+}

--- a/eval/corpus/runs/20260805T163117604Z__L1-role-basic__88237d4f07c24ed3849465b7abb123b4.json
+++ b/eval/corpus/runs/20260805T163117604Z__L1-role-basic__88237d4f07c24ed3849465b7abb123b4.json
@@ -1,0 +1,20 @@
+{
+  "runId": "20260805T163117604Z__L1-role-basic__88237d4f07c24ed3849465b7abb123b4",
+  "caseId": "L1-role-basic",
+  "tier": 1,
+  "timestampUtc": "2026-08-05T16:31:17.6063276+00:00",
+  "source": "replay",
+  "score": {
+    "xppClean": true,
+    "xppErrors": 0,
+    "referencesClean": true,
+    "referenceErrors": 0,
+    "goldenMatch": true,
+    "goldenDiff": {
+      "missing": [],
+      "extra": [],
+      "changed": [],
+      "isMatch": true
+    }
+  }
+}

--- a/eval/corpus/runs/20260805T163120303Z__L1-runbase-basic__9d21574b2bb2491581833a03e488d8ef.json
+++ b/eval/corpus/runs/20260805T163120303Z__L1-runbase-basic__9d21574b2bb2491581833a03e488d8ef.json
@@ -1,0 +1,20 @@
+{
+  "runId": "20260805T163120303Z__L1-runbase-basic__9d21574b2bb2491581833a03e488d8ef",
+  "caseId": "L1-runbase-basic",
+  "tier": 1,
+  "timestampUtc": "2026-08-05T16:31:20.3053905+00:00",
+  "source": "replay",
+  "score": {
+    "xppClean": true,
+    "xppErrors": 0,
+    "referencesClean": true,
+    "referenceErrors": 0,
+    "goldenMatch": true,
+    "goldenDiff": {
+      "missing": [],
+      "extra": [],
+      "changed": [],
+      "isMatch": true
+    }
+  }
+}

--- a/eval/corpus/runs/20260805T163122969Z__L1-sysoperation-basic__3189b70195c64a89b723b9ca35bf3fd1.json
+++ b/eval/corpus/runs/20260805T163122969Z__L1-sysoperation-basic__3189b70195c64a89b723b9ca35bf3fd1.json
@@ -1,0 +1,20 @@
+{
+  "runId": "20260805T163122969Z__L1-sysoperation-basic__3189b70195c64a89b723b9ca35bf3fd1",
+  "caseId": "L1-sysoperation-basic",
+  "tier": 1,
+  "timestampUtc": "2026-08-05T16:31:22.9706335+00:00",
+  "source": "replay",
+  "score": {
+    "xppClean": true,
+    "xppErrors": 0,
+    "referencesClean": false,
+    "referenceErrors": 3,
+    "goldenMatch": true,
+    "goldenDiff": {
+      "missing": [],
+      "extra": [],
+      "changed": [],
+      "isMatch": true
+    }
+  }
+}

--- a/eval/corpus/runs/20260805T163125857Z__L1-systest-basic__df6237323bcd43838075b5282faa844c.json
+++ b/eval/corpus/runs/20260805T163125857Z__L1-systest-basic__df6237323bcd43838075b5282faa844c.json
@@ -1,0 +1,20 @@
+{
+  "runId": "20260805T163125857Z__L1-systest-basic__df6237323bcd43838075b5282faa844c",
+  "caseId": "L1-systest-basic",
+  "tier": 1,
+  "timestampUtc": "2026-08-05T16:31:25.8595607+00:00",
+  "source": "replay",
+  "score": {
+    "xppClean": true,
+    "xppErrors": 0,
+    "referencesClean": true,
+    "referenceErrors": 0,
+    "goldenMatch": true,
+    "goldenDiff": {
+      "missing": [],
+      "extra": [],
+      "changed": [],
+      "isMatch": true
+    }
+  }
+}

--- a/eval/corpus/runs/20260805T163128597Z__L1-table-basic__3b9f00c6c08f4159b874dfbc8994601e.json
+++ b/eval/corpus/runs/20260805T163128597Z__L1-table-basic__3b9f00c6c08f4159b874dfbc8994601e.json
@@ -1,0 +1,20 @@
+{
+  "runId": "20260805T163128597Z__L1-table-basic__3b9f00c6c08f4159b874dfbc8994601e",
+  "caseId": "L1-table-basic",
+  "tier": 1,
+  "timestampUtc": "2026-08-05T16:31:28.5992249+00:00",
+  "source": "replay",
+  "score": {
+    "xppClean": true,
+    "xppErrors": 0,
+    "referencesClean": true,
+    "referenceErrors": 0,
+    "goldenMatch": true,
+    "goldenDiff": {
+      "missing": [],
+      "extra": [],
+      "changed": [],
+      "isMatch": true
+    }
+  }
+}

--- a/eval/corpus/runs/20260805T163131372Z__L1-table-tempdb__9f06045669a34bdda25626b105b3abf4.json
+++ b/eval/corpus/runs/20260805T163131372Z__L1-table-tempdb__9f06045669a34bdda25626b105b3abf4.json
@@ -1,0 +1,20 @@
+{
+  "runId": "20260805T163131372Z__L1-table-tempdb__9f06045669a34bdda25626b105b3abf4",
+  "caseId": "L1-table-tempdb",
+  "tier": 1,
+  "timestampUtc": "2026-08-05T16:31:31.3740131+00:00",
+  "source": "replay",
+  "score": {
+    "xppClean": true,
+    "xppErrors": 0,
+    "referencesClean": true,
+    "referenceErrors": 0,
+    "goldenMatch": true,
+    "goldenDiff": {
+      "missing": [],
+      "extra": [],
+      "changed": [],
+      "isMatch": true
+    }
+  }
+}

--- a/eval/corpus/runs/20260805T163133961Z__L1-view-basic__f0f06f1dcf5a4634943a285b0fa2738f.json
+++ b/eval/corpus/runs/20260805T163133961Z__L1-view-basic__f0f06f1dcf5a4634943a285b0fa2738f.json
@@ -1,0 +1,20 @@
+{
+  "runId": "20260805T163133961Z__L1-view-basic__f0f06f1dcf5a4634943a285b0fa2738f",
+  "caseId": "L1-view-basic",
+  "tier": 1,
+  "timestampUtc": "2026-08-05T16:31:33.962926+00:00",
+  "source": "replay",
+  "score": {
+    "xppClean": true,
+    "xppErrors": 0,
+    "referencesClean": true,
+    "referenceErrors": 0,
+    "goldenMatch": true,
+    "goldenDiff": {
+      "missing": [],
+      "extra": [],
+      "changed": [],
+      "isMatch": true
+    }
+  }
+}

--- a/eval/corpus/runs/20260805T163136745Z__L1-view-computed__f5ed2c6056244f00a86a4eeba00d5cae.json
+++ b/eval/corpus/runs/20260805T163136745Z__L1-view-computed__f5ed2c6056244f00a86a4eeba00d5cae.json
@@ -1,0 +1,20 @@
+{
+  "runId": "20260805T163136745Z__L1-view-computed__f5ed2c6056244f00a86a4eeba00d5cae",
+  "caseId": "L1-view-computed",
+  "tier": 1,
+  "timestampUtc": "2026-08-05T16:31:36.7467373+00:00",
+  "source": "replay",
+  "score": {
+    "xppClean": true,
+    "xppErrors": 0,
+    "referencesClean": false,
+    "referenceErrors": 1,
+    "goldenMatch": true,
+    "goldenDiff": {
+      "missing": [],
+      "extra": [],
+      "changed": [],
+      "isMatch": true
+    }
+  }
+}

--- a/eval/corpus/runs/20260805T163139500Z__L1-workflow-basic__2bb18a8fa70f4d638c5eeacd832cc308.json
+++ b/eval/corpus/runs/20260805T163139500Z__L1-workflow-basic__2bb18a8fa70f4d638c5eeacd832cc308.json
@@ -1,0 +1,20 @@
+{
+  "runId": "20260805T163139500Z__L1-workflow-basic__2bb18a8fa70f4d638c5eeacd832cc308",
+  "caseId": "L1-workflow-basic",
+  "tier": 1,
+  "timestampUtc": "2026-08-05T16:31:39.5021654+00:00",
+  "source": "replay",
+  "score": {
+    "xppClean": true,
+    "xppErrors": 0,
+    "referencesClean": true,
+    "referenceErrors": 0,
+    "goldenMatch": true,
+    "goldenDiff": {
+      "missing": [],
+      "extra": [],
+      "changed": [],
+      "isMatch": true
+    }
+  }
+}

--- a/eval/corpus/runs/20260805T163142503Z__L2-coc-extension__c0d19e8fbcd9460b83a0a1a22dfd4b05.json
+++ b/eval/corpus/runs/20260805T163142503Z__L2-coc-extension__c0d19e8fbcd9460b83a0a1a22dfd4b05.json
@@ -1,0 +1,20 @@
+{
+  "runId": "20260805T163142503Z__L2-coc-extension__c0d19e8fbcd9460b83a0a1a22dfd4b05",
+  "caseId": "L2-coc-extension",
+  "tier": 2,
+  "timestampUtc": "2026-08-05T16:31:42.5055262+00:00",
+  "source": "replay",
+  "score": {
+    "xppClean": true,
+    "xppErrors": 0,
+    "referencesClean": true,
+    "referenceErrors": 0,
+    "goldenMatch": true,
+    "goldenDiff": {
+      "missing": [],
+      "extra": [],
+      "changed": [],
+      "isMatch": true
+    }
+  }
+}

--- a/eval/corpus/runs/20260805T163144996Z__L2-control-method-basic__18a65458ce6749439b27a6555fb88c93.json
+++ b/eval/corpus/runs/20260805T163144996Z__L2-control-method-basic__18a65458ce6749439b27a6555fb88c93.json
@@ -1,0 +1,20 @@
+{
+  "runId": "20260805T163144996Z__L2-control-method-basic__18a65458ce6749439b27a6555fb88c93",
+  "caseId": "L2-control-method-basic",
+  "tier": 2,
+  "timestampUtc": "2026-08-05T16:31:44.9981677+00:00",
+  "source": "replay",
+  "score": {
+    "xppClean": true,
+    "xppErrors": 0,
+    "referencesClean": true,
+    "referenceErrors": 0,
+    "goldenMatch": true,
+    "goldenDiff": {
+      "missing": [],
+      "extra": [],
+      "changed": [],
+      "isMatch": true
+    }
+  }
+}

--- a/eval/corpus/runs/20260805T163147577Z__L2-datasource-method-basic__60ec255a4ded4b3cac898d02be93c2bc.json
+++ b/eval/corpus/runs/20260805T163147577Z__L2-datasource-method-basic__60ec255a4ded4b3cac898d02be93c2bc.json
@@ -1,0 +1,20 @@
+{
+  "runId": "20260805T163147577Z__L2-datasource-method-basic__60ec255a4ded4b3cac898d02be93c2bc",
+  "caseId": "L2-datasource-method-basic",
+  "tier": 2,
+  "timestampUtc": "2026-08-05T16:31:47.579178+00:00",
+  "source": "replay",
+  "score": {
+    "xppClean": true,
+    "xppErrors": 0,
+    "referencesClean": true,
+    "referenceErrors": 0,
+    "goldenMatch": true,
+    "goldenDiff": {
+      "missing": [],
+      "extra": [],
+      "changed": [],
+      "isMatch": true
+    }
+  }
+}

--- a/eval/corpus/runs/20260805T163150334Z__L2-edt-extension__6b5adf01451141c59572ea9b996eb6ad.json
+++ b/eval/corpus/runs/20260805T163150334Z__L2-edt-extension__6b5adf01451141c59572ea9b996eb6ad.json
@@ -1,0 +1,20 @@
+{
+  "runId": "20260805T163150334Z__L2-edt-extension__6b5adf01451141c59572ea9b996eb6ad",
+  "caseId": "L2-edt-extension",
+  "tier": 2,
+  "timestampUtc": "2026-08-05T16:31:50.3368078+00:00",
+  "source": "replay",
+  "score": {
+    "xppClean": true,
+    "xppErrors": 0,
+    "referencesClean": true,
+    "referenceErrors": 0,
+    "goldenMatch": true,
+    "goldenDiff": {
+      "missing": [],
+      "extra": [],
+      "changed": [],
+      "isMatch": true
+    }
+  }
+}

--- a/eval/corpus/runs/20260805T163153054Z__L2-enum-extension__96d66d31e335439db49bf7e7c925f858.json
+++ b/eval/corpus/runs/20260805T163153054Z__L2-enum-extension__96d66d31e335439db49bf7e7c925f858.json
@@ -1,0 +1,20 @@
+{
+  "runId": "20260805T163153054Z__L2-enum-extension__96d66d31e335439db49bf7e7c925f858",
+  "caseId": "L2-enum-extension",
+  "tier": 2,
+  "timestampUtc": "2026-08-05T16:31:53.0558995+00:00",
+  "source": "replay",
+  "score": {
+    "xppClean": true,
+    "xppErrors": 0,
+    "referencesClean": true,
+    "referenceErrors": 0,
+    "goldenMatch": true,
+    "goldenDiff": {
+      "missing": [],
+      "extra": [],
+      "changed": [],
+      "isMatch": true
+    }
+  }
+}

--- a/eval/corpus/runs/20260805T163155982Z__L2-event-handler-basic__1cf805004db243208b194e073063b7ee.json
+++ b/eval/corpus/runs/20260805T163155982Z__L2-event-handler-basic__1cf805004db243208b194e073063b7ee.json
@@ -1,0 +1,20 @@
+{
+  "runId": "20260805T163155982Z__L2-event-handler-basic__1cf805004db243208b194e073063b7ee",
+  "caseId": "L2-event-handler-basic",
+  "tier": 2,
+  "timestampUtc": "2026-08-05T16:31:55.9842794+00:00",
+  "source": "replay",
+  "score": {
+    "xppClean": true,
+    "xppErrors": 0,
+    "referencesClean": true,
+    "referenceErrors": 0,
+    "goldenMatch": true,
+    "goldenDiff": {
+      "missing": [],
+      "extra": [],
+      "changed": [],
+      "isMatch": true
+    }
+  }
+}

--- a/eval/corpus/runs/20260805T163158717Z__L2-form-extension-basic__cad28788e2de4933874d72d08472672c.json
+++ b/eval/corpus/runs/20260805T163158717Z__L2-form-extension-basic__cad28788e2de4933874d72d08472672c.json
@@ -1,0 +1,20 @@
+{
+  "runId": "20260805T163158717Z__L2-form-extension-basic__cad28788e2de4933874d72d08472672c",
+  "caseId": "L2-form-extension-basic",
+  "tier": 2,
+  "timestampUtc": "2026-08-05T16:31:58.7194184+00:00",
+  "source": "replay",
+  "score": {
+    "xppClean": true,
+    "xppErrors": 0,
+    "referencesClean": true,
+    "referenceErrors": 0,
+    "goldenMatch": true,
+    "goldenDiff": {
+      "missing": [],
+      "extra": [],
+      "changed": [],
+      "isMatch": true
+    }
+  }
+}

--- a/eval/corpus/runs/20260805T163201389Z__L2-numberseq-basic__b8ee8d9345a4438786a47bb96aaf44ba.json
+++ b/eval/corpus/runs/20260805T163201389Z__L2-numberseq-basic__b8ee8d9345a4438786a47bb96aaf44ba.json
@@ -1,0 +1,20 @@
+{
+  "runId": "20260805T163201389Z__L2-numberseq-basic__b8ee8d9345a4438786a47bb96aaf44ba",
+  "caseId": "L2-numberseq-basic",
+  "tier": 2,
+  "timestampUtc": "2026-08-05T16:32:01.3911816+00:00",
+  "source": "replay",
+  "score": {
+    "xppClean": true,
+    "xppErrors": 0,
+    "referencesClean": false,
+    "referenceErrors": 4,
+    "goldenMatch": true,
+    "goldenDiff": {
+      "missing": [],
+      "extra": [],
+      "changed": [],
+      "isMatch": true
+    }
+  }
+}

--- a/eval/corpus/runs/20260805T163204115Z__L2-security-duty-extension__deef047ab36a403bb4cec828c8b7a111.json
+++ b/eval/corpus/runs/20260805T163204115Z__L2-security-duty-extension__deef047ab36a403bb4cec828c8b7a111.json
@@ -1,0 +1,20 @@
+{
+  "runId": "20260805T163204115Z__L2-security-duty-extension__deef047ab36a403bb4cec828c8b7a111",
+  "caseId": "L2-security-duty-extension",
+  "tier": 2,
+  "timestampUtc": "2026-08-05T16:32:04.1172189+00:00",
+  "source": "replay",
+  "score": {
+    "xppClean": true,
+    "xppErrors": 0,
+    "referencesClean": true,
+    "referenceErrors": 0,
+    "goldenMatch": true,
+    "goldenDiff": {
+      "missing": [],
+      "extra": [],
+      "changed": [],
+      "isMatch": true
+    }
+  }
+}

--- a/eval/corpus/runs/20260805T163206898Z__L2-security-policy-basic__9cb82655ff484489a3ceaf5a9f001bbf.json
+++ b/eval/corpus/runs/20260805T163206898Z__L2-security-policy-basic__9cb82655ff484489a3ceaf5a9f001bbf.json
@@ -1,0 +1,20 @@
+{
+  "runId": "20260805T163206898Z__L2-security-policy-basic__9cb82655ff484489a3ceaf5a9f001bbf",
+  "caseId": "L2-security-policy-basic",
+  "tier": 2,
+  "timestampUtc": "2026-08-05T16:32:06.9003989+00:00",
+  "source": "replay",
+  "score": {
+    "xppClean": true,
+    "xppErrors": 0,
+    "referencesClean": true,
+    "referenceErrors": 0,
+    "goldenMatch": true,
+    "goldenDiff": {
+      "missing": [],
+      "extra": [],
+      "changed": [],
+      "isMatch": true
+    }
+  }
+}

--- a/eval/corpus/runs/20260805T163209679Z__L2-security-role-extension__73da0f3349c44144aad781a74cd4ceb5.json
+++ b/eval/corpus/runs/20260805T163209679Z__L2-security-role-extension__73da0f3349c44144aad781a74cd4ceb5.json
@@ -1,0 +1,20 @@
+{
+  "runId": "20260805T163209679Z__L2-security-role-extension__73da0f3349c44144aad781a74cd4ceb5",
+  "caseId": "L2-security-role-extension",
+  "tier": 2,
+  "timestampUtc": "2026-08-05T16:32:09.6812797+00:00",
+  "source": "replay",
+  "score": {
+    "xppClean": true,
+    "xppErrors": 0,
+    "referencesClean": true,
+    "referenceErrors": 0,
+    "goldenMatch": true,
+    "goldenDiff": {
+      "missing": [],
+      "extra": [],
+      "changed": [],
+      "isMatch": true
+    }
+  }
+}

--- a/eval/corpus/runs/20260805T163212572Z__L2-table-extension__9a40bd395219450b83b4dde99c088dd1.json
+++ b/eval/corpus/runs/20260805T163212572Z__L2-table-extension__9a40bd395219450b83b4dde99c088dd1.json
@@ -1,0 +1,20 @@
+{
+  "runId": "20260805T163212572Z__L2-table-extension__9a40bd395219450b83b4dde99c088dd1",
+  "caseId": "L2-table-extension",
+  "tier": 2,
+  "timestampUtc": "2026-08-05T16:32:12.5739937+00:00",
+  "source": "replay",
+  "score": {
+    "xppClean": true,
+    "xppErrors": 0,
+    "referencesClean": true,
+    "referenceErrors": 0,
+    "goldenMatch": true,
+    "goldenDiff": {
+      "missing": [],
+      "extra": [],
+      "changed": [],
+      "isMatch": true
+    }
+  }
+}

--- a/eval/corpus/runs/20260805T163215353Z__L2-virtual-entity-basic__5b9b7265ec3d4c2cbc52d3877dc72ca7.json
+++ b/eval/corpus/runs/20260805T163215353Z__L2-virtual-entity-basic__5b9b7265ec3d4c2cbc52d3877dc72ca7.json
@@ -1,0 +1,20 @@
+{
+  "runId": "20260805T163215353Z__L2-virtual-entity-basic__5b9b7265ec3d4c2cbc52d3877dc72ca7",
+  "caseId": "L2-virtual-entity-basic",
+  "tier": 2,
+  "timestampUtc": "2026-08-05T16:32:15.355266+00:00",
+  "source": "replay",
+  "score": {
+    "xppClean": true,
+    "xppErrors": 0,
+    "referencesClean": true,
+    "referenceErrors": 0,
+    "goldenMatch": true,
+    "goldenDiff": {
+      "missing": [],
+      "extra": [],
+      "changed": [],
+      "isMatch": true
+    }
+  }
+}

--- a/eval/corpus/schema.json
+++ b/eval/corpus/schema.json
@@ -2,7 +2,7 @@
   "$schema": "https://json-schema.org/draft/2020-12/schema",
   "$id": "https://github.com/dynamics365ninja/d365fo-cli/eval/corpus/schema.json",
   "title": "Eval corpus run record",
-  "description": "Documented shape of an eval/corpus/runs/<run-id>.json file, written by D365FO.Core.Eval.EvalCorpusStore.Append. One file per (case_id, run_id). Gitignored — local/CI evidence, not committed.",
+  "description": "Documented shape of an eval/corpus/runs/<run-id>.json file, written by D365FO.Core.Eval.EvalCorpusStore.Append. One file per (case_id, run_id). Committed — the corpus is the evidence the eval-improver ranks failure clusters from, so it has to survive across machines and CI runs.",
   "type": "object",
   "required": ["runId", "caseId", "tier", "timestampUtc", "source", "score"],
   "properties": {

--- a/eval/goldens/L0-edt-extends/ConFmVehicleName.xml
+++ b/eval/goldens/L0-edt-extends/ConFmVehicleName.xml
@@ -1,0 +1,6 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<AxEdt xmlns:i="http://www.w3.org/2001/XMLSchema-instance" i:type="AxEdtString">
+  <Name>ConFmVehicleName</Name>
+  <Extends>Name</Extends>
+  <Label>Vehicle name</Label>
+</AxEdt>

--- a/eval/goldens/L0-enum-non-extensible/ConFmVehicleKind.xml
+++ b/eval/goldens/L0-enum-non-extensible/ConFmVehicleKind.xml
@@ -1,0 +1,16 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<AxEnum xmlns:i="http://www.w3.org/2001/XMLSchema-instance">
+  <Name>ConFmVehicleKind</Name>
+  <Label>Vehicle kind</Label>
+  <IsExtensible>false</IsExtensible>
+  <EnumValues>
+    <AxEnumValue>
+      <Name>Car</Name>
+      <Value>0</Value>
+    </AxEnumValue>
+    <AxEnumValue>
+      <Name>Truck</Name>
+      <Value>1</Value>
+    </AxEnumValue>
+  </EnumValues>
+</AxEnum>

--- a/eval/goldens/L1-form-details-master/ConFmVehicleDetails.xml
+++ b/eval/goldens/L1-form-details-master/ConFmVehicleDetails.xml
@@ -1,0 +1,156 @@
+<?xml version="1.0" encoding="utf-8"?>
+<AxForm xmlns:i="http://www.w3.org/2001/XMLSchema-instance" xmlns="Microsoft.Dynamics.AX.Metadata.V6">
+  <Name>ConFmVehicleDetails</Name>
+  <SourceCode>
+    <Methods xmlns="">
+      <Method>
+        <Name>classDeclaration</Name>
+        <Source><![CDATA[
+[Form]
+public class ConFmVehicleDetails extends FormRun
+{
+}
+
+]]></Source>
+      </Method>
+    </Methods>
+    <DataSources xmlns="" />
+    <DataControls xmlns="" />
+    <Members xmlns="" />
+  </SourceCode>
+  <DataSources>
+    <AxFormDataSource xmlns="">
+      <Name>FmVehicle</Name>
+      <Table>FmVehicle</Table>
+      <Fields />
+      <ReferencedDataSources />
+      <InsertIfEmpty>No</InsertIfEmpty>
+      <DataSourceLinks />
+      <DerivedDataSources />
+    </AxFormDataSource>
+  </DataSources>
+  <Design>
+    <Caption xmlns="">Fleet vehicle details</Caption>
+    <DataSource xmlns="">FmVehicle</DataSource>
+    <Pattern xmlns="">DetailsMaster</Pattern>
+    <PatternVersion xmlns="">1.1</PatternVersion>
+    <Style xmlns="">DetailsFormMaster</Style>
+    <TitleDataSource xmlns="">FmVehicle</TitleDataSource>
+    <Controls xmlns="">
+      <AxFormControl xmlns="" i:type="AxFormActionPaneControl">
+        <Name>ActionPane</Name>
+        <ElementPosition>134217727</ElementPosition>
+        <FilterExpression>%1</FilterExpression>
+        <Type>ActionPane</Type>
+        <VerticalSpacing>-1</VerticalSpacing>
+        <FormControlExtension i:nil="true" />
+        <Controls>
+          <AxFormControl xmlns="" i:type="AxFormButtonGroupControl">
+            <Name>ButtonGroup</Name>
+            <Type>ButtonGroup</Type>
+            <FormControlExtension i:nil="true" />
+            <Controls />
+            <ArrangeMethod>Vertical</ArrangeMethod>
+          </AxFormControl>
+        </Controls>
+        <AlignChild>No</AlignChild>
+        <AlignChildren>No</AlignChildren>
+        <ArrangeMethod>Vertical</ArrangeMethod>
+      </AxFormControl>
+      <AxFormControl xmlns="" i:type="AxFormGroupControl">
+        <Name>NavigationFilterGroup</Name>
+        <Pattern>CustomAndQuickFilters</Pattern>
+        <PatternVersion>1.1</PatternVersion>
+        <Type>Group</Type>
+        <WidthMode>SizeToAvailable</WidthMode>
+        <FormControlExtension i:nil="true" />
+        <Controls>
+          <AxFormControl>
+            <Name>QuickFilterControl</Name>
+            <FormControlExtension>
+              <Name>QuickFilterControl</Name>
+              <ExtensionComponents />
+              <ExtensionProperties>
+                <AxFormControlExtensionProperty>
+                  <Name>targetControlName</Name>
+                  <Type>String</Type>
+                  <Value>Grid</Value>
+                </AxFormControlExtensionProperty>
+              </ExtensionProperties>
+            </FormControlExtension>
+          </AxFormControl>
+        </Controls>
+        <ArrangeMethod>HorizontalLeft</ArrangeMethod>
+        <FrameType>None</FrameType>
+        <Style>CustomFilter</Style>
+        <ViewEditMode>Edit</ViewEditMode>
+      </AxFormControl>
+      <AxFormControl xmlns="" i:type="AxFormGroupControl">
+        <Name>HeaderGroup</Name>
+        <Type>Group</Type>
+        <FormControlExtension i:nil="true" />
+        <Controls />
+        <DataSource>FmVehicle</DataSource>
+        <WidthMode>SizeToAvailable</WidthMode>
+      </AxFormControl>
+      <AxFormControl xmlns="" i:type="AxFormTabControl">
+        <Name>Tab</Name>
+        <Type>Tab</Type>
+        <FormControlExtension i:nil="true" />
+        <Controls>
+          <AxFormControl xmlns="" i:type="AxFormTabPageControl">
+            <Name>TabPageOverview</Name>
+            <Pattern>FieldsFieldGroups</Pattern>
+            <PatternVersion>1.1</PatternVersion>
+            <Type>TabPage</Type>
+            <Caption>Overview</Caption>
+            <FormControlExtension i:nil="true" />
+            <Controls>
+              <AxFormControl xmlns="" i:type="AxFormGroupControl">
+                <Name>OverviewGroup</Name>
+                <Type>Group</Type>
+                <DataGroup>Overview</DataGroup>
+                <FormControlExtension i:nil="true" />
+                <Controls>
+                <AxFormControl xmlns="" i:type="AxFormStringControl">
+                  <Name>Overview_VIN</Name>
+                  <Type>String</Type>
+                  <FormControlExtension i:nil="true" />
+                  <DataField>VIN</DataField>
+                  <DataSource>FmVehicle</DataSource>
+                </AxFormControl>
+                <AxFormControl xmlns="" i:type="AxFormStringControl">
+                  <Name>Overview_Make</Name>
+                  <Type>String</Type>
+                  <FormControlExtension i:nil="true" />
+                  <DataField>Make</DataField>
+                  <DataSource>FmVehicle</DataSource>
+                </AxFormControl>
+                </Controls>
+              </AxFormControl>
+            </Controls>
+          </AxFormControl>
+          <AxFormControl xmlns="" i:type="AxFormTabPageControl">
+            <Name>TabPageGeneral</Name>
+            <Pattern>FieldsFieldGroups</Pattern>
+            <PatternVersion>1.1</PatternVersion>
+            <Type>TabPage</Type>
+            <Caption>General</Caption>
+            <FormControlExtension i:nil="true" />
+            <Controls>
+              <AxFormControl xmlns="" i:type="AxFormGroupControl">
+                <Name>GeneralGroup</Name>
+                <Type>Group</Type>
+                <DataGroup>General</DataGroup>
+                <FormControlExtension i:nil="true" />
+                <Controls />
+              </AxFormControl>
+            </Controls>
+          </AxFormControl>
+        </Controls>
+        <Style>FastTabs</Style>
+      </AxFormControl>
+    </Controls>
+  </Design>
+  <Parts />
+</AxForm>

--- a/eval/goldens/L1-form-details-transaction/ConFmVehicleServiceOrder.xml
+++ b/eval/goldens/L1-form-details-transaction/ConFmVehicleServiceOrder.xml
@@ -1,0 +1,170 @@
+<?xml version="1.0" encoding="utf-8"?>
+<AxForm xmlns:i="http://www.w3.org/2001/XMLSchema-instance" xmlns="Microsoft.Dynamics.AX.Metadata.V6">
+  <Name>ConFmVehicleServiceOrder</Name>
+  <SourceCode>
+    <Methods xmlns="">
+      <Method>
+        <Name>classDeclaration</Name>
+        <Source><![CDATA[
+[Form]
+public class ConFmVehicleServiceOrder extends FormRun
+{
+}
+
+]]></Source>
+      </Method>
+    </Methods>
+    <DataSources xmlns="" />
+    <DataControls xmlns="" />
+    <Members xmlns="" />
+  </SourceCode>
+  <DataSources>
+    <AxFormDataSource xmlns="">
+      <Name>FmVehicle</Name>
+      <Table>FmVehicle</Table>
+      <Fields />
+      <ReferencedDataSources />
+      <InsertIfEmpty>No</InsertIfEmpty>
+      <DataSourceLinks />
+      <DerivedDataSources />
+    </AxFormDataSource>
+    <AxFormDataSource xmlns="">
+      <Name>FmVehicleLine</Name>
+      <Table>FmVehicleLine</Table>
+      <Fields />
+      <ReferencedDataSources />
+      <InsertIfEmpty>No</InsertIfEmpty>
+      <DataSourceLinks>
+        <AxFormDataSourceLink>
+          <LinkType>Active</LinkType>
+          <Table>FmVehicle</Table>
+        </AxFormDataSourceLink>
+      </DataSourceLinks>
+      <DerivedDataSources />
+    </AxFormDataSource>
+  </DataSources>
+  <Design>
+    <Caption xmlns="">Vehicle service order</Caption>
+    <DataSource xmlns="">FmVehicle</DataSource>
+    <Pattern xmlns="">DetailsTransaction</Pattern>
+    <PatternVersion xmlns="">1.1</PatternVersion>
+    <Style xmlns="">DetailsFormTransaction</Style>
+    <TitleDataSource xmlns="">FmVehicle</TitleDataSource>
+    <Controls xmlns="">
+      <AxFormControl xmlns="" i:type="AxFormActionPaneControl">
+        <Name>ActionPane</Name>
+        <ElementPosition>134217727</ElementPosition>
+        <FilterExpression>%1</FilterExpression>
+        <Type>ActionPane</Type>
+        <VerticalSpacing>-1</VerticalSpacing>
+        <FormControlExtension i:nil="true" />
+        <Controls>
+          <AxFormControl xmlns="" i:type="AxFormButtonGroupControl">
+            <Name>ButtonGroup</Name>
+            <Type>ButtonGroup</Type>
+            <FormControlExtension i:nil="true" />
+            <Controls />
+            <ArrangeMethod>Vertical</ArrangeMethod>
+          </AxFormControl>
+        </Controls>
+        <AlignChild>No</AlignChild>
+        <AlignChildren>No</AlignChildren>
+        <ArrangeMethod>Vertical</ArrangeMethod>
+      </AxFormControl>
+      <AxFormControl xmlns="" i:type="AxFormGroupControl">
+        <Name>NavigationFilterGroup</Name>
+        <Pattern>CustomAndQuickFilters</Pattern>
+        <PatternVersion>1.1</PatternVersion>
+        <Type>Group</Type>
+        <WidthMode>SizeToAvailable</WidthMode>
+        <FormControlExtension i:nil="true" />
+        <Controls>
+          <AxFormControl>
+            <Name>QuickFilterControl</Name>
+            <FormControlExtension>
+              <Name>QuickFilterControl</Name>
+              <ExtensionComponents />
+              <ExtensionProperties>
+                <AxFormControlExtensionProperty>
+                  <Name>targetControlName</Name>
+                  <Type>String</Type>
+                  <Value>Grid</Value>
+                </AxFormControlExtensionProperty>
+              </ExtensionProperties>
+            </FormControlExtension>
+          </AxFormControl>
+        </Controls>
+        <ArrangeMethod>HorizontalLeft</ArrangeMethod>
+        <FrameType>None</FrameType>
+        <Style>CustomFilter</Style>
+        <ViewEditMode>Edit</ViewEditMode>
+      </AxFormControl>
+      <AxFormControl xmlns="" i:type="AxFormTabControl">
+        <Name>Tab</Name>
+        <Type>Tab</Type>
+        <FormControlExtension i:nil="true" />
+        <Controls>
+          <AxFormControl xmlns="" i:type="AxFormTabPageControl">
+            <Name>TabPageHeader</Name>
+            <Pattern>FieldsFieldGroups</Pattern>
+            <PatternVersion>1.1</PatternVersion>
+            <Type>TabPage</Type>
+            <Caption>Header</Caption>
+            <FormControlExtension i:nil="true" />
+            <Controls>
+              <AxFormControl xmlns="" i:type="AxFormGroupControl">
+                <Name>HeaderGeneralGroup</Name>
+                <Type>Group</Type>
+                <Caption>General</Caption>
+                <DataGroup>Overview</DataGroup>
+                <FormControlExtension i:nil="true" />
+                <Controls>
+                  <AxFormControl xmlns="" i:type="AxFormStringControl">
+                    <Name>Header_VIN</Name>
+                    <Type>String</Type>
+                    <FormControlExtension i:nil="true" />
+                    <DataField>VIN</DataField>
+                    <DataSource>FmVehicle</DataSource>
+                  </AxFormControl>
+                </Controls>
+              </AxFormControl>
+            </Controls>
+          </AxFormControl>
+          <AxFormControl xmlns="" i:type="AxFormTabPageControl">
+            <Name>TabPageLines</Name>
+            <Type>TabPage</Type>
+            <Caption>Lines</Caption>
+            <FormControlExtension i:nil="true" />
+            <Controls>
+              <AxFormControl xmlns="" i:type="AxFormActionPaneTabControl">
+                <Name>LinesActionPane</Name>
+                <Type>ActionPaneTab</Type>
+                <FormControlExtension i:nil="true" />
+                <Controls>
+                  <AxFormControl xmlns="" i:type="AxFormButtonGroupControl">
+                    <Name>LinesButtonGroup</Name>
+                    <Type>ButtonGroup</Type>
+                    <FormControlExtension i:nil="true" />
+                    <Controls />
+                    <ArrangeMethod>Vertical</ArrangeMethod>
+                  </AxFormControl>
+                </Controls>
+              </AxFormControl>
+              <AxFormControl xmlns="" i:type="AxFormGridControl">
+                <Name>LinesGrid</Name>
+                <Type>Grid</Type>
+                <FormControlExtension i:nil="true" />
+                <Controls />
+                <DataSource>FmVehicleLine</DataSource>
+                <DataGroup>Overview</DataGroup>
+                <Style>Tabular</Style>
+              </AxFormControl>
+            </Controls>
+          </AxFormControl>
+        </Controls>
+        <Style>FastTabs</Style>
+      </AxFormControl>
+    </Controls>
+  </Design>
+  <Parts />
+</AxForm>

--- a/eval/goldens/L1-form-dialog/ConFmVehicleCreateDialog.xml
+++ b/eval/goldens/L1-form-dialog/ConFmVehicleCreateDialog.xml
@@ -1,0 +1,85 @@
+<?xml version="1.0" encoding="utf-8"?>
+<AxForm xmlns:i="http://www.w3.org/2001/XMLSchema-instance" xmlns="Microsoft.Dynamics.AX.Metadata.V6">
+  <Name>ConFmVehicleCreateDialog</Name>
+  <SourceCode>
+    <Methods xmlns="">
+      <Method>
+        <Name>classDeclaration</Name>
+        <Source><![CDATA[
+[Form]
+public class ConFmVehicleCreateDialog extends FormRun
+{
+}
+
+]]></Source>
+      </Method>
+    </Methods>
+    <DataSources xmlns="" />
+    <DataControls xmlns="" />
+    <Members xmlns="" />
+  </SourceCode>
+  <DataSources>
+    <AxFormDataSource xmlns="">
+      <Name>FmVehicle</Name>
+      <Table>FmVehicle</Table>
+      <Fields />
+      <ReferencedDataSources />
+      <DataSourceLinks />
+      <DerivedDataSources />
+    </AxFormDataSource>
+  </DataSources>
+  <Design>
+    <Caption xmlns="">Create vehicle</Caption>
+    <Frame xmlns="">Dialog</Frame>
+    <Pattern xmlns="">Dialog</Pattern>
+    <PatternVersion xmlns="">1.2</PatternVersion>
+    <Style xmlns="">Dialog</Style>
+    <Controls xmlns="">
+      <AxFormControl xmlns="" i:type="AxFormGroupControl">
+        <Name>DialogBody</Name>
+        <Pattern>FieldsFieldGroups</Pattern>
+        <PatternVersion>1.1</PatternVersion>
+        <Type>Group</Type>
+        <FormControlExtension i:nil="true" />
+        <Controls>
+          <AxFormControl xmlns="" i:type="AxFormStringControl">
+            <Name>VIN</Name>
+            <Type>String</Type>
+            <FormControlExtension i:nil="true" />
+            <DataField>VIN</DataField>
+            <DataSource>FmVehicle</DataSource>
+          </AxFormControl>
+          <AxFormControl xmlns="" i:type="AxFormStringControl">
+            <Name>Make</Name>
+            <Type>String</Type>
+            <FormControlExtension i:nil="true" />
+            <DataField>Make</DataField>
+            <DataSource>FmVehicle</DataSource>
+          </AxFormControl>
+        </Controls>
+        <Style>DialogContent</Style>
+      </AxFormControl>
+      <AxFormControl xmlns="" i:type="AxFormButtonGroupControl">
+        <Name>ButtonGroup</Name>
+        <Type>ButtonGroup</Type>
+        <FormControlExtension i:nil="true" />
+        <Controls>
+          <AxFormControl xmlns="" i:type="AxFormCommandButtonControl">
+            <Name>OkButton</Name>
+            <Type>CommandButton</Type>
+            <FormControlExtension i:nil="true" />
+            <Command>OK</Command>
+          </AxFormControl>
+          <AxFormControl xmlns="" i:type="AxFormCommandButtonControl">
+            <Name>CloseButton</Name>
+            <Type>CommandButton</Type>
+            <FormControlExtension i:nil="true" />
+            <Command>Cancel</Command>
+          </AxFormControl>
+        </Controls>
+        <Style>DialogCommitContainer</Style>
+      </AxFormControl>
+    </Controls>
+  </Design>
+  <Parts />
+</AxForm>

--- a/eval/goldens/L1-form-list-page/ConFmVehicleListPage.xml
+++ b/eval/goldens/L1-form-list-page/ConFmVehicleListPage.xml
@@ -1,0 +1,144 @@
+<?xml version="1.0" encoding="utf-8"?>
+<AxForm xmlns:i="http://www.w3.org/2001/XMLSchema-instance" xmlns="Microsoft.Dynamics.AX.Metadata.V6">
+  <Name>ConFmVehicleListPage</Name>
+  <SourceCode>
+    <Methods xmlns="">
+      <Method>
+        <Name>classDeclaration</Name>
+        <Source><![CDATA[
+[Form]
+public class ConFmVehicleListPage extends FormRun
+{
+}
+
+]]></Source>
+      </Method>
+    </Methods>
+    <DataSources xmlns="" />
+    <DataControls xmlns="" />
+    <Members xmlns="" />
+  </SourceCode>
+  <DataSources>
+    <AxFormDataSource xmlns="">
+      <Name>FmVehicle</Name>
+      <Table>FmVehicle</Table>
+      <Fields />
+      <ReferencedDataSources />
+      <AllowCreate>No</AllowCreate>
+      <AllowEdit>No</AllowEdit>
+      <AllowDelete>No</AllowDelete>
+      <InsertIfEmpty>No</InsertIfEmpty>
+      <DataSourceLinks />
+      <DerivedDataSources />
+    </AxFormDataSource>
+  </DataSources>
+  <Design>
+    <Caption xmlns="">Fleet vehicles</Caption>
+    <DataSource xmlns="">FmVehicle</DataSource>
+    <Pattern xmlns="">ListPage</Pattern>
+    <PatternVersion xmlns="">1.1</PatternVersion>
+    <Style xmlns="">ListPage</Style>
+    <TitleDataSource xmlns="">FmVehicle</TitleDataSource>
+    <Controls xmlns="">
+      <AxFormControl xmlns="" i:type="AxFormActionPaneControl">
+        <Name>ActionPane</Name>
+        <ElementPosition>134217727</ElementPosition>
+        <FilterExpression>%1</FilterExpression>
+        <Type>ActionPane</Type>
+        <VerticalSpacing>-1</VerticalSpacing>
+        <FormControlExtension i:nil="true" />
+        <Controls>
+          <AxFormControl xmlns="" i:type="AxFormActionPaneTabControl">
+            <Name>ActionPaneTab</Name>
+            <Type>ActionPaneTab</Type>
+            <FormControlExtension i:nil="true" />
+            <Controls>
+              <AxFormControl xmlns="" i:type="AxFormButtonGroupControl">
+                <Name>NewButtonGroup</Name>
+                <Type>ButtonGroup</Type>
+                <FormControlExtension i:nil="true" />
+                <Controls />
+              </AxFormControl>
+              <AxFormControl xmlns="" i:type="AxFormButtonGroupControl">
+                <Name>MaintainButtonGroup</Name>
+                <Type>ButtonGroup</Type>
+                <FormControlExtension i:nil="true" />
+                <Controls />
+              </AxFormControl>
+            </Controls>
+          </AxFormControl>
+        </Controls>
+        <AlignChild>No</AlignChild>
+        <AlignChildren>No</AlignChildren>
+        <ArrangeMethod>Vertical</ArrangeMethod>
+      </AxFormControl>
+      <AxFormControl xmlns="" i:type="AxFormGroupControl">
+        <Name>CustomFilterGroup</Name>
+        <Pattern>CustomAndQuickFilters</Pattern>
+        <PatternVersion>1.1</PatternVersion>
+        <Type>Group</Type>
+        <WidthMode>SizeToAvailable</WidthMode>
+        <FormControlExtension i:nil="true" />
+        <Controls>
+          <AxFormControl>
+            <Name>QuickFilterControl</Name>
+            <FormControlExtension>
+              <Name>QuickFilterControl</Name>
+              <ExtensionComponents />
+              <ExtensionProperties>
+                <AxFormControlExtensionProperty>
+                  <Name>targetControlName</Name>
+                  <Type>String</Type>
+                  <Value>Grid</Value>
+                </AxFormControlExtensionProperty>
+                <AxFormControlExtensionProperty>
+                  <Name>defaultColumnName</Name>
+                  <Type>String</Type>
+                  <Value>Grid_VIN</Value>
+                </AxFormControlExtensionProperty>
+                <AxFormControlExtensionProperty>
+                  <Name>placeholderText</Name>
+                  <Type>String</Type>
+                </AxFormControlExtensionProperty>
+              </ExtensionProperties>
+            </FormControlExtension>
+          </AxFormControl>
+        </Controls>
+        <ArrangeMethod>HorizontalLeft</ArrangeMethod>
+        <FrameType>None</FrameType>
+        <Style>CustomFilter</Style>
+        <ViewEditMode>Edit</ViewEditMode>
+      </AxFormControl>
+      <AxFormControl xmlns="" i:type="AxFormGridControl">
+        <Name>Grid</Name>
+        <ElementPosition>1431655764</ElementPosition>
+        <FilterExpression>%1</FilterExpression>
+        <Type>Grid</Type>
+        <VerticalSpacing>-1</VerticalSpacing>
+        <FormControlExtension i:nil="true" />
+        <Controls>
+          <AxFormControl xmlns="" i:type="AxFormStringControl">
+            <Name>Grid_VIN</Name>
+            <Type>String</Type>
+            <FormControlExtension i:nil="true" />
+            <DataField>VIN</DataField>
+            <DataSource>FmVehicle</DataSource>
+          </AxFormControl>
+          <AxFormControl xmlns="" i:type="AxFormStringControl">
+            <Name>Grid_Make</Name>
+            <Type>String</Type>
+            <FormControlExtension i:nil="true" />
+            <DataField>Make</DataField>
+            <DataSource>FmVehicle</DataSource>
+          </AxFormControl>
+        </Controls>
+        <AlternateRowShading>No</AlternateRowShading>
+        <DataSource>FmVehicle</DataSource>
+        <MultiSelect>Yes</MultiSelect>
+        <ShowRowLabels>No</ShowRowLabels>
+        <Style>Tabular</Style>
+      </AxFormControl>
+    </Controls>
+  </Design>
+  <Parts />
+</AxForm>

--- a/eval/goldens/L1-form-lookup/ConFmVehicleLookupForm.xml
+++ b/eval/goldens/L1-form-lookup/ConFmVehicleLookupForm.xml
@@ -1,0 +1,102 @@
+<?xml version="1.0" encoding="utf-8"?>
+<AxForm xmlns:i="http://www.w3.org/2001/XMLSchema-instance" xmlns="Microsoft.Dynamics.AX.Metadata.V6">
+  <Name>ConFmVehicleLookupForm</Name>
+  <SourceCode>
+    <Methods xmlns="">
+      <Method>
+        <Name>classDeclaration</Name>
+        <Source><![CDATA[
+[Form]
+public class ConFmVehicleLookupForm extends FormRun
+{
+}
+
+]]></Source>
+      </Method>
+    </Methods>
+    <DataSources xmlns="" />
+    <DataControls xmlns="" />
+    <Members xmlns="" />
+  </SourceCode>
+  <DataSources>
+    <AxFormDataSource xmlns="">
+      <Name>FmVehicle</Name>
+      <Table>FmVehicle</Table>
+      <Fields />
+      <ReferencedDataSources />
+      <DataSourceLinks />
+      <DerivedDataSources />
+    </AxFormDataSource>
+  </DataSources>
+  <Design>
+    <Caption xmlns="">Vehicle lookup</Caption>
+    <Pattern xmlns="">Lookup</Pattern>
+    <PatternVersion xmlns="">1.2</PatternVersion>
+    <Style xmlns="">Lookup</Style>
+    <Controls xmlns="">
+      <AxFormControl xmlns="" i:type="AxFormGroupControl">
+        <Name>CustomFilterGroup</Name>
+        <Pattern>CustomAndQuickFilters</Pattern>
+        <PatternVersion>1.1</PatternVersion>
+        <Type>Group</Type>
+        <WidthMode>SizeToAvailable</WidthMode>
+        <FormControlExtension i:nil="true" />
+        <Controls>
+          <AxFormControl>
+            <Name>QuickFilterControl</Name>
+            <FormControlExtension>
+              <Name>QuickFilterControl</Name>
+              <ExtensionComponents />
+              <ExtensionProperties>
+                <AxFormControlExtensionProperty>
+                  <Name>targetControlName</Name>
+                  <Type>String</Type>
+                  <Value>Grid</Value>
+                </AxFormControlExtensionProperty>
+                <AxFormControlExtensionProperty>
+                  <Name>defaultColumnName</Name>
+                  <Type>String</Type>
+                  <Value>Grid_VIN</Value>
+                </AxFormControlExtensionProperty>
+                <AxFormControlExtensionProperty>
+                  <Name>placeholderText</Name>
+                  <Type>String</Type>
+                </AxFormControlExtensionProperty>
+              </ExtensionProperties>
+            </FormControlExtension>
+          </AxFormControl>
+        </Controls>
+        <ArrangeMethod>HorizontalLeft</ArrangeMethod>
+        <FrameType>None</FrameType>
+        <Style>CustomFilter</Style>
+      </AxFormControl>
+      <AxFormControl xmlns="" i:type="AxFormGridControl">
+        <Name>Grid</Name>
+        <ElementPosition>1431655764</ElementPosition>
+        <FilterExpression>%1</FilterExpression>
+        <Type>Grid</Type>
+        <VerticalSpacing>-1</VerticalSpacing>
+        <FormControlExtension i:nil="true" />
+        <Controls>
+          <AxFormControl xmlns="" i:type="AxFormStringControl">
+            <Name>Grid_VIN</Name>
+            <Type>String</Type>
+            <FormControlExtension i:nil="true" />
+            <DataField>VIN</DataField>
+            <DataSource>FmVehicle</DataSource>
+          </AxFormControl>
+          <AxFormControl xmlns="" i:type="AxFormStringControl">
+            <Name>Grid_Make</Name>
+            <Type>String</Type>
+            <FormControlExtension i:nil="true" />
+            <DataField>Make</DataField>
+            <DataSource>FmVehicle</DataSource>
+          </AxFormControl>
+        </Controls>
+        <DataSource>FmVehicle</DataSource>
+        <Style>Tabular</Style>
+      </AxFormControl>
+    </Controls>
+  </Design>
+  <Parts />
+</AxForm>

--- a/eval/goldens/L1-form-simplelist-details/ConFmVehicleListDetails.xml
+++ b/eval/goldens/L1-form-simplelist-details/ConFmVehicleListDetails.xml
@@ -1,0 +1,183 @@
+<?xml version="1.0" encoding="utf-8"?>
+<AxForm xmlns:i="http://www.w3.org/2001/XMLSchema-instance" xmlns="Microsoft.Dynamics.AX.Metadata.V6">
+  <Name>ConFmVehicleListDetails</Name>
+  <SourceCode>
+    <Methods xmlns="">
+      <Method>
+        <Name>classDeclaration</Name>
+        <Source><![CDATA[
+[Form]
+public class ConFmVehicleListDetails extends FormRun
+{
+}
+
+]]></Source>
+      </Method>
+    </Methods>
+    <DataSources xmlns="" />
+    <DataControls xmlns="" />
+    <Members xmlns="" />
+  </SourceCode>
+  <DataSources>
+    <AxFormDataSource xmlns="">
+      <Name>FmVehicle</Name>
+      <Table>FmVehicle</Table>
+      <Fields />
+      <ReferencedDataSources />
+      <InsertIfEmpty>No</InsertIfEmpty>
+      <DataSourceLinks />
+      <DerivedDataSources />
+    </AxFormDataSource>
+  </DataSources>
+  <Design>
+    <Caption xmlns="">Fleet vehicles</Caption>
+    <DataSource xmlns="">FmVehicle</DataSource>
+    <Pattern xmlns="">SimpleListDetails</Pattern>
+    <PatternVersion xmlns="">1.3</PatternVersion>
+    <Style xmlns="">SimpleListDetails</Style>
+    <TitleDataSource xmlns="">FmVehicle</TitleDataSource>
+    <Controls xmlns="">
+      <AxFormControl xmlns="" i:type="AxFormActionPaneControl">
+        <Name>ActionPane</Name>
+        <ElementPosition>134217727</ElementPosition>
+        <FilterExpression>%1</FilterExpression>
+        <Type>ActionPane</Type>
+        <VerticalSpacing>-1</VerticalSpacing>
+        <FormControlExtension i:nil="true" />
+        <Controls>
+          <AxFormControl xmlns="" i:type="AxFormButtonGroupControl">
+            <Name>ButtonGroup</Name>
+            <Type>ButtonGroup</Type>
+            <FormControlExtension i:nil="true" />
+            <Controls />
+            <ArrangeMethod>Vertical</ArrangeMethod>
+          </AxFormControl>
+        </Controls>
+        <AlignChild>No</AlignChild>
+        <AlignChildren>No</AlignChildren>
+        <ArrangeMethod>Vertical</ArrangeMethod>
+      </AxFormControl>
+      <AxFormControl xmlns="" i:type="AxFormGroupControl">
+        <Name>GridContainer</Name>
+        <Pattern>SidePanel</Pattern>
+        <PatternVersion>1.0</PatternVersion>
+        <Type>Group</Type>
+        <FormControlExtension i:nil="true" />
+        <Controls>
+          <AxFormControl>
+            <Name>QuickFilterControl</Name>
+            <FormControlExtension>
+              <Name>QuickFilterControl</Name>
+              <ExtensionComponents />
+              <ExtensionProperties>
+                <AxFormControlExtensionProperty>
+                  <Name>targetControlName</Name>
+                  <Type>String</Type>
+                  <Value>Grid</Value>
+                </AxFormControlExtensionProperty>
+                <AxFormControlExtensionProperty>
+                  <Name>defaultColumnName</Name>
+                  <Type>String</Type>
+                  <Value>Grid_VIN</Value>
+                </AxFormControlExtensionProperty>
+                <AxFormControlExtensionProperty>
+                  <Name>placeholderText</Name>
+                  <Type>String</Type>
+                </AxFormControlExtensionProperty>
+              </ExtensionProperties>
+            </FormControlExtension>
+          </AxFormControl>
+          <AxFormControl xmlns="" i:type="AxFormGridControl">
+            <Name>Grid</Name>
+            <Type>Grid</Type>
+            <FormControlExtension i:nil="true" />
+            <Controls>
+              <AxFormControl xmlns="" i:type="AxFormStringControl">
+                <Name>Grid_VIN</Name>
+                <Type>String</Type>
+                <FormControlExtension i:nil="true" />
+                <DataField>VIN</DataField>
+                <DataSource>FmVehicle</DataSource>
+              </AxFormControl>
+              <AxFormControl xmlns="" i:type="AxFormStringControl">
+                <Name>Grid_Make</Name>
+                <Type>String</Type>
+                <FormControlExtension i:nil="true" />
+                <DataField>Make</DataField>
+                <DataSource>FmVehicle</DataSource>
+              </AxFormControl>
+            </Controls>
+            <DataSource>FmVehicle</DataSource>
+            <GridLinesStyle>Vertical</GridLinesStyle>
+            <Style>List</Style>
+          </AxFormControl>
+        </Controls>
+        <Style>SidePanel</Style>
+      </AxFormControl>
+      <AxFormControl xmlns="" i:type="AxFormGroupControl">
+        <Name>DetailsGroup</Name>
+        <Type>Group</Type>
+        <FormControlExtension i:nil="true" />
+        <Controls>
+          <AxFormControl xmlns="" i:type="AxFormTabControl">
+            <Name>Tab</Name>
+            <Type>Tab</Type>
+            <FormControlExtension i:nil="true" />
+            <Controls>
+              <AxFormControl xmlns="" i:type="AxFormTabPageControl">
+                <Name>TabPageOverview</Name>
+                <Pattern>FieldsFieldGroups</Pattern>
+                <PatternVersion>1.1</PatternVersion>
+                <Type>TabPage</Type>
+                <Caption>Overview</Caption>
+                <FormControlExtension i:nil="true" />
+                <Controls>
+                  <AxFormControl xmlns="" i:type="AxFormGroupControl">
+                    <Name>OverviewGroup</Name>
+                    <Type>Group</Type>
+                    <DataGroup>Overview</DataGroup>
+                    <FormControlExtension i:nil="true" />
+                    <Controls>
+                    <AxFormControl xmlns="" i:type="AxFormStringControl">
+                      <Name>Overview_VIN</Name>
+                      <Type>String</Type>
+                      <FormControlExtension i:nil="true" />
+                      <DataField>VIN</DataField>
+                      <DataSource>FmVehicle</DataSource>
+                    </AxFormControl>
+                    <AxFormControl xmlns="" i:type="AxFormStringControl">
+                      <Name>Overview_Make</Name>
+                      <Type>String</Type>
+                      <FormControlExtension i:nil="true" />
+                      <DataField>Make</DataField>
+                      <DataSource>FmVehicle</DataSource>
+                    </AxFormControl>
+                    </Controls>
+                  </AxFormControl>
+                </Controls>
+              </AxFormControl>
+              <AxFormControl xmlns="" i:type="AxFormTabPageControl">
+                <Name>TabPageGeneral</Name>
+                <Pattern>FieldsFieldGroups</Pattern>
+                <PatternVersion>1.1</PatternVersion>
+                <Type>TabPage</Type>
+                <Caption>General</Caption>
+                <FormControlExtension i:nil="true" />
+                <Controls>
+                  <AxFormControl xmlns="" i:type="AxFormGroupControl">
+                    <Name>GeneralGroup</Name>
+                    <Type>Group</Type>
+                    <DataGroup>General</DataGroup>
+                    <FormControlExtension i:nil="true" />
+                    <Controls />
+                  </AxFormControl>
+                </Controls>
+              </AxFormControl>
+            </Controls>
+          </AxFormControl>
+        </Controls>
+      </AxFormControl>
+    </Controls>
+  </Design>
+  <Parts />
+</AxForm>

--- a/eval/goldens/L1-form-table-of-contents/ConFmVehicleParametersForm.xml
+++ b/eval/goldens/L1-form-table-of-contents/ConFmVehicleParametersForm.xml
@@ -1,0 +1,91 @@
+<?xml version="1.0" encoding="utf-8"?>
+<AxForm xmlns:i="http://www.w3.org/2001/XMLSchema-instance" xmlns="Microsoft.Dynamics.AX.Metadata.V6">
+  <Name>ConFmVehicleParametersForm</Name>
+  <SourceCode>
+    <Methods xmlns="">
+      <Method>
+        <Name>classDeclaration</Name>
+        <Source><![CDATA[
+[Form]
+public class ConFmVehicleParametersForm extends FormRun
+{
+}
+
+]]></Source>
+      </Method>
+    </Methods>
+    <DataSources xmlns="" />
+    <DataControls xmlns="" />
+    <Members xmlns="" />
+  </SourceCode>
+  <DataSources>
+    <AxFormDataSource xmlns="">
+      <Name>FmVehicle</Name>
+      <Table>FmVehicle</Table>
+      <Fields />
+      <ReferencedDataSources />
+      <InsertIfEmpty>No</InsertIfEmpty>
+      <DataSourceLinks />
+      <DerivedDataSources />
+    </AxFormDataSource>
+  </DataSources>
+  <Design>
+    <Caption xmlns="">Fleet parameters</Caption>
+    <DataSource xmlns="">FmVehicle</DataSource>
+    <Pattern xmlns="">TableOfContents</Pattern>
+    <PatternVersion xmlns="">1.1</PatternVersion>
+    <Style xmlns="">TableOfContents</Style>
+    <Controls xmlns="">
+      <AxFormControl xmlns="" i:type="AxFormActionPaneControl">
+        <Name>ActionPane</Name>
+        <Type>ActionPane</Type>
+        <FormControlExtension i:nil="true" />
+        <Controls />
+      </AxFormControl>
+      <AxFormControl xmlns="" i:type="AxFormTabControl">
+        <Name>Tab</Name>
+        <Type>Tab</Type>
+        <FormControlExtension i:nil="true" />
+        <Controls>
+        <AxFormControl xmlns="" i:type="AxFormTabPageControl">
+          <Name>TabPageGeneral</Name>
+          <Pattern>FieldsFieldGroups</Pattern>
+          <PatternVersion>1.1</PatternVersion>
+          <Type>TabPage</Type>
+          <Caption>General</Caption>
+          <FrameType>None</FrameType>
+          <FormControlExtension i:nil="true" />
+          <Controls>
+            <AxFormControl xmlns="" i:type="AxFormStringControl">
+              <Name>VIN</Name>
+              <Type>String</Type>
+              <FormControlExtension i:nil="true" />
+              <DataField>VIN</DataField>
+              <DataSource>FmVehicle</DataSource>
+            </AxFormControl>
+            <AxFormControl xmlns="" i:type="AxFormStringControl">
+              <Name>Make</Name>
+              <Type>String</Type>
+              <FormControlExtension i:nil="true" />
+              <DataField>Make</DataField>
+              <DataSource>FmVehicle</DataSource>
+            </AxFormControl>
+          </Controls>
+        </AxFormControl>
+        <AxFormControl xmlns="" i:type="AxFormTabPageControl">
+          <Name>TabPageSetup</Name>
+          <Pattern>FieldsFieldGroups</Pattern>
+          <PatternVersion>1.1</PatternVersion>
+          <Type>TabPage</Type>
+          <Caption>Setup</Caption>
+          <FrameType>None</FrameType>
+          <FormControlExtension i:nil="true" />
+          <Controls />
+        </AxFormControl>
+        </Controls>
+        <Style>TOCList</Style>
+      </AxFormControl>
+    </Controls>
+  </Design>
+  <Parts />
+</AxForm>

--- a/eval/goldens/L1-form-workspace/ConFmVehicleWorkspace.xml
+++ b/eval/goldens/L1-form-workspace/ConFmVehicleWorkspace.xml
@@ -1,0 +1,180 @@
+<?xml version="1.0" encoding="utf-8"?>
+<AxForm xmlns:i="http://www.w3.org/2001/XMLSchema-instance" xmlns="Microsoft.Dynamics.AX.Metadata.V6">
+  <Name>ConFmVehicleWorkspace</Name>
+  <SourceCode>
+    <Methods xmlns="">
+      <Method>
+        <Name>classDeclaration</Name>
+        <Source><![CDATA[
+[Form]
+public class ConFmVehicleWorkspace extends FormRun
+{
+}
+
+]]></Source>
+      </Method>
+    </Methods>
+    <DataSources xmlns="" />
+    <DataControls xmlns="" />
+    <Members xmlns="" />
+  </SourceCode>
+  <DataSources>
+    <AxFormDataSource xmlns="">
+      <Name>FmVehicle</Name>
+      <Table>FmVehicle</Table>
+      <Fields />
+      <ReferencedDataSources />
+      <AllowCreate>No</AllowCreate>
+      <AllowEdit>No</AllowEdit>
+      <AllowDelete>No</AllowDelete>
+      <InsertIfEmpty>No</InsertIfEmpty>
+      <DataSourceLinks />
+      <DerivedDataSources />
+    </AxFormDataSource>
+  </DataSources>
+  <Design>
+    <Caption xmlns="">Fleet management</Caption>
+    <Pattern xmlns="">Workspace</Pattern>
+    <PatternVersion xmlns="">1.0</PatternVersion>
+    <Style xmlns="">Workspace</Style>
+    <Controls xmlns="">
+      <AxFormControl xmlns="" i:type="AxFormActionPaneControl">
+        <Name>ActionPane</Name>
+        <ElementPosition>134217727</ElementPosition>
+        <FilterExpression>%1</FilterExpression>
+        <Type>ActionPane</Type>
+        <VerticalSpacing>-1</VerticalSpacing>
+        <FormControlExtension i:nil="true" />
+        <Controls>
+          <AxFormControl xmlns="" i:type="AxFormActionPaneTabControl">
+            <Name>ActionPaneTab</Name>
+            <Type>ActionPaneTab</Type>
+            <FormControlExtension i:nil="true" />
+            <Controls>
+              <AxFormControl xmlns="" i:type="AxFormButtonGroupControl">
+                <Name>NewButtonGroup</Name>
+                <Type>ButtonGroup</Type>
+                <FormControlExtension i:nil="true" />
+                <Controls />
+              </AxFormControl>
+            </Controls>
+          </AxFormControl>
+        </Controls>
+        <AlignChild>No</AlignChild>
+        <AlignChildren>No</AlignChildren>
+        <ArrangeMethod>Vertical</ArrangeMethod>
+      </AxFormControl>
+      <AxFormControl xmlns="" i:type="AxFormTabControl">
+        <Name>PanoramaBody</Name>
+        <ElementPosition>268435455</ElementPosition>
+        <Type>Tab</Type>
+        <WidthMode>SizeToAvailable</WidthMode>
+        <HeightMode>SizeToAvailable</HeightMode>
+        <FormControlExtension i:nil="true" />
+        <Controls>
+          <AxFormControl xmlns="" i:type="AxFormTabPageControl">
+            <Name>SummarySection</Name>
+            <Caption>Summary</Caption>
+            <ElementPosition>536870911</ElementPosition>
+            <Type>TabPage</Type>
+            <FormControlExtension i:nil="true" />
+            <Controls>
+              <AxFormControl xmlns="" i:type="AxFormGroupControl">
+                <Name>TileSection</Name>
+                <Pattern>Workspace_SummaryNumbers_UnboundFields</Pattern>
+                <PatternVersion>1.0</PatternVersion>
+                <Type>Group</Type>
+                <WidthMode>SizeToAvailable</WidthMode>
+                <FormControlExtension i:nil="true" />
+                <Controls>
+                  <!-- Add AxFormControlButtonControl tiles here -->
+                </Controls>
+                <ArrangeMethod>HorizontalLeft</ArrangeMethod>
+                <FrameType>None</FrameType>
+                <Style>TileSection</Style>
+              </AxFormControl>
+              <AxFormControl xmlns="" i:type="AxFormGroupControl">
+                <Name>ChartSection</Name>
+                <Type>Group</Type>
+                <WidthMode>SizeToAvailable</WidthMode>
+                <FormControlExtension i:nil="true" />
+                <Controls>
+                  <!-- Add FormPart references for charts/KPIs here -->
+                </Controls>
+                <ArrangeMethod>HorizontalLeft</ArrangeMethod>
+                <FrameType>None</FrameType>
+              </AxFormControl>
+            </Controls>
+            <FrameType>None</FrameType>
+          </AxFormControl>
+          <AxFormControl xmlns="" i:type="AxFormTabPageControl">
+            <Name>FmVehicleSection</Name>
+            <Caption>FmVehicle</Caption>
+            <ElementPosition>1073741824</ElementPosition>
+            <Type>TabPage</Type>
+            <FormControlExtension i:nil="true" />
+            <Controls>
+              <AxFormControl xmlns="" i:type="AxFormGroupControl">
+                <Name>FmVehicleCustomFilterGroup</Name>
+                <Pattern>CustomAndQuickFilters</Pattern>
+                <PatternVersion>1.1</PatternVersion>
+                <Type>Group</Type>
+                <WidthMode>SizeToAvailable</WidthMode>
+                <FormControlExtension i:nil="true" />
+                <Controls>
+                  <AxFormControl xmlns="">
+                    <Name>FmVehicleQuickFilter</Name>
+                    <FormControlExtension>
+                      <Name>QuickFilterControl</Name>
+                      <ExtensionComponents />
+                      <ExtensionProperties>
+                        <AxFormControlExtensionProperty>
+                          <Name>targetControlName</Name>
+                          <Type>String</Type>
+                          <Value>FmVehicleGrid</Value>
+                        </AxFormControlExtensionProperty>
+                      </ExtensionProperties>
+                    </FormControlExtension>
+                  </AxFormControl>
+                </Controls>
+                <ArrangeMethod>HorizontalLeft</ArrangeMethod>
+                <FrameType>None</FrameType>
+                <Style>CustomFilter</Style>
+              </AxFormControl>
+              <AxFormControl xmlns="" i:type="AxFormGridControl">
+                <Name>FmVehicleGrid</Name>
+                <Type>Grid</Type>
+                <WidthMode>SizeToAvailable</WidthMode>
+                <FormControlExtension i:nil="true" />
+                <Controls>
+                  <AxFormControl xmlns="" i:type="AxFormStringControl">
+                    <Name>FmVehicleGrid_VIN</Name>
+                    <Type>String</Type>
+                    <FormControlExtension i:nil="true" />
+                    <DataField>VIN</DataField>
+                    <DataSource>FmVehicle</DataSource>
+                  </AxFormControl>
+                  <AxFormControl xmlns="" i:type="AxFormStringControl">
+                    <Name>FmVehicleGrid_Make</Name>
+                    <Type>String</Type>
+                    <FormControlExtension i:nil="true" />
+                    <DataField>Make</DataField>
+                    <DataSource>FmVehicle</DataSource>
+                  </AxFormControl>
+                </Controls>
+                <DataSource>FmVehicle</DataSource>
+                <ShowRowLabels>No</ShowRowLabels>
+                <Style>Tabular</Style>
+              </AxFormControl>
+            </Controls>
+            <FrameType>None</FrameType>
+          </AxFormControl>
+        </Controls>
+        <AlignChild>No</AlignChild>
+        <ShowTabs>No</ShowTabs>
+        <Style>Panorama</Style>
+      </AxFormControl>
+    </Controls>
+  </Design>
+  <Parts />
+</AxForm>

--- a/eval/goldens/L1-map-multi-table/ConFmVehicleSharedMap.xml
+++ b/eval/goldens/L1-map-multi-table/ConFmVehicleSharedMap.xml
@@ -1,0 +1,39 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<AxMap xmlns:i="http://www.w3.org/2001/XMLSchema-instance">
+  <Name>ConFmVehicleSharedMap</Name>
+  <SourceCode>
+    <Declaration><![CDATA[
+public class ConFmVehicleSharedMap extends common
+{
+}
+]]></Declaration>
+    <Methods />
+  </SourceCode>
+  <FieldGroups />
+  <Fields>
+    <AxMapBaseField i:type="AxMapFieldString">
+      <Name>VIN</Name>
+      <ExtendedDataType>VinEdt</ExtendedDataType>
+    </AxMapBaseField>
+  </Fields>
+  <Mappings>
+    <AxTableMapping>
+      <MappingTable>FmVehicle</MappingTable>
+      <Connections>
+        <AxTableMappingConnection>
+          <MapField>VIN</MapField>
+          <MapFieldTo>VIN</MapFieldTo>
+        </AxTableMappingConnection>
+      </Connections>
+    </AxTableMapping>
+    <AxTableMapping>
+      <MappingTable>FmVehicleLine</MappingTable>
+      <Connections>
+        <AxTableMappingConnection>
+          <MapField>VIN</MapField>
+          <MapFieldTo>VIN</MapFieldTo>
+        </AxTableMappingConnection>
+      </Connections>
+    </AxTableMapping>
+  </Mappings>
+</AxMap>

--- a/eval/goldens/L1-menu-item-action/ConFmVehicleServiceMenuItem.xml
+++ b/eval/goldens/L1-menu-item-action/ConFmVehicleServiceMenuItem.xml
@@ -1,0 +1,10 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<AxMenuItemAction>
+  <Name>ConFmVehicleServiceMenuItem</Name>
+  <Label>Run vehicle service</Label>
+  <Image>
+    <ImageType>Symbol</ImageType>
+  </Image>
+  <Object>FmVehicleService</Object>
+  <ObjectType>Class</ObjectType>
+</AxMenuItemAction>

--- a/eval/goldens/L1-menu-item-output/ConFmVehicleReportMenuItem.xml
+++ b/eval/goldens/L1-menu-item-output/ConFmVehicleReportMenuItem.xml
@@ -1,0 +1,10 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<AxMenuItemOutput>
+  <Name>ConFmVehicleReportMenuItem</Name>
+  <Label>Fleet vehicle report</Label>
+  <Image>
+    <ImageType>Symbol</ImageType>
+  </Image>
+  <Object>ConFmVehicleParamReport</Object>
+  <ObjectType>SSRSReport</ObjectType>
+</AxMenuItemOutput>

--- a/eval/goldens/L1-privilege-data-entity/ConFmVehicleEntityPriv.xml
+++ b/eval/goldens/L1-privilege-data-entity/ConFmVehicleEntityPriv.xml
@@ -1,0 +1,20 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<AxSecurityPrivilege>
+  <Name>ConFmVehicleEntityPriv</Name>
+  <Label>Fleet vehicle entity maintain</Label>
+  <DataEntityPermissions>
+    <AxSecurityDataEntityPermission>
+      <Grant>
+        <Correct>Allow</Correct>
+        <Create>Allow</Create>
+        <Delete>Allow</Delete>
+        <Read>Allow</Read>
+        <Update>Allow</Update>
+      </Grant>
+      <Name>ConFmVehicleEntity</Name>
+      <Fields />
+      <Methods />
+    </AxSecurityDataEntityPermission>
+  </DataEntityPermissions>
+  <EntryPoints />
+</AxSecurityPrivilege>

--- a/eval/goldens/L1-query-join/ConFmVehicleLineQuery.xml
+++ b/eval/goldens/L1-query-join/ConFmVehicleLineQuery.xml
@@ -1,0 +1,18 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<AxQuery>
+  <Name>ConFmVehicleLineQuery</Name>
+  <DataSources>
+    <AxQuerySimpleRootDataSource>
+      <Name>FmVehicle</Name>
+      <Table>FmVehicle</Table>
+      <DataSources>
+        <AxQuerySimpleEmbeddedDataSource>
+          <Name>FmVehicleLine</Name>
+          <Table>FmVehicleLine</Table>
+          <JoinMode>InnerJoin</JoinMode>
+          <UseRelations>Yes</UseRelations>
+        </AxQuerySimpleEmbeddedDataSource>
+      </DataSources>
+    </AxQuerySimpleRootDataSource>
+  </DataSources>
+</AxQuery>

--- a/eval/goldens/L1-report-parameters/ConFmVehicleParamReport.xml
+++ b/eval/goldens/L1-report-parameters/ConFmVehicleParamReport.xml
@@ -1,0 +1,152 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<AxReport>
+  <Name>ConFmVehicleParamReport</Name>
+  <ReportParameters>
+    <AxReportParameter>
+      <Name>FromDate</Name>
+      <AllowBlank>Yes</AllowBlank>
+      <DataType>DateTime</DataType>
+      <Prompt>Yes</Prompt>
+    </AxReportParameter>
+  </ReportParameters>
+  <Datasets>
+    <AxReportDataset>
+      <Name>ConFmVehicleParamReportDS</Name>
+      <DataProvider>ConFmVehicleParamReportDP</DataProvider>
+      <QueryType>DataProvider</QueryType>
+      <DynamicFilters>Yes</DynamicFilters>
+    </AxReportDataset>
+    <AxReportDataset>
+      <Name>ConFmVehicleSummaryDS</Name>
+      <DataProvider>ConFmVehicleSummaryDP</DataProvider>
+      <QueryType>DataProvider</QueryType>
+      <DynamicFilters>Yes</DynamicFilters>
+    </AxReportDataset>
+  </Datasets>
+  <Designs>
+    <AxReportDesign>
+      <Name>Report</Name>
+      <Caption>Fleet vehicle parameter report</Caption>
+      <AutoDesignSpecs>
+        <AxReportAutoDesignNode>
+          <Name>AutoDesign</Name>
+          <DataSet>ConFmVehicleParamReportDS</DataSet>
+          <ReportAutoDesignItems>
+            <AxReportAutoDesignDataSet>
+              <Name>AutoDesignDataSet1</Name>
+              <DataSet>ConFmVehicleParamReportDS</DataSet>
+              <AutoFields>Yes</AutoFields>
+            </AxReportAutoDesignDataSet>
+          </ReportAutoDesignItems>
+        </AxReportAutoDesignNode>
+        <AxReportAutoDesignNode>
+          <Name>AutoDesign2</Name>
+          <DataSet>ConFmVehicleSummaryDS</DataSet>
+          <ReportAutoDesignItems>
+            <AxReportAutoDesignDataSet>
+              <Name>AutoDesignDataSet2</Name>
+              <DataSet>ConFmVehicleSummaryDS</DataSet>
+              <AutoFields>Yes</AutoFields>
+            </AxReportAutoDesignDataSet>
+          </ReportAutoDesignItems>
+        </AxReportAutoDesignNode>
+      </AutoDesignSpecs>
+      <ReportDesignItems>
+        <AxReportTablix>
+          <Name>Tablix1</Name>
+          <DataSetName>ConFmVehicleParamReportDS</DataSetName>
+          <TablixBody>
+            <TablixColumns>
+              <TablixColumn>
+                <Width>2in</Width>
+              </TablixColumn>
+              <TablixColumn>
+                <Width>2in</Width>
+              </TablixColumn>
+            </TablixColumns>
+            <TablixRows>
+              <TablixRow>
+                <Height>0.25in</Height>
+                <TablixCells>
+                  <TablixCell>
+                    <CellContents>
+                      <Textbox Name="Tablix1_VIN_Header">
+                        <Value>VIN</Value>
+                        <Style>
+                          <FontWeight>Bold</FontWeight>
+                          <BackgroundColor>#e0e0e0</BackgroundColor>
+                        </Style>
+                      </Textbox>
+                    </CellContents>
+                  </TablixCell>
+                  <TablixCell>
+                    <CellContents>
+                      <Textbox Name="Tablix1_Make_Header">
+                        <Value>Make</Value>
+                        <Style>
+                          <FontWeight>Bold</FontWeight>
+                          <BackgroundColor>#e0e0e0</BackgroundColor>
+                        </Style>
+                      </Textbox>
+                    </CellContents>
+                  </TablixCell>
+                </TablixCells>
+              </TablixRow>
+              <TablixRow>
+                <Height>0.25in</Height>
+                <TablixCells>
+                  <TablixCell>
+                    <CellContents>
+                      <Textbox Name="Tablix1_VIN">
+                        <Value>=Fields!VIN.Value</Value>
+                      </Textbox>
+                    </CellContents>
+                  </TablixCell>
+                  <TablixCell>
+                    <CellContents>
+                      <Textbox Name="Tablix1_Make">
+                        <Value>=Fields!Make.Value</Value>
+                      </Textbox>
+                    </CellContents>
+                  </TablixCell>
+                </TablixCells>
+              </TablixRow>
+            </TablixRows>
+          </TablixBody>
+          <TablixColumnHierarchy>
+            <TablixMembers>
+              <TablixMember />
+              <TablixMember />
+            </TablixMembers>
+          </TablixColumnHierarchy>
+          <TablixRowHierarchy>
+            <TablixMembers>
+              <TablixMember />
+              <TablixMember>
+                <Group Name="Detail" />
+              </TablixMember>
+            </TablixMembers>
+          </TablixRowHierarchy>
+        </AxReportTablix>
+        <AxReportTablix>
+          <Name>Tablix2</Name>
+          <DataSetName>ConFmVehicleSummaryDS</DataSetName>
+          <TablixBody>
+            <TablixColumns />
+            <TablixRows />
+          </TablixBody>
+          <TablixColumnHierarchy>
+            <TablixMembers />
+          </TablixColumnHierarchy>
+          <TablixRowHierarchy>
+            <TablixMembers>
+              <TablixMember>
+                <Group Name="Detail" />
+              </TablixMember>
+            </TablixMembers>
+          </TablixRowHierarchy>
+        </AxReportTablix>
+      </ReportDesignItems>
+    </AxReportDesign>
+  </Designs>
+</AxReport>

--- a/eval/goldens/L1-table-tempdb/ConFmVehicleTmp.xml
+++ b/eval/goldens/L1-table-tempdb/ConFmVehicleTmp.xml
@@ -1,0 +1,76 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<AxTable xmlns:i="http://www.w3.org/2001/XMLSchema-instance">
+  <Name>ConFmVehicleTmp</Name>
+  <Label>Vehicle scratch table</Label>
+  <TableGroup>Miscellaneous</TableGroup>
+  <TableType>TempDB</TableType>
+  <ClusteredIndex>PrimaryIdx</ClusteredIndex>
+  <Fields>
+    <AxTableField i:type="AxTableFieldString">
+      <Name>VIN</Name>
+      <ExtendedDataType>VinEdt</ExtendedDataType>
+      <Mandatory>Yes</Mandatory>
+    </AxTableField>
+    <AxTableField i:type="AxTableFieldString">
+      <Name>ServiceNote</Name>
+      <ExtendedDataType>Notes</ExtendedDataType>
+    </AxTableField>
+  </Fields>
+  <FieldGroups>
+    <AxTableFieldGroup>
+      <Name>AutoReport</Name>
+      <Fields />
+    </AxTableFieldGroup>
+    <AxTableFieldGroup>
+      <Name>AutoLookup</Name>
+      <Fields />
+    </AxTableFieldGroup>
+    <AxTableFieldGroup>
+      <Name>AutoIdentification</Name>
+      <AutoPopulate>Yes</AutoPopulate>
+      <Fields />
+    </AxTableFieldGroup>
+    <AxTableFieldGroup>
+      <Name>AutoSummary</Name>
+      <Fields />
+    </AxTableFieldGroup>
+    <AxTableFieldGroup>
+      <Name>AutoBrowse</Name>
+      <Fields />
+    </AxTableFieldGroup>
+    <AxTableFieldGroup>
+      <Name>Overview</Name>
+      <Fields>
+        <AxTableFieldGroupField>
+          <DataField>VIN</DataField>
+        </AxTableFieldGroupField>
+        <AxTableFieldGroupField>
+          <DataField>ServiceNote</DataField>
+        </AxTableFieldGroupField>
+      </Fields>
+    </AxTableFieldGroup>
+    <AxTableFieldGroup>
+      <Name>General</Name>
+      <Fields>
+        <AxTableFieldGroupField>
+          <DataField>VIN</DataField>
+        </AxTableFieldGroupField>
+        <AxTableFieldGroupField>
+          <DataField>ServiceNote</DataField>
+        </AxTableFieldGroupField>
+      </Fields>
+    </AxTableFieldGroup>
+  </FieldGroups>
+  <Indexes>
+    <AxTableIndex>
+      <Name>PrimaryIdx</Name>
+      <AlternateKey>Yes</AlternateKey>
+      <AllowDuplicates>No</AllowDuplicates>
+      <Fields>
+        <AxTableIndexField>
+          <DataField>VIN</DataField>
+        </AxTableIndexField>
+      </Fields>
+    </AxTableIndex>
+  </Indexes>
+</AxTable>

--- a/eval/goldens/L1-view-computed/ConFmVehicleAgeView.xml
+++ b/eval/goldens/L1-view-computed/ConFmVehicleAgeView.xml
@@ -1,0 +1,73 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<AxView xmlns:i="http://www.w3.org/2001/XMLSchema-instance">
+  <Name>ConFmVehicleAgeView</Name>
+  <SourceCode>
+    <Declaration><![CDATA[
+public class ConFmVehicleAgeView extends common
+{
+}
+]]></Declaration>
+    <Methods>
+      <Method>
+        <Name>computeServiceCount</Name>
+        <Source>/// &lt;summary&gt;
+/// Computed column backing the view field that names this method.
+/// &lt;/summary&gt;
+/// &lt;returns&gt;The SQL expression evaluated when the view is synchronised.&lt;/returns&gt;
+private static server str computeServiceCount()
+{
+    // TODO: replace the placeholder literal with the real expression, e.g.
+    // SysComputedColumn::returnField(tableStr(MyView), identifierStr(MyDataSource), fieldStr(MyTable, MyField))
+    return SysComputedColumn::returnLiteral(0);
+}
+</Source>
+      </Method>
+    </Methods>
+  </SourceCode>
+  <Query>ConFmVehicleLineQuery</Query>
+  <FieldGroups>
+    <AxTableFieldGroup>
+      <Name>AutoReport</Name>
+      <Fields />
+    </AxTableFieldGroup>
+    <AxTableFieldGroup>
+      <Name>AutoLookup</Name>
+      <Fields />
+    </AxTableFieldGroup>
+    <AxTableFieldGroup>
+      <Name>AutoIdentification</Name>
+      <AutoPopulate>Yes</AutoPopulate>
+      <Fields />
+    </AxTableFieldGroup>
+    <AxTableFieldGroup>
+      <Name>AutoSummary</Name>
+      <Fields />
+    </AxTableFieldGroup>
+    <AxTableFieldGroup>
+      <Name>AutoBrowse</Name>
+      <Fields />
+    </AxTableFieldGroup>
+  </FieldGroups>
+  <Fields>
+    <AxViewField i:type="AxViewFieldBound">
+      <Name>VIN</Name>
+      <DataField>VIN</DataField>
+      <DataSource>FmVehicle</DataSource>
+    </AxViewField>
+    <AxViewField i:type="AxViewFieldComputedInt">
+      <Name>ServiceCount</Name>
+      <ViewMethod>computeServiceCount</ViewMethod>
+    </AxViewField>
+  </Fields>
+  <Indexes />
+  <Mappings />
+  <Relations />
+  <StateMachines />
+  <ViewMetadata>
+    <Name>Metadata</Name>
+    <SourceCode>
+      <Methods />
+    </SourceCode>
+    <DataSources />
+  </ViewMetadata>
+</AxView>

--- a/eval/goldens/L2-security-duty-extension/ConFmVehicleMaintainDuty.Extension.xml
+++ b/eval/goldens/L2-security-duty-extension/ConFmVehicleMaintainDuty.Extension.xml
@@ -1,0 +1,10 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<AxSecurityDutyExtension>
+  <Name>ConFmVehicleMaintainDuty.Extension</Name>
+  <Privileges>
+    <AxSecurityPrivilegeReference>
+      <Name>ConFmVehicleMaintainPriv</Name>
+    </AxSecurityPrivilegeReference>
+  </Privileges>
+  <PropertyModifications />
+</AxSecurityDutyExtension>

--- a/eval/goldens/L2-security-role-extension/ConFmVehicleOperatorRole.Extension.xml
+++ b/eval/goldens/L2-security-role-extension/ConFmVehicleOperatorRole.Extension.xml
@@ -1,0 +1,12 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<AxSecurityRoleExtension>
+  <Name>ConFmVehicleOperatorRole.Extension</Name>
+  <DirectAccessPermissions />
+  <Duties />
+  <Privileges>
+    <AxSecurityPrivilegeReference>
+      <Name>ConFmVehicleMaintainPriv</Name>
+    </AxSecurityPrivilegeReference>
+  </Privileges>
+  <PropertyModifications />
+</AxSecurityRoleExtension>

--- a/src/D365FO.Cli/Commands/Generate/GenerateCommands.cs
+++ b/src/D365FO.Cli/Commands/Generate/GenerateCommands.cs
@@ -337,6 +337,20 @@ public sealed class GenerateTableCommand : Command<GenerateTableCommand.Settings
         var tableTypeStr = storage == TableStorage.RegularTable ? null : storage.ToString();
         var usedDefaults = fields2.Count == 0 && pattern != TablePattern.None;
 
+        // Without --pattern the scaffold deliberately emits no <TableGroup>, so the
+        // AOT default (Miscellaneous) applies and nothing is flipped by accident.
+        // The consequence is not obvious though: this tool's own `validate xpp`
+        // raises XML003 on that very table. Say so here rather than letting the
+        // caller discover it one command later.
+        var warnings = new List<string>();
+        if (pattern == TablePattern.None)
+        {
+            warnings.Add(
+                "No --pattern given, so no <TableGroup> is emitted and the AOT default (Miscellaneous) applies. " +
+                "`d365fo validate xpp` reports XML003 for that. Pass --pattern (main|transaction|parameter|group|" +
+                "worksheet-header|worksheet-line|reference|framework|miscellaneous) to stamp the table's business role.");
+        }
+
         // Prefer the live metadata provider for --install-to (canonical output,
         // consistent with VS / d365fo-mcp-server); fall back to the scaffold.
         return GenerateInstaller.Emit(
@@ -358,6 +372,7 @@ public sealed class GenerateTableCommand : Command<GenerateTableCommand.Settings
                 usedPatternDefaults = usedDefaults,
                 model = settings.InstallTo,
             },
+            warnings.Count > 0 ? warnings : null,
             verify: settings.Verify);
     }
 

--- a/src/D365FO.Core/Scaffolding/FormPatternTemplates.cs
+++ b/src/D365FO.Core/Scaffolding/FormPatternTemplates.cs
@@ -187,7 +187,13 @@ public static class FormPatternTemplates
                   new FormSectionSpec("TabPageGeneral", "General"),
                   new FormSectionSpec("TabPageSetup",   "Setup"),
               };
-        var pages = string.Concat(sections.Select(s => RenderTocTabPage(s, indent: 8)));
+        // Requested fields land on the FIRST tab page — its FieldsFieldGroups
+        // sub-pattern allows input controls directly. Rendering them on every
+        // page would bind the same field twice. Dropping them (what this did
+        // before) silently discarded --field while the command still reported
+        // fieldCount = N.
+        var pages = string.Concat(sections.Select((s, i) =>
+            RenderTocTabPage(s, i == 0 ? opt.GridFields : Array.Empty<string>(), opt.DsName, indent: 8)));
 
         var (dsName, dsTable) = (opt.DsName, opt.DsTable);
         var dsXml = !string.IsNullOrEmpty(dsName) && !string.IsNullOrEmpty(dsTable)
@@ -238,7 +244,19 @@ public static class FormPatternTemplates
     public static string BuildWorkspace(FormTemplateOptions opt)
     {
         var (dsName, dsTable) = ResolveDs(opt);
-        var sections = string.Concat(opt.Sections.Select((s, i) => RenderWorkspaceListSection(s, i, dsName, indent: 10)));
+
+        // A workspace with requested fields but no --section used to render the
+        // Summary tiles only, silently dropping every --field. Give those fields
+        // a home: one implicit list section named after the datasource, matching
+        // what a real panorama workspace does (Summary + one list per subject).
+        var specs = opt.Sections.Count > 0
+            ? opt.Sections
+            : opt.GridFields.Count > 0
+                ? new[] { new FormSectionSpec(dsName, dsName) }
+                : Array.Empty<FormSectionSpec>();
+
+        var sections = string.Concat(specs.Select((s, i) =>
+            RenderWorkspaceListSection(s, i, dsName, opt.GridFields, indent: 10)));
         return Fill("Workspace.template.xml", new()
         {
             ["FormName"]      = opt.FormName,
@@ -333,23 +351,8 @@ public static class FormPatternTemplates
         return sb.ToString();
     }
 
-    private static string RenderTabPage(FormSectionSpec s, int indent)
-    {
-        var pad = new string(' ', indent);
-        var sb = new StringBuilder();
-        sb.Append(pad).Append("<AxFormControl xmlns=\"\" i:type=\"AxFormTabPageControl\">\n");
-        sb.Append(pad).Append("  <Name>").Append(s.Name).Append("</Name>\n");
-        sb.Append(pad).Append("  <Pattern>FieldsFieldGroups</Pattern>\n");
-        sb.Append(pad).Append("  <PatternVersion>1.1</PatternVersion>\n");
-        sb.Append(pad).Append("  <Type>TabPage</Type>\n");
-        sb.Append(pad).Append("  <Caption>").Append(s.Caption).Append("</Caption>\n");
-        sb.Append(pad).Append("  <FormControlExtension i:nil=\"true\" />\n");
-        sb.Append(pad).Append("  <Controls />\n");
-        sb.Append(pad).Append("</AxFormControl>\n");
-        return sb.ToString();
-    }
-
-    private static string RenderTocTabPage(FormSectionSpec s, int indent)
+    private static string RenderTocTabPage(
+        FormSectionSpec s, IReadOnlyList<string> fields, string? ds, int indent)
     {
         var pad = new string(' ', indent);
         var sb = new StringBuilder();
@@ -361,12 +364,22 @@ public static class FormPatternTemplates
         sb.Append(pad).Append("  <Caption>").Append(s.Caption).Append("</Caption>\n");
         sb.Append(pad).Append("  <FrameType>None</FrameType>\n");
         sb.Append(pad).Append("  <FormControlExtension i:nil=\"true\" />\n");
-        sb.Append(pad).Append("  <Controls />\n");
+        if (fields.Count == 0)
+        {
+            sb.Append(pad).Append("  <Controls />\n");
+        }
+        else
+        {
+            sb.Append(pad).Append("  <Controls>\n");
+            foreach (var f in fields) sb.Append(RenderDialogField(f, ds, indent + 4));
+            sb.Append(pad).Append("  </Controls>\n");
+        }
         sb.Append(pad).Append("</AxFormControl>\n");
         return sb.ToString();
     }
 
-    private static string RenderWorkspaceListSection(FormSectionSpec s, int idx, string dsName, int indent)
+    private static string RenderWorkspaceListSection(
+        FormSectionSpec s, int idx, string dsName, IReadOnlyList<string> fields, int indent)
     {
         // ElementPosition follows MCP's heuristic: 536870912 * (idx + 2)
         var pos = 536870912L * (idx + 2);
@@ -414,7 +427,19 @@ public static class FormPatternTemplates
         sb.Append(pad).Append("      <Type>Grid</Type>\n");
         sb.Append(pad).Append("      <WidthMode>SizeToAvailable</WidthMode>\n");
         sb.Append(pad).Append("      <FormControlExtension i:nil=\"true\" />\n");
-        sb.Append(pad).Append("      <Controls />\n");
+        // The section's grid is where --field belongs; leaving it empty dropped
+        // the caller's fields while the command still reported fieldCount = N.
+        if (fields.Count == 0)
+        {
+            sb.Append(pad).Append("      <Controls />\n");
+        }
+        else
+        {
+            sb.Append(pad).Append("      <Controls>\n");
+            foreach (var f in fields)
+                sb.Append(RenderGridFieldControl($"{s.Name}Grid", f, dsName, indent + 8));
+            sb.Append(pad).Append("      </Controls>\n");
+        }
         sb.Append(pad).Append("      <DataSource>").Append(dsName).Append("</DataSource>\n");
         sb.Append(pad).Append("      <ShowRowLabels>No</ShowRowLabels>\n");
         sb.Append(pad).Append("      <Style>Tabular</Style>\n");

--- a/src/D365FO.Core/Scaffolding/ViewScaffolder.cs
+++ b/src/D365FO.Core/Scaffolding/ViewScaffolder.cs
@@ -75,10 +75,26 @@ public static class ViewScaffolder
 
         // <SourceCode> holds the view's own class declaration; the AOT stamps every
         // view with one extending `common`, even when it has no methods.
+        //
+        // Every computed field points <ViewMethod> at a method that must exist on
+        // this very class — a view whose ViewMethod resolves to nothing does not
+        // compile. Emitting the field without its method produced XML that looked
+        // complete and could never build, so each computed field gets a stub the
+        // developer then fills in.
+        var methodEls = fieldList
+            .Where(f => f.IsComputed)
+            .Select(f => f.ViewMethod!)
+            .Distinct(StringComparer.Ordinal)
+            .Select(m => new XElement("Method",
+                new XElement("Name", m),
+                new XElement("Source", BuildComputedMethodSource(
+                    m, fieldList.First(f => f.IsComputed && f.ViewMethod == m).ComputedType))))
+            .ToList();
+
         var sourceCode = new XElement("SourceCode",
             new XElement("Declaration",
                 new XCData($"\npublic class {name} extends common\n{{\n}}\n")),
-            new XElement("Methods"));
+            new XElement("Methods", methodEls));
 
         return new XDocument(
             new XElement("AxView",
@@ -144,6 +160,36 @@ public static class ViewScaffolder
             new XElement("Name", f.Name),
             new XElement("DataField", f.DataField),
             new XElement("DataSource", f.DataSource));
+    }
+
+    /// <summary>
+    /// Stub body for a computed field's view method. Computed columns are
+    /// evaluated at sync time: the method always returns <c>str</c> — a SQL
+    /// fragment — regardless of the column's own type, which is why the literal
+    /// (not the return type) varies with <paramref name="computedType"/>.
+    /// </summary>
+    private static string BuildComputedMethodSource(string methodName, string? computedType)
+    {
+        var literal = (computedType ?? "String").ToLowerInvariant() switch
+        {
+            "int" or "int64" or "enum" => "0",
+            "real"                     => "0.0",
+            "date"                     => "dateNull()",
+            "utcdatetime"              => "DateTimeUtil::minValue()",
+            _                          => "''",
+        };
+
+        return
+            "/// <summary>\n" +
+            "/// Computed column backing the view field that names this method.\n" +
+            "/// </summary>\n" +
+            "/// <returns>The SQL expression evaluated when the view is synchronised.</returns>\n" +
+            "private static server str " + methodName + "()\n" +
+            "{\n" +
+            "    // TODO: replace the placeholder literal with the real expression, e.g.\n" +
+            "    // SysComputedColumn::returnField(tableStr(MyView), identifierStr(MyDataSource), fieldStr(MyTable, MyField))\n" +
+            $"    return SysComputedColumn::returnLiteral({literal});\n" +
+            "}\n";
     }
 
     private static XElement BuildEmptyFieldGroup(string name, bool autoPopulate = false) =>

--- a/tests/D365FO.Cli.Tests/Eval/EvalListCommandTests.cs
+++ b/tests/D365FO.Cli.Tests/Eval/EvalListCommandTests.cs
@@ -33,8 +33,9 @@ public class EvalListCommandTests
 
         Assert.Equal(0, exit);
         Assert.Contains("\"ok\":true", stdout);
-        Assert.Contains("\"count\":31", stdout);
+        Assert.Contains("\"count\":51", stdout);
         Assert.Contains("L0-edt-basic", stdout);
         Assert.Contains("L2-coc-extension", stdout);
+        Assert.Contains("L1-form-workspace", stdout);
     }
 }

--- a/tests/D365FO.Cli.Tests/FormPatternScaffoldingTests.cs
+++ b/tests/D365FO.Cli.Tests/FormPatternScaffoldingTests.cs
@@ -119,6 +119,80 @@ public class FormPatternScaffoldingTests
         Assert.Contains("<Style>Panorama</Style>", xml);
     }
 
+    /// <summary>
+    /// The generate-form command reports <c>fieldCount = --field count</c> for
+    /// every pattern. TableOfContents and Workspace used to render their
+    /// templates without ever consulting <c>GridFields</c>, so the caller got a
+    /// success payload claiming two fields over XML that bound none — the
+    /// "confident lie" failure mode eval/README.md ranks worst. No pattern may
+    /// silently discard the fields it was handed.
+    /// </summary>
+    [Theory]
+    [MemberData(nameof(AllPatterns))]
+    public void No_pattern_silently_discards_requested_fields(FormPattern pattern)
+    {
+        var xml = XppScaffolder.Form(
+            formName:        "FmFieldSink",
+            dataSourceTable: "FmVehicle",
+            pattern:         pattern,
+            gridFields:      new[] { "VIN", "Make" });
+
+        var bound = XDocument.Parse(xml).Descendants("DataField").Select(e => e.Value).ToList();
+        Assert.Contains("VIN", bound);
+        Assert.Contains("Make", bound);
+    }
+
+    [Fact]
+    public void TableOfContents_binds_requested_fields_on_the_first_tab_page()
+    {
+        var xml = XppScaffolder.Form("FmParameters", "FmVehicle", FormPattern.TableOfContents,
+            gridFields: new[] { "VIN", "Make" });
+
+        // Fields belong to the first page only — binding them on every page would
+        // bind the same field twice.
+        var pages = XDocument.Parse(xml).Descendants("AxFormControl")
+            .Where(c => c.Element("Type")?.Value == "TabPage")
+            .ToList();
+        Assert.Equal(2, pages.Count);
+        Assert.Equal(new[] { "VIN", "Make" }, pages[0].Descendants("DataField").Select(e => e.Value));
+        Assert.Empty(pages[1].Descendants("DataField"));
+    }
+
+    [Fact]
+    public void Workspace_gives_fields_an_implicit_list_section_when_none_requested()
+    {
+        var xml = XppScaffolder.Form("FmWorkspace", "FmVehicle", FormPattern.Workspace,
+            gridFields: new[] { "VIN", "Make" });
+
+        // No --section, but --field was supplied: one implicit list section named
+        // after the datasource carries them, rather than the fields vanishing.
+        Assert.Contains("<Name>FmVehicleSection</Name>", xml);
+        Assert.Contains("<Name>FmVehicleGrid_VIN</Name>", xml);
+        Assert.Contains("<Name>FmVehicleGrid_Make</Name>", xml);
+    }
+
+    [Fact]
+    public void Workspace_binds_fields_into_every_requested_section_grid()
+    {
+        var xml = XppScaffolder.Form("FmWorkspace", "FmVehicle", FormPattern.Workspace,
+            gridFields: new[] { "VIN" },
+            sections: new[]
+            {
+                new FormSectionSpec("OpenOrders", "Open orders"),
+                new FormSectionSpec("BackOrders", "Back orders"),
+            });
+        Assert.Contains("<Name>OpenOrdersGrid_VIN</Name>", xml);
+        Assert.Contains("<Name>BackOrdersGrid_VIN</Name>", xml);
+    }
+
+    [Fact]
+    public void Workspace_without_fields_still_renders_only_the_summary_section()
+    {
+        var xml = XppScaffolder.Form("FmWorkspace", "FmVehicle", FormPattern.Workspace);
+        Assert.Contains("<Name>SummarySection</Name>", xml);
+        Assert.DoesNotContain("<Name>FmVehicleSection</Name>", xml);
+    }
+
     [Fact]
     public void ListPage_locks_datasource_to_read_only()
     {

--- a/tests/D365FO.Cli.Tests/TablePatternScaffoldingTests.cs
+++ b/tests/D365FO.Cli.Tests/TablePatternScaffoldingTests.cs
@@ -64,6 +64,29 @@ public class TablePatternScaffoldingTests
         Assert.Null(doc.Root.Element("TableType"));
     }
 
+    /// <summary>
+    /// Leaving &lt;TableGroup&gt; out is deliberate — the AOT default (Miscellaneous)
+    /// then applies and no default is flipped by accident. But the very same tool's
+    /// `validate xpp` raises XML003 on that table, so `generate table` warns about
+    /// the consequence instead of leaving the caller to hit it one command later.
+    /// This test pins the tension the warning describes: if XML003 ever stops
+    /// firing here, the warning is stale and must go.
+    /// </summary>
+    [Fact]
+    public void Pattern_None_table_trips_the_XML003_rule_the_command_warns_about()
+    {
+        var withoutPattern = XppScaffolder.Table("FmThing", label: "@Fm:Thing").ToString();
+        var violations = D365FO.Core.Validation.XppValidator.Validate(
+            withoutPattern, D365FO.Core.Validation.XppValidator.CodeTypeXmlTable);
+        Assert.Contains(violations, v => v.Rule == "XML003" && v.Severity == "error");
+
+        var withPattern = XppScaffolder.Table("FmThing", label: "@Fm:Thing",
+            pattern: TablePattern.Miscellaneous).ToString();
+        var clean = D365FO.Core.Validation.XppValidator.Validate(
+            withPattern, D365FO.Core.Validation.XppValidator.CodeTypeXmlTable);
+        Assert.DoesNotContain(clean, v => v.Rule == "XML003");
+    }
+
     [Theory]
     [InlineData(TablePattern.Main,            "Main")]
     [InlineData(TablePattern.Transaction,     "Transaction")]

--- a/tests/D365FO.Cli.Tests/ViewMapScaffoldingTests.cs
+++ b/tests/D365FO.Cli.Tests/ViewMapScaffoldingTests.cs
@@ -68,6 +68,73 @@ public class ViewMapScaffoldingTests
         Assert.Null(field.Element("DataSource"));
     }
 
+    /// <summary>
+    /// A computed field's &lt;ViewMethod&gt; must resolve to a method on the view's
+    /// own class. Emitting the field with an empty &lt;Methods /&gt; produced XML that
+    /// looked complete and could never compile — every computed field now brings
+    /// its stub.
+    /// </summary>
+    [Fact]
+    public void View_computed_field_scaffolds_the_view_method_it_names()
+    {
+        var doc = ViewScaffolder.View("V", "Q", new[]
+        {
+            new ViewFieldSpec("Total", ViewMethod: "getTotalSQL", ComputedType: "Real"),
+        });
+
+        var method = doc.Root!.Element("SourceCode")!.Element("Methods")!.Elements("Method").Single();
+        Assert.Equal("getTotalSQL", method.Element("Name")!.Value);
+
+        var src = method.Element("Source")!.Value;
+        // Computed columns always return a SQL fragment (str), whatever the
+        // column's own type — only the placeholder literal follows the type.
+        Assert.Contains("private static server str getTotalSQL()", src);
+        Assert.Contains("SysComputedColumn::returnLiteral(0.0)", src);
+    }
+
+    [Theory]
+    [InlineData("String", "''")]
+    [InlineData("Int", "0")]
+    [InlineData("Int64", "0")]
+    [InlineData("Real", "0.0")]
+    [InlineData("Date", "dateNull()")]
+    [InlineData("UtcDateTime", "DateTimeUtil::minValue()")]
+    [InlineData("Enum", "0")]
+    public void View_computed_stub_literal_matches_the_column_type(string computedType, string literal)
+    {
+        var doc = ViewScaffolder.View("V", "Q", new[]
+        {
+            new ViewFieldSpec("C", ViewMethod: "computeC", ComputedType: computedType),
+        });
+        var src = doc.Root!.Element("SourceCode")!.Element("Methods")!
+            .Elements("Method").Single().Element("Source")!.Value;
+
+        Assert.Contains($"SysComputedColumn::returnLiteral({literal})", src);
+    }
+
+    [Fact]
+    public void View_with_only_bound_fields_scaffolds_no_methods()
+    {
+        var doc = ViewScaffolder.View("V", "Q", new[]
+        {
+            new ViewFieldSpec("AccountNum", DataSource: "CustTable", DataField: "AccountNum"),
+        });
+        Assert.Empty(doc.Root!.Element("SourceCode")!.Element("Methods")!.Elements());
+    }
+
+    [Fact]
+    public void View_computed_fields_sharing_a_view_method_scaffold_it_once()
+    {
+        var doc = ViewScaffolder.View("V", "Q", new[]
+        {
+            new ViewFieldSpec("A", ViewMethod: "shared", ComputedType: "Int"),
+            new ViewFieldSpec("B", ViewMethod: "shared", ComputedType: "Int"),
+        });
+        // Two <Method> elements with the same <Name> is a duplicate-member
+        // compile error, not a harmless repeat.
+        Assert.Single(doc.Root!.Element("SourceCode")!.Element("Methods")!.Elements("Method"));
+    }
+
     [Fact]
     public void View_computed_field_without_a_type_is_rejected()
     {

--- a/tests/D365FO.Core.Tests/Eval/EvalCaseCatalogTests.cs
+++ b/tests/D365FO.Core.Tests/Eval/EvalCaseCatalogTests.cs
@@ -14,7 +14,7 @@ public class EvalCaseCatalogTests
         var (cases, errors) = EvalCaseCatalog.LoadAll(EvalPaths.CasesDir(RepoRoot));
 
         Assert.Empty(errors);
-        Assert.Equal(31, cases.Count);
+        Assert.Equal(51, cases.Count);
         Assert.Contains(cases, c => c.Id == "L0-edt-basic");
         Assert.Contains(cases, c => c.Id == "L0-enum-basic");
         Assert.Contains(cases, c => c.Id == "L1-table-basic");
@@ -39,20 +39,27 @@ public class EvalCaseCatalogTests
         }
     }
 
+    /// <summary>
+    /// `requires_fixture_index: true` makes every replay of that case pay for a
+    /// full extract of tests/Samples/MiniAot, so it must be earned: the case has
+    /// to actually name one of the fixture's objects. Asserted as a property
+    /// rather than a hard-coded id list, which went stale the first time the
+    /// catalog grew.
+    /// </summary>
     [Fact]
     public void Only_cases_grounded_against_the_FmVehicle_fixture_require_the_fixture_index()
     {
         var (cases, _) = EvalCaseCatalog.LoadAll(EvalPaths.CasesDir(RepoRoot));
+        string[] fixtureObjects = { "FmVehicleService", "FmVehicleLine", "FmVehicle" };
 
-        var fixtureCases = cases.Where(c => c.RequiresFixtureIndex).Select(c => c.Id).OrderBy(id => id).ToList();
-        Assert.Equal(
-            new[]
-            {
-                "L1-form-basic", "L1-map-basic", "L1-migration-script-basic", "L1-query-basic", "L1-systest-basic",
-                "L1-workflow-basic", "L2-coc-extension", "L2-event-handler-basic", "L2-security-policy-basic",
-                "L2-table-extension", "L2-virtual-entity-basic",
-            },
-            fixtureCases);
+        foreach (var c in cases.Where(c => c.RequiresFixtureIndex))
+        {
+            var args = string.Join(' ', c.CanonicalArgs ?? new List<string>());
+            Assert.True(
+                fixtureObjects.Any(o => args.Contains(o, StringComparison.Ordinal)),
+                $"{c.Id}: requires_fixture_index is true but its canonical_args name no fixture object " +
+                $"({string.Join('/', fixtureObjects)}) — drop the flag or ground the case.");
+        }
     }
 
     [Fact]

--- a/tests/D365FO.Core.Tests/MiniAotEndToEndTests.cs
+++ b/tests/D365FO.Core.Tests/MiniAotEndToEndTests.cs
@@ -79,8 +79,7 @@ public class MiniAotEndToEndTests : IDisposable
         var ex = new MetadataExtractor();
         var batch = ex.ExtractAll(SamplesDir).Single();
 
-        var table = Assert.Single(batch.Tables);
-        Assert.Equal("FmVehicle", table.Name);
+        var table = batch.Tables.Single(t => t.Name == "FmVehicle");
         Assert.Equal(3, table.Fields.Count);
 
         var vin = table.Fields.Single(f => f.Name == "VIN");
@@ -114,9 +113,24 @@ public class MiniAotEndToEndTests : IDisposable
     public void Repository_counts_match_fixture()
     {
         var counts = _repo.CountAll();
-        Assert.Equal(1, counts.Tables);
-        Assert.Equal(3, counts.Fields);
+        // FmVehicle (3 fields) + FmVehicleLine (3 fields). The second table exists
+        // so eval cases can exercise header/lines and join-shaped generators
+        // (query --join, form --pattern DetailsTransaction) against a real
+        // relation instead of a phantom target.
+        Assert.Equal(2, counts.Tables);
+        Assert.Equal(6, counts.Fields);
         Assert.Equal(1, counts.Classes);
+    }
+
+    [Fact]
+    public void ExtractAll_parses_FmVehicleLine_relation_to_FmVehicle()
+    {
+        var ex = new MetadataExtractor();
+        var batch = ex.ExtractAll(SamplesDir).Single();
+
+        var line = batch.Tables.Single(t => t.Name == "FmVehicleLine");
+        var rel = Assert.Single(line.Relations);
+        Assert.Equal("FmVehicle", rel.RelatedTable);
     }
 
     // ─── Repository: GetTableDetails snapshot ──────────────────────────────
@@ -195,8 +209,8 @@ public class MiniAotEndToEndTests : IDisposable
             _repo.ApplyExtract(b);
 
         var counts = _repo.CountAll();
-        Assert.Equal(1, counts.Tables);
-        Assert.Equal(3, counts.Fields);
+        Assert.Equal(2, counts.Tables);
+        Assert.Equal(6, counts.Fields);
         Assert.Equal(1, counts.Classes);
     }
 }

--- a/tests/Samples/MiniAot/TestModel/TestModel/AxTable/FmVehicleLine.xml
+++ b/tests/Samples/MiniAot/TestModel/TestModel/AxTable/FmVehicleLine.xml
@@ -1,0 +1,51 @@
+<AxTable>
+  <Name>FmVehicleLine</Name>
+  <Label>@Fleet:VehicleLine</Label>
+  <Fields>
+    <AxTableField xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:type="AxTableFieldString">
+      <Name>VIN</Name>
+      <ExtendedDataType>VinEdt</ExtendedDataType>
+      <Mandatory>Yes</Mandatory>
+      <StringSize>17</StringSize>
+    </AxTableField>
+    <AxTableField xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:type="AxTableFieldInt">
+      <Name>LineNum</Name>
+    </AxTableField>
+    <AxTableField xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:type="AxTableFieldString">
+      <Name>ServiceNote</Name>
+      <ExtendedDataType>Notes</ExtendedDataType>
+    </AxTableField>
+  </Fields>
+  <FullTextIndexes />
+  <Indexes>
+    <AxTableIndex>
+      <Name>LineIdx</Name>
+      <AlternateKey>Yes</AlternateKey>
+      <Fields>
+        <AxTableIndexField>
+          <DataField>VIN</DataField>
+        </AxTableIndexField>
+        <AxTableIndexField>
+          <DataField>LineNum</DataField>
+        </AxTableIndexField>
+      </Fields>
+    </AxTableIndex>
+  </Indexes>
+  <Relations>
+    <AxTableRelation>
+      <Name>FmVehicle</Name>
+      <Cardinality>ZeroMore</Cardinality>
+      <RelatedTable>FmVehicle</RelatedTable>
+      <RelatedTableCardinality>ExactlyOne</RelatedTableCardinality>
+      <RelationshipType>Association</RelationshipType>
+      <Constraints>
+        <AxTableRelationConstraint xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:type="AxTableRelationConstraintField">
+          <Name>VIN</Name>
+          <Field>VIN</Field>
+          <RelatedField>VIN</RelatedField>
+        </AxTableRelationConstraint>
+      </Constraints>
+    </AxTableRelation>
+  </Relations>
+  <StateMachines />
+</AxTable>


### PR DESCRIPTION
## What

Grows the eval catalog from **31 to 51 cases**. The remaining gap was never whole subcommands — batch 2 closed those — but the **option axes that select a different code path** inside one. Three of those axes turned out to be broken, not merely untested.

## Defects found and fixed

**1. `form --pattern TableOfContents` / `--pattern Workspace` silently discarded `--field`.**
Both templates rendered without ever reading `GridFields`, while the command reported `fieldCount: 2`. TOC now binds the requested fields on its first tab page (whose `FieldsFieldGroups` sub-pattern allows input controls directly — binding them on every page would bind the same field twice). Workspace binds them into each section's grid, and when `--section` was not passed but `--field` was, it gets one implicit list section named after the datasource rather than dropping them. A theory over **all nine patterns** now asserts no pattern can discard the fields it was handed.

**2. `view --computed` produced a view that cannot compile.**
The field's `<ViewMethod>` pointed at a method the scaffolder never emitted. Each computed field now brings a stub — `private static server str …` returning `SysComputedColumn::returnLiteral(<literal for the column type>)`. Computed columns always return a SQL fragment (`str`) whatever the column's own type, so only the placeholder literal varies. Fields sharing one view method get a single stub, not a duplicate-member error.

**3. `generate table` without `--pattern` said nothing about XML003.**
Omitting `<TableGroup>` is deliberate (the AOT default then applies, and no default is flipped by accident) — but this tool's own `validate xpp` raises XML003 on exactly that table. The XML is unchanged; the command now names the consequence up front instead of letting the caller discover it one command later. A test pins both sides of the tension, so the warning cannot go stale silently.

## New coverage

All nine `form --pattern` templates · `extension SecurityDuty`/`SecurityRole` · `edt --extends` · `enum --non-extensible` · `table --table-type TempDB` · `query --join` · `view --computed` · `report --parameter`/`--extra-dataset` · `privilege --data-entity` · `menu-item --kind Action`/`Output` · `map --map-to` over two tables.

Every golden was generated by the CLI and reviewed before capture — none hand-authored. Axes that only vary a literal (another `--label`, one more `--field`) are deliberately *not* separate cases: they exercise no new branch.

## Fixture

`tests/Samples/MiniAot` gains a second table, `FmVehicleLine`, related to `FmVehicle`. Joins and header/lines forms could not be grounded against a single-table fixture without pointing at phantom targets. `MiniAotEndToEndTests` updated for the new counts, plus a relation assertion.

`EvalCaseCatalogTests`' fixture-index check moves from a hard-coded id list to the property it was really asserting — a case may only set `requires_fixture_index` if its `canonical_args` name a fixture object. The list had gone stale the first time the catalog grew.

## Result

51/51 cases match their golden. The 4 with `referencesClean: false` all carry `known-reference-gap` — a system object a minimal offline index cannot hold (`SysComputedColumn` for the new one). Full suite green (845 tests on this branch).

## Note on ordering

Independent of #147 — no shared files. Either can merge first.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WvH3MvWaiYapWVsrhjXDez
