### PR TITLE
docs: audit of D365FO/X++ knowledge & generation validity, with implementation plan

### DIFF
--- a/docs/KNOWLEDGE_AUDIT.md
+++ b/docs/KNOWLEDGE_AUDIT.md
@@ -1,0 +1,249 @@
+# Knowledge & Generation Audit — D365FO / X++ competency and MetadataProvider-valid object generation
+
+Date: 2026-08-05. Scope: complete audit of (a) the D365FO/X++ knowledge embedded in this
+repository (skills, knowledge base, agent guidance), (b) the object-generation surface and its
+validity guarantees against the Microsoft MetadataProvider library, and (c) the eval loop that
+keeps both honest. A companion implementation plan derived from this audit lives in
+[`KNOWLEDGE_AUDIT_PLAN.md`](KNOWLEDGE_AUDIT_PLAN.md).
+
+---
+
+## 1. Executive summary
+
+The solution's two load-bearing competencies — deep D365FO/X++ knowledge and the ability to
+generate AOT objects that are valid against `Microsoft.Dynamics.AX.Metadata` — are real but
+uneven:
+
+- **Knowledge** is single-sourced (19 topics in `skills/_source/`, CI-guarded fan-out to
+  Copilot/Anthropic/CLI variants, embedded into `D365FO.Core` as the `knowledge` command corpus).
+  However the *rule canon* is triplicated by hand (skill bundle, `agent-prompt`, MCP tool
+  descriptions) with no drift check, the corpus is command-heavy and X++-snippet-light
+  (21 `xpp` blocks total), and the emitted Anthropic skills are not wired into this repo's own
+  `.claude/`.
+- **Generation** covers 29 CLI subcommands and ~27 artifact families, but validity against the
+  MetadataProvider is only *proven* for the subset that reaches the Windows bridge
+  (`generate --install-to` / `--verify`): 16 kinds in `MetadataBootstrap.KindToCollection`.
+  Reports, workflows, menu items, all security types, services and number sequences are written
+  as raw `XDocument` output with no round-trip proof. Four divergent type registries exist; one
+  known divergence bug ships today (workflow `AxWorkflow` vs. `AxWorkflowType`).
+- **Validation** is strongest for forms (FP001–FP010 + repairer + 37-pattern catalog) and tables
+  (XML001–XML005), and absent for every other XML family. The X++ validator is regex-based BP
+  linting plus index-backed reference proving — there is no parser and no in-process compiler;
+  compile truth arrives only post-hoc via `xppc` log parsing.
+- **Eval loop** is healthy at L0–L2 (31 cases, 31 goldens, 39 committed runs) but has no CI gate,
+  no L3/L4 tier, `classification` is null on every corpus record, and the corpus schema
+  contradicts reality about gitignoring.
+- **The predecessor `d365fo-mcp-server`** contains battle-tested material this repo has not yet
+  absorbed — see §7.
+
+The single highest-leverage theme: **make bridge round-trip (deserialize → provider save → read
+back) the definition of "valid", extend it to every generated family, and backfill offline
+validators from what the round-trip teaches.**
+
+---
+
+## 2. Knowledge assets — findings
+
+### 2.1 What exists (strong)
+
+| Asset | Location | State |
+|---|---|---|
+| Single-source topic corpus | `skills/_source/*.md` — 19 topics, 2,639 lines | ✅ single fact, one place |
+| Emission pipeline | `scripts/emit-skills.py` / `.ps1`; CI job `skills` enforces zero drift | ✅ |
+| Copilot variant | `skills/copilot/*.instructions.md` (19) + `Install-D365FoCopilotSkills.ps1` | ✅ deployable |
+| Anthropic variant | `skills/anthropic/*/SKILL.md` (19) | ⚠️ emitted, no installer, not wired locally |
+| CLI skill bundle | `skills/d365fo-cli/SKILL.md` + `references/*.md` | ✅ umbrella canon, 200 lines |
+| Embedded knowledge base | topics embedded as resources; `Knowledge/KnowledgeBase.cs` (section-aware search); `d365fo knowledge list|get|search`; MCP `get_knowledge` | ✅ |
+| Agent system prompt | `Commands/Agent/AgentPromptCommand.cs` (413 lines): prepare→generate→validate loop, 13 X++ rules, select grammar, CoC rules, 8 workflow templates | ✅ rich |
+| Compiler-error knowledge | `Validation/XppcFixHints.cs` — 11 weighted rules, each back-pointing to a knowledge topic | ✅ |
+| Eval agents/commands | `.claude/agents/eval-{runner,improver,author}.md` + `.claude/commands/` | ✅ |
+
+### 2.2 Gaps
+
+- **K1 — Triplicated rule canon, no drift check.** `AgentPromptCommand.cs`,
+  `skills/d365fo-cli/SKILL.md`, and `D365FO.Mcp/ToolCatalog.cs` descriptions each restate the
+  X++/workflow rules independently. CI guards only `skills/_source` → emitted variants.
+- **K2 — Anthropic skills not consumable.** No installer for `skills/anthropic/`; no
+  `.claude/skills/` in this repo; a Claude session here gets eval agents but zero D365FO
+  knowledge unless it manually reads `skills/_source`.
+- **K3 — Corpus is command-heavy, X++-light.** 57 `sh` blocks vs 21 `xpp` blocks; only 5
+  `[learn:*]` Microsoft Learn anchors. Topics teach *how to drive the CLI* more than *how to
+  write correct X++/metadata* — thin exactly where generation is weakest (reports, security,
+  entities, workflow).
+- **K4 — No knowledge-feedback loop.** `AGENT_EVAL_LOOP.md` §12 plans MODEL_ERROR →
+  `skills/_source` feedback tooling; unbuilt. Corpus `classification` is null on all 39 runs, so
+  KNOWLEDGE_GAP clusters can't be ranked.
+- **K5 — Frontmatter inconsistency.** `skills/_source/object-extension-authoring.md` lacks
+  `appliesWhen` in-source while its emitted variant carries one.
+- **K6 — Stale counts.** README claims 26 generate subcommands; `CliApp.cs` registers 29.
+
+---
+
+## 3. Generation surface — findings
+
+### 3.1 Coverage matrix (condensed)
+
+Full detail per type in §3 of the exploration record; condensed status:
+
+| Family | Generate | Bridge install/verify | MCP `generate_object` | Dedicated validator | Unit tests |
+|---|---|---|---|---|---|
+| Table, Class, CoC, EDT, Enum | ✅ | ✅ | ✅ | XML001–005 / COC / writer guards | ✅ strong |
+| Form (9 patterns) + DS/control methods | ✅ | ✅ | ✅ | FP001–FP010 + repairer | ✅ strong |
+| Query, View, Map | ✅ | ✅ | partial | writer guards only | ✅ |
+| Data entity | ✅ shallow | ✅ | ❌ | ❌ | 3 tests |
+| Report (AxReport+DP+Contract) | ✅ shallow | ❌ | ❌ | ❌ | **0 tests** |
+| Menu item | ✅ minimal | ❌ | ❌ | ❌ | via snapshots |
+| Security (priv/duty/role/policy) | ✅ asymmetric | ❌ | policy XML-only | ❌ | partial |
+| Workflow | ✅ **wrong folder** | ❌ | ❌ | ❌ | **0 tests** |
+| Custom service, business event, sysoperation, runbase, systest, migration, numberseq | ✅ | classes only | partial XML-only | ❌ | mixed; numberseq/migration **0** |
+| Extensions (Table/Form/Edt/Enum/Duty/Role) | ✅ | partial | ❌ | ❌ | 8 tests |
+| Labels | ✅ | ❌ | ✅ | key sanitizer | ✅ |
+
+Not generatable at all: `AxMenu`, `AxTile`, `AxWorkspace` (AOT object), `AxConfigurationKey`,
+composite/aggregate data entities, `AxKPI`, `AxPerspective`, `AxResource`,
+`AxDataEntityViewExtension`/`AxViewExtension`/`AxQueryExtension` (known to modify layers but not
+to `generate extension`), `AxLabelFile` manifest.
+
+### 3.2 Validity against MetadataProvider — how it actually works
+
+- No compile-time reference to `Microsoft.Dynamics.AX.*` anywhere; the net48
+  `D365FO.Bridge` late-binds the assemblies from `D365FO_BIN_PATH` via reflection
+  (`MetadataBootstrap.cs`), tolerating PU drift (3 factory fallbacks, 2 config ctor shapes).
+- The only true "MetadataProvider validity" check is `Handlers.WriteArtifact`:
+  `XmlSerializer(Ax*Type).Deserialize(xml)` + provider `Create/Update`, plus
+  `BridgeGate.TryVerifyObject` read-back after `generate --verify`.
+- The bridge has **no `validate*` RPC** — Microsoft's own validation surface is never invoked.
+- Off-bridge (macOS/Linux/CI), "validity" degrades to `ScaffoldFileWriter` guards
+  (abstract-root, `xmlns:i`, CLR-bool) + per-family offline validators where they exist.
+
+### 3.3 Defects and structural risks
+
+- **G1 — Workflow folder/type bug.** `GenerateWorkflowCommand.cs:77` installs to `AxWorkflow`,
+  scaffolder emits `<AxWorkflow>`, but the real AOT folder/type is `AxWorkflowType`
+  (`MetadataExtractor.cs:231` reads only the latter) → generated workflows are invisible to the
+  index and wrong for the compiler.
+- **G2 — Four divergent type registries.** Bridge `KindToCollection`/`KindToTypeName` (16),
+  ~30 hard-coded subfolder literals in `Commands/Generate/*`, `ObjectLookup` (15 read kinds),
+  `MetadataExtractor` (30 folders). No single source of truth; G1 is the first visible casualty.
+- **G3 — Bridge kind set ⊂ generate set.** Report, workflow, menu item, security*, service,
+  label manifest never reach the provider, so their XML is never proven deserializable.
+- **G4 — Grounding gate applied to only 3 of 29 generate commands** (coc, extension,
+  event-handler). The anti-hallucination token from `prepare` is optional everywhere else.
+- **G5 — Form pattern silent fallback.** `FormPatternNormalizer.Normalize` maps any unknown
+  `--pattern` (incl. catalog-known but non-generatable ones like `Wizard`, `FormPart*`) to
+  `SimpleList` instead of erroring.
+- **G6 — MCP surface lags CLI.** `generate_object` accepts 11 of ~27 types; no
+  `validate_xpp`/`resolve_references` tool over MCP; view/map/entity/report/security/menu-item
+  not exposed.
+- **G7 — SSRS depth.** No RDL/precision design, tablix-only, no chart/matrix, no bridge, no
+  tests. AxReport XML shape is plausible but unproven.
+- **G8 — prepare is type-blind.** `StrategiesFor()` has bespoke advice only for
+  table/class/form/map; advertised kind lists differ between `prepare change` (10) and
+  `prepare create` (13) and are unenforced.
+- **G9 — XML BP rules are AxTable-only** (XML001–005). No structural rules for form (beyond FP),
+  EDT, enum, entity, report, query, view, map, security.
+
+---
+
+## 4. Validation & compiler integration — findings
+
+- Offline: `XppValidator` (SEL/COC/BP/XML rules, regex-based), `ReferenceResolver`
+  (index-backed identifier proving, 7 violation kinds), `FormPatternValidator`+`Repairer`,
+  `ObjectNamingRules`, `lint` (16 index-wide categories, SARIF).
+- Data-driven rules (XML002–005) mine `PropertyStats` from the customer's own AOT with a 0.8
+  threshold — a good pattern worth extending to more properties/families.
+- Compiler: no in-process parser/compiler; `XppcDiagnostics` parses `xppc` logs post-hoc,
+  `XppcFixHints` maps messages → hint + knowledge topic; `build`/`bp check`/`test run`/`sync`
+  shell out on the VM.
+- Enforcement: `FormPatternGate` on by default; `GroundingGate` opt-in via env and only on 3
+  commands; eval `EvalScorer` re-runs XppValidator+ReferenceResolver against goldens.
+
+## 5. Eval loop — findings
+
+- 31 cases (L0: 2, L1: 18, L2: 11), 31 reviewed goldens, schema-checked by `EvalCaseCatalog`;
+  39 committed corpus runs, 37 replay / 2 agent.
+- Open items: no `eval` job in CI; `classification` null everywhere → `eval clusters` idle;
+  corpus schema says runs are gitignored but they are tracked; one stale corpus record predates
+  the XML001 table-extension fix at HEAD; no L3 (build/xppc oracle) or L4 (runtime/SysTest) tier;
+  fixture AOT (`tests/Samples/MiniAot`) contains only one table + one class, limiting
+  reference-resolution realism.
+
+---
+
+## 6. Test coverage — findings
+
+~500 test attributes across 55 files; strong on scaffolding snapshots (84), table patterns (71),
+form patterns (42+25+25), XppValidator (30), ReferenceResolver (28). **Zero dedicated tests** for
+report, workflow, number-sequence, migration-script generators and `entity --all-fields` — the
+exact families that also lack bridge proof and validators (compounding risk: three nets missing
+at once).
+
+---
+
+## 7. Reuse from `d365fo-mcp-server` (the debugged predecessor)
+
+Audited at `dynamics365ninja/d365fo-mcp-server` v1.8.0 (TypeScript MCP server, 26 unified tools,
+195 Vitest files, net48 C# bridge over `IMetadataProvider`, 80-case L0–L4 eval harness). It is
+substantially *ahead* of this repo in several of the exact areas §3 flags as weak. Absorbable
+assets, in value order:
+
+- **R1 — Curated X++ knowledge base (63 entries).** `src/tools/xppKnowledge.ts` (3,400+ lines):
+  structured `{id, keywords, summary, ax2012→d365fo migration, rules, examples, related}`
+  entries covering ~44 domains this repo's 19 topics do not (posting engine, financial
+  dimensions, SSRS reports, print management, dual-write, DMF, warehouse, ER, SysDa, OCC,
+  caching, datetime/timezones, .NET interop, table inheritance, …). Plus
+  `d365foErrorHelp.ts` — a pattern-matched compiler/runtime error catalog with fix code.
+  Critically, the predecessor *audits* its knowledge: `apiSymbols.test.ts` +
+  `exampleValidation.test.ts` prove that symbols named in entries exist and examples pass the BP
+  validator — and its own `eval/README.md:179` explicitly flags that this repo's skill files
+  have never had that treatment.
+- **R2 — AOT XML serializer-quirk knowledge.** `src/utils/axTablePropertyOrder.ts`: the AxTable
+  deserializer **silently drops misordered property elements** (file looks right, validators
+  pass, xppbp later fails with `BPErrorTableTitleField1NotDeclared`). Canonical property order
+  captured from a VM-built golden, plus `AX_TABLE_NON_EXISTENT_PROPERTIES` (plausible-but-fake
+  property names with corrective messages), enforced as rules **XML006/XML007** — both absent
+  from this repo's `XppValidator`.
+- **R3 — SSRS report stack.** `generateSmartReport.ts` (64 KB): one call emits TmpTable
+  (TempDB) + Contract + DP + Controller + Output menu item + AxReport **including CDATA-embedded
+  RDL 2016** with page-header injection and grouped-tablix/subtotals support; carries two
+  regression-locked EDT-resolution bugs (`:1337`, `:1387`). This is exactly what §3.3-G7 lacks.
+- **R4 — Bridge/MetadataProvider workarounds.** `bridge/D365MetadataBridge/` (9.8 kLOC):
+  `Main()` JIT-loading trap (assembly resolve must be installed before any D365FO type is
+  referenced); relations must be written *through the provider* to get serializer element order
+  (`MetadataWriteService.cs:2262`); top-level form datasource must be `AxFormDataSourceRoot`
+  (`:1138`); `AxQuery`→`AxQuerySimple` abstract-type mapping; table extensions have two relation
+  collections; `ResolveModelSaveInfo` for real model Id/SequenceId; **writes never retried**
+  (may already have applied), reads retried after health-checked respawn;
+  `bridgeValidateAfterWrite` re-read after every write. Also the documented split: 13 types go
+  through `IMetadataProvider` (`BRIDGE_CREATE_TYPES`), the rest through purpose-built XML
+  writers because the provider's property channel can't express them — a rationale this repo's
+  bridge/scaffolder split should mirror deliberately instead of accidentally.
+- **R5 — Form engine extras.** Catalog-as-data with `xmlAliases`, `referenceForms`,
+  `lifecycleGuidance`, per-pattern method stubs; `formCloner.ts` (clone a Microsoft reference
+  form and re-bind datasources, string-level by design — XML round-trips corrupt AOT files);
+  `fieldControlTypes.ts` (control type from the field's real `i:type`, not EDT-name
+  heuristics); mined-usage cross-check (`crossCheck.ts`) that reports catalog gaps after every
+  index build; the `<DataGroup>` ⇒ sibling `<DataSource>` trap (full build fails, incremental
+  passes).
+- **R6 — Guardrail mechanics.** HMAC-signed grounding tokens (stateless verification for a
+  write-only companion); property-honesty reconciliation (`createTablePropertyHonesty.ts` —
+  requested vs. actually-written diff, catching the silent-drop defect class); per-`.rnrproj`
+  mutex; agentic-loop detection; dispatch-parity tests between duplicated dispatchers.
+- **R7 — Eval maturity.** 80 cases L0–L4 (vs. 31 L0–L2 here), runtime SysTest oracle,
+  golden re-compilation via xppc one-case-at-a-time (`verify-goldens-build.ts`, 57/65 green),
+  coverage taxonomy (78 leaves) defining done as **K ∧ E ∧ T** (knowledge teaches ∧ eval proves
+  ∧ tool builds), CI-gated; improver toolchain (`eval:clusters/report/knowledge/flakes/mine`).
+- **Caveat:** ~25 source comments cite `docs/eval-sweep-findings-2026-07-21.md` (findings
+  #1–#38) which is absent from the repo; recovering it would unlock the reasoning behind the
+  regression locks.
+
+---
+
+## 8. Risk ranking (what bites first)
+
+1. **G1** workflow bug — ships wrong artifacts today.
+2. **G2/G3** registry divergence + unproven families — silent invalid XML for
+   reports/security/workflow/menu items, the exact types the user calls out (SSRS aj.).
+3. **Eval not in CI** — regressions in either competency land unnoticed.
+4. **K1/K4** — knowledge drift and no feedback loop erode the "deep knowledge" claim over time.
+5. **G5/G4** — silent fallbacks defeat the guardrail design.

--- a/docs/KNOWLEDGE_AUDIT_PLAN.md
+++ b/docs/KNOWLEDGE_AUDIT_PLAN.md
@@ -1,0 +1,162 @@
+# Implementation plan — closing the knowledge & generation gaps
+
+Derived from [`KNOWLEDGE_AUDIT.md`](KNOWLEDGE_AUDIT.md) (findings K1–K6, G1–G9, R1–R7).
+Ordering principle: fix shipping defects first, then make "valid against MetadataProvider"
+provable for every family, then deepen generation where the audit found it shallow, then close
+the knowledge and eval loops so the level holds. Each phase is independently shippable and ends
+with a verification gate.
+
+---
+
+## Phase 0 — Ship-blocking fixes (small, immediate)
+
+| # | Item | Findings | Where |
+|---|---|---|---|
+| 0.1 | Fix workflow type: emit `<AxWorkflowType>`, install to `AxWorkflowType`, update eval golden `L1-workflow-basic` | G1 | `Scaffolding/WorkflowScaffolder.cs`, `Commands/Generate/GenerateWorkflowCommand.cs` |
+| 0.2 | `FormPatternNormalizer`: unknown or non-generatable `--pattern` → error listing generatable + catalog-only patterns (no silent `SimpleList` fallback) | G5 | `Core/Scaffolding/FormPattern.cs` normalizer + `GenerateCommands.cs` |
+| 0.3 | Corpus hygiene: align `eval/corpus/schema.json` prose with reality (runs are committed), re-run the stale `L2-table-extension` record against HEAD, fix the `L1-form-basic` golden caption (`@Fleet:Vehicle`) | audit §5 | `eval/corpus/`, `eval/goldens/` |
+| 0.4 | Doc/frontmatter drift: README generate-count (26→29), add `appliesWhen` to `skills/_source/object-extension-authoring.md` | K5, K6 | `README.md`, `skills/_source/` |
+
+**Gate:** `dotnet test` green; `d365fo eval run --all` replay green; workflow object now visible
+to `index build` over a fixture containing it.
+
+## Phase 1 — Single type registry + provable validity (the core)
+
+1.1 **Unified object-type registry.** One table in `D365FO.Core` (e.g.
+`Core/ObjectTypes/ObjectTypeRegistry.cs`): kind → Ax root element, concrete MetaModel type name,
+AOT subfolder, bridge collection name, abstract-root/i:type policy, MCP exposure flag, naming
+rule id. Consume it from `MetadataBootstrap.KindToCollection/KindToTypeName`,
+`GenerateInstaller` call sites (drop the ~30 subfolder literals), `ObjectLookup`,
+`MetadataExtractor` folder list, `ToolCatalog` objectType enum, `ObjectNamingRules`. Add a
+parity test asserting the registry covers every `generate` subcommand and every extractor
+folder (prevents the next G1). Mirrors the predecessor's dispatch-parity tests (R6).
+
+1.2 **Extend the bridge to all generated families.** Add registry-driven kinds for
+`AxReport`, `AxWorkflowType`, `AxMenuItem{Display,Action,Output}`, `AxSecurity{Role,Duty,
+Privilege,Policy}`, `AxService`, `AxServiceGroup`, `AxDataEntityView` extensions, so
+`generate --install-to/--verify` round-trips them through `IMetadataProvider`. Port bridge
+workarounds from R4 as they become relevant: abstract-type mapping table
+(`AxQuery→AxQuerySimple` style), `AxFormDataSourceRoot` rule, provider-side relation writes,
+never-retry-writes policy, read-back after every write (`bridgeValidateAfterWrite` equivalent —
+promote `BridgeGate.TryVerifyObject` from opt-in flag to default when the bridge is up).
+
+1.3 **Serializer-order knowledge (R2).** Port `axTablePropertyOrder` + non-existent-property
+catalog as `XML006` (misordered property will be silently dropped) and `XML007`
+(plausible-but-nonexistent property) in `XppValidator`; apply canonical ordering in
+`XppScaffolder.Table` and `TablePattern`. Extend the same treatment to other families where
+goldens reveal order sensitivity.
+
+1.4 **Deserialization self-check without Windows.** Add an eval/CI-side structural check per
+family: root element + `xsi:type` policy + property-order lint driven by the registry, so
+non-Windows CI approximates what `Handlers.WriteArtifact` would reject. (True provider
+round-trip stays a VM-only L3 gate — Phase 4.)
+
+**Gate:** parity test green; on a VM, `generate <each family> --install-to --verify` returns
+`Readable` for every kind in the registry.
+
+## Phase 2 — Generation depth where the audit found it shallow
+
+2.1 **SSRS reports (G7, R3).** Port `generateSmartReport` semantics into a
+`ReportStackScaffolder`: one command emits TmpTable (TempDB) + Contract + DP + Controller +
+Output menu item + AxReport **with embedded RDL 2016** (page header injection, SimpleList +
+GroupedWithTotals designs, grouped tablix with subtotals). Reuse the shared EDT-resolution path
+(regression R3 shows resolver and emitted `i:type` must come from one computation). Unit tests
++ new eval case `L2-report-stack`.
+
+2.2 **Menu items, security, entities, extensions.**
+- Menu item: add `EnumTypeParameter`, `Parameters`, `ConfigurationKey`, `NeededPermission`,
+  `LinkedPermissionObject`, `Query`.
+- Security: privilege entry-point shapes are OK; deepen duty/role beyond reference lists,
+  give `AxSecurityPolicy` its `PolicyGroup`/`Constrained*` collections, make
+  `Security{Duty,Role}Extension` emit real `PropertyModifications` payloads.
+- Data entity: keys, `EntityCategory`, `PrimaryCompanyContext`, relations, computed columns,
+  optional staging-table emission; support `AxDataEntityViewExtension`.
+- `generate extension`: add `view`/`query`/`dataEntityView` kinds already known to
+  `ObjectModifyEngine.ExtensionKindFor`.
+
+2.3 **Guardrails uniformly applied (G4).** Move `GroundingGate` invocation into the shared
+`GenerateInstaller` path so all 29 commands honor `D365FO_GROUNDING_ENFORCE`; port
+property-honesty reconciliation (R6) into `ScaffoldFileWriter`/bridge writes (requested vs.
+written diff in the result envelope).
+
+2.4 **MCP parity (G6).** Widen `generate_object` from 11 to the full registry (registry-driven
+enum), add `validate` tool exposing `xpp` + `references` + `form-pattern` modes over MCP.
+
+2.5 **prepare type-awareness (G8).** Drive `StrategiesFor` and advertised kind lists from the
+registry; add bespoke strategies for report/entity/security (the new depth areas).
+
+**Gate:** new unit tests per family (kill the zero-test list: report, workflow,
+number-sequence, migration-script, `entity --all-fields`); eval cases added for each deepened
+family; MCP schema snapshot test.
+
+## Phase 3 — Knowledge: absorb, single-source, audit
+
+3.1 **Port the 63-entry knowledge base (R1).** Convert `xppKnowledge.ts` entries into
+`skills/_source/` topics (grouped: ~10–14 new topic files, e.g. `ssrs-report-authoring`,
+`security-modeling`, `posting-and-financials`, `integration-dmf-dualwrite`,
+`performance-and-caching`, `runtime-frameworks`), preserving the
+`{summary, migration, rules, examples}` structure. Extend `emit-skills.py` if new frontmatter
+fields are needed. Port `d365foErrorHelp.ts` patterns into `XppcFixHints` rules + a knowledge
+topic each.
+
+3.2 **Knowledge audit harness (R1).** Add xUnit equivalents of `apiSymbols` +
+`exampleValidation`: every API symbol named in `skills/_source` must exist in the fixture/std
+index or an allowlist; every ```xpp example must pass `XppValidator` + `ReferenceResolver`.
+CI-gate it. (The predecessor explicitly flags this repo as un-audited.)
+
+3.3 **Single-source the rule canon (K1).** Generate the rule sections of
+`AgentPromptCommand` output and the long MCP tool descriptions from `skills/_source` (new
+emit target in `emit-skills.py`, embedded as resources like the knowledge corpus). CI drift
+check covers all three consumers.
+
+3.4 **Wire skills for consumption (K2).** Add an installer for the `skills/anthropic/`
+variant (mirror `Install-D365FoCopilotSkills.ps1`), and reference the emitted skills from this
+repo's own `.claude/` so sessions here load the D365FO knowledge.
+
+**Gate:** `d365fo knowledge search` hits the new domains; knowledge-audit CI job green; drift
+job covers agent-prompt + MCP descriptions.
+
+## Phase 4 — Eval loop to predecessor parity (R7)
+
+4.1 **CI gate:** add `eval` job running replay cases (`requires_fixture_index` subset) on every
+PR; fail on golden mismatch or validator regressions.
+
+4.2 **L3 build oracle:** VM-side `verify-goldens-build` equivalent — recompile every golden via
+`xppc` one case at a time, persist `eval/golden-build-verification.json`; wire
+`XppcDiagnostics` results back into corpus records.
+
+4.3 **L4 runtime oracle:** SysTest-backed cases via existing `test run` shell-out, fixtures
+provisioned per run in a throwaway model.
+
+4.4 **Classification & clusters:** populate `classification`
+(TOOL_DEFECT/VALIDATOR_GAP/KNOWLEDGE_GAP/MODEL_ERROR) on new runs, make `eval clusters` rank
+them, and implement the MODEL_ERROR → `skills/_source` feedback path (K4) so knowledge gaps
+found in evals become topic edits with provenance.
+
+4.5 **Coverage taxonomy:** port the K ∧ E ∧ T model (knowledge teaches ∧ eval proves ∧ tool
+builds) into a generated `eval/COVERAGE.md` with a `--check` CI mode; grow the fixture AOT
+beyond one table + one class so reference resolution in evals is realistic.
+
+**Gate:** CI red on any eval regression; coverage report shows per-family K/E/T status;
+clusters command returns ranked, classified clusters.
+
+---
+
+## Sequencing & dependencies
+
+- Phase 0 is independent; land first.
+- 1.1 (registry) unblocks 1.2, 2.2, 2.4, 2.5 — do it before any Phase 2 item.
+- 3.1/3.2 are independent of Phases 1–2 and can run in parallel.
+- 4.1 should land as soon as Phase 0 stabilizes goldens; 4.2/4.3 need VM access; 4.4/4.5 close
+  the loop last.
+
+## Verification (end-to-end)
+
+1. `dotnet build && dotnet test` — all suites incl. new parity, knowledge-audit, per-family
+   scaffolder tests.
+2. `d365fo eval run --all` replay green locally and in the new CI job.
+3. On a Windows VM with `D365FO_BRIDGE_ENABLED`: `generate <family> --install-to <model>
+   --verify` returns `Readable` for every registry kind; `build --msbuild` on a model containing
+   one generated object of each family compiles clean; `bp check` reports no new BP errors.
+4. MCP smoke: `generate_object` accepts every registry kind; `validate` tool returns the same
+   verdicts as the CLI.


### PR DESCRIPTION
## What

Adds two documents, no code changes:

- **`docs/KNOWLEDGE_AUDIT.md`** (249 lines) — a complete audit of the two load-bearing competencies: the D365FO/X++ knowledge embedded in this repo (skills, knowledge base, agent guidance), and the object-generation surface with its validity guarantees against `Microsoft.Dynamics.AX.Metadata`. Findings are numbered so they can be cited: **K1–K6** (knowledge), **G1–G9** (generation), **R1–R7** (reusable assets from the predecessor).
- **`docs/KNOWLEDGE_AUDIT_PLAN.md`** (162 lines) — a phased implementation plan derived from those findings, each phase independently shippable and ending in a verification gate.

## Why

The audit was cross-referenced against `dynamics365ninja/d365fo-mcp-server` v1.8.0, the battle-tested predecessor, which is measurably ahead in several of the exact areas this repo is weakest (SSRS stack, serializer-quirk knowledge, bridge workarounds, eval maturity at L0–L4 vs. L0–L2 here).

## Headline findings

- **G1** — `generate workflow` installs to `AxWorkflow`, but the real AOT folder/type is `AxWorkflowType`, so generated workflows are invisible to `index build` and wrong for the compiler. **Ships today.**
- **G2/G3** — four divergent type registries, and the bridge kind set is a strict subset of the generate set: reports, workflows, menu items, all security types, services and number sequences never reach `IMetadataProvider`, so their XML is never proven deserializable.
- **Eval not in CI** — regressions in either competency land unnoticed.
- **K1/K4** — the rule canon is triplicated by hand (skill bundle, `agent-prompt`, MCP tool descriptions) with no drift check, and there is no knowledge-feedback loop.

The single highest-leverage theme: make bridge round-trip (deserialize → provider save → read back) the definition of "valid", extend it to every generated family, and backfill offline validators from what the round-trip teaches.

## Plan shape

**Phase 0** ship-blocking fixes (workflow type, silent form-pattern fallback, corpus hygiene) → **Phase 1** unified object-type registry + provable validity → **Phase 2** generation depth where it's shallow (SSRS, security, entities, MCP parity) → **Phase 3** knowledge absorption and auditing → **Phase 4** eval loop to predecessor parity.

Phase 1.1 (the registry) unblocks most of Phase 2 and should land before any of it.

## Reviewer note

Documentation only — nothing to build or test. The value is whether the findings and their ranking match your read of the codebase; the plan is a proposal, not a commitment.

🤖 Generated with [Claude Code](https://claude.com/claude-code)