### PR TITLE
feat: object-type registry + provider-verified metadata (knowledge-audit Phase 1.1 + 1.2)

### DIFF
--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -45,6 +45,16 @@ Single file at `$D365FO_INDEX_DB` (default `%LOCALAPPDATA%\d365fo-cli\d365fo-ind
 
 ### AOT object type coverage
 
+Type facts live in one table — [`src/D365FO.Core/ObjectTypes/ObjectTypeRegistry.cs`](../src/D365FO.Core/ObjectTypes/ObjectTypeRegistry.cs):
+root element, AOT folder, MetaModel type, `IMetadataProvider` collection, `i:type`/abstract-root
+policy, and which `generate` subcommand and MCP objectType expose it. The extractor, the index
+model-detection heuristic, the scaffold writer's write guards, the generate commands' install
+paths and the net48 bridge's kind tables all read it (the bridge shared-compiles the same file,
+since it cannot reference the net10 Core). Folder names are ground-truthed against a full
+`PackagesLocalDirectory` census, and `ObjectTypeRegistryAotTests` re-checks them whenever
+`D365FO_PACKAGES_PATH` points at a real AOS — the check that would have caught the
+`AxWorkflowType` folder that never existed.
+
 | AOT Type | Directory | Notes |
 |----------|-----------|-------|
 | Table | `AxTable` | Fields, indexes, relations, delete actions, CacheLookup, OCC, ValidTimeState |

--- a/docs/KNOWLEDGE_AUDIT.md
+++ b/docs/KNOWLEDGE_AUDIT.md
@@ -135,6 +135,12 @@ to `generate extension`), `AxLabelFile` manifest.
 - **G2 — Four divergent type registries.** Bridge `KindToCollection`/`KindToTypeName` (16),
   ~30 hard-coded subfolder literals in `Commands/Generate/*`, `ObjectLookup` (15 read kinds),
   `MetadataExtractor` (30 folders). No single source of truth; G1 is the first visible casualty.
+  Fixed 2026-08-05 in Phase 1.1: `Core/ObjectTypes/ObjectTypeRegistry.cs` is the single table,
+  shared-compiled into the net48 bridge. Consolidating it surfaced three more phantom folders
+  (`AxWorkspace`, `AxReportSsrs`, `AxQuerySimple` — read by the extractor, present on no AOS)
+  and one shipping defect: `generate query` emitted a bare `<AxQuery>`, but `AxQuery` is an
+  abstract MetaModel base and every shipped file is `<AxQuery i:type="AxQuerySimple">`, so the
+  metadata reader would reject every generated query.
 - **G3 — Bridge kind set ⊂ generate set.** Report, workflow, menu item, security*, service,
   label manifest never reach the provider, so their XML is never proven deserializable.
 - **G4 — Grounding gate applied to only 3 of 29 generate commands** (coc, extension,

--- a/docs/KNOWLEDGE_AUDIT_PLAN.md
+++ b/docs/KNOWLEDGE_AUDIT_PLAN.md
@@ -22,14 +22,19 @@ to `index build` over a fixture containing it.
 
 ## Phase 1 — Single type registry + provable validity (the core)
 
-1.1 **Unified object-type registry.** One table in `D365FO.Core` (e.g.
-`Core/ObjectTypes/ObjectTypeRegistry.cs`): kind → Ax root element, concrete MetaModel type name,
-AOT subfolder, bridge collection name, abstract-root/i:type policy, MCP exposure flag, naming
-rule id. Consume it from `MetadataBootstrap.KindToCollection/KindToTypeName`,
-`GenerateInstaller` call sites (drop the ~30 subfolder literals), `ObjectLookup`,
-`MetadataExtractor` folder list, `ToolCatalog` objectType enum, `ObjectNamingRules`. Add a
-parity test asserting the registry covers every `generate` subcommand and every extractor
-folder (prevents the next G1). Mirrors the predecessor's dispatch-parity tests (R6).
+1.1 ✅ **Unified object-type registry** — `Core/ObjectTypes/ObjectTypeRegistry.cs`: kind → root
+element, AOT subfolder, MetaModel type, provider collection, abstract-root/`i:type` policy,
+generate subcommand, MCP objectType, naming kind, plus an `ExistsInStandardAot` flag. Consumed by
+`MetadataBootstrap.KindToCollection/KindToTypeName` (the net48 bridge shared-compiles the file
+rather than referencing net10 Core), the `GenerateInstaller` call sites (subfolder literals →
+`ObjectTypeRegistry.Folders.*` constants, so a typo is a build error), `ScaffoldFileWriter`'s
+xsi/abstract-root guards, `MetadataExtractor` + `index refresh` folder lists, and
+`ObjectLookup.NormalizeKind`. Parity tests cover kind/root uniqueness, the folder constants, the
+bridge's 16 kinds, and — when `D365FO_PACKAGES_PATH` points at an AOS — every folder name against
+a live census. `ToolCatalog`'s objectType enum stays with 2.4, which widens it.
+Fallout found and fixed: three phantom folders the extractor read (`AxWorkspace`,
+`AxReportSsrs`, `AxQuerySimple`), and `generate query` emitting a bare abstract `<AxQuery>` root
+without `i:type="AxQuerySimple"`.
 
 1.2 **Extend the bridge to all generated families.** Add registry-driven kinds for
 `AxReport`, `AxWorkflowTemplate`, `AxMenuItem{Display,Action,Output}`, `AxSecurity{Role,Duty,

--- a/eval/corpus/runs/20260805T182424564Z__L0-edt-basic__71ed3598708344d2bb2132d063085dd7.json
+++ b/eval/corpus/runs/20260805T182424564Z__L0-edt-basic__71ed3598708344d2bb2132d063085dd7.json
@@ -1,0 +1,21 @@
+{
+  "runId": "20260805T182424564Z__L0-edt-basic__71ed3598708344d2bb2132d063085dd7",
+  "caseId": "L0-edt-basic",
+  "tier": 0,
+  "timestampUtc": "2026-08-05T18:24:24.5658271+00:00",
+  "source": "replay",
+  "score": {
+    "xppClean": true,
+    "xppErrors": 0,
+    "referencesClean": true,
+    "referenceErrors": 0,
+    "goldenMatch": true,
+    "goldenDiff": {
+      "missing": [],
+      "extra": [],
+      "changed": [],
+      "isMatch": true
+    }
+  },
+  "note": "Phase 1.1: ObjectTypeRegistry; AxQuery abstract-root fix"
+}

--- a/eval/corpus/runs/20260805T182425158Z__L0-edt-extends__bddac5d308534fe6b1f1bb2c9e366461.json
+++ b/eval/corpus/runs/20260805T182425158Z__L0-edt-extends__bddac5d308534fe6b1f1bb2c9e366461.json
@@ -1,0 +1,21 @@
+{
+  "runId": "20260805T182425158Z__L0-edt-extends__bddac5d308534fe6b1f1bb2c9e366461",
+  "caseId": "L0-edt-extends",
+  "tier": 0,
+  "timestampUtc": "2026-08-05T18:24:25.1585293+00:00",
+  "source": "replay",
+  "score": {
+    "xppClean": true,
+    "xppErrors": 0,
+    "referencesClean": true,
+    "referenceErrors": 0,
+    "goldenMatch": true,
+    "goldenDiff": {
+      "missing": [],
+      "extra": [],
+      "changed": [],
+      "isMatch": true
+    }
+  },
+  "note": "Phase 1.1: ObjectTypeRegistry; AxQuery abstract-root fix"
+}

--- a/eval/corpus/runs/20260805T182425786Z__L0-enum-basic__d68f83e65d474a7a8a95bbfaba4020aa.json
+++ b/eval/corpus/runs/20260805T182425786Z__L0-enum-basic__d68f83e65d474a7a8a95bbfaba4020aa.json
@@ -1,0 +1,21 @@
+{
+  "runId": "20260805T182425786Z__L0-enum-basic__d68f83e65d474a7a8a95bbfaba4020aa",
+  "caseId": "L0-enum-basic",
+  "tier": 0,
+  "timestampUtc": "2026-08-05T18:24:25.7867204+00:00",
+  "source": "replay",
+  "score": {
+    "xppClean": true,
+    "xppErrors": 0,
+    "referencesClean": true,
+    "referenceErrors": 0,
+    "goldenMatch": true,
+    "goldenDiff": {
+      "missing": [],
+      "extra": [],
+      "changed": [],
+      "isMatch": true
+    }
+  },
+  "note": "Phase 1.1: ObjectTypeRegistry; AxQuery abstract-root fix"
+}

--- a/eval/corpus/runs/20260805T182426362Z__L0-enum-non-extensible__12ed5763d8dd4dec8a537c8e0f528fac.json
+++ b/eval/corpus/runs/20260805T182426362Z__L0-enum-non-extensible__12ed5763d8dd4dec8a537c8e0f528fac.json
@@ -1,0 +1,21 @@
+{
+  "runId": "20260805T182426362Z__L0-enum-non-extensible__12ed5763d8dd4dec8a537c8e0f528fac",
+  "caseId": "L0-enum-non-extensible",
+  "tier": 0,
+  "timestampUtc": "2026-08-05T18:24:26.3625041+00:00",
+  "source": "replay",
+  "score": {
+    "xppClean": true,
+    "xppErrors": 0,
+    "referencesClean": true,
+    "referenceErrors": 0,
+    "goldenMatch": true,
+    "goldenDiff": {
+      "missing": [],
+      "extra": [],
+      "changed": [],
+      "isMatch": true
+    }
+  },
+  "note": "Phase 1.1: ObjectTypeRegistry; AxQuery abstract-root fix"
+}

--- a/eval/corpus/runs/20260805T182426960Z__L1-business-event-basic__3dcfadcfbc20425d87aa16799abf9a46.json
+++ b/eval/corpus/runs/20260805T182426960Z__L1-business-event-basic__3dcfadcfbc20425d87aa16799abf9a46.json
@@ -1,0 +1,21 @@
+{
+  "runId": "20260805T182426960Z__L1-business-event-basic__3dcfadcfbc20425d87aa16799abf9a46",
+  "caseId": "L1-business-event-basic",
+  "tier": 1,
+  "timestampUtc": "2026-08-05T18:24:26.9607889+00:00",
+  "source": "replay",
+  "score": {
+    "xppClean": true,
+    "xppErrors": 0,
+    "referencesClean": false,
+    "referenceErrors": 1,
+    "goldenMatch": true,
+    "goldenDiff": {
+      "missing": [],
+      "extra": [],
+      "changed": [],
+      "isMatch": true
+    }
+  },
+  "note": "Phase 1.1: ObjectTypeRegistry; AxQuery abstract-root fix"
+}

--- a/eval/corpus/runs/20260805T182427524Z__L1-class-basic__97a76f2e9c494924934c89a5522cb912.json
+++ b/eval/corpus/runs/20260805T182427524Z__L1-class-basic__97a76f2e9c494924934c89a5522cb912.json
@@ -1,0 +1,21 @@
+{
+  "runId": "20260805T182427524Z__L1-class-basic__97a76f2e9c494924934c89a5522cb912",
+  "caseId": "L1-class-basic",
+  "tier": 1,
+  "timestampUtc": "2026-08-05T18:24:27.5247153+00:00",
+  "source": "replay",
+  "score": {
+    "xppClean": true,
+    "xppErrors": 0,
+    "referencesClean": true,
+    "referenceErrors": 0,
+    "goldenMatch": true,
+    "goldenDiff": {
+      "missing": [],
+      "extra": [],
+      "changed": [],
+      "isMatch": true
+    }
+  },
+  "note": "Phase 1.1: ObjectTypeRegistry; AxQuery abstract-root fix"
+}

--- a/eval/corpus/runs/20260805T182428111Z__L1-custom-service-basic__0ceb357da4e64c5186fb85fd145bcdfd.json
+++ b/eval/corpus/runs/20260805T182428111Z__L1-custom-service-basic__0ceb357da4e64c5186fb85fd145bcdfd.json
@@ -1,0 +1,21 @@
+{
+  "runId": "20260805T182428111Z__L1-custom-service-basic__0ceb357da4e64c5186fb85fd145bcdfd",
+  "caseId": "L1-custom-service-basic",
+  "tier": 1,
+  "timestampUtc": "2026-08-05T18:24:28.1113793+00:00",
+  "source": "replay",
+  "score": {
+    "xppClean": true,
+    "xppErrors": 0,
+    "referencesClean": true,
+    "referenceErrors": 0,
+    "goldenMatch": true,
+    "goldenDiff": {
+      "missing": [],
+      "extra": [],
+      "changed": [],
+      "isMatch": true
+    }
+  },
+  "note": "Phase 1.1: ObjectTypeRegistry; AxQuery abstract-root fix"
+}

--- a/eval/corpus/runs/20260805T182428684Z__L1-duty-basic__eb373ae03580460fa71f55e91c51e478.json
+++ b/eval/corpus/runs/20260805T182428684Z__L1-duty-basic__eb373ae03580460fa71f55e91c51e478.json
@@ -1,0 +1,21 @@
+{
+  "runId": "20260805T182428684Z__L1-duty-basic__eb373ae03580460fa71f55e91c51e478",
+  "caseId": "L1-duty-basic",
+  "tier": 1,
+  "timestampUtc": "2026-08-05T18:24:28.6845244+00:00",
+  "source": "replay",
+  "score": {
+    "xppClean": true,
+    "xppErrors": 0,
+    "referencesClean": true,
+    "referenceErrors": 0,
+    "goldenMatch": true,
+    "goldenDiff": {
+      "missing": [],
+      "extra": [],
+      "changed": [],
+      "isMatch": true
+    }
+  },
+  "note": "Phase 1.1: ObjectTypeRegistry; AxQuery abstract-root fix"
+}

--- a/eval/corpus/runs/20260805T182429631Z__L1-form-basic__a9a017a0cd124e8abec6f67590728e08.json
+++ b/eval/corpus/runs/20260805T182429631Z__L1-form-basic__a9a017a0cd124e8abec6f67590728e08.json
@@ -1,0 +1,21 @@
+{
+  "runId": "20260805T182429631Z__L1-form-basic__a9a017a0cd124e8abec6f67590728e08",
+  "caseId": "L1-form-basic",
+  "tier": 1,
+  "timestampUtc": "2026-08-05T18:24:29.6313219+00:00",
+  "source": "replay",
+  "score": {
+    "xppClean": true,
+    "xppErrors": 0,
+    "referencesClean": true,
+    "referenceErrors": 0,
+    "goldenMatch": true,
+    "goldenDiff": {
+      "missing": [],
+      "extra": [],
+      "changed": [],
+      "isMatch": true
+    }
+  },
+  "note": "Phase 1.1: ObjectTypeRegistry; AxQuery abstract-root fix"
+}

--- a/eval/corpus/runs/20260805T182430472Z__L1-form-details-master__530b6fc4f40b4f659bfd7ba147df8ad8.json
+++ b/eval/corpus/runs/20260805T182430472Z__L1-form-details-master__530b6fc4f40b4f659bfd7ba147df8ad8.json
@@ -1,0 +1,21 @@
+{
+  "runId": "20260805T182430472Z__L1-form-details-master__530b6fc4f40b4f659bfd7ba147df8ad8",
+  "caseId": "L1-form-details-master",
+  "tier": 1,
+  "timestampUtc": "2026-08-05T18:24:30.4724814+00:00",
+  "source": "replay",
+  "score": {
+    "xppClean": true,
+    "xppErrors": 0,
+    "referencesClean": true,
+    "referenceErrors": 0,
+    "goldenMatch": true,
+    "goldenDiff": {
+      "missing": [],
+      "extra": [],
+      "changed": [],
+      "isMatch": true
+    }
+  },
+  "note": "Phase 1.1: ObjectTypeRegistry; AxQuery abstract-root fix"
+}

--- a/eval/corpus/runs/20260805T182431330Z__L1-form-details-transaction__630396517c1148d2a7683d90f13b860a.json
+++ b/eval/corpus/runs/20260805T182431330Z__L1-form-details-transaction__630396517c1148d2a7683d90f13b860a.json
@@ -1,0 +1,21 @@
+{
+  "runId": "20260805T182431330Z__L1-form-details-transaction__630396517c1148d2a7683d90f13b860a",
+  "caseId": "L1-form-details-transaction",
+  "tier": 1,
+  "timestampUtc": "2026-08-05T18:24:31.3308795+00:00",
+  "source": "replay",
+  "score": {
+    "xppClean": true,
+    "xppErrors": 0,
+    "referencesClean": true,
+    "referenceErrors": 0,
+    "goldenMatch": true,
+    "goldenDiff": {
+      "missing": [],
+      "extra": [],
+      "changed": [],
+      "isMatch": true
+    }
+  },
+  "note": "Phase 1.1: ObjectTypeRegistry; AxQuery abstract-root fix"
+}

--- a/eval/corpus/runs/20260805T182432126Z__L1-form-dialog__fb725477868f4351a85aad5cbbce0f85.json
+++ b/eval/corpus/runs/20260805T182432126Z__L1-form-dialog__fb725477868f4351a85aad5cbbce0f85.json
@@ -1,0 +1,21 @@
+{
+  "runId": "20260805T182432126Z__L1-form-dialog__fb725477868f4351a85aad5cbbce0f85",
+  "caseId": "L1-form-dialog",
+  "tier": 1,
+  "timestampUtc": "2026-08-05T18:24:32.1261638+00:00",
+  "source": "replay",
+  "score": {
+    "xppClean": true,
+    "xppErrors": 0,
+    "referencesClean": true,
+    "referenceErrors": 0,
+    "goldenMatch": true,
+    "goldenDiff": {
+      "missing": [],
+      "extra": [],
+      "changed": [],
+      "isMatch": true
+    }
+  },
+  "note": "Phase 1.1: ObjectTypeRegistry; AxQuery abstract-root fix"
+}

--- a/eval/corpus/runs/20260805T182432956Z__L1-form-list-page__50c1beeb3c524ec5aed5c4f20ed76a1a.json
+++ b/eval/corpus/runs/20260805T182432956Z__L1-form-list-page__50c1beeb3c524ec5aed5c4f20ed76a1a.json
@@ -1,0 +1,21 @@
+{
+  "runId": "20260805T182432956Z__L1-form-list-page__50c1beeb3c524ec5aed5c4f20ed76a1a",
+  "caseId": "L1-form-list-page",
+  "tier": 1,
+  "timestampUtc": "2026-08-05T18:24:32.9567567+00:00",
+  "source": "replay",
+  "score": {
+    "xppClean": true,
+    "xppErrors": 0,
+    "referencesClean": true,
+    "referenceErrors": 0,
+    "goldenMatch": true,
+    "goldenDiff": {
+      "missing": [],
+      "extra": [],
+      "changed": [],
+      "isMatch": true
+    }
+  },
+  "note": "Phase 1.1: ObjectTypeRegistry; AxQuery abstract-root fix"
+}

--- a/eval/corpus/runs/20260805T182433810Z__L1-form-lookup__2bd1cc5a4e4e48bcae3d8e49bf47b2db.json
+++ b/eval/corpus/runs/20260805T182433810Z__L1-form-lookup__2bd1cc5a4e4e48bcae3d8e49bf47b2db.json
@@ -1,0 +1,21 @@
+{
+  "runId": "20260805T182433810Z__L1-form-lookup__2bd1cc5a4e4e48bcae3d8e49bf47b2db",
+  "caseId": "L1-form-lookup",
+  "tier": 1,
+  "timestampUtc": "2026-08-05T18:24:33.8101015+00:00",
+  "source": "replay",
+  "score": {
+    "xppClean": true,
+    "xppErrors": 0,
+    "referencesClean": true,
+    "referenceErrors": 0,
+    "goldenMatch": true,
+    "goldenDiff": {
+      "missing": [],
+      "extra": [],
+      "changed": [],
+      "isMatch": true
+    }
+  },
+  "note": "Phase 1.1: ObjectTypeRegistry; AxQuery abstract-root fix"
+}

--- a/eval/corpus/runs/20260805T182434623Z__L1-form-simplelist-details__0fabf83a3e5d4f58a7b17a0b881e7456.json
+++ b/eval/corpus/runs/20260805T182434623Z__L1-form-simplelist-details__0fabf83a3e5d4f58a7b17a0b881e7456.json
@@ -1,0 +1,21 @@
+{
+  "runId": "20260805T182434623Z__L1-form-simplelist-details__0fabf83a3e5d4f58a7b17a0b881e7456",
+  "caseId": "L1-form-simplelist-details",
+  "tier": 1,
+  "timestampUtc": "2026-08-05T18:24:34.623295+00:00",
+  "source": "replay",
+  "score": {
+    "xppClean": true,
+    "xppErrors": 0,
+    "referencesClean": true,
+    "referenceErrors": 0,
+    "goldenMatch": true,
+    "goldenDiff": {
+      "missing": [],
+      "extra": [],
+      "changed": [],
+      "isMatch": true
+    }
+  },
+  "note": "Phase 1.1: ObjectTypeRegistry; AxQuery abstract-root fix"
+}

--- a/eval/corpus/runs/20260805T182435493Z__L1-form-table-of-contents__1009f2b5ba644c578a82e50dcc6abd7b.json
+++ b/eval/corpus/runs/20260805T182435493Z__L1-form-table-of-contents__1009f2b5ba644c578a82e50dcc6abd7b.json
@@ -1,0 +1,21 @@
+{
+  "runId": "20260805T182435493Z__L1-form-table-of-contents__1009f2b5ba644c578a82e50dcc6abd7b",
+  "caseId": "L1-form-table-of-contents",
+  "tier": 1,
+  "timestampUtc": "2026-08-05T18:24:35.4935825+00:00",
+  "source": "replay",
+  "score": {
+    "xppClean": true,
+    "xppErrors": 0,
+    "referencesClean": true,
+    "referenceErrors": 0,
+    "goldenMatch": true,
+    "goldenDiff": {
+      "missing": [],
+      "extra": [],
+      "changed": [],
+      "isMatch": true
+    }
+  },
+  "note": "Phase 1.1: ObjectTypeRegistry; AxQuery abstract-root fix"
+}

--- a/eval/corpus/runs/20260805T182436345Z__L1-form-workspace__c5a8a25de4844a59866d68dc84f0df2f.json
+++ b/eval/corpus/runs/20260805T182436345Z__L1-form-workspace__c5a8a25de4844a59866d68dc84f0df2f.json
@@ -1,0 +1,21 @@
+{
+  "runId": "20260805T182436345Z__L1-form-workspace__c5a8a25de4844a59866d68dc84f0df2f",
+  "caseId": "L1-form-workspace",
+  "tier": 1,
+  "timestampUtc": "2026-08-05T18:24:36.3452331+00:00",
+  "source": "replay",
+  "score": {
+    "xppClean": true,
+    "xppErrors": 0,
+    "referencesClean": true,
+    "referenceErrors": 0,
+    "goldenMatch": true,
+    "goldenDiff": {
+      "missing": [],
+      "extra": [],
+      "changed": [],
+      "isMatch": true
+    }
+  },
+  "note": "Phase 1.1: ObjectTypeRegistry; AxQuery abstract-root fix"
+}

--- a/eval/corpus/runs/20260805T182437076Z__L1-map-basic__5feea45fe6f94ad5b9a35b1d39b4bc07.json
+++ b/eval/corpus/runs/20260805T182437076Z__L1-map-basic__5feea45fe6f94ad5b9a35b1d39b4bc07.json
@@ -1,0 +1,21 @@
+{
+  "runId": "20260805T182437076Z__L1-map-basic__5feea45fe6f94ad5b9a35b1d39b4bc07",
+  "caseId": "L1-map-basic",
+  "tier": 1,
+  "timestampUtc": "2026-08-05T18:24:37.0770084+00:00",
+  "source": "replay",
+  "score": {
+    "xppClean": true,
+    "xppErrors": 0,
+    "referencesClean": true,
+    "referenceErrors": 0,
+    "goldenMatch": true,
+    "goldenDiff": {
+      "missing": [],
+      "extra": [],
+      "changed": [],
+      "isMatch": true
+    }
+  },
+  "note": "Phase 1.1: ObjectTypeRegistry; AxQuery abstract-root fix"
+}

--- a/eval/corpus/runs/20260805T182437829Z__L1-map-multi-table__09fde7f45a594c798aac3124c739763f.json
+++ b/eval/corpus/runs/20260805T182437829Z__L1-map-multi-table__09fde7f45a594c798aac3124c739763f.json
@@ -1,0 +1,21 @@
+{
+  "runId": "20260805T182437829Z__L1-map-multi-table__09fde7f45a594c798aac3124c739763f",
+  "caseId": "L1-map-multi-table",
+  "tier": 1,
+  "timestampUtc": "2026-08-05T18:24:37.8293866+00:00",
+  "source": "replay",
+  "score": {
+    "xppClean": true,
+    "xppErrors": 0,
+    "referencesClean": true,
+    "referenceErrors": 0,
+    "goldenMatch": true,
+    "goldenDiff": {
+      "missing": [],
+      "extra": [],
+      "changed": [],
+      "isMatch": true
+    }
+  },
+  "note": "Phase 1.1: ObjectTypeRegistry; AxQuery abstract-root fix"
+}

--- a/eval/corpus/runs/20260805T182438461Z__L1-menu-item-action__23c30a2a112041efa2c5b7e381005069.json
+++ b/eval/corpus/runs/20260805T182438461Z__L1-menu-item-action__23c30a2a112041efa2c5b7e381005069.json
@@ -1,0 +1,21 @@
+{
+  "runId": "20260805T182438461Z__L1-menu-item-action__23c30a2a112041efa2c5b7e381005069",
+  "caseId": "L1-menu-item-action",
+  "tier": 1,
+  "timestampUtc": "2026-08-05T18:24:38.4616154+00:00",
+  "source": "replay",
+  "score": {
+    "xppClean": true,
+    "xppErrors": 0,
+    "referencesClean": true,
+    "referenceErrors": 0,
+    "goldenMatch": true,
+    "goldenDiff": {
+      "missing": [],
+      "extra": [],
+      "changed": [],
+      "isMatch": true
+    }
+  },
+  "note": "Phase 1.1: ObjectTypeRegistry; AxQuery abstract-root fix"
+}

--- a/eval/corpus/runs/20260805T182439054Z__L1-menu-item-basic__483e3312bd8b4361add0f962996fff5e.json
+++ b/eval/corpus/runs/20260805T182439054Z__L1-menu-item-basic__483e3312bd8b4361add0f962996fff5e.json
@@ -1,0 +1,21 @@
+{
+  "runId": "20260805T182439054Z__L1-menu-item-basic__483e3312bd8b4361add0f962996fff5e",
+  "caseId": "L1-menu-item-basic",
+  "tier": 1,
+  "timestampUtc": "2026-08-05T18:24:39.0541861+00:00",
+  "source": "replay",
+  "score": {
+    "xppClean": true,
+    "xppErrors": 0,
+    "referencesClean": true,
+    "referenceErrors": 0,
+    "goldenMatch": true,
+    "goldenDiff": {
+      "missing": [],
+      "extra": [],
+      "changed": [],
+      "isMatch": true
+    }
+  },
+  "note": "Phase 1.1: ObjectTypeRegistry; AxQuery abstract-root fix"
+}

--- a/eval/corpus/runs/20260805T182439633Z__L1-menu-item-output__8e90dd761ab84c3093aa7835268b4d32.json
+++ b/eval/corpus/runs/20260805T182439633Z__L1-menu-item-output__8e90dd761ab84c3093aa7835268b4d32.json
@@ -1,0 +1,21 @@
+{
+  "runId": "20260805T182439633Z__L1-menu-item-output__8e90dd761ab84c3093aa7835268b4d32",
+  "caseId": "L1-menu-item-output",
+  "tier": 1,
+  "timestampUtc": "2026-08-05T18:24:39.633788+00:00",
+  "source": "replay",
+  "score": {
+    "xppClean": true,
+    "xppErrors": 0,
+    "referencesClean": true,
+    "referenceErrors": 0,
+    "goldenMatch": true,
+    "goldenDiff": {
+      "missing": [],
+      "extra": [],
+      "changed": [],
+      "isMatch": true
+    }
+  },
+  "note": "Phase 1.1: ObjectTypeRegistry; AxQuery abstract-root fix"
+}

--- a/eval/corpus/runs/20260805T182440330Z__L1-migration-script-basic__f47d1b9d23bf46968aef472f2dd4829f.json
+++ b/eval/corpus/runs/20260805T182440330Z__L1-migration-script-basic__f47d1b9d23bf46968aef472f2dd4829f.json
@@ -1,0 +1,21 @@
+{
+  "runId": "20260805T182440330Z__L1-migration-script-basic__f47d1b9d23bf46968aef472f2dd4829f",
+  "caseId": "L1-migration-script-basic",
+  "tier": 1,
+  "timestampUtc": "2026-08-05T18:24:40.3309353+00:00",
+  "source": "replay",
+  "score": {
+    "xppClean": true,
+    "xppErrors": 0,
+    "referencesClean": true,
+    "referenceErrors": 0,
+    "goldenMatch": true,
+    "goldenDiff": {
+      "missing": [],
+      "extra": [],
+      "changed": [],
+      "isMatch": true
+    }
+  },
+  "note": "Phase 1.1: ObjectTypeRegistry; AxQuery abstract-root fix"
+}

--- a/eval/corpus/runs/20260805T182440873Z__L1-privilege-basic__490944ea4178477995734c42c239a43a.json
+++ b/eval/corpus/runs/20260805T182440873Z__L1-privilege-basic__490944ea4178477995734c42c239a43a.json
@@ -1,0 +1,21 @@
+{
+  "runId": "20260805T182440873Z__L1-privilege-basic__490944ea4178477995734c42c239a43a",
+  "caseId": "L1-privilege-basic",
+  "tier": 1,
+  "timestampUtc": "2026-08-05T18:24:40.8734798+00:00",
+  "source": "replay",
+  "score": {
+    "xppClean": true,
+    "xppErrors": 0,
+    "referencesClean": true,
+    "referenceErrors": 0,
+    "goldenMatch": true,
+    "goldenDiff": {
+      "missing": [],
+      "extra": [],
+      "changed": [],
+      "isMatch": true
+    }
+  },
+  "note": "Phase 1.1: ObjectTypeRegistry; AxQuery abstract-root fix"
+}

--- a/eval/corpus/runs/20260805T182441428Z__L1-privilege-data-entity__2d670eaa3d6f47fe9cfcd28985b6fe89.json
+++ b/eval/corpus/runs/20260805T182441428Z__L1-privilege-data-entity__2d670eaa3d6f47fe9cfcd28985b6fe89.json
@@ -1,0 +1,21 @@
+{
+  "runId": "20260805T182441428Z__L1-privilege-data-entity__2d670eaa3d6f47fe9cfcd28985b6fe89",
+  "caseId": "L1-privilege-data-entity",
+  "tier": 1,
+  "timestampUtc": "2026-08-05T18:24:41.4288033+00:00",
+  "source": "replay",
+  "score": {
+    "xppClean": true,
+    "xppErrors": 0,
+    "referencesClean": true,
+    "referenceErrors": 0,
+    "goldenMatch": true,
+    "goldenDiff": {
+      "missing": [],
+      "extra": [],
+      "changed": [],
+      "isMatch": true
+    }
+  },
+  "note": "Phase 1.1: ObjectTypeRegistry; AxQuery abstract-root fix"
+}

--- a/eval/corpus/runs/20260805T182442053Z__L1-query-basic__fde786745ee04346975650bf13b64c2b.json
+++ b/eval/corpus/runs/20260805T182442053Z__L1-query-basic__fde786745ee04346975650bf13b64c2b.json
@@ -1,0 +1,21 @@
+{
+  "runId": "20260805T182442053Z__L1-query-basic__fde786745ee04346975650bf13b64c2b",
+  "caseId": "L1-query-basic",
+  "tier": 1,
+  "timestampUtc": "2026-08-05T18:24:42.0536598+00:00",
+  "source": "replay",
+  "score": {
+    "xppClean": true,
+    "xppErrors": 0,
+    "referencesClean": true,
+    "referenceErrors": 0,
+    "goldenMatch": true,
+    "goldenDiff": {
+      "missing": [],
+      "extra": [],
+      "changed": [],
+      "isMatch": true
+    }
+  },
+  "note": "Phase 1.1: ObjectTypeRegistry; AxQuery abstract-root fix"
+}

--- a/eval/corpus/runs/20260805T182442671Z__L1-query-join__85247dc7422d4a1982750ec35dbed682.json
+++ b/eval/corpus/runs/20260805T182442671Z__L1-query-join__85247dc7422d4a1982750ec35dbed682.json
@@ -1,0 +1,21 @@
+{
+  "runId": "20260805T182442671Z__L1-query-join__85247dc7422d4a1982750ec35dbed682",
+  "caseId": "L1-query-join",
+  "tier": 1,
+  "timestampUtc": "2026-08-05T18:24:42.6718336+00:00",
+  "source": "replay",
+  "score": {
+    "xppClean": true,
+    "xppErrors": 0,
+    "referencesClean": true,
+    "referenceErrors": 0,
+    "goldenMatch": true,
+    "goldenDiff": {
+      "missing": [],
+      "extra": [],
+      "changed": [],
+      "isMatch": true
+    }
+  },
+  "note": "Phase 1.1: ObjectTypeRegistry; AxQuery abstract-root fix"
+}

--- a/eval/corpus/runs/20260805T182443281Z__L1-report-basic__e596c15e96954b89b75c92860c05cd10.json
+++ b/eval/corpus/runs/20260805T182443281Z__L1-report-basic__e596c15e96954b89b75c92860c05cd10.json
@@ -1,0 +1,21 @@
+{
+  "runId": "20260805T182443281Z__L1-report-basic__e596c15e96954b89b75c92860c05cd10",
+  "caseId": "L1-report-basic",
+  "tier": 1,
+  "timestampUtc": "2026-08-05T18:24:43.2819605+00:00",
+  "source": "replay",
+  "score": {
+    "xppClean": true,
+    "xppErrors": 0,
+    "referencesClean": true,
+    "referenceErrors": 0,
+    "goldenMatch": true,
+    "goldenDiff": {
+      "missing": [],
+      "extra": [],
+      "changed": [],
+      "isMatch": true
+    }
+  },
+  "note": "Phase 1.1: ObjectTypeRegistry; AxQuery abstract-root fix"
+}

--- a/eval/corpus/runs/20260805T182443869Z__L1-report-parameters__6e15ca195c4543a392a31ca7067f382e.json
+++ b/eval/corpus/runs/20260805T182443869Z__L1-report-parameters__6e15ca195c4543a392a31ca7067f382e.json
@@ -1,0 +1,21 @@
+{
+  "runId": "20260805T182443869Z__L1-report-parameters__6e15ca195c4543a392a31ca7067f382e",
+  "caseId": "L1-report-parameters",
+  "tier": 1,
+  "timestampUtc": "2026-08-05T18:24:43.8691415+00:00",
+  "source": "replay",
+  "score": {
+    "xppClean": true,
+    "xppErrors": 0,
+    "referencesClean": true,
+    "referenceErrors": 0,
+    "goldenMatch": true,
+    "goldenDiff": {
+      "missing": [],
+      "extra": [],
+      "changed": [],
+      "isMatch": true
+    }
+  },
+  "note": "Phase 1.1: ObjectTypeRegistry; AxQuery abstract-root fix"
+}

--- a/eval/corpus/runs/20260805T182444488Z__L1-role-basic__4f11707e18fe4671b9ac1b6c16f6dd47.json
+++ b/eval/corpus/runs/20260805T182444488Z__L1-role-basic__4f11707e18fe4671b9ac1b6c16f6dd47.json
@@ -1,0 +1,21 @@
+{
+  "runId": "20260805T182444488Z__L1-role-basic__4f11707e18fe4671b9ac1b6c16f6dd47",
+  "caseId": "L1-role-basic",
+  "tier": 1,
+  "timestampUtc": "2026-08-05T18:24:44.4884248+00:00",
+  "source": "replay",
+  "score": {
+    "xppClean": true,
+    "xppErrors": 0,
+    "referencesClean": true,
+    "referenceErrors": 0,
+    "goldenMatch": true,
+    "goldenDiff": {
+      "missing": [],
+      "extra": [],
+      "changed": [],
+      "isMatch": true
+    }
+  },
+  "note": "Phase 1.1: ObjectTypeRegistry; AxQuery abstract-root fix"
+}

--- a/eval/corpus/runs/20260805T182445071Z__L1-runbase-basic__4cb23a1df41e4434a76c207490aaf96d.json
+++ b/eval/corpus/runs/20260805T182445071Z__L1-runbase-basic__4cb23a1df41e4434a76c207490aaf96d.json
@@ -1,0 +1,21 @@
+{
+  "runId": "20260805T182445071Z__L1-runbase-basic__4cb23a1df41e4434a76c207490aaf96d",
+  "caseId": "L1-runbase-basic",
+  "tier": 1,
+  "timestampUtc": "2026-08-05T18:24:45.0711273+00:00",
+  "source": "replay",
+  "score": {
+    "xppClean": true,
+    "xppErrors": 0,
+    "referencesClean": true,
+    "referenceErrors": 0,
+    "goldenMatch": true,
+    "goldenDiff": {
+      "missing": [],
+      "extra": [],
+      "changed": [],
+      "isMatch": true
+    }
+  },
+  "note": "Phase 1.1: ObjectTypeRegistry; AxQuery abstract-root fix"
+}

--- a/eval/corpus/runs/20260805T182445678Z__L1-sysoperation-basic__cc5a1aba4f87461c9cb7896ce2f12281.json
+++ b/eval/corpus/runs/20260805T182445678Z__L1-sysoperation-basic__cc5a1aba4f87461c9cb7896ce2f12281.json
@@ -1,0 +1,21 @@
+{
+  "runId": "20260805T182445678Z__L1-sysoperation-basic__cc5a1aba4f87461c9cb7896ce2f12281",
+  "caseId": "L1-sysoperation-basic",
+  "tier": 1,
+  "timestampUtc": "2026-08-05T18:24:45.6787085+00:00",
+  "source": "replay",
+  "score": {
+    "xppClean": true,
+    "xppErrors": 0,
+    "referencesClean": false,
+    "referenceErrors": 3,
+    "goldenMatch": true,
+    "goldenDiff": {
+      "missing": [],
+      "extra": [],
+      "changed": [],
+      "isMatch": true
+    }
+  },
+  "note": "Phase 1.1: ObjectTypeRegistry; AxQuery abstract-root fix"
+}

--- a/eval/corpus/runs/20260805T182446448Z__L1-systest-basic__46826753a64244e59713dd935f07e296.json
+++ b/eval/corpus/runs/20260805T182446448Z__L1-systest-basic__46826753a64244e59713dd935f07e296.json
@@ -1,0 +1,21 @@
+{
+  "runId": "20260805T182446448Z__L1-systest-basic__46826753a64244e59713dd935f07e296",
+  "caseId": "L1-systest-basic",
+  "tier": 1,
+  "timestampUtc": "2026-08-05T18:24:46.4487777+00:00",
+  "source": "replay",
+  "score": {
+    "xppClean": true,
+    "xppErrors": 0,
+    "referencesClean": true,
+    "referenceErrors": 0,
+    "goldenMatch": true,
+    "goldenDiff": {
+      "missing": [],
+      "extra": [],
+      "changed": [],
+      "isMatch": true
+    }
+  },
+  "note": "Phase 1.1: ObjectTypeRegistry; AxQuery abstract-root fix"
+}

--- a/eval/corpus/runs/20260805T182447130Z__L1-table-basic__464a2a6d6470495097ccf24c3ec9adf5.json
+++ b/eval/corpus/runs/20260805T182447130Z__L1-table-basic__464a2a6d6470495097ccf24c3ec9adf5.json
@@ -1,0 +1,21 @@
+{
+  "runId": "20260805T182447130Z__L1-table-basic__464a2a6d6470495097ccf24c3ec9adf5",
+  "caseId": "L1-table-basic",
+  "tier": 1,
+  "timestampUtc": "2026-08-05T18:24:47.130388+00:00",
+  "source": "replay",
+  "score": {
+    "xppClean": true,
+    "xppErrors": 0,
+    "referencesClean": true,
+    "referenceErrors": 0,
+    "goldenMatch": true,
+    "goldenDiff": {
+      "missing": [],
+      "extra": [],
+      "changed": [],
+      "isMatch": true
+    }
+  },
+  "note": "Phase 1.1: ObjectTypeRegistry; AxQuery abstract-root fix"
+}

--- a/eval/corpus/runs/20260805T182447787Z__L1-table-tempdb__d15ca619339643db93663797ebca8d84.json
+++ b/eval/corpus/runs/20260805T182447787Z__L1-table-tempdb__d15ca619339643db93663797ebca8d84.json
@@ -1,0 +1,21 @@
+{
+  "runId": "20260805T182447787Z__L1-table-tempdb__d15ca619339643db93663797ebca8d84",
+  "caseId": "L1-table-tempdb",
+  "tier": 1,
+  "timestampUtc": "2026-08-05T18:24:47.7875945+00:00",
+  "source": "replay",
+  "score": {
+    "xppClean": true,
+    "xppErrors": 0,
+    "referencesClean": true,
+    "referenceErrors": 0,
+    "goldenMatch": true,
+    "goldenDiff": {
+      "missing": [],
+      "extra": [],
+      "changed": [],
+      "isMatch": true
+    }
+  },
+  "note": "Phase 1.1: ObjectTypeRegistry; AxQuery abstract-root fix"
+}

--- a/eval/corpus/runs/20260805T182448346Z__L1-view-basic__1185120933d046af80e052d4b3795af2.json
+++ b/eval/corpus/runs/20260805T182448346Z__L1-view-basic__1185120933d046af80e052d4b3795af2.json
@@ -1,0 +1,21 @@
+{
+  "runId": "20260805T182448346Z__L1-view-basic__1185120933d046af80e052d4b3795af2",
+  "caseId": "L1-view-basic",
+  "tier": 1,
+  "timestampUtc": "2026-08-05T18:24:48.3461728+00:00",
+  "source": "replay",
+  "score": {
+    "xppClean": true,
+    "xppErrors": 0,
+    "referencesClean": true,
+    "referenceErrors": 0,
+    "goldenMatch": true,
+    "goldenDiff": {
+      "missing": [],
+      "extra": [],
+      "changed": [],
+      "isMatch": true
+    }
+  },
+  "note": "Phase 1.1: ObjectTypeRegistry; AxQuery abstract-root fix"
+}

--- a/eval/corpus/runs/20260805T182448982Z__L1-view-computed__2dbb313c67634ccb964b258bffc3aa85.json
+++ b/eval/corpus/runs/20260805T182448982Z__L1-view-computed__2dbb313c67634ccb964b258bffc3aa85.json
@@ -1,0 +1,21 @@
+{
+  "runId": "20260805T182448982Z__L1-view-computed__2dbb313c67634ccb964b258bffc3aa85",
+  "caseId": "L1-view-computed",
+  "tier": 1,
+  "timestampUtc": "2026-08-05T18:24:48.9828787+00:00",
+  "source": "replay",
+  "score": {
+    "xppClean": true,
+    "xppErrors": 0,
+    "referencesClean": false,
+    "referenceErrors": 1,
+    "goldenMatch": true,
+    "goldenDiff": {
+      "missing": [],
+      "extra": [],
+      "changed": [],
+      "isMatch": true
+    }
+  },
+  "note": "Phase 1.1: ObjectTypeRegistry; AxQuery abstract-root fix"
+}

--- a/eval/corpus/runs/20260805T182449674Z__L1-workflow-basic__13179ec877bd4b0c9451ca79e25579bd.json
+++ b/eval/corpus/runs/20260805T182449674Z__L1-workflow-basic__13179ec877bd4b0c9451ca79e25579bd.json
@@ -1,0 +1,21 @@
+{
+  "runId": "20260805T182449674Z__L1-workflow-basic__13179ec877bd4b0c9451ca79e25579bd",
+  "caseId": "L1-workflow-basic",
+  "tier": 1,
+  "timestampUtc": "2026-08-05T18:24:49.6746875+00:00",
+  "source": "replay",
+  "score": {
+    "xppClean": true,
+    "xppErrors": 0,
+    "referencesClean": true,
+    "referenceErrors": 0,
+    "goldenMatch": true,
+    "goldenDiff": {
+      "missing": [],
+      "extra": [],
+      "changed": [],
+      "isMatch": true
+    }
+  },
+  "note": "Phase 1.1: ObjectTypeRegistry; AxQuery abstract-root fix"
+}

--- a/eval/corpus/runs/20260805T182450508Z__L2-coc-extension__cdb569f4e8294cdaaf972c5b88bc2bf0.json
+++ b/eval/corpus/runs/20260805T182450508Z__L2-coc-extension__cdb569f4e8294cdaaf972c5b88bc2bf0.json
@@ -1,0 +1,21 @@
+{
+  "runId": "20260805T182450508Z__L2-coc-extension__cdb569f4e8294cdaaf972c5b88bc2bf0",
+  "caseId": "L2-coc-extension",
+  "tier": 2,
+  "timestampUtc": "2026-08-05T18:24:50.5084116+00:00",
+  "source": "replay",
+  "score": {
+    "xppClean": true,
+    "xppErrors": 0,
+    "referencesClean": true,
+    "referenceErrors": 0,
+    "goldenMatch": true,
+    "goldenDiff": {
+      "missing": [],
+      "extra": [],
+      "changed": [],
+      "isMatch": true
+    }
+  },
+  "note": "Phase 1.1: ObjectTypeRegistry; AxQuery abstract-root fix"
+}

--- a/eval/corpus/runs/20260805T182451042Z__L2-control-method-basic__f4dbe44926474e638f5c621349d5fb37.json
+++ b/eval/corpus/runs/20260805T182451042Z__L2-control-method-basic__f4dbe44926474e638f5c621349d5fb37.json
@@ -1,0 +1,21 @@
+{
+  "runId": "20260805T182451042Z__L2-control-method-basic__f4dbe44926474e638f5c621349d5fb37",
+  "caseId": "L2-control-method-basic",
+  "tier": 2,
+  "timestampUtc": "2026-08-05T18:24:51.0427689+00:00",
+  "source": "replay",
+  "score": {
+    "xppClean": true,
+    "xppErrors": 0,
+    "referencesClean": true,
+    "referenceErrors": 0,
+    "goldenMatch": true,
+    "goldenDiff": {
+      "missing": [],
+      "extra": [],
+      "changed": [],
+      "isMatch": true
+    }
+  },
+  "note": "Phase 1.1: ObjectTypeRegistry; AxQuery abstract-root fix"
+}

--- a/eval/corpus/runs/20260805T182451555Z__L2-datasource-method-basic__d3378ce6a4b440cca3178b55013b5e95.json
+++ b/eval/corpus/runs/20260805T182451555Z__L2-datasource-method-basic__d3378ce6a4b440cca3178b55013b5e95.json
@@ -1,0 +1,21 @@
+{
+  "runId": "20260805T182451555Z__L2-datasource-method-basic__d3378ce6a4b440cca3178b55013b5e95",
+  "caseId": "L2-datasource-method-basic",
+  "tier": 2,
+  "timestampUtc": "2026-08-05T18:24:51.5550452+00:00",
+  "source": "replay",
+  "score": {
+    "xppClean": true,
+    "xppErrors": 0,
+    "referencesClean": true,
+    "referenceErrors": 0,
+    "goldenMatch": true,
+    "goldenDiff": {
+      "missing": [],
+      "extra": [],
+      "changed": [],
+      "isMatch": true
+    }
+  },
+  "note": "Phase 1.1: ObjectTypeRegistry; AxQuery abstract-root fix"
+}

--- a/eval/corpus/runs/20260805T182452247Z__L2-edt-extension__01c9f9de0f4041cfb7afd5ea3a4412ef.json
+++ b/eval/corpus/runs/20260805T182452247Z__L2-edt-extension__01c9f9de0f4041cfb7afd5ea3a4412ef.json
@@ -1,0 +1,21 @@
+{
+  "runId": "20260805T182452247Z__L2-edt-extension__01c9f9de0f4041cfb7afd5ea3a4412ef",
+  "caseId": "L2-edt-extension",
+  "tier": 2,
+  "timestampUtc": "2026-08-05T18:24:52.2479078+00:00",
+  "source": "replay",
+  "score": {
+    "xppClean": true,
+    "xppErrors": 0,
+    "referencesClean": true,
+    "referenceErrors": 0,
+    "goldenMatch": true,
+    "goldenDiff": {
+      "missing": [],
+      "extra": [],
+      "changed": [],
+      "isMatch": true
+    }
+  },
+  "note": "Phase 1.1: ObjectTypeRegistry; AxQuery abstract-root fix"
+}

--- a/eval/corpus/runs/20260805T182452947Z__L2-enum-extension__89ff4513b23345ff80636c78b003831b.json
+++ b/eval/corpus/runs/20260805T182452947Z__L2-enum-extension__89ff4513b23345ff80636c78b003831b.json
@@ -1,0 +1,21 @@
+{
+  "runId": "20260805T182452947Z__L2-enum-extension__89ff4513b23345ff80636c78b003831b",
+  "caseId": "L2-enum-extension",
+  "tier": 2,
+  "timestampUtc": "2026-08-05T18:24:52.9479945+00:00",
+  "source": "replay",
+  "score": {
+    "xppClean": true,
+    "xppErrors": 0,
+    "referencesClean": true,
+    "referenceErrors": 0,
+    "goldenMatch": true,
+    "goldenDiff": {
+      "missing": [],
+      "extra": [],
+      "changed": [],
+      "isMatch": true
+    }
+  },
+  "note": "Phase 1.1: ObjectTypeRegistry; AxQuery abstract-root fix"
+}

--- a/eval/corpus/runs/20260805T182453777Z__L2-event-handler-basic__403889970c464ee6b03a361d94cb458b.json
+++ b/eval/corpus/runs/20260805T182453777Z__L2-event-handler-basic__403889970c464ee6b03a361d94cb458b.json
@@ -1,0 +1,21 @@
+{
+  "runId": "20260805T182453777Z__L2-event-handler-basic__403889970c464ee6b03a361d94cb458b",
+  "caseId": "L2-event-handler-basic",
+  "tier": 2,
+  "timestampUtc": "2026-08-05T18:24:53.7772356+00:00",
+  "source": "replay",
+  "score": {
+    "xppClean": true,
+    "xppErrors": 0,
+    "referencesClean": true,
+    "referenceErrors": 0,
+    "goldenMatch": true,
+    "goldenDiff": {
+      "missing": [],
+      "extra": [],
+      "changed": [],
+      "isMatch": true
+    }
+  },
+  "note": "Phase 1.1: ObjectTypeRegistry; AxQuery abstract-root fix"
+}

--- a/eval/corpus/runs/20260805T182454433Z__L2-form-extension-basic__1456222856df459db415bda8d72cc1c5.json
+++ b/eval/corpus/runs/20260805T182454433Z__L2-form-extension-basic__1456222856df459db415bda8d72cc1c5.json
@@ -1,0 +1,21 @@
+{
+  "runId": "20260805T182454433Z__L2-form-extension-basic__1456222856df459db415bda8d72cc1c5",
+  "caseId": "L2-form-extension-basic",
+  "tier": 2,
+  "timestampUtc": "2026-08-05T18:24:54.4334025+00:00",
+  "source": "replay",
+  "score": {
+    "xppClean": true,
+    "xppErrors": 0,
+    "referencesClean": true,
+    "referenceErrors": 0,
+    "goldenMatch": true,
+    "goldenDiff": {
+      "missing": [],
+      "extra": [],
+      "changed": [],
+      "isMatch": true
+    }
+  },
+  "note": "Phase 1.1: ObjectTypeRegistry; AxQuery abstract-root fix"
+}

--- a/eval/corpus/runs/20260805T182454989Z__L2-numberseq-basic__168558c39a6341e7b5886f743959f59a.json
+++ b/eval/corpus/runs/20260805T182454989Z__L2-numberseq-basic__168558c39a6341e7b5886f743959f59a.json
@@ -1,0 +1,21 @@
+{
+  "runId": "20260805T182454989Z__L2-numberseq-basic__168558c39a6341e7b5886f743959f59a",
+  "caseId": "L2-numberseq-basic",
+  "tier": 2,
+  "timestampUtc": "2026-08-05T18:24:54.9890519+00:00",
+  "source": "replay",
+  "score": {
+    "xppClean": true,
+    "xppErrors": 0,
+    "referencesClean": false,
+    "referenceErrors": 4,
+    "goldenMatch": true,
+    "goldenDiff": {
+      "missing": [],
+      "extra": [],
+      "changed": [],
+      "isMatch": true
+    }
+  },
+  "note": "Phase 1.1: ObjectTypeRegistry; AxQuery abstract-root fix"
+}

--- a/eval/corpus/runs/20260805T182455717Z__L2-security-duty-extension__ef6dd4ff58344fab9f24712e845efd12.json
+++ b/eval/corpus/runs/20260805T182455717Z__L2-security-duty-extension__ef6dd4ff58344fab9f24712e845efd12.json
@@ -1,0 +1,21 @@
+{
+  "runId": "20260805T182455717Z__L2-security-duty-extension__ef6dd4ff58344fab9f24712e845efd12",
+  "caseId": "L2-security-duty-extension",
+  "tier": 2,
+  "timestampUtc": "2026-08-05T18:24:55.7172068+00:00",
+  "source": "replay",
+  "score": {
+    "xppClean": true,
+    "xppErrors": 0,
+    "referencesClean": true,
+    "referenceErrors": 0,
+    "goldenMatch": true,
+    "goldenDiff": {
+      "missing": [],
+      "extra": [],
+      "changed": [],
+      "isMatch": true
+    }
+  },
+  "note": "Phase 1.1: ObjectTypeRegistry; AxQuery abstract-root fix"
+}

--- a/eval/corpus/runs/20260805T182456342Z__L2-security-policy-basic__a742237e869747bdbe219b4436ac2e9a.json
+++ b/eval/corpus/runs/20260805T182456342Z__L2-security-policy-basic__a742237e869747bdbe219b4436ac2e9a.json
@@ -1,0 +1,21 @@
+{
+  "runId": "20260805T182456342Z__L2-security-policy-basic__a742237e869747bdbe219b4436ac2e9a",
+  "caseId": "L2-security-policy-basic",
+  "tier": 2,
+  "timestampUtc": "2026-08-05T18:24:56.3421558+00:00",
+  "source": "replay",
+  "score": {
+    "xppClean": true,
+    "xppErrors": 0,
+    "referencesClean": true,
+    "referenceErrors": 0,
+    "goldenMatch": true,
+    "goldenDiff": {
+      "missing": [],
+      "extra": [],
+      "changed": [],
+      "isMatch": true
+    }
+  },
+  "note": "Phase 1.1: ObjectTypeRegistry; AxQuery abstract-root fix"
+}

--- a/eval/corpus/runs/20260805T182457031Z__L2-security-role-extension__0222275b4d6442a8a2031fd825350be6.json
+++ b/eval/corpus/runs/20260805T182457031Z__L2-security-role-extension__0222275b4d6442a8a2031fd825350be6.json
@@ -1,0 +1,21 @@
+{
+  "runId": "20260805T182457031Z__L2-security-role-extension__0222275b4d6442a8a2031fd825350be6",
+  "caseId": "L2-security-role-extension",
+  "tier": 2,
+  "timestampUtc": "2026-08-05T18:24:57.0319319+00:00",
+  "source": "replay",
+  "score": {
+    "xppClean": true,
+    "xppErrors": 0,
+    "referencesClean": true,
+    "referenceErrors": 0,
+    "goldenMatch": true,
+    "goldenDiff": {
+      "missing": [],
+      "extra": [],
+      "changed": [],
+      "isMatch": true
+    }
+  },
+  "note": "Phase 1.1: ObjectTypeRegistry; AxQuery abstract-root fix"
+}

--- a/eval/corpus/runs/20260805T182457777Z__L2-table-extension__296b665ad639458a89ed29138b838c3d.json
+++ b/eval/corpus/runs/20260805T182457777Z__L2-table-extension__296b665ad639458a89ed29138b838c3d.json
@@ -1,0 +1,21 @@
+{
+  "runId": "20260805T182457777Z__L2-table-extension__296b665ad639458a89ed29138b838c3d",
+  "caseId": "L2-table-extension",
+  "tier": 2,
+  "timestampUtc": "2026-08-05T18:24:57.7776894+00:00",
+  "source": "replay",
+  "score": {
+    "xppClean": true,
+    "xppErrors": 0,
+    "referencesClean": true,
+    "referenceErrors": 0,
+    "goldenMatch": true,
+    "goldenDiff": {
+      "missing": [],
+      "extra": [],
+      "changed": [],
+      "isMatch": true
+    }
+  },
+  "note": "Phase 1.1: ObjectTypeRegistry; AxQuery abstract-root fix"
+}

--- a/eval/corpus/runs/20260805T182458405Z__L2-virtual-entity-basic__d0f44838c5c4463c90640e753b015516.json
+++ b/eval/corpus/runs/20260805T182458405Z__L2-virtual-entity-basic__d0f44838c5c4463c90640e753b015516.json
@@ -1,0 +1,21 @@
+{
+  "runId": "20260805T182458405Z__L2-virtual-entity-basic__d0f44838c5c4463c90640e753b015516",
+  "caseId": "L2-virtual-entity-basic",
+  "tier": 2,
+  "timestampUtc": "2026-08-05T18:24:58.4054057+00:00",
+  "source": "replay",
+  "score": {
+    "xppClean": true,
+    "xppErrors": 0,
+    "referencesClean": true,
+    "referenceErrors": 0,
+    "goldenMatch": true,
+    "goldenDiff": {
+      "missing": [],
+      "extra": [],
+      "changed": [],
+      "isMatch": true
+    }
+  },
+  "note": "Phase 1.1: ObjectTypeRegistry; AxQuery abstract-root fix"
+}

--- a/eval/goldens/L1-query-basic/ConFmVehicleQuery.xml
+++ b/eval/goldens/L1-query-basic/ConFmVehicleQuery.xml
@@ -1,5 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
-<AxQuery>
+<AxQuery xmlns:i="http://www.w3.org/2001/XMLSchema-instance" i:type="AxQuerySimple">
   <Name>ConFmVehicleQuery</Name>
   <DataSources>
     <AxQuerySimpleRootDataSource>

--- a/eval/goldens/L1-query-join/ConFmVehicleLineQuery.xml
+++ b/eval/goldens/L1-query-join/ConFmVehicleLineQuery.xml
@@ -1,5 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
-<AxQuery>
+<AxQuery xmlns:i="http://www.w3.org/2001/XMLSchema-instance" i:type="AxQuerySimple">
   <Name>ConFmVehicleLineQuery</Name>
   <DataSources>
     <AxQuerySimpleRootDataSource>

--- a/src/D365FO.Bridge/D365FO.Bridge.csproj
+++ b/src/D365FO.Bridge/D365FO.Bridge.csproj
@@ -23,4 +23,15 @@
     <PackageReference Include="System.Text.Json" Version="8.0.5" />
   </ItemGroup>
 
+  <ItemGroup>
+    <!--
+      Shared source, not a project reference: D365FO.Core targets net10 and this
+      process must stay net48. The registry file is deliberately written to compile
+      under both (no records, no init accessors, no nullable annotations), so the
+      bridge's kind → collection / kind → MetaModel type tables and the CLI's folder
+      names cannot drift apart again (audit finding G2).
+    -->
+    <Compile Include="..\D365FO.Core\ObjectTypes\ObjectTypeRegistry.cs" Link="Shared\ObjectTypeRegistry.cs" />
+  </ItemGroup>
+
 </Project>

--- a/src/D365FO.Bridge/MetadataBootstrap.cs
+++ b/src/D365FO.Bridge/MetadataBootstrap.cs
@@ -372,52 +372,21 @@ namespace D365FO.Bridge
         /// not expose degrades to a <c>"&lt;collection&gt; provider not exposed"</c> error
         /// rather than a crash (see <see cref="SaveArtifact"/>).
         /// </remarks>
+        /// <remarks>
+        /// Both tables come from <see cref="D365FO.Core.ObjectTypes.ObjectTypeRegistry"/>
+        /// (shared-compiled into this net48 process): every kind whose registry entry names a
+        /// provider collection. Abstract roots — <c>AxEdt</c>, <c>AxEdtExtension</c> — resolve
+        /// here to the abstract base on purpose; the concrete subtype
+        /// (<c>AxEdtStringExtension</c>, …) comes from the input XML's root element or
+        /// <c>xsi:type</c>, which <see cref="Handlers.WriteArtifact"/> already handles.
+        /// </remarks>
         internal static readonly System.Collections.Generic.Dictionary<string, string> KindToCollection =
-            new System.Collections.Generic.Dictionary<string, string>(StringComparer.OrdinalIgnoreCase)
-            {
-                { "class", "Classes" },
-                { "table", "Tables" },
-                { "edt",   "Edts"    },
-                { "enum",  "Enums"   },
-                { "form",  "Forms"   },
-                { "view",  "Views"   },
-                { "map",   "Maps"    },
-                { "query", "Queries" },
-                { "dataentityview", "DataEntityViews" },
-                { "tableextension", "TableExtensions" },
-                { "formextension", "FormExtensions" },
-                { "edtextension",  "EdtExtensions"  },
-                { "enumextension", "EnumExtensions" },
-                { "viewextension", "ViewExtensions" },
-                { "queryextension", "QueryExtensions" },
-                { "dataentityviewextension", "DataEntityViewExtensions" },
-            };
+            D365FO.Core.ObjectTypes.ObjectTypeRegistry.BridgeCollections();
 
         private const string MetaModelNs = "Microsoft.Dynamics.AX.Metadata.MetaModel.";
 
         private static readonly System.Collections.Generic.Dictionary<string, string> KindToTypeName =
-            new System.Collections.Generic.Dictionary<string, string>(StringComparer.OrdinalIgnoreCase)
-            {
-                { "class", MetaModelNs + "AxClass" },
-                { "table", MetaModelNs + "AxTable" },
-                { "edt",   MetaModelNs + "AxEdt"   },
-                { "enum",  MetaModelNs + "AxEnum"  },
-                { "form",  MetaModelNs + "AxForm"  },
-                { "view",  MetaModelNs + "AxView"  },
-                { "map",   MetaModelNs + "AxMap"   },
-                { "query", MetaModelNs + "AxQuery" },
-                { "dataentityview", MetaModelNs + "AxDataEntityView" },
-                { "tableextension", MetaModelNs + "AxTableExtension" },
-                { "formextension", MetaModelNs + "AxFormExtension" },
-                // AxEdtExtension is abstract — the concrete subtype (AxEdtStringExtension,
-                // …) must come from the input XML's root element or xsi:type, exactly as
-                // for AxEdt itself. WriteArtifact already handles that.
-                { "edtextension",  MetaModelNs + "AxEdtExtension"  },
-                { "enumextension", MetaModelNs + "AxEnumExtension" },
-                { "viewextension", MetaModelNs + "AxViewExtension" },
-                { "queryextension", MetaModelNs + "AxQueryExtension" },
-                { "dataentityviewextension", MetaModelNs + "AxDataEntityViewExtension" },
-            };
+            D365FO.Core.ObjectTypes.ObjectTypeRegistry.BridgeMetaModelTypes(MetaModelNs);
 
         /// <summary>
         /// Look up the <c>AxClass</c>/<c>AxTable</c>/... Type from the loaded

--- a/src/D365FO.Cli/Commands/Generate/GenerateBusinessEventCommand.cs
+++ b/src/D365FO.Cli/Commands/Generate/GenerateBusinessEventCommand.cs
@@ -2,6 +2,8 @@ using D365FO.Core;
 using D365FO.Core.Scaffolding;
 using Spectre.Console.Cli;
 
+using static D365FO.Core.ObjectTypes.ObjectTypeRegistry;
+
 namespace D365FO.Cli.Commands.Generate;
 
 /// <summary>
@@ -58,10 +60,10 @@ public sealed class GenerateBusinessEventCommand : Command<GenerateBusinessEvent
         string? eventPath, contractPath;
         if (hasInstall && !hasOut)
         {
-            eventPath = GenerateInstaller.ResolveInstallPath(kind, "AxClass", settings.Name, settings.InstallTo!, out var f1);
+            eventPath = GenerateInstaller.ResolveInstallPath(kind, Folders.Class, settings.Name, settings.InstallTo!, out var f1);
             if (f1.HasValue) return f1.Value;
             contractPath = string.IsNullOrWhiteSpace(settings.OutContract)
-                ? GenerateInstaller.ResolveInstallPath(kind, "AxClass", contractName, settings.InstallTo!, out _)
+                ? GenerateInstaller.ResolveInstallPath(kind, Folders.Class, contractName, settings.InstallTo!, out _)
                 : settings.OutContract;
         }
         else

--- a/src/D365FO.Cli/Commands/Generate/GenerateCommands.cs
+++ b/src/D365FO.Cli/Commands/Generate/GenerateCommands.cs
@@ -4,6 +4,8 @@ using D365FO.Core.Scaffolding;
 using Spectre.Console.Cli;
 using D365FO.Cli.Commands.Get;
 
+using static D365FO.Core.ObjectTypes.ObjectTypeRegistry;
+
 namespace D365FO.Cli.Commands.Generate;
 
 public abstract class GenerateSettings : D365OutputSettings
@@ -354,7 +356,7 @@ public sealed class GenerateTableCommand : Command<GenerateTableCommand.Settings
         // Prefer the live metadata provider for --install-to (canonical output,
         // consistent with VS / d365fo-mcp-server); fall back to the scaffold.
         return GenerateInstaller.Emit(
-            kind, "table", "AxTable", settings.Name,
+            kind, "table", Folders.Table, settings.Name,
             settings.InstallTo, settings.Out, settings.Overwrite, doc,
             r => new
             {
@@ -408,7 +410,7 @@ public sealed class GenerateClassCommand : Command<GenerateClassCommand.Settings
 
         var doc = XppScaffolder.Class(settings.Name, settings.Extends, !settings.NonFinal);
         return GenerateInstaller.Emit(
-            kind, "class", "AxClass", settings.Name,
+            kind, "class", Folders.Class, settings.Name,
             settings.InstallTo, settings.Out, settings.Overwrite, doc,
             r => new
             {
@@ -469,7 +471,7 @@ public sealed class GenerateCocCommand : Command<GenerateCocCommand.Settings>
         warnings.AddRange(gate.Warnings);
 
         return GenerateInstaller.Emit(
-            kind, "class", "AxClass", settings.Target + "_Extension",
+            kind, "class", Folders.Class, settings.Target + "_Extension",
             settings.InstallTo, settings.Out, settings.Overwrite, doc,
             r => new
             {
@@ -690,7 +692,7 @@ internal static class GenerateFormImpl
         }
 
         return GenerateInstaller.EmitString(
-            kind, "form", "AxForm", formName,
+            kind, "form", Folders.Form, formName,
             installTo, outPath, overwrite, xml,
             r => new
             {

--- a/src/D365FO.Cli/Commands/Generate/GenerateCustomServiceCommand.cs
+++ b/src/D365FO.Cli/Commands/Generate/GenerateCustomServiceCommand.cs
@@ -2,6 +2,8 @@ using D365FO.Core;
 using D365FO.Core.Scaffolding;
 using Spectre.Console.Cli;
 
+using static D365FO.Core.ObjectTypes.ObjectTypeRegistry;
+
 namespace D365FO.Cli.Commands.Generate;
 
 /// <summary>
@@ -64,13 +66,13 @@ public sealed class GenerateCustomServiceCommand : Command<GenerateCustomService
         string? servicePath, classPath, groupPath;
         if (hasInstall && !hasOut)
         {
-            servicePath = GenerateInstaller.ResolveInstallPath(kind, "AxService", settings.Name, settings.InstallTo!, out var f1);
+            servicePath = GenerateInstaller.ResolveInstallPath(kind, Folders.Service, settings.Name, settings.InstallTo!, out var f1);
             if (f1.HasValue) return f1.Value;
             classPath = string.IsNullOrWhiteSpace(settings.OutClass)
-                ? GenerateInstaller.ResolveInstallPath(kind, "AxClass", className, settings.InstallTo!, out _)
+                ? GenerateInstaller.ResolveInstallPath(kind, Folders.Class, className, settings.InstallTo!, out _)
                 : settings.OutClass;
             groupPath = string.IsNullOrWhiteSpace(settings.OutGroup)
-                ? GenerateInstaller.ResolveInstallPath(kind, "AxServiceGroup", groupName, settings.InstallTo!, out _)
+                ? GenerateInstaller.ResolveInstallPath(kind, Folders.ServiceGroup, groupName, settings.InstallTo!, out _)
                 : settings.OutGroup;
         }
         else

--- a/src/D365FO.Cli/Commands/Generate/GenerateEdtCommand.cs
+++ b/src/D365FO.Cli/Commands/Generate/GenerateEdtCommand.cs
@@ -2,6 +2,8 @@ using D365FO.Core;
 using D365FO.Core.Scaffolding;
 using Spectre.Console.Cli;
 
+using static D365FO.Core.ObjectTypes.ObjectTypeRegistry;
+
 namespace D365FO.Cli.Commands.Generate;
 
 /// <summary>Scaffolds an <c>AxEdt</c> Extended Data Type.</summary>
@@ -52,7 +54,7 @@ public sealed class GenerateEdtCommand : Command<GenerateEdtCommand.Settings>
 
         var doc = XppScaffolder.Edt(settings.Name, settings.Extends, settings.BaseType, settings.Size, settings.Label, effectiveEnumType);
         return GenerateInstaller.Emit(
-            kind, "edt", "AxEdt", settings.Name,
+            kind, "edt", Folders.Edt, settings.Name,
             settings.InstallTo, settings.Out, settings.Overwrite, doc,
             r => new
             {

--- a/src/D365FO.Cli/Commands/Generate/GenerateEnumCommand.cs
+++ b/src/D365FO.Cli/Commands/Generate/GenerateEnumCommand.cs
@@ -2,6 +2,8 @@ using D365FO.Core;
 using D365FO.Core.Scaffolding;
 using Spectre.Console.Cli;
 
+using static D365FO.Core.ObjectTypes.ObjectTypeRegistry;
+
 namespace D365FO.Cli.Commands.Generate;
 
 /// <summary>Scaffolds an <c>AxEnum</c> base enumeration.</summary>
@@ -37,7 +39,7 @@ public sealed class GenerateEnumCommand : Command<GenerateEnumCommand.Settings>
         var doc = XppScaffolder.Enum(settings.Name, values, !settings.NonExtensible, settings.Label);
 
         return GenerateInstaller.Emit(
-            kind, "enum", "AxEnum", settings.Name,
+            kind, "enum", Folders.Enum, settings.Name,
             settings.InstallTo, settings.Out, settings.Overwrite, doc,
             r => new
             {

--- a/src/D365FO.Cli/Commands/Generate/GenerateMigrationScriptCommand.cs
+++ b/src/D365FO.Cli/Commands/Generate/GenerateMigrationScriptCommand.cs
@@ -2,6 +2,8 @@ using D365FO.Core;
 using D365FO.Core.Scaffolding;
 using Spectre.Console.Cli;
 
+using static D365FO.Core.ObjectTypes.ObjectTypeRegistry;
+
 namespace D365FO.Cli.Commands.Generate;
 
 /// <summary>
@@ -55,7 +57,7 @@ public sealed class GenerateMigrationScriptCommand : Command<GenerateMigrationSc
         var outPath = settings.Out;
         if (hasInstall && !hasOut)
         {
-            outPath = GenerateInstaller.ResolveInstallPath(kind, "AxClass", settings.Name, settings.InstallTo!, out var fail);
+            outPath = GenerateInstaller.ResolveInstallPath(kind, Folders.Class, settings.Name, settings.InstallTo!, out var fail);
             if (fail.HasValue) return fail.Value;
         }
 

--- a/src/D365FO.Cli/Commands/Generate/GenerateMoreCommands.cs
+++ b/src/D365FO.Cli/Commands/Generate/GenerateMoreCommands.cs
@@ -2,6 +2,8 @@ using D365FO.Core;
 using D365FO.Core.Scaffolding;
 using Spectre.Console.Cli;
 
+using static D365FO.Core.ObjectTypes.ObjectTypeRegistry;
+
 namespace D365FO.Cli.Commands.Generate;
 
 /// <summary>Scaffolds an <c>AxDataEntityView</c>. ROADMAP §6.</summary>
@@ -53,7 +55,7 @@ public sealed class GenerateEntityCommand : Command<GenerateEntityCommand.Settin
         var outPath = settings.Out;
         if (hasInstall && !hasOut)
         {
-            outPath = GenerateInstaller.ResolveInstallPath(kind, "AxDataEntityView", settings.EntityName, settings.InstallTo!, out var fail);
+            outPath = GenerateInstaller.ResolveInstallPath(kind, Folders.DataEntityView, settings.EntityName, settings.InstallTo!, out var fail);
             if (fail.HasValue) return fail.Value;
         }
 
@@ -247,7 +249,7 @@ public sealed class GenerateEventHandlerCommand : Command<GenerateEventHandlerCo
         if (gate.Failure is not null) return RenderHelpers.Render(kind, gate.Failure);
 
         return GenerateInstaller.Emit(
-            kind, "class", "AxClass", settings.ClassName,
+            kind, "class", Folders.Class, settings.ClassName,
             settings.InstallTo, settings.Out, settings.Overwrite, doc,
             r => new
             {
@@ -326,7 +328,7 @@ public sealed class GeneratePrivilegeCommand : Command<GeneratePrivilegeCommand.
         var outPath = settings.Out;
         if (hasInstall && !hasOut)
         {
-            outPath = GenerateInstaller.ResolveInstallPath(kind, "AxSecurityPrivilege", settings.Name, settings.InstallTo!, out var fail);
+            outPath = GenerateInstaller.ResolveInstallPath(kind, Folders.SecurityPrivilege, settings.Name, settings.InstallTo!, out var fail);
             if (fail.HasValue) return fail.Value;
         }
 
@@ -404,7 +406,7 @@ public sealed class GenerateDutyCommand : Command<GenerateDutyCommand.Settings>
         var outPath = settings.Out;
         if (hasInstall && !hasOut)
         {
-            outPath = GenerateInstaller.ResolveInstallPath(kind, "AxSecurityDuty", settings.Name, settings.InstallTo!, out var fail);
+            outPath = GenerateInstaller.ResolveInstallPath(kind, Folders.SecurityDuty, settings.Name, settings.InstallTo!, out var fail);
             if (fail.HasValue) return fail.Value;
         }
 
@@ -495,7 +497,7 @@ public sealed class GenerateRoleCommand : Command<GenerateRoleCommand.Settings>
         var outPath = settings.Out;
         if (hasInstall && !hasOut)
         {
-            outPath = GenerateInstaller.ResolveInstallPath(kind, "AxSecurityRole", settings.Name, settings.InstallTo!, out var fail);
+            outPath = GenerateInstaller.ResolveInstallPath(kind, Folders.SecurityRole, settings.Name, settings.InstallTo!, out var fail);
             if (fail.HasValue) return fail.Value;
         }
 
@@ -679,7 +681,7 @@ public sealed class GenerateReportCommand : Command<GenerateReportCommand.Settin
         string? reportPath, dpPath, contractPath;
         if (hasInstall && !hasOut)
         {
-            reportPath = GenerateInstaller.ResolveInstallPath(kind, "AxReport", settings.Name, settings.InstallTo!, out var f1);
+            reportPath = GenerateInstaller.ResolveInstallPath(kind, Folders.Report, settings.Name, settings.InstallTo!, out var f1);
             if (f1.HasValue) return f1.Value;
 
             if (!string.IsNullOrWhiteSpace(settings.OutDp))
@@ -688,7 +690,7 @@ public sealed class GenerateReportCommand : Command<GenerateReportCommand.Settin
             }
             else
             {
-                dpPath = GenerateInstaller.ResolveInstallPath(kind, "AxClass", spec.EffectiveDpClass, settings.InstallTo!, out var f2);
+                dpPath = GenerateInstaller.ResolveInstallPath(kind, Folders.Class, spec.EffectiveDpClass, settings.InstallTo!, out var f2);
                 if (f2.HasValue) return f2.Value;
             }
 
@@ -700,7 +702,7 @@ public sealed class GenerateReportCommand : Command<GenerateReportCommand.Settin
                 }
                 else
                 {
-                    contractPath = GenerateInstaller.ResolveInstallPath(kind, "AxClass", spec.ContractClass, settings.InstallTo!, out var f3);
+                    contractPath = GenerateInstaller.ResolveInstallPath(kind, Folders.Class, spec.ContractClass, settings.InstallTo!, out var f3);
                     if (f3.HasValue) return f3.Value;
                 }
             }

--- a/src/D365FO.Cli/Commands/Generate/GenerateNumberSequenceCommand.cs
+++ b/src/D365FO.Cli/Commands/Generate/GenerateNumberSequenceCommand.cs
@@ -2,6 +2,8 @@ using D365FO.Core;
 using D365FO.Core.Scaffolding;
 using Spectre.Console.Cli;
 
+using static D365FO.Core.ObjectTypes.ObjectTypeRegistry;
+
 namespace D365FO.Cli.Commands.Generate;
 
 /// <summary>
@@ -71,14 +73,14 @@ public sealed class GenerateNumberSequenceCommand : Command<GenerateNumberSequen
         string? modulePath, edtPath, handlerPath;
         if (hasInstall && !hasOut)
         {
-            modulePath = GenerateInstaller.ResolveInstallPath(kind, "AxClass", extensionName, settings.InstallTo!, out var f1);
+            modulePath = GenerateInstaller.ResolveInstallPath(kind, Folders.Class, extensionName, settings.InstallTo!, out var f1);
             if (f1.HasValue) return f1.Value;
             edtPath = string.IsNullOrWhiteSpace(settings.OutEdt)
-                ? GenerateInstaller.ResolveInstallPath(kind, "AxEdt", edtName, settings.InstallTo!, out _)
+                ? GenerateInstaller.ResolveInstallPath(kind, Folders.Edt, edtName, settings.InstallTo!, out _)
                 : settings.OutEdt;
             handlerPath = handlerClass is null ? null
                 : string.IsNullOrWhiteSpace(settings.OutHandler)
-                    ? GenerateInstaller.ResolveInstallPath(kind, "AxClass", handlerClass, settings.InstallTo!, out _)
+                    ? GenerateInstaller.ResolveInstallPath(kind, Folders.Class, handlerClass, settings.InstallTo!, out _)
                     : settings.OutHandler;
         }
         else

--- a/src/D365FO.Cli/Commands/Generate/GenerateQueryCommand.cs
+++ b/src/D365FO.Cli/Commands/Generate/GenerateQueryCommand.cs
@@ -3,6 +3,8 @@ using D365FO.Core;
 using D365FO.Core.Scaffolding;
 using Spectre.Console.Cli;
 
+using static D365FO.Core.ObjectTypes.ObjectTypeRegistry;
+
 namespace D365FO.Cli.Commands.Generate;
 
 /// <summary>Scaffolds an <c>AxQuery</c> with data sources and optional joins.</summary>
@@ -40,7 +42,7 @@ public sealed class GenerateQueryCommand : Command<GenerateQueryCommand.Settings
         var outPath = settings.Out;
         if (hasInstall && !hasOut)
         {
-            outPath = GenerateInstaller.ResolveInstallPath(kind, "AxQuery", settings.Name, settings.InstallTo!, out var fail);
+            outPath = GenerateInstaller.ResolveInstallPath(kind, Folders.Query, settings.Name, settings.InstallTo!, out var fail);
             if (fail.HasValue) return fail.Value;
         }
 

--- a/src/D365FO.Cli/Commands/Generate/GenerateRunBaseCommand.cs
+++ b/src/D365FO.Cli/Commands/Generate/GenerateRunBaseCommand.cs
@@ -2,6 +2,8 @@ using D365FO.Core;
 using D365FO.Core.Scaffolding;
 using Spectre.Console.Cli;
 
+using static D365FO.Core.ObjectTypes.ObjectTypeRegistry;
+
 namespace D365FO.Cli.Commands.Generate;
 
 /// <summary>
@@ -42,7 +44,7 @@ public sealed class GenerateRunBaseCommand : Command<GenerateRunBaseCommand.Sett
         var outPath = settings.Out;
         if (hasInstall && !hasOut)
         {
-            outPath = GenerateInstaller.ResolveInstallPath(kind, "AxClass", settings.Name, settings.InstallTo!, out var fail);
+            outPath = GenerateInstaller.ResolveInstallPath(kind, Folders.Class, settings.Name, settings.InstallTo!, out var fail);
             if (fail.HasValue) return fail.Value;
         }
 

--- a/src/D365FO.Cli/Commands/Generate/GenerateSecurityPolicyCommand.cs
+++ b/src/D365FO.Cli/Commands/Generate/GenerateSecurityPolicyCommand.cs
@@ -2,6 +2,8 @@ using D365FO.Core;
 using D365FO.Core.Scaffolding;
 using Spectre.Console.Cli;
 
+using static D365FO.Core.ObjectTypes.ObjectTypeRegistry;
+
 namespace D365FO.Cli.Commands.Generate;
 
 /// <summary>
@@ -64,7 +66,7 @@ public sealed class GenerateSecurityPolicyCommand : Command<GenerateSecurityPoli
         var outPath = settings.Out;
         if (hasInstall && !hasOut)
         {
-            outPath = GenerateInstaller.ResolveInstallPath(kind, "AxSecurityPolicy", settings.Name, settings.InstallTo!, out var fail);
+            outPath = GenerateInstaller.ResolveInstallPath(kind, Folders.SecurityPolicy, settings.Name, settings.InstallTo!, out var fail);
             if (fail.HasValue) return fail.Value;
         }
 

--- a/src/D365FO.Cli/Commands/Generate/GenerateSysOperationCommand.cs
+++ b/src/D365FO.Cli/Commands/Generate/GenerateSysOperationCommand.cs
@@ -2,6 +2,8 @@ using D365FO.Core;
 using D365FO.Core.Scaffolding;
 using Spectre.Console.Cli;
 
+using static D365FO.Core.ObjectTypes.ObjectTypeRegistry;
+
 namespace D365FO.Cli.Commands.Generate;
 
 /// <summary>
@@ -73,15 +75,15 @@ public sealed class GenerateSysOperationCommand : Command<GenerateSysOperationCo
         string? controllerPath, contractPath, servicePath;
         if (hasInstall && !hasOut)
         {
-            controllerPath = GenerateInstaller.ResolveInstallPath(kind, "AxClass", controllerName, settings.InstallTo!, out var f1);
+            controllerPath = GenerateInstaller.ResolveInstallPath(kind, Folders.Class, controllerName, settings.InstallTo!, out var f1);
             if (f1.HasValue) return f1.Value;
             contractPath = string.IsNullOrWhiteSpace(settings.OutContract)
-                ? GenerateInstaller.ResolveInstallPath(kind, "AxClass", contractName, settings.InstallTo!, out var f2)
+                ? GenerateInstaller.ResolveInstallPath(kind, Folders.Class, contractName, settings.InstallTo!, out var f2)
                 : settings.OutContract;
             if (hasInstall && string.IsNullOrWhiteSpace(settings.OutContract) && contractPath is null)
                 return RenderHelpers.Render(kind, ToolResult<object>.Fail(D365FoErrorCodes.BadInput, "Could not resolve contract path."));
             servicePath = string.IsNullOrWhiteSpace(settings.OutService)
-                ? GenerateInstaller.ResolveInstallPath(kind, "AxClass", serviceName, settings.InstallTo!, out var f3)
+                ? GenerateInstaller.ResolveInstallPath(kind, Folders.Class, serviceName, settings.InstallTo!, out var f3)
                 : settings.OutService;
             if (hasInstall && string.IsNullOrWhiteSpace(settings.OutService) && servicePath is null)
                 return RenderHelpers.Render(kind, ToolResult<object>.Fail(D365FoErrorCodes.BadInput, "Could not resolve service path."));

--- a/src/D365FO.Cli/Commands/Generate/GenerateSysTestCommand.cs
+++ b/src/D365FO.Cli/Commands/Generate/GenerateSysTestCommand.cs
@@ -3,6 +3,8 @@ using D365FO.Core.Index;
 using D365FO.Core.Scaffolding;
 using Spectre.Console.Cli;
 
+using static D365FO.Core.ObjectTypes.ObjectTypeRegistry;
+
 namespace D365FO.Cli.Commands.Generate;
 
 /// <summary>
@@ -108,7 +110,7 @@ public sealed class GenerateSysTestCommand : Command<GenerateSysTestCommand.Sett
         var outPath = settings.Out;
         if (hasInstall && !hasOut)
         {
-            outPath = GenerateInstaller.ResolveInstallPath(kind, "AxClass", settings.Name, settings.InstallTo!, out var fail);
+            outPath = GenerateInstaller.ResolveInstallPath(kind, Folders.Class, settings.Name, settings.InstallTo!, out var fail);
             if (fail.HasValue) return fail.Value;
         }
 

--- a/src/D365FO.Cli/Commands/Generate/GenerateViewMapCommands.cs
+++ b/src/D365FO.Cli/Commands/Generate/GenerateViewMapCommands.cs
@@ -3,6 +3,8 @@ using D365FO.Core;
 using D365FO.Core.Scaffolding;
 using Spectre.Console.Cli;
 
+using static D365FO.Core.ObjectTypes.ObjectTypeRegistry;
+
 namespace D365FO.Cli.Commands.Generate;
 
 /// <summary>Scaffolds an <c>AxView</c> — a read-only projection over an <c>AxQuery</c>.</summary>
@@ -85,7 +87,7 @@ public sealed class GenerateViewCommand : Command<GenerateViewCommand.Settings>
         // "Metadata API rejected the object" warning on every install. Same approach
         // as `generate query`, which has the same constraint. (`--verify` is likewise
         // inapplicable — there is no readView verb to check against.)
-        if (!TryResolveOutPath(kind, settings, "AxView", settings.Name, out var outPath, out var pathFailure))
+        if (!TryResolveOutPath(kind, settings, Folders.View, settings.Name, out var outPath, out var pathFailure))
             return pathFailure;
 
         try
@@ -228,7 +230,7 @@ public sealed class GenerateMapCommand : Command<GenerateMapCommand.Settings>
         }
 
         // Same reasoning as GenerateViewCommand: the bridge has no "map" kind.
-        if (!GenerateViewCommand.TryResolveOutPath(kind, settings, "AxMap", settings.Name, out var outPath, out var pathFailure))
+        if (!GenerateViewCommand.TryResolveOutPath(kind, settings, Folders.Map, settings.Name, out var outPath, out var pathFailure))
             return pathFailure;
 
         try

--- a/src/D365FO.Cli/Commands/Generate/GenerateWorkflowCommand.cs
+++ b/src/D365FO.Cli/Commands/Generate/GenerateWorkflowCommand.cs
@@ -2,6 +2,8 @@ using D365FO.Core;
 using D365FO.Core.Scaffolding;
 using Spectre.Console.Cli;
 
+using static D365FO.Core.ObjectTypes.ObjectTypeRegistry;
+
 namespace D365FO.Cli.Commands.Generate;
 
 /// <summary>
@@ -106,11 +108,11 @@ public sealed class GenerateWorkflowCommand : Command<GenerateWorkflowCommand.Se
             workflowPath  = GenerateInstaller.ResolveInstallPath(kind, WorkflowScaffolder.TemplateRoot, settings.Name, settings.InstallTo!, out var f1);
             if (f1.HasValue) return f1.Value;
             documentPath  = string.IsNullOrWhiteSpace(settings.OutDocument)
-                ? GenerateInstaller.ResolveInstallPath(kind, "AxClass", docClassName, settings.InstallTo!, out _)
+                ? GenerateInstaller.ResolveInstallPath(kind, Folders.Class, docClassName, settings.InstallTo!, out _)
                 : settings.OutDocument;
             submitPath    = !generateSubmit ? null
                 : string.IsNullOrWhiteSpace(settings.OutSubmit)
-                    ? GenerateInstaller.ResolveInstallPath(kind, "AxClass", submitExtName, settings.InstallTo!, out _)
+                    ? GenerateInstaller.ResolveInstallPath(kind, Folders.Class, submitExtName, settings.InstallTo!, out _)
                     : settings.OutSubmit;
             approvalPath  = approvalName is null ? null
                 : string.IsNullOrWhiteSpace(settings.OutApproval)

--- a/src/D365FO.Cli/Commands/Index/IndexCommands.cs
+++ b/src/D365FO.Cli/Commands/Index/IndexCommands.cs
@@ -491,16 +491,11 @@ public sealed class IndexExtractCommand : Command<IndexExtractCommand.Settings>
             catch (UnauthorizedAccessException) { return Array.Empty<string>(); }
         }
 
+        // Same registry-driven marker list the extractor uses, so `index refresh` and
+        // MetadataExtractor never disagree about what counts as a model directory.
         static bool HasAot(string dir)
         {
-            foreach (var s in new[] {
-                "AxTable", "AxClass", "AxEdt", "AxEnum", "AxLabelFile", "AxForm",
-                "AxTableExtension", "AxFormExtension", "AxEdtExtension", "AxEnumExtension",
-                "AxSecurityRole", "AxSecurityDuty", "AxSecurityPrivilege",
-                "AxMenuItemDisplay", "AxMenuItemAction", "AxMenuItemOutput",
-                "AxQuery", "AxQuerySimple", "AxView", "AxDataEntityView",
-                "AxReport", "AxReportSsrs", "AxService", "AxServiceGroup", "AxWorkflowTemplate",
-            })
+            foreach (var s in D365FO.Core.ObjectTypes.ObjectTypeRegistry.ModelMarkerFolders())
                 if (Directory.Exists(Path.Combine(dir, s))) return true;
             return false;
         }

--- a/src/D365FO.Core/Extract/MetadataExtractor.cs
+++ b/src/D365FO.Core/Extract/MetadataExtractor.cs
@@ -145,15 +145,15 @@ public sealed class MetadataExtractor
         List<ExtractedWorkspace>         workspaces       = null!;
 
         Parallel.Invoke(
-            () => tables       = ReadAll(Path.Combine(modelRoot, "AxTable"), ParseTable),
-            () => classes      = ReadAll(Path.Combine(modelRoot, "AxClass"), ParseClass),
-            () => edts         = ReadAll(Path.Combine(modelRoot, "AxEdt"), ParseEdt),
-            () => enums        = ReadAll(Path.Combine(modelRoot, "AxEnum"), ParseEnum),
-            () => forms        = ReadAll(Path.Combine(modelRoot, "AxForm"), ParseForm),
+            () => tables       = ReadAll(Path.Combine(modelRoot, Folder("table")), ParseTable),
+            () => classes      = ReadAll(Path.Combine(modelRoot, Folder("class")), ParseClass),
+            () => edts         = ReadAll(Path.Combine(modelRoot, Folder("edt")),   ParseEdt),
+            () => enums        = ReadAll(Path.Combine(modelRoot, Folder("enum")),  ParseEnum),
+            () => forms        = ReadAll(Path.Combine(modelRoot, Folder("form")),  ParseForm),
             () =>
             {
                 var mi = new List<ExtractedMenuItem>();
-                foreach (var kind in new[] { "AxMenuItemDisplay", "AxMenuItemAction", "AxMenuItemOutput" })
+                foreach (var kind in new[] { Folder("menuitemdisplay"), Folder("menuitemaction"), Folder("menuitemoutput") })
                     mi.AddRange(ReadAll(Path.Combine(modelRoot, kind), (doc, path) => ParseMenuItem(doc, path, kind)));
                 menuItems = mi;
             },
@@ -163,12 +163,12 @@ public sealed class MetadataExtractor
                 // whose root element name is e.g. "CustTable.FleetExtension" (Name element).
                 var exts = new List<ExtractedObjectExtension>();
                 foreach (var (dir, kind) in new[] {
-                    ("AxTableExtension", "Table"),
-                    ("AxFormExtension",  "Form"),
-                    ("AxEdtExtension",   "Edt"),
-                    ("AxEnumExtension",  "Enum"),
-                    ("AxViewExtension",  "View"),
-                    ("AxMapExtension",   "Map"),
+                    (Folder("tableextension"), "Table"),
+                    (Folder("formextension"),  "Form"),
+                    (Folder("edtextension"),   "Edt"),
+                    (Folder("enumextension"),  "Enum"),
+                    (Folder("viewextension"),  "View"),
+                    (Folder("mapextension"),   "Map"),
                 })
                 {
                     var extDir = Path.Combine(modelRoot, dir);
@@ -186,7 +186,7 @@ public sealed class MetadataExtractor
                 // Label files: parallelize across individual *.label.txt files since
                 // each can be several MB and the files are fully independent.
                 var lbls = new List<ExtractedLabel>();
-                var labelsDir = Path.Combine(modelRoot, "AxLabelFile");
+                var labelsDir = Path.Combine(modelRoot, Folder("labelfile"));
                 if (Directory.Exists(labelsDir))
                 {
                     // Modern D365 layout: AxLabelFile/LabelResources/<lang>/<Name>.<lang>.label.txt
@@ -209,31 +209,30 @@ public sealed class MetadataExtractor
                 }
                 labels = lbls;
             },
-            () => roles        = ReadAll(Path.Combine(modelRoot, "AxSecurityRole"),     ParseSecurityRole),
-            () => duties       = ReadAll(Path.Combine(modelRoot, "AxSecurityDuty"),     ParseSecurityDuty),
-            () => privileges   = ReadAll(Path.Combine(modelRoot, "AxSecurityPrivilege"),ParseSecurityPrivilege),
-            () =>
-            {
-                queries = ReadAll(Path.Combine(modelRoot, "AxQuery"), ParseQuery);
-                var sq  = ReadAll(Path.Combine(modelRoot, "AxQuerySimple"), ParseQuery);
-                if (sq.Count > 0) queries = queries.Concat(sq).ToList();
-            },
-            () => views        = ReadAll(Path.Combine(modelRoot, "AxView"),           ParseView),
-            () => dataEntities = ReadAll(Path.Combine(modelRoot, "AxDataEntityView"), ParseDataEntity),
-            () =>
-            {
-                reports = new List<ExtractedReport>();
-                reports.AddRange(ReadAll(Path.Combine(modelRoot, "AxReport"),     (d, f) => ParseReport(d, f, "Rdl")));
-                reports.AddRange(ReadAll(Path.Combine(modelRoot, "AxReportSsrs"), (d, f) => ParseReport(d, f, "Ssrs")));
-            },
-            () => services     = ReadAll(Path.Combine(modelRoot, "AxService"),      ParseService),
-            () => serviceGroups = ReadAll(Path.Combine(modelRoot, "AxServiceGroup"), ParseServiceGroup),
-            () => workflowTypes    = ReadAll(Path.Combine(modelRoot, "AxWorkflowTemplate"),ParseWorkflowType),
-            () => maps             = ReadAll(Path.Combine(modelRoot, "AxMap"),             ParseMap),
-            () => securityPolicies = ReadAll(Path.Combine(modelRoot, "AxSecurityPolicy"),  ParseSecurityPolicy),
-            () => configKeys       = ReadAll(Path.Combine(modelRoot, "AxConfigurationKey"),ParseConfigurationKey),
-            () => tiles            = ReadAll(Path.Combine(modelRoot, "AxTile"),            ParseTile),
-            () => workspaces       = ReadAll(Path.Combine(modelRoot, "AxWorkspace"),       ParseWorkspace)
+            () => roles        = ReadAll(Path.Combine(modelRoot, Folder("securityrole")),      ParseSecurityRole),
+            () => duties       = ReadAll(Path.Combine(modelRoot, Folder("securityduty")),      ParseSecurityDuty),
+            () => privileges   = ReadAll(Path.Combine(modelRoot, Folder("securityprivilege")), ParseSecurityPrivilege),
+            // Queries all live in AxQuery — the concrete AxQuerySimple appears as the root's
+            // i:type, never as a folder (registry: query, ground-truthed against a full AOS
+            // folder census).
+            () => queries      = ReadAll(Path.Combine(modelRoot, Folder("query")), ParseQuery),
+            () => views        = ReadAll(Path.Combine(modelRoot, Folder("view")),           ParseView),
+            () => dataEntities = ReadAll(Path.Combine(modelRoot, Folder("dataentityview")), ParseDataEntity),
+            // AxReportSsrs was read here too; no such folder exists on any AOS (census 2026-08-05)
+            // — SSRS reports are AxReport files whose design is RDL.
+            () => reports      = ReadAll(Path.Combine(modelRoot, Folder("report")), (d, f) => ParseReport(d, f, "Rdl")),
+            () => services         = ReadAll(Path.Combine(modelRoot, Folder("service")),          ParseService),
+            () => serviceGroups    = ReadAll(Path.Combine(modelRoot, Folder("servicegroup")),     ParseServiceGroup),
+            () => workflowTypes    = ReadAll(Path.Combine(modelRoot, Folder("workflowtemplate")), ParseWorkflowType),
+            () => maps             = ReadAll(Path.Combine(modelRoot, Folder("map")),              ParseMap),
+            () => securityPolicies = ReadAll(Path.Combine(modelRoot, Folder("securitypolicy")),   ParseSecurityPolicy),
+            () => configKeys       = ReadAll(Path.Combine(modelRoot, Folder("configurationkey")), ParseConfigurationKey),
+            () => tiles            = ReadAll(Path.Combine(modelRoot, Folder("tile")),             ParseTile),
+            // Workspaces were read from AxWorkspace, a folder that exists on no AOS (census
+            // 2026-08-05) — so this has always yielded zero rows. A D365FO workspace is an
+            // AxForm whose design Pattern is Workspace; indexing them properly means walking
+            // forms, not a folder. Left empty rather than pretending to read something.
+            () => workspaces       = new List<ExtractedWorkspace>()
         );
 
         var coc = classes.SelectMany(DetectCoc).ToList();
@@ -294,17 +293,23 @@ public sealed class MetadataExtractor
         (name.EndsWith("FormAdaptor", StringComparison.OrdinalIgnoreCase) ||
          name.EndsWith("_FormAdaptor", StringComparison.OrdinalIgnoreCase));
 
+    /// <summary>
+    /// AOT subfolder for a registry kind. Every folder this extractor reads comes through
+    /// here, so a folder name can only be wrong in one place — and
+    /// <c>ObjectTypeRegistryTests</c> asserts each one exists on a real AOS.
+    /// </summary>
+    private static string Folder(string kind)
+        => D365FO.Core.ObjectTypes.ObjectTypeRegistry.Subfolder(kind);
+
+    /// <summary>
+    /// Folder names that identify <paramref name="dir"/> as a model root. Driven by
+    /// <see cref="D365FO.Core.ObjectTypes.ObjectTypeRegistry"/> so this list cannot drift
+    /// from the folders the extractor actually reads, and so names that exist on no AOS
+    /// (the <c>AxWorkflowType</c> class of bug) cannot creep back in.
+    /// </summary>
     private static bool HasAnyAotSubfolder(string dir)
     {
-        foreach (var s in new[] {
-            "AxTable", "AxClass", "AxEdt", "AxEnum", "AxLabelFile", "AxForm",
-            "AxTableExtension", "AxFormExtension", "AxEdtExtension", "AxEnumExtension",
-            "AxSecurityRole", "AxSecurityDuty", "AxSecurityPrivilege",
-            "AxMenuItemDisplay", "AxMenuItemAction", "AxMenuItemOutput",
-            "AxQuery", "AxQuerySimple", "AxView", "AxDataEntityView",
-            "AxReport", "AxReportSsrs", "AxService", "AxServiceGroup", "AxWorkflowTemplate",
-            "AxMap", "AxSecurityPolicy", "AxConfigurationKey", "AxTile", "AxWorkspace",
-        })
+        foreach (var s in D365FO.Core.ObjectTypes.ObjectTypeRegistry.ModelMarkerFolders())
             if (Directory.Exists(Path.Combine(dir, s))) return true;
         return false;
     }

--- a/src/D365FO.Core/Index/ObjectLookup.cs
+++ b/src/D365FO.Core/Index/ObjectLookup.cs
@@ -11,9 +11,13 @@ public static class ObjectLookup
     public const string SupportedKindsHint =
         "Use class, table, edt, enum, form, menu-item, query, view, entity, report, service, service-group, role, duty, or privilege.";
 
-    /// <summary>Lower-case the kind and strip separators: "menu-item" → "menuitem".</summary>
+    /// <summary>
+    /// Lower-case the kind and strip separators: "menu-item" → "menuitem". Shares
+    /// <see cref="D365FO.Core.ObjectTypes.ObjectTypeRegistry.NormalizeKind"/> so a kind
+    /// string means the same thing to the reader, the writer and the bridge.
+    /// </summary>
     public static string NormalizeKind(string value)
-        => new(value.Where(char.IsLetterOrDigit).Select(char.ToLowerInvariant).ToArray());
+        => D365FO.Core.ObjectTypes.ObjectTypeRegistry.NormalizeKind(value);
 
     public static (object? Data, string? Code, string? Message) Fetch(MetadataRepository repo, string kind, string name)
     {

--- a/src/D365FO.Core/ObjectTypes/ObjectTypeRegistry.cs
+++ b/src/D365FO.Core/ObjectTypes/ObjectTypeRegistry.cs
@@ -1,0 +1,363 @@
+using System;
+using System.Collections.Generic;
+
+namespace D365FO.Core.ObjectTypes
+{
+    /// <summary>
+    /// One AOT object type: its XML root element, on-disk folder, MetaModel type,
+    /// provider collection, and the policies every writer/reader needs to agree on.
+    /// </summary>
+    /// <remarks>
+    /// Deliberately a plain class with a positional constructor and no records,
+    /// <c>init</c> accessors or nullable annotations: this file is compiled into
+    /// <c>D365FO.Bridge</c> too, which targets net48 (no <c>IsExternalInit</c>,
+    /// nullable disabled). Keep it dependency-free.
+    /// </remarks>
+    public sealed class ObjectTypeInfo
+    {
+        public ObjectTypeInfo(
+            string kind,
+            string rootElement,
+            string aotSubfolder,
+            string metaModelType,
+            string providerCollection,
+            string generateCommand,
+            string mcpObjectType,
+            string namingKind,
+            bool requiresXsiNamespace,
+            bool abstractRoot,
+            bool existsInStandardAot,
+            bool indexed)
+        {
+            Kind = kind;
+            RootElement = rootElement;
+            AotSubfolder = aotSubfolder;
+            MetaModelType = metaModelType;
+            ProviderCollection = providerCollection;
+            GenerateCommand = generateCommand;
+            McpObjectType = mcpObjectType;
+            NamingKind = namingKind;
+            RequiresXsiNamespace = requiresXsiNamespace;
+            AbstractRoot = abstractRoot;
+            ExistsInStandardAot = existsInStandardAot;
+            Indexed = indexed;
+        }
+
+        /// <summary>Canonical kind id: lower-case, letters and digits only ("menuitemdisplay").</summary>
+        public string Kind { get; }
+
+        /// <summary>Root element of the object's AOT XML ("AxTable").</summary>
+        public string RootElement { get; }
+
+        /// <summary>Folder under the model root holding these files. Always equals the root element in a real AOT.</summary>
+        public string AotSubfolder { get; }
+
+        /// <summary>
+        /// Short MetaModel class name under <c>Microsoft.Dynamics.AX.Metadata.MetaModel</c>.
+        /// Differs from <see cref="RootElement"/> where the root is abstract and the
+        /// provider needs the concrete subtype (queries: <c>AxQuery</c> → <c>AxQuerySimple</c>).
+        /// </summary>
+        public string MetaModelType { get; }
+
+        /// <summary>
+        /// <c>IMetadataProvider</c> collection name ("Tables"), or null when this build of
+        /// the platform exposes no provider channel for the type and it must be written as XML.
+        /// </summary>
+        public string ProviderCollection { get; }
+
+        /// <summary><c>d365fo generate &lt;name&gt;</c> subcommand that emits this type, or null.</summary>
+        public string GenerateCommand { get; }
+
+        /// <summary>Discriminator accepted by the MCP <c>generate_object</c> tool, or null when not exposed.</summary>
+        public string McpObjectType { get; }
+
+        /// <summary>Kind string understood by <see cref="ObjectNamingRules"/>.</summary>
+        public string NamingKind { get; }
+
+        /// <summary>The metadata reader rejects the file unless the XMLSchema-instance namespace is declared on the root.</summary>
+        public bool RequiresXsiNamespace { get; }
+
+        /// <summary>Root type is abstract — the concrete subtype must be pinned via <c>i:type</c>.</summary>
+        public bool AbstractRoot { get; }
+
+        /// <summary>
+        /// The folder is present in a shipped D365FO installation. False marks a name that
+        /// looks plausible but matches nothing on any AOS — the failure mode behind audit
+        /// finding G1, where <c>AxWorkflowType</c> was read for years and never existed.
+        /// </summary>
+        public bool ExistsInStandardAot { get; }
+
+        /// <summary>The extractor reads this folder into the index.</summary>
+        public bool Indexed { get; }
+
+        public override string ToString() => Kind + " (" + RootElement + ")";
+    }
+
+    /// <summary>
+    /// The single source of truth for AOT object types: root element, AOT folder,
+    /// MetaModel type, provider collection, write policies, and which surfaces expose
+    /// each type.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// Replaces four registries that drifted apart independently (audit finding G2):
+    /// the bridge's <c>KindToCollection</c>/<c>KindToTypeName</c>, ~30 hard-coded folder
+    /// literals across <c>Commands/Generate/*</c>, <c>ObjectLookup</c>'s read kinds, and
+    /// <c>MetadataExtractor</c>'s folder list. The first visible casualty of that drift was
+    /// G1: the generator wrote <c>AxWorkflow</c>, the extractor read <c>AxWorkflowType</c>,
+    /// and the real folder is <c>AxWorkflowTemplate</c>.
+    /// </para>
+    /// <para>
+    /// Folder names and their existence are ground-truthed against a full census of
+    /// <c>PackagesLocalDirectory</c> on a real AOS (2026-08-05, ~80 distinct <c>Ax*</c>
+    /// folders across every package). <c>ObjectTypeRegistryAotTests</c> re-runs that census
+    /// when <c>D365FO_PACKAGES_PATH</c> points at one.
+    /// </para>
+    /// <para>
+    /// This file is shared-compiled into <c>D365FO.Bridge</c> (net48) — see the remarks on
+    /// <see cref="ObjectTypeInfo"/> before adding language features.
+    /// </para>
+    /// </remarks>
+    public static class ObjectTypeRegistry
+    {
+        /// <summary>
+        /// AOT subfolder names as compile-time constants, for the write paths that used to
+        /// carry ~30 loose <c>"AxSomething"</c> literals. Using these makes a mistyped or
+        /// invented folder a build error instead of a file written where nothing reads it.
+        /// <c>ObjectTypeRegistryTests</c> asserts every constant is a registered subfolder.
+        /// </summary>
+        public static class Folders
+        {
+            public const string Table = "AxTable";
+            public const string Class = "AxClass";
+            public const string Edt = "AxEdt";
+            public const string Enum = "AxEnum";
+            public const string Form = "AxForm";
+            public const string View = "AxView";
+            public const string Map = "AxMap";
+            public const string Query = "AxQuery";
+            public const string DataEntityView = "AxDataEntityView";
+
+            public const string TableExtension = "AxTableExtension";
+            public const string FormExtension = "AxFormExtension";
+            public const string EdtExtension = "AxEdtExtension";
+            public const string EnumExtension = "AxEnumExtension";
+            public const string SecurityDutyExtension = "AxSecurityDutyExtension";
+            public const string SecurityRoleExtension = "AxSecurityRoleExtension";
+
+            public const string MenuItemDisplay = "AxMenuItemDisplay";
+            public const string MenuItemAction = "AxMenuItemAction";
+            public const string MenuItemOutput = "AxMenuItemOutput";
+
+            public const string Report = "AxReport";
+            public const string Service = "AxService";
+            public const string ServiceGroup = "AxServiceGroup";
+
+            public const string SecurityRole = "AxSecurityRole";
+            public const string SecurityDuty = "AxSecurityDuty";
+            public const string SecurityPrivilege = "AxSecurityPrivilege";
+            public const string SecurityPolicy = "AxSecurityPolicy";
+
+            public const string WorkflowTemplate = "AxWorkflowTemplate";
+            public const string WorkflowApproval = "AxWorkflowApproval";
+            public const string WorkflowTask = "AxWorkflowTask";
+        }
+
+        private static readonly ObjectTypeInfo[] _all = BuildAll();
+
+        private static ObjectTypeInfo[] BuildAll()
+        {
+            return new[]
+            {
+                // ── Core types the provider can write ──────────────────────────────
+                New("table", "AxTable", "Tables", "table", "table", "Table", xsi: true),
+                New("class", "AxClass", "Classes", "class", "class", "Class"),
+                New("edt", "AxEdt", "Edts", "edt", "edt", "Edt", xsi: true, abstractRoot: true),
+                New("enum", "AxEnum", "Enums", "enum", "enum", "Enum", xsi: true),
+                New("form", "AxForm", "Forms", "form", "form", "Form"),
+                New("view", "AxView", "Views", "view", null, "View", xsi: true),
+                New("map", "AxMap", "Maps", "map", null, "Map", xsi: true),
+                // AxQuery is an abstract MetaModel base: every shipped file is
+                // <AxQuery xmlns:i=… i:type="AxQuerySimple">, and the reader throws
+                // "Cannot create an abstract class" without that discriminator. The folder
+                // stays AxQuery (census: 4,989 files; no AxQuerySimple folder exists), and the
+                // bridge keeps mapping to the abstract type — WriteArtifact resolves the
+                // concrete subtype from the root's i:type, exactly as it does for AxEdt.
+                New("query", "AxQuery", "Queries", "query", "query", "Query", xsi: true, abstractRoot: true),
+                New("dataentityview", "AxDataEntityView", "DataEntityViews", "entity", null, "Entity"),
+
+                // ── Extensions ─────────────────────────────────────────────────────
+                New("tableextension", "AxTableExtension", "TableExtensions", "extension", null, "TableExtension"),
+                New("formextension", "AxFormExtension", "FormExtensions", "extension", null, "FormExtension"),
+                New("edtextension", "AxEdtExtension", "EdtExtensions", "extension", null, "EdtExtension", xsi: true, abstractRoot: true),
+                New("enumextension", "AxEnumExtension", "EnumExtensions", "extension", null, "EnumExtension"),
+                New("viewextension", "AxViewExtension", "ViewExtensions", null, null, "ViewExtension"),
+                // Query extensions are concrete on disk: the folder and the root element are
+                // both AxQuerySimpleExtension (no i:type needed). The bridge collection is
+                // still QueryExtensions, and the abstract AxQueryExtension is what the
+                // provider's kind→type lookup resolves — the one place where the MetaModel
+                // type the bridge constructs differs from the file's root element.
+                New("queryextension", "AxQuerySimpleExtension", "QueryExtensions", null, null, "QueryExtension",
+                    metaModelType: "AxQueryExtension", xsi: true),
+                New("dataentityviewextension", "AxDataEntityViewExtension", "DataEntityViewExtensions", null, null, "DataEntityViewExtension"),
+                // Folder ships in every model; no standard model has a file in it yet.
+                New("mapextension", "AxMapExtension", null, null, null, "MapExtension"),
+                New("securitydutyextension", "AxSecurityDutyExtension", null, "extension", null, "SecurityDutyExtension"),
+                New("securityroleextension", "AxSecurityRoleExtension", null, "extension", null, "SecurityRoleExtension"),
+
+                // ── Written as XML only (no provider collection wired yet) ──────────
+                New("menuitemdisplay", "AxMenuItemDisplay", null, "menu-item", null, "MenuItemDisplay"),
+                New("menuitemaction", "AxMenuItemAction", null, "menu-item", null, "MenuItemAction"),
+                New("menuitemoutput", "AxMenuItemOutput", null, "menu-item", null, "MenuItemOutput"),
+                New("report", "AxReport", null, "report", null, "Report"),
+                New("service", "AxService", null, "custom-service", null, "Service"),
+                New("servicegroup", "AxServiceGroup", null, "custom-service", null, "ServiceGroup"),
+                New("securityrole", "AxSecurityRole", null, "role", null, "SecurityRole"),
+                New("securityduty", "AxSecurityDuty", null, "duty", null, "SecurityDuty"),
+                New("securityprivilege", "AxSecurityPrivilege", null, "privilege", null, "SecurityPrivilege"),
+                New("securitypolicy", "AxSecurityPolicy", null, "security-policy", "security-policy", "SecurityPolicy"),
+                // The AOT node Visual Studio labels "workflow type".
+                New("workflowtemplate", "AxWorkflowTemplate", null, "workflow", null, "WorkflowTemplate"),
+                New("workflowapproval", "AxWorkflowApproval", null, "workflow", null, "WorkflowApproval"),
+                New("workflowtask", "AxWorkflowTask", null, "workflow", null, "WorkflowTask"),
+
+                // ── Read-only types the index knows but nothing generates ───────────
+                New("workflowcategory", "AxWorkflowCategory", null, null, null, "WorkflowCategory", indexed: false),
+                New("configurationkey", "AxConfigurationKey", null, null, null, "ConfigurationKey"),
+                New("labelfile", "AxLabelFile", null, null, null, "LabelFile"),
+                New("tile", "AxTile", null, null, null, "Tile"),
+                New("menu", "AxMenu", null, null, null, "Menu", indexed: false),
+                New("compositedataentityview", "AxCompositeDataEntityView", null, null, null, "CompositeDataEntityView", indexed: false),
+                New("aggregatedataentity", "AxAggregateDataEntity", null, null, null, "AggregateDataEntity", indexed: false),
+                New("formpart", "AxFormPart", null, null, null, "FormPart", indexed: false),
+                New("resource", "AxResource", null, null, null, "Resource", indexed: false),
+
+                // ── Names that exist in this codebase but not on any AOS ────────────
+                // Kept so the parity test can assert nothing reads them: an extractor
+                // pointed at a folder that never exists silently indexes zero objects
+                // and looks healthy (finding G1).
+                New("workspace", "AxWorkspace", null, null, null, "Workspace", existsInStandardAot: false),
+                New("reportssrs", "AxReportSsrs", null, null, null, "Report", existsInStandardAot: false, indexed: false),
+            };
+        }
+
+        private static ObjectTypeInfo New(
+            string kind,
+            string rootElement,
+            string providerCollection,
+            string generateCommand,
+            string mcpObjectType,
+            string namingKind,
+            bool xsi = false,
+            bool abstractRoot = false,
+            bool existsInStandardAot = true,
+            bool indexed = true,
+            string aotSubfolder = null,
+            string metaModelType = null)
+            => new ObjectTypeInfo(
+                kind, rootElement,
+                aotSubfolder ?? rootElement,
+                metaModelType ?? rootElement,
+                providerCollection, generateCommand, mcpObjectType, namingKind,
+                xsi, abstractRoot, existsInStandardAot, indexed);
+
+        /// <summary>Every registered type.</summary>
+        public static IReadOnlyList<ObjectTypeInfo> All
+        {
+            get { return _all; }
+        }
+
+        /// <summary>Normalise a caller-supplied kind: lower-case, drop separators ("menu-item" → "menuitem").</summary>
+        public static string NormalizeKind(string value)
+        {
+            if (string.IsNullOrEmpty(value)) return string.Empty;
+            var chars = new char[value.Length];
+            var n = 0;
+            for (var i = 0; i < value.Length; i++)
+            {
+                var c = value[i];
+                if (char.IsLetterOrDigit(c)) chars[n++] = char.ToLowerInvariant(c);
+            }
+            return new string(chars, 0, n);
+        }
+
+        /// <summary>Look up by kind id, root element, or AOT folder name. Null when unknown.</summary>
+        public static ObjectTypeInfo Find(string kindOrRoot)
+        {
+            var key = NormalizeKind(kindOrRoot);
+            if (key.Length == 0) return null;
+            for (var i = 0; i < _all.Length; i++)
+            {
+                var t = _all[i];
+                if (key == t.Kind
+                    || key == NormalizeKind(t.RootElement)
+                    || key == NormalizeKind(t.AotSubfolder))
+                    return t;
+            }
+            return null;
+        }
+
+        /// <summary>AOT subfolder for a kind. Throws for an unknown kind — callers hard-code folders otherwise.</summary>
+        public static string Subfolder(string kindOrRoot)
+        {
+            var t = Find(kindOrRoot);
+            if (t == null)
+                throw new ArgumentException("Unknown AOT object type '" + kindOrRoot + "'.", "kindOrRoot");
+            return t.AotSubfolder;
+        }
+
+        /// <summary>Kinds the bridge can write through <c>IMetadataProvider</c>, kind → collection name.</summary>
+        public static Dictionary<string, string> BridgeCollections()
+        {
+            var map = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
+            for (var i = 0; i < _all.Length; i++)
+                if (_all[i].ProviderCollection != null)
+                    map[_all[i].Kind] = _all[i].ProviderCollection;
+            return map;
+        }
+
+        /// <summary>Bridge-writable kinds, kind → fully qualified MetaModel type name.</summary>
+        public static Dictionary<string, string> BridgeMetaModelTypes(string metaModelNamespace)
+        {
+            var map = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
+            for (var i = 0; i < _all.Length; i++)
+                if (_all[i].ProviderCollection != null)
+                    map[_all[i].Kind] = metaModelNamespace + _all[i].MetaModelType;
+            return map;
+        }
+
+        /// <summary>Root elements whose files are unreadable without the XMLSchema-instance declaration.</summary>
+        public static HashSet<string> XsiRequiredRoots()
+        {
+            var set = new HashSet<string>(StringComparer.Ordinal);
+            for (var i = 0; i < _all.Length; i++)
+                if (_all[i].RequiresXsiNamespace)
+                    set.Add(_all[i].RootElement);
+            return set;
+        }
+
+        /// <summary>Root elements that are abstract MetaModel bases and need a concrete <c>i:type</c>.</summary>
+        public static HashSet<string> AbstractRoots()
+        {
+            var set = new HashSet<string>(StringComparer.Ordinal);
+            for (var i = 0; i < _all.Length; i++)
+                if (_all[i].AbstractRoot)
+                    set.Add(_all[i].RootElement);
+            return set;
+        }
+
+        /// <summary>
+        /// AOT folders that identify a directory as a model root. Only folders that
+        /// actually exist on an AOS qualify — a name that matches nothing can never
+        /// prove anything.
+        /// </summary>
+        public static string[] ModelMarkerFolders()
+        {
+            var list = new List<string>();
+            for (var i = 0; i < _all.Length; i++)
+                if (_all[i].ExistsInStandardAot && _all[i].Indexed)
+                    list.Add(_all[i].AotSubfolder);
+            return list.ToArray();
+        }
+    }
+}

--- a/src/D365FO.Core/Scaffolding/QueryScaffolder.cs
+++ b/src/D365FO.Core/Scaffolding/QueryScaffolder.cs
@@ -40,8 +40,15 @@ public static class QueryScaffolder
             joins  = dsList.Skip(1).Select(ds => ds with { ParentDs = dsList[0].Name ?? dsList[0].Table }).ToList();
         }
 
+        // AxQuery is an abstract MetaModel base, like AxEdt: every shipped query file is
+        // <AxQuery xmlns:i="…" i:type="AxQuerySimple">, and without that discriminator the
+        // metadata reader throws "Cannot create an abstract class". The datasource elements
+        // below already commit to the AxQuerySimple family, so the root has to say so too.
+        XNamespace xsi = "http://www.w3.org/2001/XMLSchema-instance";
         return new XDocument(
             new XElement("AxQuery",
+                new XAttribute(XNamespace.Xmlns + "i", xsi.NamespaceName),
+                new XAttribute(xsi + "type", "AxQuerySimple"),
                 new XElement("Name", name),
                 new XElement("DataSources",
                     roots.Select(r => BuildRoot(r, joins)))));

--- a/src/D365FO.Core/Scaffolding/WorkflowScaffolder.cs
+++ b/src/D365FO.Core/Scaffolding/WorkflowScaffolder.cs
@@ -20,13 +20,13 @@ namespace D365FO.Core.Scaffolding;
 public static class WorkflowScaffolder
 {
     /// <summary>AOT subfolder / root element for a workflow type.</summary>
-    public const string TemplateRoot = "AxWorkflowTemplate";
+    public const string TemplateRoot = ObjectTypes.ObjectTypeRegistry.Folders.WorkflowTemplate;
 
     /// <summary>AOT subfolder / root element for a workflow approval element.</summary>
-    public const string ApprovalRoot = "AxWorkflowApproval";
+    public const string ApprovalRoot = ObjectTypes.ObjectTypeRegistry.Folders.WorkflowApproval;
 
     /// <summary>AOT subfolder / root element for a workflow task element.</summary>
-    public const string TaskRoot = "AxWorkflowTask";
+    public const string TaskRoot = ObjectTypes.ObjectTypeRegistry.Folders.WorkflowTask;
 
     /// <summary>
     /// Scaffolds an <c>AxClass</c> extending <c>WorkflowDocument</c>.

--- a/src/D365FO.Core/Scaffolding/XppScaffolder.cs
+++ b/src/D365FO.Core/Scaffolding/XppScaffolder.cs
@@ -1157,30 +1157,26 @@ public static class ScaffoldFileWriter
     // AOT root elements that are abstract bases in Microsoft.Dynamics.AX.Metadata.MetaModel.
     // Writing one of these as the document root makes VS metadata reader throw
     // "Cannot create an abstract class" when the file is opened — callers must use the
-    // concrete subtype (AxEdtString, AxEdtInt, AxEdtStringExtension, …).
-    private static readonly HashSet<string> _abstractAxRoots = new(StringComparer.Ordinal)
-    {
-        "AxEdtExtension",
-    };
+    // concrete subtype (AxEdtString, AxEdtInt, AxEdtStringExtension, AxQuerySimple, …).
+    // AxEdt itself is handled separately by EnsureValidEdtRoot, which explains the
+    // concrete subtypes on offer.
+    private static readonly HashSet<string> _abstractAxRoots =
+        D365FO.Core.ObjectTypes.ObjectTypeRegistry.AbstractRoots();
 
     private const string XsiNamespace = "http://www.w3.org/2001/XMLSchema-instance";
 
     // AOT roots whose files are unreadable without the XMLSchema-instance namespace
-    // declared on the root element. AxEdt* carries i:type on the root itself, while
-    // AxTable / AxView / AxMap carry it on every field (AxTableField, AxViewField,
+    // declared on the root element. AxEdt* and AxQuery carry i:type on the root itself,
+    // while AxTable / AxView / AxMap carry it on every field (AxTableField, AxViewField,
     // AxMapBaseField are all polymorphic, abstract-based types — see issue #91);
     // AxEnum needs it because Visual Studio's metadata reader rejects the file
-    // outright when the declaration is absent (issue #70). Every entry here is
-    // ground-truthed against shipped standard-model files on a real AOS.
-    // Deliberately NOT a blanket rule for every AxXxx root: AxClass/AxMenuItem/AxQuery/…
+    // outright when the declaration is absent (issue #70). Every entry is
+    // ground-truthed against shipped standard-model files on a real AOS and lives in
+    // ObjectTypeRegistry, not here.
+    // Deliberately NOT a blanket rule for every AxXxx root: AxClass/AxMenuItem/…
     // are written without it today and are read back fine.
-    private static readonly HashSet<string> _xsiRequiredAxRoots = new(StringComparer.Ordinal)
-    {
-        "AxEnum",
-        "AxTable",
-        "AxView",
-        "AxMap",
-    };
+    private static readonly HashSet<string> _xsiRequiredAxRoots =
+        D365FO.Core.ObjectTypes.ObjectTypeRegistry.XsiRequiredRoots();
 
     // AOT elements that deserialize into a CLR bool, not a NoYes-style enum. The
     // DataContractSerializer reads these with XmlConvert.ToBoolean, so the NoYes
@@ -1293,6 +1289,9 @@ public static class ScaffoldFileWriter
     {
         var rootLocalName = root?.Name.LocalName;
         if (rootLocalName is null || !_abstractAxRoots.Contains(rootLocalName)) return;
+        // The AxEdt family gets the more specific diagnostic from EnsureValidEdtRoot,
+        // which can name the concrete subtypes on offer.
+        if (rootLocalName is "AxEdt" or "AxEdtExtension") return;
         if (HasConcreteXsiType(root!, rootLocalName)) return;
 
         throw new InvalidOperationException(

--- a/tests/D365FO.Core.Tests/ObjectTypeRegistryAotTests.cs
+++ b/tests/D365FO.Core.Tests/ObjectTypeRegistryAotTests.cs
@@ -1,0 +1,83 @@
+using D365FO.Core.ObjectTypes;
+using Xunit;
+
+namespace D365FO.Core.Tests;
+
+/// <summary>
+/// Ground-truth check for the registry's folder names against a real installation.
+/// Inert unless <c>D365FO_PACKAGES_PATH</c> points at a <c>PackagesLocalDirectory</c>
+/// — CI has no AOS, and a test that silently passes on an empty directory would be
+/// exactly the kind of confident lie this repo's triage rubric warns about, so the
+/// assertions only run once real packages are found.
+/// </summary>
+/// <remarks>
+/// This is the check that would have caught audit finding G1 years earlier:
+/// <c>AxWorkflowType</c> was read by the extractor and matches no folder on any AOS.
+/// </remarks>
+public class ObjectTypeRegistryAotTests
+{
+    private static string? PackagesRoot()
+    {
+        var root = Environment.GetEnvironmentVariable("D365FO_PACKAGES_PATH");
+        return string.IsNullOrWhiteSpace(root) || !Directory.Exists(root) ? null : root;
+    }
+
+    /// <summary>Distinct <c>Ax*</c> folder names present under &lt;root&gt;/&lt;package&gt;/&lt;model&gt;/.</summary>
+    private static HashSet<string> AotFolderNames(string root)
+    {
+        var names = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+        foreach (var package in SafeDirs(root))
+            foreach (var model in SafeDirs(package))
+                foreach (var folder in SafeDirs(model))
+                {
+                    var name = Path.GetFileName(folder);
+                    if (name.StartsWith("Ax", StringComparison.Ordinal)) names.Add(name);
+                }
+        return names;
+
+        static IEnumerable<string> SafeDirs(string d)
+        {
+            try { return Directory.EnumerateDirectories(d); }
+            catch (UnauthorizedAccessException) { return Array.Empty<string>(); }
+            catch (IOException) { return Array.Empty<string>(); }
+        }
+    }
+
+    [Fact]
+    public void Registry_folder_names_match_a_real_installation()
+    {
+        var root = PackagesRoot();
+        if (root is null) return;
+
+        var actual = AotFolderNames(root);
+        if (actual.Count == 0) return; // Path exists but holds no AOT — nothing proven either way.
+
+        var wrong = ObjectTypeRegistry.All
+            .Where(t => t.ExistsInStandardAot && !actual.Contains(t.AotSubfolder))
+            .Select(t => $"{t.Kind} → {t.AotSubfolder}")
+            .ToList();
+
+        Assert.True(wrong.Count == 0,
+            "Registry claims these folders exist, but no package/model under " + root + " has them: " +
+            string.Join(", ", wrong));
+    }
+
+    [Fact]
+    public void Folders_marked_absent_really_are_absent()
+    {
+        var root = PackagesRoot();
+        if (root is null) return;
+
+        var actual = AotFolderNames(root);
+        if (actual.Count == 0) return;
+
+        var present = ObjectTypeRegistry.All
+            .Where(t => !t.ExistsInStandardAot && actual.Contains(t.AotSubfolder))
+            .Select(t => $"{t.Kind} → {t.AotSubfolder}")
+            .ToList();
+
+        Assert.True(present.Count == 0,
+            "These folders are marked as existing on no AOS, but " + root + " has them: " +
+            string.Join(", ", present));
+    }
+}

--- a/tests/D365FO.Core.Tests/ObjectTypeRegistryTests.cs
+++ b/tests/D365FO.Core.Tests/ObjectTypeRegistryTests.cs
@@ -1,0 +1,182 @@
+using System.Reflection;
+using D365FO.Core.ObjectTypes;
+using Xunit;
+
+namespace D365FO.Core.Tests;
+
+/// <summary>
+/// Guards the registry that replaced four independently drifting kind tables
+/// (audit finding G2). The drift that motivated it shipped as G1: the generator wrote
+/// <c>AxWorkflow</c>, the extractor read <c>AxWorkflowType</c>, and the folder a real
+/// AOS actually uses is <c>AxWorkflowTemplate</c> — three names, none of them agreeing.
+/// </summary>
+public class ObjectTypeRegistryTests
+{
+    [Fact]
+    public void Kinds_are_unique_and_already_normalized()
+    {
+        var kinds = ObjectTypeRegistry.All.Select(t => t.Kind).ToList();
+
+        Assert.Equal(kinds.Count, kinds.Distinct(StringComparer.Ordinal).Count());
+        Assert.All(kinds, k => Assert.Equal(k, ObjectTypeRegistry.NormalizeKind(k)));
+    }
+
+    [Fact]
+    public void Root_elements_are_unique()
+    {
+        var roots = ObjectTypeRegistry.All.Select(t => t.RootElement).ToList();
+
+        Assert.Equal(roots.Count, roots.Distinct(StringComparer.Ordinal).Count());
+        Assert.All(roots, r => Assert.StartsWith("Ax", r, StringComparison.Ordinal));
+    }
+
+    [Fact]
+    public void Lookup_accepts_kind_root_element_and_folder_spellings()
+    {
+        Assert.Equal("table", ObjectTypeRegistry.Find("table")!.Kind);
+        Assert.Equal("table", ObjectTypeRegistry.Find("AxTable")!.Kind);
+        Assert.Equal("menuitemdisplay", ObjectTypeRegistry.Find("menu-item-display")!.Kind);
+        Assert.Equal("queryextension", ObjectTypeRegistry.Find("AxQuerySimpleExtension")!.Kind);
+        Assert.Null(ObjectTypeRegistry.Find("AxNonsense"));
+    }
+
+    /// <summary>The name at the heart of G1 must resolve to the folder that exists, not the two that never did.</summary>
+    [Fact]
+    public void Workflow_type_resolves_to_AxWorkflowTemplate()
+    {
+        var t = ObjectTypeRegistry.Find("workflowtemplate")!;
+
+        Assert.Equal("AxWorkflowTemplate", t.RootElement);
+        Assert.Equal("AxWorkflowTemplate", t.AotSubfolder);
+        Assert.Equal("workflow", t.GenerateCommand);
+        Assert.Null(ObjectTypeRegistry.Find("AxWorkflow"));
+    }
+
+    [Fact]
+    public void Folder_constants_all_name_a_registered_subfolder()
+    {
+        var folders = ObjectTypeRegistry.All.Select(t => t.AotSubfolder).ToHashSet(StringComparer.Ordinal);
+
+        var consts = typeof(ObjectTypeRegistry.Folders)
+            .GetFields(BindingFlags.Public | BindingFlags.Static | BindingFlags.FlattenHierarchy)
+            .Where(f => f.IsLiteral && f.FieldType == typeof(string))
+            .ToList();
+
+        Assert.NotEmpty(consts);
+        foreach (var c in consts)
+        {
+            var value = (string)c.GetRawConstantValue()!;
+            Assert.True(folders.Contains(value),
+                $"ObjectTypeRegistry.Folders.{c.Name} = \"{value}\" is not a registered AOT subfolder.");
+        }
+    }
+
+    [Fact]
+    public void Folders_that_exist_on_no_AOS_are_marked_and_never_used_as_model_markers()
+    {
+        var phantom = ObjectTypeRegistry.All.Where(t => !t.ExistsInStandardAot).ToList();
+
+        // The census these are drawn from found no such folder in any package.
+        Assert.Contains(phantom, t => t.RootElement == "AxWorkspace");
+        Assert.Contains(phantom, t => t.RootElement == "AxReportSsrs");
+
+        var markers = ObjectTypeRegistry.ModelMarkerFolders();
+        foreach (var t in phantom)
+            Assert.DoesNotContain(t.AotSubfolder, markers);
+    }
+
+    [Fact]
+    public void Model_marker_folders_are_real_indexed_folders()
+    {
+        var markers = ObjectTypeRegistry.ModelMarkerFolders();
+
+        Assert.NotEmpty(markers);
+        Assert.Equal(markers.Length, markers.Distinct(StringComparer.Ordinal).Count());
+        foreach (var m in markers)
+        {
+            var t = ObjectTypeRegistry.Find(m)!;
+            Assert.True(t.ExistsInStandardAot);
+            Assert.True(t.Indexed);
+        }
+    }
+
+    [Fact]
+    public void Bridge_tables_cover_exactly_the_kinds_with_a_provider_collection()
+    {
+        var expected = ObjectTypeRegistry.All.Where(t => t.ProviderCollection is not null).ToList();
+
+        var collections = ObjectTypeRegistry.BridgeCollections();
+        var types = ObjectTypeRegistry.BridgeMetaModelTypes("Microsoft.Dynamics.AX.Metadata.MetaModel.");
+
+        Assert.Equal(expected.Count, collections.Count);
+        Assert.Equal(expected.Count, types.Count);
+        foreach (var t in expected)
+        {
+            Assert.Equal(t.ProviderCollection, collections[t.Kind]);
+            Assert.Equal("Microsoft.Dynamics.AX.Metadata.MetaModel." + t.MetaModelType, types[t.Kind]);
+        }
+
+        // The 16 kinds the bridge shipped with, so a refactor cannot quietly drop one.
+        Assert.Equal(
+            new[]
+            {
+                "class", "dataentityview", "dataentityviewextension", "edt", "edtextension",
+                "enum", "enumextension", "form", "formextension", "map", "query",
+                "queryextension", "table", "tableextension", "view", "viewextension",
+            },
+            collections.Keys.OrderBy(k => k, StringComparer.Ordinal).ToArray());
+    }
+
+    /// <summary>
+    /// Every shipped query file is <c>&lt;AxQuery i:type="AxQuerySimple"&gt;</c>; the
+    /// generator used to emit a bare abstract root, which the metadata reader rejects.
+    /// </summary>
+    [Fact]
+    public void Abstract_roots_also_require_the_xsi_declaration()
+    {
+        var abstractRoots = ObjectTypeRegistry.AbstractRoots();
+
+        Assert.Contains("AxEdt", abstractRoots);
+        Assert.Contains("AxEdtExtension", abstractRoots);
+        Assert.Contains("AxQuery", abstractRoots);
+
+        var xsi = ObjectTypeRegistry.XsiRequiredRoots();
+        foreach (var root in abstractRoots)
+            Assert.Contains(root, xsi);
+    }
+
+    [Fact]
+    public void Xsi_required_roots_keep_the_ground_truthed_set()
+    {
+        var xsi = ObjectTypeRegistry.XsiRequiredRoots();
+
+        // Polymorphic children (issue #91) or a reader that rejects the file outright (#70).
+        Assert.Contains("AxTable", xsi);
+        Assert.Contains("AxView", xsi);
+        Assert.Contains("AxMap", xsi);
+        Assert.Contains("AxEnum", xsi);
+        // Written without it today and read back fine — see ScaffoldFileWriter.
+        Assert.DoesNotContain("AxClass", xsi);
+        Assert.DoesNotContain("AxForm", xsi);
+    }
+
+    [Fact]
+    public void Every_generate_subcommand_maps_to_at_least_one_registered_type()
+    {
+        // Subcommands that compose several object types are represented by the type they
+        // create; the ones missing here emit only AxClass artifacts (covered by "class").
+        var commands = ObjectTypeRegistry.All
+            .Where(t => t.GenerateCommand is not null)
+            .Select(t => t.GenerateCommand!)
+            .Distinct(StringComparer.Ordinal)
+            .ToHashSet(StringComparer.Ordinal);
+
+        foreach (var expected in new[]
+                 {
+                     "table", "class", "form", "edt", "enum", "query", "view", "map", "entity",
+                     "extension", "menu-item", "report", "role", "duty", "privilege",
+                     "security-policy", "workflow", "custom-service",
+                 })
+            Assert.Contains(expected, commands);
+    }
+}


### PR DESCRIPTION
Phases 1.1 and 1.2 of [`docs/KNOWLEDGE_AUDIT_PLAN.md`](docs/KNOWLEDGE_AUDIT_PLAN.md), closing audit findings **G2** and **G3**.

> Stacked on `fix/knowledge-audit-phase-0` (#151) — review that first; this PR's base flips to `main` once it merges.

## 1.1 — one object-type registry (G2)

`src/D365FO.Core/ObjectTypes/ObjectTypeRegistry.cs` replaces four independently drifting tables: the bridge's `KindToCollection`/`KindToTypeName`, ~30 loose `"AxSomething"` literals in `Commands/Generate/*` (now `ObjectTypeRegistry.Folders.*` constants, so a typo is a build error), `ScaffoldFileWriter`'s xsi/abstract-root sets, and the extractor's + `index refresh`'s folder lists. The net48 bridge cannot reference the net10 Core, so it **shared-compiles** the registry file.

Fallout, all "a name nothing on disk matches":

- `generate query` emitted a bare `<AxQuery>`; `AxQuery` is abstract and every shipped file is `<AxQuery i:type="AxQuerySimple">`
- the extractor read `AxWorkspace`, `AxReportSsrs` and `AxQuerySimple` — folders that exist in no package on a real AOS

## 1.2 — the provider's own verdict (G3)

Every validator here checked the XML against *our* expectations. The bridge gained `validateArtifact`: deserialize into the MetaModel type, serialize back, report what the round-trip lost. No model touched, nothing written — safe against a live installation. Exposed as `d365fo validate metadata <file|dir> [--recursive]`.

Two of this repo's assumptions were wrong, and the assembly settled both:

- **the on-disk format is DataContract, not `XmlSerializer`** — each type declares its own namespace (`AxTable` none, `AxForm` V6, `AxMenuItem*` V1, `AxReport`/`AxWorkflow*` V2) and member order, and the serializer *silently drops* elements that are unknown or out of order
- **`IMetadataProvider` exposes a collection for every family** the audit listed as unreachable. Read off the interface itself — which is how `queryextension → QueryExtensions` / `AxQueryExtension` was caught naming two things that do not exist (`QuerySimpleExtensions` / `AxQuerySimpleExtension`).

Calibrated against shipped Microsoft files first (zero loss), then pointed at our output. **Ten families could not be read at all:**

| Defect | Effect |
|---|---|
| menu items (V1), reports (V2), workflow types (V2), form extensions (V6) written with no contract namespace | rejected before a single property is read |
| `TableOfContents` form with `<Style>TOCList</Style>` on its Tab | `TabStyle` has no such member; whole form unreadable |
| `AxSecurityPolicy` with the table name in `ConstrainedTable` | that is a `NoYes` flag; the name belongs in `PrimaryTable` |
| `AxEdtExtension` pinned to `i:type="AxEdtStringExtension"` | no such type in any D365FO build — and the write guard **required** it |

All fixed. All 51 goldens now deserialize (was 41). The 26 still reporting dropped elements are the member-ordering problem — Phase 1.3, next.

## Tests

- `ObjectTypeRegistryTests` — uniqueness, folder constants, the bridge's kinds, contract namespaces, abstract ⊆ xsi-required
- `ObjectTypeRegistryAotTests` — folder census against a live AOS, both directions, when `D365FO_PACKAGES_PATH` is set
- `MetadataRoundTripTests` — every golden read back through the provider, when the bridge is configured
- all three are inert on CI, which has no D365FO installation

## Verification

- `dotnet test` — 883/883 green
- `eval run --all` — 51/51 golden match
- `validate metadata eval/goldens --recursive` — 0 unreadable documents
- net48 bridge builds with the shared registry source
- indexing the real `ApplicationFoundation` model returns its 3 workflow templates with `Category` + `DocumentClass`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01U5rweebVxabZzreN7N19rT