### PR TITLE
Work the open issue log: #158, #163, #161, #162, #164, #160

### DIFF
--- a/docs/CAPABILITIES.md
+++ b/docs/CAPABILITIES.md
@@ -181,12 +181,12 @@ All scaffolders write atomically (`.tmp` + move, `.bak` on overwrite). Pass `--i
 | `generate form` | `AxForm` XML (9 patterns: SimpleList, DetailsMaster, Workspace …) |
 | `generate datasource-method` | Add/override a method on a form datasource (form-level `SourceCode`); `--list` shows overridable methods |
 | `generate control-method` | Add/override a method on a form control (form-level `SourceCode`); `--list` shows overridable methods |
-| `generate entity` | `AxDataEntityView` (`DataManagementEnabled=No` by default; opt in via `--data-management`) |
+| `generate entity` | `AxDataEntityView` — fields, keys, `--relation` (constraint-joined), `--computed-field` (unmapped, method-backed). `--data-management` also emits the DMF staging table |
 | `generate extension` | `AxTableExtension` / `AxFormExtension` / `AxEdtExtension` / `AxEnumExtension` / `AxSecurityDutyExtension` / `AxSecurityRoleExtension` |
 | `generate event-handler` | X++ event subscriber class with correct attribute |
 | `generate privilege` | `AxSecurityPrivilege` (entry point and/or `--data-entity` OData/DMF grant) |
-| `generate duty` | `AxSecurityDuty` |
-| `generate role` | `AxSecurityRole` (new or merge into existing) |
+| `generate duty` | `AxSecurityDuty` — privileges plus `--description`, `--context-string`, `--disabled` |
+| `generate role` | `AxSecurityRole` (new or merge into existing) — duties, privileges, `--sub-role` composition, `--context-string`, `--disabled`, `--no-delete-from-ui` |
 | `generate menu-item` | `AxMenuItemDisplay` / `AxMenuItemAction` / `AxMenuItemOutput` |
 | `generate report` | `AxReport` + DP class + optional DataContract class |
 | `generate edt` | `AxEdt` |
@@ -200,7 +200,7 @@ All scaffolders write atomically (`.tmp` + move, `.bak` on overwrite). Pass `--i
 | `generate business-event` | Event class + contract class |
 | `generate custom-service` | `AxService` + service class + `AxServiceGroup` |
 | `generate runbase` | `RunBase` / `RunBaseBatch` skeleton with dialog parameters |
-| `generate security-policy` | `AxSecurityPolicy` (XDS row-level security) |
+| `generate security-policy` | `AxSecurityPolicy` (XDS row-level security), including the nested `--constrained` table tree |
 | `generate systest` | `SysTestCase` skeleton — `[SysTestMethod]` Arrange/Act/Assert stub, optional `[SysTestCaseDataDependency]` and `--atl` `AtlDataRootNode` wiring (ATL-ready MVP, no test-logic generation) |
 | `generate migration-script` | Data-fix `Runnable` class with `ttsbegin`/`ttscommit` batching |
 | `generate simple-list` | Alias for `generate form --pattern SimpleList` |

--- a/docs/CAPABILITIES.md
+++ b/docs/CAPABILITIES.md
@@ -225,6 +225,37 @@ same object already uses, so a model does not accumulate `CustTable.Fleet` next 
 Every `modify` write (including `modify method`) records its exact pre-image in the
 modification journal — revert with `d365fo undo`.
 
+#### The grounding gate
+
+Every `generate` subcommand runs the same gate before it writes anything — not just the
+extension-shaped ones. The gate does three things:
+
+- **Token.** `--grounding-token` from `d365fo prepare change` / `prepare create` proves the
+  index was consulted first. Tokens are object-bound and expire after 30 minutes. Under
+  `D365FO_GROUNDING_ENFORCE=true` a missing or mismatched token fails the write; otherwise it
+  is a warning.
+- **Self-check.** Every identifier in the generated X++ must resolve in the index, and the
+  code must be free of error-severity BP findings. Each command also names the AOT objects it
+  is claiming exist — a form's datasource, an EDT's `Extends`, a workflow's driving table, a
+  CoC target's methods. Under enforcement, unresolved references fail the write.
+- **Property honesty.** After the write, everything the caller asked for is looked for in the
+  document that actually reached disk. Anything missing comes back as a `property-honesty`
+  warning naming the option and the value:
+
+  ```
+  property-honesty: --primary-key NotAField — "NotAField" is not in the generated object.
+  The scaffolder either does not carry that option onto this AOT type, or the value was
+  dropped on the way to disk.
+  ```
+
+  This is the only check that can see an option being accepted and quietly discarded; every
+  other validator judges the document on its own terms, and a document missing a property
+  nobody asked it for is perfectly valid.
+
+The gate is not something a subcommand can opt out of: `GenerateInstaller.Write` takes the
+gate's result as an argument, so there is no way to reach the writer without having gated, and
+`GenerateGateSurfaceTests` fails the build if a command reaches around the shared path.
+
 ### Scaffolding validation helpers
 
 ```sh

--- a/docs/CAPABILITIES.md
+++ b/docs/CAPABILITIES.md
@@ -240,6 +240,38 @@ catalog is generated from the metadata assembly by `scripts/emit-metadata-contra
 committed, so this works with no D365FO install. Generated files are also written in contract
 order, which is what keeps a table's field groups from being dropped.
 
+#### The XML rule canon, and which families each rule speaks for
+
+| Rule | Finds | Families |
+|------|-------|----------|
+| `XML001` | Table with no `<AlternateKey>Yes</AlternateKey>` index | `AxTable` only |
+| `XML002` | Table missing `<Label>` (mined) | `AxTable` only |
+| `XML003` | Table missing `<TableGroup>` (mined) | `AxTable` only |
+| `XML004` | Field with neither `<ExtendedDataType>` nor `<EnumType>` (mined) | `AxTable` only |
+| `XML005` | Table missing `<ClusteredIndex>` (mined) | `AxTable` only |
+| `XML007` | Member the type does not declare — silently dropped on read | every family |
+| `XML008` | Value outside the enum its member is typed as — the read throws | every family |
+| `XML009` | Root element names no AOT type, or one no shipped AOS has | every family |
+| `XML010` | Abstract root with no concrete `i:type`, or one that resolves to nothing | every family |
+| `XML011` | `xmlns:i` missing where the reader needs it | every family |
+| `XML012` | Document not in the XML namespace its contract declares | every family |
+| `XML013` | File sitting in an AOT folder another family owns | every family (path-aware) |
+
+XML001–XML005 are AxTable-only by nature: they are property-presence rules mined from standard
+tables, and there is no equivalent evidence for other families. Everything from XML007 down is
+driven by the `MetadataContracts` catalog (565 types, generated from
+`Microsoft.Dynamics.AX.Metadata.dll`) and by `ObjectTypeRegistry`, so it applies uniformly —
+form, EDT, enum, entity, report, query, view, map and every security type included. XML009–XML012
+are the offline approximation of what the bridge's `Handlers.WriteArtifact` rejects before the
+provider ever sees the document (`TYPE_NOT_FOUND`, `ABSTRACT_TYPE`, and the two
+`XML_DESERIALIZE_FAILED` shapes), which is what lets non-Windows CI catch those failures.
+
+There is deliberately **no member-order lint**. Order matters and generated files are written in
+contract order, but shipped Microsoft files deviate from it in places and the provider reads them
+back with no loss — so flagging deviation in other people's files would assert a defect the
+evidence does not support. The ordering knowledge is applied where it is proven (canonical
+output), not asserted as a rule.
+
 ### `validate metadata` — the provider's own verdict
 
 Every other validator checks the XML against *our* expectations. This one hands the file to

--- a/src/D365FO.Cli/CliApp.cs
+++ b/src/D365FO.Cli/CliApp.cs
@@ -286,7 +286,7 @@ public static class CliApp
             cfg.AddBranch("test", b =>
             {
                 b.SetDescription("Run D365FO developer tests (Windows VM).");
-                b.AddCommand<TestRunCommand>("run").WithDescription("Invoke SysTestRunner.");
+                b.AddCommand<TestRunCommand>("run").WithDescription("Invoke the platform SysTest console runner (SysTestConsole.exe).");
             });
 
             cfg.AddBranch("bp", b =>

--- a/src/D365FO.Cli/Commands/Agent/SchemaCommand.cs
+++ b/src/D365FO.Cli/Commands/Agent/SchemaCommand.cs
@@ -223,7 +223,7 @@ public sealed class SchemaCommand : Command<SchemaCommand.Settings>
         C("review diff", "Inspect AOT changes vs. a git revision.", [], ["--base", "--head", "--repo", "--output"], []),
         C("build", "Invoke MSBuild on a D365FO project.", [], ["--msbuild", "--project", "--config", "--output"], []),
         C("sync", "Run DB sync.", [], ["--tool", "--full", "--output"], []),
-        C("test run", "Invoke SysTestRunner.", [], ["--runner", "--suite", "--output"], []),
+        C("test run", "Invoke the platform SysTest console runner (SysTestConsole.exe).", [], ["--runner", "--test", "--suite", "--granularity", "--results", "--parallel", "--output"], []),
         C("bp check", "Invoke xppbp best-practice checks.", [], ["--tool", "--model", "--packages", "--metadata", "--output"], []),
         C("daemon start", "Start warm JSON-RPC daemon.", [], ["--db", "--packages", "--foreground", "--no-watch", "--watch-debounce"], []),
         C("daemon stop", "Stop daemon.", [], [], []),

--- a/src/D365FO.Cli/Commands/Generate/GenerateBusinessEventCommand.cs
+++ b/src/D365FO.Cli/Commands/Generate/GenerateBusinessEventCommand.cs
@@ -89,15 +89,20 @@ public sealed class GenerateBusinessEventCommand : Command<GenerateBusinessEvent
 
         var payload = settings.Payload.Select(ParsePayload).ToList();
 
+        var eventDoc    = BusinessEventScaffolder.EventClass(settings.Name, contractName, module, settings.PrimaryTable);
+        var contractDoc = BusinessEventScaffolder.ContractClass(contractName, payload);
+
+        // Grounding gate (issue #161). The driving table is the one claim this command makes
+        // about the existing AOT, so it is what the gate proves.
+        var gate = GenerateInstaller.Gate(
+            settings, settings.Name, eventDoc,
+            requiredSymbols: string.IsNullOrWhiteSpace(settings.PrimaryTable) ? null : new[] { settings.PrimaryTable! });
+        if (gate.Failure is not null) return RenderHelpers.Render(kind, gate.Failure);
+
         try
         {
-            var eventResult = ScaffoldFileWriter.Write(
-                BusinessEventScaffolder.EventClass(settings.Name, contractName, module, settings.PrimaryTable),
-                eventPath!, settings.Overwrite);
-
-            var contractResult = ScaffoldFileWriter.Write(
-                BusinessEventScaffolder.ContractClass(contractName, payload),
-                contractPath!, settings.Overwrite);
+            var eventResult    = GenerateInstaller.Write(gate, eventDoc, eventPath!, settings.Overwrite);
+            var contractResult = GenerateInstaller.Write(gate, contractDoc, contractPath!, settings.Overwrite);
 
             return RenderHelpers.Render(kind, ToolResult<object>.Success(new
             {
@@ -110,7 +115,8 @@ public sealed class GenerateBusinessEventCommand : Command<GenerateBusinessEvent
                 @event       = new { path = eventResult.Path,    bytes = eventResult.Bytes,    backup = eventResult.BackupPath },
                 contract     = new { path = contractResult.Path, bytes = contractResult.Bytes, backup = contractResult.BackupPath },
                 model        = settings.InstallTo,
-            }));
+                grounding    = gate.Grounding,
+            }, gate.Warnings));
         }
         catch (Exception ex)
         {

--- a/src/D365FO.Cli/Commands/Generate/GenerateCommands.cs
+++ b/src/D365FO.Cli/Commands/Generate/GenerateCommands.cs
@@ -33,6 +33,117 @@ public abstract class GenerateSettings : D365OutputSettings
 internal static class GenerateInstaller
 {
     /// <summary>
+    /// Run the grounding gate for a generate command. Every generate subcommand calls this
+    /// before it writes anything, and writes through the handle it returns.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// Issue #161 / finding G4. The gate used to be wired into three subcommands by hand, which
+    /// made it decorative for the other twenty-six: the anti-hallucination token was simply
+    /// optional everywhere else. Moving it here — the path every generate command already goes
+    /// through to reach disk — is what makes it uniform, and pairing it with
+    /// <see cref="Write"/> is what makes bypassing it require deliberately not using the shared
+    /// path. <c>GenerateSurfaceTests</c> fails the build if a command does that.
+    /// </para>
+    /// <para>
+    /// <paramref name="targetObject"/> is the object the write is bound to: the extension or CoC
+    /// target for extension-shaped commands, and the artefact's own name for the rest, which is
+    /// what <c>prepare create</c> issues a token against.
+    /// </para>
+    /// </remarks>
+    internal static GroundingGate.GateResult Gate(
+        GenerateSettings settings,
+        string targetObject,
+        System.Xml.Linq.XDocument? doc = null,
+        IEnumerable<(string Owner, string Method)>? requiredMethods = null,
+        IEnumerable<string>? requiredSymbols = null)
+        => GroundingGate.Check(
+            settings.GroundingToken, targetObject, doc, requiredMethods, requiredSymbols,
+            RequestedValues(settings));
+
+    /// <summary>
+    /// The option/value pairs a caller actually supplied, for the property-honesty
+    /// reconciliation.
+    /// </summary>
+    /// <remarks>
+    /// Read off the settings instance rather than declared per command, because a per-command
+    /// list is exactly the hand-maintained table that goes stale the first time someone adds an
+    /// option. Only properties declared on the command's own settings type count: everything on
+    /// <see cref="GenerateSettings"/> and <c>D365OutputSettings</c> is plumbing (<c>--out</c>,
+    /// <c>--overwrite</c>, <c>--install-to</c>, the token, the output format) and has no business
+    /// appearing in the generated object. Booleans are skipped too — a flag selects a shape, and
+    /// its absence from the document says nothing.
+    /// </remarks>
+    internal static IReadOnlyList<(string Option, string Value)> RequestedValues(GenerateSettings settings)
+    {
+        var requested = new List<(string, string)>();
+
+        foreach (var prop in settings.GetType().GetProperties())
+        {
+            if (prop.DeclaringType is null || prop.DeclaringType == typeof(GenerateSettings)) continue;
+            if (!prop.DeclaringType.IsSubclassOf(typeof(GenerateSettings))) continue;
+
+            var option = OptionNameOf(prop);
+            if (option is null) continue;
+
+            switch (prop.GetValue(settings))
+            {
+                case string s when !string.IsNullOrWhiteSpace(s):
+                    requested.Add((option, s));
+                    break;
+                case string[] many:
+                    foreach (var s in many.Where(s => !string.IsNullOrWhiteSpace(s)))
+                        requested.Add((option, s));
+                    break;
+            }
+        }
+
+        return requested;
+    }
+
+    /// <summary>The command-line spelling of a settings property, or null when it is not an option.</summary>
+    private static string? OptionNameOf(System.Reflection.PropertyInfo prop)
+    {
+        var opt = prop.GetCustomAttributes(typeof(CommandOptionAttribute), inherit: true)
+            .Cast<CommandOptionAttribute>().FirstOrDefault();
+        if (opt is not null)
+        {
+            // "--field <SPEC>" / "-f|--field <SPEC>" → "--field".
+            var longest = opt.LongNames.OrderByDescending(n => n.Length).FirstOrDefault();
+            return longest is null ? null : "--" + longest;
+        }
+
+        var arg = prop.GetCustomAttributes(typeof(CommandArgumentAttribute), inherit: true)
+            .Cast<CommandArgumentAttribute>().FirstOrDefault();
+        return arg is null ? null : "<" + arg.ValueName + ">";
+    }
+
+    /// <summary>
+    /// Write a generated document. Takes the gate handle, so reaching the writer without having
+    /// gated is not something a caller can express.
+    /// </summary>
+    internal static ScaffoldFileWriter.WriteResult Write(
+        GroundingGate.GateResult gate, System.Xml.Linq.XDocument doc, string path, bool overwrite = false)
+    {
+        ArgumentNullException.ThrowIfNull(gate);
+        var result = ScaffoldFileWriter.Write(doc, path, overwrite);
+        // Write finalises the document in place, so this is the form that reached disk — not the
+        // scaffolder's pre-canonicalisation draft.
+        gate.Observe(doc.ToString());
+        return result;
+    }
+
+    /// <summary>String-rendered counterpart of <see cref="Write(GroundingGate.GateResult, System.Xml.Linq.XDocument, string, bool)"/>.</summary>
+    internal static ScaffoldFileWriter.WriteResult Write(
+        GroundingGate.GateResult gate, string xml, string path, bool overwrite = false)
+    {
+        ArgumentNullException.ThrowIfNull(gate);
+        var result = ScaffoldFileWriter.Write(xml, path, overwrite);
+        gate.Observe(xml);
+        return result;
+    }
+
+    /// <summary>
     /// Resolve the on-disk install path for a scaffolded artefact. When
     /// <c>--install-to &lt;MODEL&gt;</c> is supplied we ask the bridge where
     /// the model lives on disk and compose
@@ -161,7 +272,7 @@ internal static class GenerateInstaller
     /// collection kinds: <c>class | table | edt | enum | form</c>.
     /// </summary>
     internal static int Emit(
-        OutputMode.Kind kind, string axKind, string axSubfolder, string name,
+        OutputMode.Kind kind, GroundingGate.GateResult gate, string axKind, string axSubfolder, string name,
         string? installTo, string? outPath, bool overwrite,
         System.Xml.Linq.XDocument doc,
         Func<EmitResult, object> buildPayload,
@@ -175,20 +286,20 @@ internal static class GenerateInstaller
         ContractNamespaceApplier.Apply(doc);
         ContractOrderCanonicalizer.Apply(doc);
 
-        return EmitCore(kind, axKind, axSubfolder, name, installTo, outPath, doc.ToString(),
-            path => ScaffoldFileWriter.Write(doc, path, overwrite), buildPayload, warnings, verify);
+        return EmitCore(kind, gate, axKind, axSubfolder, name, installTo, outPath, doc.ToString(),
+            path => Write(gate, doc, path, overwrite), buildPayload, warnings, verify);
     }
 
     /// <summary>String-rendered counterpart of <see cref="Emit"/> (used for forms).</summary>
     internal static int EmitString(
-        OutputMode.Kind kind, string axKind, string axSubfolder, string name,
+        OutputMode.Kind kind, GroundingGate.GateResult gate, string axKind, string axSubfolder, string name,
         string? installTo, string? outPath, bool overwrite,
         string xml,
         Func<EmitResult, object> buildPayload,
         List<string>? warnings = null,
         bool verify = false)
-        => EmitCore(kind, axKind, axSubfolder, name, installTo, outPath, xml,
-            path => ScaffoldFileWriter.Write(xml, path, overwrite), buildPayload, warnings, verify);
+        => EmitCore(kind, gate, axKind, axSubfolder, name, installTo, outPath, xml,
+            path => Write(gate, xml, path, overwrite), buildPayload, warnings, verify);
 
     /// <summary>
     /// Opt-in post-write check for <c>--verify</c>: read the artefact back through the
@@ -231,8 +342,28 @@ internal static class GenerateInstaller
         }
     }
 
+    /// <summary>
+    /// Fold the gate's property-honesty findings into the warnings a command is about to
+    /// return.
+    /// </summary>
+    /// <remarks>
+    /// The gate can only reconcile once the document exists, which is after the point where
+    /// <see cref="EmitCore"/> has already snapshotted the caller's warnings. Merging here rather
+    /// than appending blindly keeps the report out of the list twice when the caller passed
+    /// <c>gate.Warnings</c> itself, which is the normal case.
+    /// </remarks>
+    private static List<string> WithHonesty(List<string> warnings, GroundingGate.GateResult gate)
+    {
+        foreach (var gap in gate.PropertyGaps)
+        {
+            var message = $"property-honesty: {gap}";
+            if (!warnings.Contains(message)) warnings.Add(message);
+        }
+        return warnings;
+    }
+
     private static int EmitCore(
-        OutputMode.Kind kind, string axKind, string axSubfolder, string name,
+        OutputMode.Kind kind, GroundingGate.GateResult gate, string axKind, string axSubfolder, string name,
         string? installTo, string? outPath, string xml,
         Func<string, ScaffoldFileWriter.WriteResult> write,
         Func<EmitResult, object> buildPayload,
@@ -253,11 +384,14 @@ internal static class GenerateInstaller
 
             if (plan.outcome == InstallOutcome.CreatedViaApi)
             {
+                // Nothing reached disk, but the provider was handed exactly this XML — which is
+                // the document the honesty report has to judge.
+                gate.Observe(xml);
                 if (verify && VerifyWritten(kind, axKind, name, installTo, null, all) is int apiFailure)
                     return apiFailure;
                 return RenderHelpers.Render(kind, ToolResult<object>.Success(
                     buildPayload(new EmitResult("bridge", null, null, null)),
-                    all.Count > 0 ? all : null));
+                    WithHonesty(all, gate) is { Count: > 0 } w ? w : null));
             }
 
             try
@@ -267,7 +401,7 @@ internal static class GenerateInstaller
                     return failure;
                 return RenderHelpers.Render(kind, ToolResult<object>.Success(
                     buildPayload(new EmitResult("scaffold", res.Path, res.Bytes, res.BackupPath)),
-                    all.Count > 0 ? all : null));
+                    WithHonesty(all, gate) is { Count: > 0 } w ? w : null));
             }
             catch (Exception ex)
             {
@@ -282,7 +416,7 @@ internal static class GenerateInstaller
                 return outFailure;
             return RenderHelpers.Render(kind, ToolResult<object>.Success(
                 buildPayload(new EmitResult("scaffold", res.Path, res.Bytes, res.BackupPath)),
-                warnings.Count > 0 ? warnings : null));
+                WithHonesty(warnings, gate) is { Count: > 0 } w ? w : null));
         }
         catch (Exception ex)
         {
@@ -362,10 +496,17 @@ public sealed class GenerateTableCommand : Command<GenerateTableCommand.Settings
                 "worksheet-header|worksheet-line|reference|framework|miscellaneous) to stamp the table's business role.");
         }
 
+        // Grounding gate (issue #161): every generate subcommand runs it, not just the
+        // extension-shaped three. A table is bound to its own name — that is what
+        // `prepare create` issues a token against.
+        var gate = GenerateInstaller.Gate(settings, settings.Name, doc);
+        if (gate.Failure is not null) return RenderHelpers.Render(kind, gate.Failure);
+        warnings.AddRange(gate.Warnings);
+
         // Prefer the live metadata provider for --install-to (canonical output,
         // consistent with VS / d365fo-mcp-server); fall back to the scaffold.
         return GenerateInstaller.Emit(
-            kind, "table", Folders.Table, settings.Name,
+            kind, gate, "table", Folders.Table, settings.Name,
             settings.InstallTo, settings.Out, settings.Overwrite, doc,
             r => new
             {
@@ -382,8 +523,9 @@ public sealed class GenerateTableCommand : Command<GenerateTableCommand.Settings
                 formRef = settings.FormRef,
                 usedPatternDefaults = usedDefaults,
                 model = settings.InstallTo,
+                grounding = gate.Grounding,
             },
-            warnings.Count > 0 ? warnings : null,
+            warnings,
             verify: settings.Verify);
     }
 
@@ -418,14 +560,22 @@ public sealed class GenerateClassCommand : Command<GenerateClassCommand.Settings
             return RenderHelpers.Render(kind, ToolResult<object>.Fail("BAD_INPUT", "Class name required."));
 
         var doc = XppScaffolder.Class(settings.Name, settings.Extends, !settings.NonFinal);
+
+        var gate = GenerateInstaller.Gate(
+            settings, settings.Name, doc,
+            requiredSymbols: string.IsNullOrWhiteSpace(settings.Extends) ? null : new[] { settings.Extends! });
+        if (gate.Failure is not null) return RenderHelpers.Render(kind, gate.Failure);
+
         return GenerateInstaller.Emit(
-            kind, "class", Folders.Class, settings.Name,
+            kind, gate, "class", Folders.Class, settings.Name,
             settings.InstallTo, settings.Out, settings.Overwrite, doc,
             r => new
             {
                 kind = "AxClass", name = settings.Name, source = r.Source,
                 path = r.Path, bytes = r.Bytes, backup = r.Backup, model = settings.InstallTo,
+                grounding = gate.Grounding,
             },
+            gate.Warnings,
             verify: settings.Verify);
     }
 }
@@ -471,8 +621,8 @@ public sealed class GenerateCocCommand : Command<GenerateCocCommand.Settings>
 
         // Grounding gate: prove the target and every wrapped method against the
         // index; fail closed under D365FO_GROUNDING_ENFORCE=true.
-        var gate = GroundingGate.Check(
-            settings.GroundingToken,
+        var gate = GenerateInstaller.Gate(
+            settings,
             settings.Target,
             doc,
             settings.Methods.Select(m => (settings.Target, m)));
@@ -480,7 +630,7 @@ public sealed class GenerateCocCommand : Command<GenerateCocCommand.Settings>
         warnings.AddRange(gate.Warnings);
 
         return GenerateInstaller.Emit(
-            kind, "class", Folders.Class, settings.Target + "_Extension",
+            kind, gate, "class", Folders.Class, settings.Target + "_Extension",
             settings.InstallTo, settings.Out, settings.Overwrite, doc,
             r => new
             {
@@ -513,6 +663,7 @@ public sealed class GenerateSimpleListCommand : Command<GenerateSimpleListComman
     public override int Execute(CommandContext ctx, Settings settings)
     {
         return GenerateFormImpl.Run(
+            settings:     settings,
             output:       settings.Output,
             formName:     settings.FormName,
             table:        settings.Table,
@@ -569,6 +720,7 @@ public sealed class GenerateFormCommand : Command<GenerateFormCommand.Settings>
     public override int Execute(CommandContext ctx, Settings settings)
     {
         return GenerateFormImpl.Run(
+            settings:     settings,
             output:       settings.Output,
             formName:     settings.FormName,
             table:        settings.Table,
@@ -587,6 +739,7 @@ public sealed class GenerateFormCommand : Command<GenerateFormCommand.Settings>
 internal static class GenerateFormImpl
 {
     public static int Run(
+        GenerateSettings settings,
         string? output,
         string formName,
         string? table,
@@ -688,7 +841,8 @@ internal static class GenerateFormImpl
                 caption:         effectiveCaption,
                 gridFields:      fields,
                 sections:        sectionSpecs,
-                linesTable:      linesTable);
+                linesTable:      linesTable,
+                controlTypeResolver: BuildControlTypeResolver(table, linesTable));
         }
         catch (Exception ex)
         {
@@ -715,8 +869,17 @@ internal static class GenerateFormImpl
                 "or set D365FO_FORM_PATTERN_ENFORCE=false to bypass the gate."));
         }
 
+        // A form carries no X++ for the gate to resolve, so what it can prove is the
+        // datasource: a form bound to a table the index has never seen is the hallucination
+        // this gate exists to stop, and it used to sail straight through (issue #161).
+        var gate = GenerateInstaller.Gate(
+            settings, formName, doc: null,
+            requiredSymbols: new[] { table, linesTable }.Where(t => !string.IsNullOrWhiteSpace(t)).Select(t => t!));
+        if (gate.Failure is not null) return RenderHelpers.Render(kind, gate.Failure);
+        patternWarnings.AddRange(gate.Warnings);
+
         return GenerateInstaller.EmitString(
-            kind, "form", Folders.Form, formName,
+            kind, gate, "form", Folders.Form, formName,
             installTo, outPath, overwrite, xml,
             r => new
             {
@@ -736,9 +899,70 @@ internal static class GenerateFormImpl
                     errors   = patternReport.ErrorCount,
                     warnings = patternReport.WarningCount,
                 },
+                grounding    = gate.Grounding,
             },
-            patternWarnings.Count > 0 ? patternWarnings : null,
+            patternWarnings,
             verify: verify);
+    }
+
+    /// <summary>
+    /// Field name → the control it should be rendered as, resolved through the index.
+    /// </summary>
+    /// <remarks>
+    /// Issue #164 / R5. The form templates emitted <c>AxFormStringControl</c> for every bound
+    /// field regardless of what the field was, so a generated form put a text box on a quantity,
+    /// a date and a status enum alike. The index knows each field's EDT and enum, and
+    /// <see cref="D365FO.Core.FormPatterns.FieldControlTypes"/> knows what shipped forms do with
+    /// them. Returns null when there is no index or no table — the templates then fall back to
+    /// the string control, which is exactly the old behaviour and no worse.
+    /// </remarks>
+    private static Func<string, (string AxType, string TypeElement)>? BuildControlTypeResolver(
+        string? table, string? linesTable)
+    {
+        if (string.IsNullOrWhiteSpace(table)) return null;
+
+        Dictionary<string, (string? Edt, string? EnumType)> byField;
+        try
+        {
+            var repo = RepoFactory.Create();
+            byField = new Dictionary<string, (string?, string?)>(StringComparer.OrdinalIgnoreCase);
+            foreach (var t in new[] { table, linesTable }.Where(t => !string.IsNullOrWhiteSpace(t)))
+            {
+                var details = repo.GetTableDetails(t!);
+                if (details is null) continue;
+                foreach (var f in details.Fields)
+                {
+                    // First table wins: the header's fields are the ones the pattern's primary
+                    // controls bind to.
+                    if (byField.ContainsKey(f.Name)) continue;
+                    // The index records the field's kind in Type ("ExtendedDataType" /
+                    // "EnumType") and the name of that type in EdtName — one column doing two
+                    // jobs, so which job it is doing has to be read off Type.
+                    var isEnum = string.Equals(f.Type, "EnumType", StringComparison.OrdinalIgnoreCase);
+                    byField[f.Name] = (isEnum ? null : f.EdtName, isEnum ? f.EdtName : null);
+                }
+            }
+            if (byField.Count == 0) return null;
+
+            return field =>
+            {
+                if (!byField.TryGetValue(field, out var info))
+                    return (D365FO.Core.FormPatterns.FieldControlTypes.DefaultControl, "String");
+
+                if (info.EnumType is not null)
+                    return D365FO.Core.FormPatterns.FieldControlTypes.For("AxTableFieldEnum", info.EnumType);
+
+                string? baseType = null;
+                try { baseType = info.Edt is null ? null : repo.GetEdt(info.Edt)?.BaseType; }
+                catch { /* index hiccup — fall back below */ }
+
+                return D365FO.Core.FormPatterns.FieldControlTypes.ForEdtBaseType(baseType);
+            };
+        }
+        catch
+        {
+            return null;
+        }
     }
 
     /// <summary>Field groups a pattern's controls reference via &lt;DataGroup&gt; (see FormTemplates/*.template.xml).</summary>

--- a/src/D365FO.Cli/Commands/Generate/GenerateCustomServiceCommand.cs
+++ b/src/D365FO.Cli/Commands/Generate/GenerateCustomServiceCommand.cs
@@ -94,19 +94,19 @@ public sealed class GenerateCustomServiceCommand : Command<GenerateCustomService
 
         var ops = ParseOperations(settings.Operations, settings.ContractParam);
 
+        var classDoc   = CustomServiceScaffolder.ServiceClass(className, ops);
+        var serviceDoc = CustomServiceScaffolder.ServiceXml(settings.Name, className, ops, settings.ExternalName);
+        var groupDoc   = CustomServiceScaffolder.ServiceGroupXml(groupName, settings.Name);
+
+        // Grounding gate (issue #161) — the service class carries the X++ the gate resolves.
+        var gate = GenerateInstaller.Gate(settings, settings.Name, classDoc);
+        if (gate.Failure is not null) return RenderHelpers.Render(kind, gate.Failure);
+
         try
         {
-            var classResult = ScaffoldFileWriter.Write(
-                CustomServiceScaffolder.ServiceClass(className, ops),
-                classPath!, settings.Overwrite);
-
-            var serviceResult = ScaffoldFileWriter.Write(
-                CustomServiceScaffolder.ServiceXml(settings.Name, className, ops, settings.ExternalName),
-                servicePath!, settings.Overwrite);
-
-            var groupResult = ScaffoldFileWriter.Write(
-                CustomServiceScaffolder.ServiceGroupXml(groupName, settings.Name),
-                groupPath!, settings.Overwrite);
+            var classResult   = GenerateInstaller.Write(gate, classDoc,   classPath!,   settings.Overwrite);
+            var serviceResult = GenerateInstaller.Write(gate, serviceDoc, servicePath!, settings.Overwrite);
+            var groupResult   = GenerateInstaller.Write(gate, groupDoc,   groupPath!,   settings.Overwrite);
 
             return RenderHelpers.Render(kind, ToolResult<object>.Success(new
             {
@@ -120,7 +120,8 @@ public sealed class GenerateCustomServiceCommand : Command<GenerateCustomService
                 service        = new { path = serviceResult.Path, bytes = serviceResult.Bytes, backup = serviceResult.BackupPath },
                 serviceGroup   = new { path = groupResult.Path,   bytes = groupResult.Bytes,   backup = groupResult.BackupPath },
                 model          = settings.InstallTo,
-            }));
+                grounding      = gate.Grounding,
+            }, gate.Warnings));
         }
         catch (Exception ex)
         {

--- a/src/D365FO.Cli/Commands/Generate/GenerateEdtCommand.cs
+++ b/src/D365FO.Cli/Commands/Generate/GenerateEdtCommand.cs
@@ -53,8 +53,17 @@ public sealed class GenerateEdtCommand : Command<GenerateEdtCommand.Settings>
         }
 
         var doc = XppScaffolder.Edt(settings.Name, settings.Extends, settings.BaseType, settings.Size, settings.Label, effectiveEnumType);
+
+        // An EDT that extends an EDT the index has never heard of, or is backed by a
+        // non-existent enum, is exactly the hallucination the gate exists to catch.
+        var gate = GenerateInstaller.Gate(
+            settings, settings.Name, doc,
+            requiredSymbols: new[] { settings.Extends, effectiveEnumType }
+                .Where(s => !string.IsNullOrWhiteSpace(s)).Select(s => s!));
+        if (gate.Failure is not null) return RenderHelpers.Render(kind, gate.Failure);
+
         return GenerateInstaller.Emit(
-            kind, "edt", Folders.Edt, settings.Name,
+            kind, gate, "edt", Folders.Edt, settings.Name,
             settings.InstallTo, settings.Out, settings.Overwrite, doc,
             r => new
             {
@@ -70,7 +79,9 @@ public sealed class GenerateEdtCommand : Command<GenerateEdtCommand.Settings>
                 bytes      = r.Bytes,
                 backup     = r.Backup,
                 model      = settings.InstallTo,
+                grounding  = gate.Grounding,
             },
+            gate.Warnings,
             verify: settings.Verify);
     }
 

--- a/src/D365FO.Cli/Commands/Generate/GenerateEnumCommand.cs
+++ b/src/D365FO.Cli/Commands/Generate/GenerateEnumCommand.cs
@@ -38,8 +38,11 @@ public sealed class GenerateEnumCommand : Command<GenerateEnumCommand.Settings>
         var values = settings.Values.Select(ParseValue).ToList();
         var doc = XppScaffolder.Enum(settings.Name, values, !settings.NonExtensible, settings.Label);
 
+        var gate = GenerateInstaller.Gate(settings, settings.Name, doc);
+        if (gate.Failure is not null) return RenderHelpers.Render(kind, gate.Failure);
+
         return GenerateInstaller.Emit(
-            kind, "enum", Folders.Enum, settings.Name,
+            kind, gate, "enum", Folders.Enum, settings.Name,
             settings.InstallTo, settings.Out, settings.Overwrite, doc,
             r => new
             {
@@ -54,7 +57,9 @@ public sealed class GenerateEnumCommand : Command<GenerateEnumCommand.Settings>
                 bytes        = r.Bytes,
                 backup       = r.Backup,
                 model        = settings.InstallTo,
+                grounding    = gate.Grounding,
             },
+            gate.Warnings,
             verify: settings.Verify);
     }
 

--- a/src/D365FO.Cli/Commands/Generate/GenerateFormMethodCommands.cs
+++ b/src/D365FO.Cli/Commands/Generate/GenerateFormMethodCommands.cs
@@ -177,8 +177,21 @@ internal static class FormMethodImpl
 
         warnings.Add("Index not auto-refreshed — run `d365fo index refresh` so the new method is searchable.");
 
+        // ---- Grounding gate ----
+        // This command mutates an existing form, which is the strongest case for the gate and
+        // was one of the twenty-six subcommands it never ran for (issue #161). It is gated on
+        // the injected method rather than the whole form: judging Microsoft's form as if this
+        // command had written it would report their code as our hallucinations.
+        var gate = GenerateInstaller.Gate(
+            s, formName,
+            doc: new XDocument(new XElement("Method", new XElement("Source", inject.Source))),
+            requiredSymbols: new[] { formName });
+        if (gate.Failure is not null) return RenderHelpers.Render(kind, gate.Failure);
+        warnings.AddRange(gate.Warnings);
+
         // ---- Persist: bridge update, explicit --out, or in-place ----
         var xml = doc.ToString(SaveOptions.DisableFormatting);
+        gate.Observe(xml);
 
         object PayloadFor(string source, string? path) => new
         {

--- a/src/D365FO.Cli/Commands/Generate/GenerateMenuItemCommand.cs
+++ b/src/D365FO.Cli/Commands/Generate/GenerateMenuItemCommand.cs
@@ -106,7 +106,11 @@ public sealed class GenerateMenuItemCommand : Command<GenerateMenuItemCommand.Se
             settings.LinkedPermissionObject, settings.LinkedPermissionType);
         try
         {
-            var res = ScaffoldFileWriter.Write(doc, outPath!, settings.Overwrite);
+            // Grounding gate (issue #161): uniform across every generate subcommand.
+            var gate = GenerateInstaller.Gate(settings, settings.Name, doc);
+            if (gate.Failure is not null) return RenderHelpers.Render(kind, gate.Failure);
+
+            var res = GenerateInstaller.Write(gate, doc, outPath!, settings.Overwrite);
             return RenderHelpers.Render(kind, ToolResult<object>.Success(new
             {
                 kind        = axSubfolder,
@@ -125,7 +129,7 @@ public sealed class GenerateMenuItemCommand : Command<GenerateMenuItemCommand.Se
                 bytes       = res.Bytes,
                 backup      = res.BackupPath,
                 model       = settings.InstallTo,
-            }));
+            }, gate.Warnings));
         }
         catch (Exception ex)
         {

--- a/src/D365FO.Cli/Commands/Generate/GenerateMigrationScriptCommand.cs
+++ b/src/D365FO.Cli/Commands/Generate/GenerateMigrationScriptCommand.cs
@@ -68,7 +68,11 @@ public sealed class GenerateMigrationScriptCommand : Command<GenerateMigrationSc
         {
             var doc = MigrationScriptScaffolder.MigrationClass(
                 settings.Name, settings.SourceTable!, targetTable, mode, batchSize);
-            var res = ScaffoldFileWriter.Write(doc, outPath!, settings.Overwrite);
+            // Grounding gate (issue #161): uniform across every generate subcommand.
+            var gate = GenerateInstaller.Gate(settings, settings.Name, doc);
+            if (gate.Failure is not null) return RenderHelpers.Render(kind, gate.Failure);
+
+            var res = GenerateInstaller.Write(gate, doc, outPath!, settings.Overwrite);
 
             return RenderHelpers.Render(kind, ToolResult<object>.Success(new
             {
@@ -82,7 +86,7 @@ public sealed class GenerateMigrationScriptCommand : Command<GenerateMigrationSc
                 bytes       = res.Bytes,
                 backup      = res.BackupPath,
                 model       = settings.InstallTo,
-            }));
+            }, gate.Warnings));
         }
         catch (Exception ex)
         {

--- a/src/D365FO.Cli/Commands/Generate/GenerateMoreCommands.cs
+++ b/src/D365FO.Cli/Commands/Generate/GenerateMoreCommands.cs
@@ -43,6 +43,22 @@ public sealed class GenerateEntityCommand : Command<GenerateEntityCommand.Settin
         [CommandOption("--key <FIELD>")]
         [System.ComponentModel.Description("Repeatable: entity field forming the EntityKey. Derived from the table's alternate-key index when omitted — a public entity is invalid without one.")]
         public string[] Keys { get; init; } = Array.Empty<string>();
+
+        [CommandOption("--relation <SPEC>")]
+        [System.ComponentModel.Description("Repeatable: <Name>:<RelatedEntity>:<field>=<relatedField>[[,<field>=<relatedField>]][[:<Cardinality>]][[:<RelationshipType>]]. Example: --relation Customer:CustCustomerV3Entity:CustomerAccount=CustomerAccount:ZeroOne:Association")]
+        public string[] Relations { get; init; } = Array.Empty<string>();
+
+        [CommandOption("--computed-field <SPEC>")]
+        [System.ComponentModel.Description("Repeatable: <Name>:<staticMethodName>[[:<EDT>]]. Emits an AxDataEntityViewUnmappedField with IsComputedField=Yes; write the method on the entity yourself — it must return the SQL text of the expression.")]
+        public string[] ComputedFields { get; init; } = Array.Empty<string>();
+
+        [CommandOption("--out-staging <PATH>")]
+        [System.ComponentModel.Description("Where to write the DMF staging table generated alongside a --data-management entity (default: a sibling of the entity, under AxTable when --install-to is used).")]
+        public string? OutStaging { get; init; }
+
+        [CommandOption("--no-staging-table")]
+        [System.ComponentModel.Description("With --data-management, do not generate the staging table. The entity then names a table that must already exist, or the next build fails.")]
+        public bool NoStagingTable { get; init; }
     }
 
     public override int Execute(CommandContext ctx, Settings settings)
@@ -80,12 +96,48 @@ public sealed class GenerateEntityCommand : Command<GenerateEntityCommand.Settin
         var (keys, keySource, keyFailure) = ResolveKeys(kind, settings, fields);
         if (keyFailure.HasValue) return keyFailure.Value;
 
+        if (!TryParseRelations(settings.Relations, out var relations, out var relErr))
+            return RenderHelpers.Render(kind, ToolResult<object>.Fail(D365FoErrorCodes.BadInput, relErr!));
+        if (!TryParseComputedFields(settings.ComputedFields, out var computed, out var compErr))
+            return RenderHelpers.Render(kind, ToolResult<object>.Fail(D365FoErrorCodes.BadInput, compErr!));
+
         var doc = XppScaffolder.DataEntity(
             settings.EntityName, settings.Table!, settings.PublicEntity, settings.PublicCollection, fields,
-            settings.DataManagement, settings.StagingTable, entityCategory: null, keyFields: keys);
+            settings.DataManagement, settings.StagingTable, entityCategory: null, keyFields: keys,
+            relations: relations, computedFields: computed);
         try
         {
-            var res = ScaffoldFileWriter.Write(doc, outPath!, settings.Overwrite);
+            // Grounding gate (issue #161): uniform across every generate subcommand.
+            var gate = GenerateInstaller.Gate(settings, settings.EntityName, doc);
+            if (gate.Failure is not null) return RenderHelpers.Render(kind, gate.Failure);
+
+            var res = GenerateInstaller.Write(gate, doc, outPath!, settings.Overwrite);
+
+            // The staging table is not optional decoration: DataManagementEnabled=Yes names a
+            // table, and the build fails on the next compile if it is not there (issue #162).
+            object? staging = null;
+            if (settings.DataManagement && !settings.NoStagingTable)
+            {
+                var stagingName = string.IsNullOrWhiteSpace(settings.StagingTable)
+                    ? settings.EntityName + "Staging"
+                    : settings.StagingTable!;
+
+                var stagingPath = settings.OutStaging;
+                if (string.IsNullOrWhiteSpace(stagingPath))
+                {
+                    stagingPath = hasInstall && !hasOut
+                        ? GenerateInstaller.ResolveInstallPath(kind, Folders.Table, stagingName, settings.InstallTo!, out var sf)
+                        : System.IO.Path.Combine(System.IO.Path.GetDirectoryName(res.Path)!, stagingName + ".xml");
+                    if (stagingPath is null)
+                        return RenderHelpers.Render(kind, ToolResult<object>.Fail(D365FoErrorCodes.WriteFailed,
+                            $"Wrote the entity but could not resolve where to put its staging table '{stagingName}'."));
+                }
+
+                var stagingRes = GenerateInstaller.Write(gate,
+                    XppScaffolder.EntityStagingTable(stagingName, fields), stagingPath!, settings.Overwrite);
+                staging = new { name = stagingName, path = stagingRes.Path, bytes = stagingRes.Bytes };
+            }
+
             return RenderHelpers.Render(kind, ToolResult<object>.Success(new
             {
                 kind = "AxDataEntityView",
@@ -98,13 +150,106 @@ public sealed class GenerateEntityCommand : Command<GenerateEntityCommand.Settin
                 fieldsFromTable = autoFromTable,
                 keyFields = keys,
                 keySource,
+                relations = relations.Select(r => new { r.Name, related = r.RelatedDataEntity, constraints = r.Constraints.Count }).ToList(),
+                computedFields = computed.Select(c => new { c.Name, c.Method, c.Edt }).ToList(),
+                stagingTable = staging,
                 model = settings.InstallTo,
-            }));
+            }, gate.Warnings));
         }
         catch (Exception ex)
         {
             return RenderHelpers.Render(kind, ToolResult<object>.Fail(D365FoErrorCodes.WriteFailed, ex.Message));
         }
+    }
+
+    /// <summary>
+    /// Parse <c>--relation &lt;Name&gt;:&lt;RelatedEntity&gt;:&lt;f&gt;=&lt;rf&gt;[,…][:Cardinality][:RelationshipType]</c>.
+    /// </summary>
+    /// <remarks>
+    /// The enum values are checked here rather than left to the writer: they come from the
+    /// contract catalog, and a value outside the enum is XML008 — the whole entity fails to
+    /// deserialize, so refusing at parse time with the list of valid values is strictly better
+    /// than a rejected write.
+    /// </remarks>
+    private static bool TryParseRelations(
+        string[] raw, out List<EntityRelationSpec> relations, out string? error)
+    {
+        relations = [];
+        error = null;
+
+        foreach (var spec in raw.Where(r => !string.IsNullOrWhiteSpace(r)))
+        {
+            var parts = spec.Split(':', StringSplitOptions.TrimEntries);
+            if (parts.Length < 3)
+            {
+                error = $"Invalid --relation '{spec}'. Expected <Name>:<RelatedEntity>:<field>=<relatedField>[,…][:<Cardinality>][:<RelationshipType>].";
+                return false;
+            }
+
+            var constraints = new List<EntityRelationConstraintSpec>();
+            foreach (var pair in parts[2].Split(',', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries))
+            {
+                var kv = pair.Split('=', 2, StringSplitOptions.TrimEntries);
+                if (kv.Length != 2 || kv[0].Length == 0 || kv[1].Length == 0)
+                {
+                    error = $"Invalid constraint '{pair}' in --relation '{spec}'. Expected <field>=<relatedField>.";
+                    return false;
+                }
+                constraints.Add(new EntityRelationConstraintSpec(kv[0], kv[1]));
+            }
+            if (constraints.Count == 0)
+            {
+                error = $"--relation '{spec}' has no constraints. A relation that joins on nothing is not a relation.";
+                return false;
+            }
+
+            string? cardinality = parts.Length > 3 && parts[3].Length > 0 ? parts[3] : null;
+            string? relationshipType = parts.Length > 4 && parts[4].Length > 0 ? parts[4] : null;
+
+            if (!EnumValueOk("Cardinality", cardinality, out error)) return false;
+            if (!EnumValueOk("RelationshipType", relationshipType, out error)) return false;
+
+            relations.Add(new EntityRelationSpec(
+                parts[0], parts[1], constraints,
+                Cardinality: cardinality,
+                RelationshipType: relationshipType));
+        }
+
+        return true;
+    }
+
+    private static bool EnumValueOk(string enumName, string? value, out string? error)
+    {
+        error = null;
+        if (string.IsNullOrWhiteSpace(value)) return true;
+
+        var allowed = D365FO.Core.Metadata.MetadataContracts.EnumValues(enumName);
+        if (allowed.Count == 0 || allowed.Contains(value, StringComparer.Ordinal)) return true;
+
+        error = $"'{value}' is not a value of {enumName}. Valid: {string.Join(", ", allowed)}.";
+        return false;
+    }
+
+    /// <summary>Parse <c>--computed-field &lt;Name&gt;:&lt;method&gt;[:&lt;EDT&gt;]</c>.</summary>
+    private static bool TryParseComputedFields(
+        string[] raw, out List<EntityComputedFieldSpec> computed, out string? error)
+    {
+        computed = [];
+        error = null;
+
+        foreach (var spec in raw.Where(c => !string.IsNullOrWhiteSpace(c)))
+        {
+            var parts = spec.Split(':', StringSplitOptions.TrimEntries);
+            if (parts.Length < 2 || parts[0].Length == 0 || parts[1].Length == 0)
+            {
+                error = $"Invalid --computed-field '{spec}'. Expected <Name>:<staticMethodName>[:<EDT>].";
+                return false;
+            }
+            computed.Add(new EntityComputedFieldSpec(
+                parts[0], parts[1], parts.Length > 2 && parts[2].Length > 0 ? parts[2] : null));
+        }
+
+        return true;
     }
 
     private static EntityFieldSpec ParseField(string raw)
@@ -185,6 +330,38 @@ public sealed class GenerateExtensionCommand : Command<GenerateExtensionCommand.
         [CommandOption("--duty <NAME>")]
         [System.ComponentModel.Description("Repeatable; SecurityRole only: duty reference to add to the base role.")]
         public string[] Duties { get; init; } = Array.Empty<string>();
+
+        [CommandOption("--set-property <SPEC>")]
+        [System.ComponentModel.Description("Repeatable; SecurityDuty/SecurityRole only: <Member>=<Value>. Overrides a property of the base object (Enabled, Label, Description, ContextString…) without overlaying it.")]
+        public string[] PropertyModifications { get; init; } = Array.Empty<string>();
+    }
+
+    /// <summary>Parse <c>--set-property &lt;Member&gt;=&lt;Value&gt;</c> pairs.</summary>
+    /// <remarks>
+    /// The member is not checked against the base type's contract here: an extension's
+    /// PropertyModifications name members of the object being extended, and this command does
+    /// not read that object. A misspelled member is caught where it shows — the provider
+    /// ignores the modification — which is a weaker guarantee than the rest of the write path
+    /// gives and is called out in the command's help rather than papered over.
+    /// </remarks>
+    private static bool TryParsePropertyModifications(
+        string[] raw, out List<XppScaffolder.PropertyModificationSpec> mods, out string? error)
+    {
+        mods = [];
+        error = null;
+
+        foreach (var spec in raw.Where(p => !string.IsNullOrWhiteSpace(p)))
+        {
+            var kv = spec.Split('=', 2, StringSplitOptions.TrimEntries);
+            if (kv.Length != 2 || kv[0].Length == 0)
+            {
+                error = $"Invalid --set-property '{spec}'. Expected <Member>=<Value>.";
+                return false;
+            }
+            mods.Add(new XppScaffolder.PropertyModificationSpec(kv[0], kv[1]));
+        }
+
+        return true;
     }
 
     public override int Execute(CommandContext ctx, Settings settings)
@@ -229,10 +406,18 @@ public sealed class GenerateExtensionCommand : Command<GenerateExtensionCommand.
             if (fail.HasValue) return fail.Value;
         }
 
+        if (!TryParsePropertyModifications(settings.PropertyModifications, out var propertyMods, out var pmErr))
+            return RenderHelpers.Render(kind, ToolResult<object>.Fail(D365FoErrorCodes.BadInput, pmErr!));
+        if (propertyMods.Count > 0 && axFolder is not ("AxSecurityDutyExtension" or "AxSecurityRoleExtension"))
+            return RenderHelpers.Render(kind, ToolResult<object>.Fail(
+                D365FoErrorCodes.BadInput,
+                $"--set-property applies to SecurityDuty and SecurityRole extensions only; {axFolder} has no PropertyModifications member, " +
+                "so the overrides would be dropped on read."));
+
         var doc = axFolder switch
         {
-            "AxSecurityDutyExtension" => XppScaffolder.SecurityDutyExtension(settings.Target, suffix, settings.Privileges),
-            "AxSecurityRoleExtension" => XppScaffolder.SecurityRoleExtension(settings.Target, suffix, settings.Duties, settings.Privileges),
+            "AxSecurityDutyExtension" => XppScaffolder.SecurityDutyExtension(settings.Target, suffix, settings.Privileges, propertyMods),
+            "AxSecurityRoleExtension" => XppScaffolder.SecurityRoleExtension(settings.Target, suffix, settings.Duties, settings.Privileges, propertyMods),
             // The EDT case needs the index-backed base-type resolver to pin the concrete
             // AxEdt*Extension subtype; the other kinds ignore it.
             // The scaffolder takes the base kind, not the type name — and the two differ for
@@ -246,13 +431,13 @@ public sealed class GenerateExtensionCommand : Command<GenerateExtensionCommand.
 
         // Grounding gate: the target object must exist in the index; fail
         // closed under D365FO_GROUNDING_ENFORCE=true.
-        var gate = GroundingGate.Check(settings.GroundingToken, settings.Target, doc,
+        var gate = GenerateInstaller.Gate(settings, settings.Target, doc,
             requiredSymbols: new[] { settings.Target });
         if (gate.Failure is not null) return RenderHelpers.Render(kind, gate.Failure);
 
         try
         {
-            var res = ScaffoldFileWriter.Write(doc, outPath!, settings.Overwrite);
+            var res = GenerateInstaller.Write(gate, doc, outPath!, settings.Overwrite);
             return RenderHelpers.Render(kind, ToolResult<object>.Success(new
             {
                 kind = axFolder,
@@ -264,7 +449,7 @@ public sealed class GenerateExtensionCommand : Command<GenerateExtensionCommand.
                 backup = res.BackupPath,
                 model = settings.InstallTo,
                 grounding = gate.Grounding,
-            }, warnings: gate.Warnings.Count > 0 ? gate.Warnings : null));
+            }, gate.Warnings));
         }
         catch (Exception ex)
         {
@@ -308,12 +493,12 @@ public sealed class GenerateEventHandlerCommand : Command<GenerateEventHandlerCo
 
         // Grounding gate: the event source object must exist in the index;
         // fail closed under D365FO_GROUNDING_ENFORCE=true.
-        var gate = GroundingGate.Check(settings.GroundingToken, settings.SourceObject!, doc,
+        var gate = GenerateInstaller.Gate(settings, settings.SourceObject!, doc,
             requiredSymbols: new[] { settings.SourceObject! });
         if (gate.Failure is not null) return RenderHelpers.Render(kind, gate.Failure);
 
         return GenerateInstaller.Emit(
-            kind, "class", Folders.Class, settings.ClassName,
+            kind, gate, "class", Folders.Class, settings.ClassName,
             settings.InstallTo, settings.Out, settings.Overwrite, doc,
             r => new
             {
@@ -331,7 +516,7 @@ public sealed class GenerateEventHandlerCommand : Command<GenerateEventHandlerCo
                 model = settings.InstallTo,
                 grounding = gate.Grounding,
             },
-            gate.Warnings.Count > 0 ? gate.Warnings.ToList() : null,
+            gate.Warnings,
             verify: settings.Verify);
     }
 }
@@ -400,7 +585,11 @@ public sealed class GeneratePrivilegeCommand : Command<GeneratePrivilegeCommand.
             settings.DataEntity, settings.DataEntityAccess);
         try
         {
-            var res = ScaffoldFileWriter.Write(doc, outPath!, settings.Overwrite);
+            // Grounding gate (issue #161): uniform across every generate subcommand.
+            var gate = GenerateInstaller.Gate(settings, settings.Name, doc);
+            if (gate.Failure is not null) return RenderHelpers.Render(kind, gate.Failure);
+
+            var res = GenerateInstaller.Write(gate, doc, outPath!, settings.Overwrite);
             object? intoRole = null;
             if (!string.IsNullOrWhiteSpace(settings.IntoRole))
             {
@@ -427,7 +616,7 @@ public sealed class GeneratePrivilegeCommand : Command<GeneratePrivilegeCommand.
                 backup = res.BackupPath,
                 model = settings.InstallTo,
                 intoRole,
-            }));
+            }, gate.Warnings));
         }
         catch (Exception ex)
         {
@@ -454,6 +643,18 @@ public sealed class GenerateDutyCommand : Command<GenerateDutyCommand.Settings>
         [CommandOption("--into-role <PATH>")]
         [System.ComponentModel.Description("Path to an existing AxSecurityRole XML; after scaffolding, merge this duty's Name into the role's <Duties>.")]
         public string? IntoRole { get; init; }
+
+        [CommandOption("--description <TEXT>")]
+        [System.ComponentModel.Description("Description shown to administrators in the security-configuration UI.")]
+        public string? Description { get; init; }
+
+        [CommandOption("--context-string <TEXT>")]
+        [System.ComponentModel.Description("ContextString the role-assignment rules match on.")]
+        public string? ContextString { get; init; }
+
+        [CommandOption("--disabled")]
+        [System.ComponentModel.Description("Emit Enabled=No — the duty ships switched off.")]
+        public bool Disabled { get; init; }
     }
 
     public override int Execute(CommandContext ctx, Settings settings)
@@ -474,10 +675,18 @@ public sealed class GenerateDutyCommand : Command<GenerateDutyCommand.Settings>
             if (fail.HasValue) return fail.Value;
         }
 
-        var doc = XppScaffolder.Duty(settings.Name, settings.Privileges, settings.Label);
+        var doc = XppScaffolder.Duty(
+            settings.Name, settings.Privileges, settings.Label,
+            description: settings.Description,
+            enabled: settings.Disabled ? false : null,
+            contextString: settings.ContextString);
         try
         {
-            var res = ScaffoldFileWriter.Write(doc, outPath!, settings.Overwrite);
+            // Grounding gate (issue #161): uniform across every generate subcommand.
+            var gate = GenerateInstaller.Gate(settings, settings.Name, doc);
+            if (gate.Failure is not null) return RenderHelpers.Render(kind, gate.Failure);
+
+            var res = GenerateInstaller.Write(gate, doc, outPath!, settings.Overwrite);
             object? intoRole = null;
             if (!string.IsNullOrWhiteSpace(settings.IntoRole))
             {
@@ -501,7 +710,7 @@ public sealed class GenerateDutyCommand : Command<GenerateDutyCommand.Settings>
                 backup = res.BackupPath,
                 model = settings.InstallTo,
                 intoRole,
-            }));
+            }, gate.Warnings));
         }
         catch (Exception ex)
         {
@@ -538,6 +747,22 @@ public sealed class GenerateRoleCommand : Command<GenerateRoleCommand.Settings>
         [CommandOption("--add-to <PATH>")]
         [System.ComponentModel.Description("Path to an existing AxSecurityRole XML file; duties/privileges are merged in-place instead of creating a new file.")]
         public string? AddTo { get; init; }
+
+        [CommandOption("--sub-role <NAME>")]
+        [System.ComponentModel.Description("Repeatable. Roles composed into this one — how the shipped roles are actually built.")]
+        public string[] SubRoles { get; init; } = Array.Empty<string>();
+
+        [CommandOption("--context-string <TEXT>")]
+        [System.ComponentModel.Description("ContextString the role-assignment rules match on.")]
+        public string? ContextString { get; init; }
+
+        [CommandOption("--disabled")]
+        [System.ComponentModel.Description("Emit Enabled=No — the role ships switched off.")]
+        public bool Disabled { get; init; }
+
+        [CommandOption("--no-delete-from-ui")]
+        [System.ComponentModel.Description("Emit CanBeDeletedFromUI=No — administrators cannot remove the role.")]
+        public bool NoDeleteFromUI { get; init; }
     }
 
     public override int Execute(CommandContext ctx, Settings settings)
@@ -549,10 +774,10 @@ public sealed class GenerateRoleCommand : Command<GenerateRoleCommand.Settings>
 
         if (string.IsNullOrWhiteSpace(settings.Name))
             return RenderHelpers.Render(kind, ToolResult<object>.Fail(D365FoErrorCodes.BadInput, "Role name required."));
-        if (settings.Duties.Length == 0 && settings.Privileges.Length == 0)
+        if (settings.Duties.Length == 0 && settings.Privileges.Length == 0 && settings.SubRoles.Length == 0)
             return RenderHelpers.Render(kind, ToolResult<object>.Fail(
                 D365FoErrorCodes.BadInput,
-                "At least one --duty or --privilege required."));
+                "At least one --duty, --privilege or --sub-role required."));
 
         var hasInstall = !string.IsNullOrWhiteSpace(settings.InstallTo);
         var hasOut = !string.IsNullOrWhiteSpace(settings.Out);
@@ -565,10 +790,19 @@ public sealed class GenerateRoleCommand : Command<GenerateRoleCommand.Settings>
             if (fail.HasValue) return fail.Value;
         }
 
-        var doc = XppScaffolder.Role(settings.Name, settings.Duties, settings.Privileges, settings.Label, settings.Description);
+        var doc = XppScaffolder.Role(
+            settings.Name, settings.Duties, settings.Privileges, settings.Label, settings.Description,
+            subRoles: settings.SubRoles,
+            contextString: settings.ContextString,
+            enabled: settings.Disabled ? false : null,
+            canBeDeletedFromUI: settings.NoDeleteFromUI ? false : null);
         try
         {
-            var res = ScaffoldFileWriter.Write(doc, outPath!, settings.Overwrite);
+            // Grounding gate (issue #161): uniform across every generate subcommand.
+            var gate = GenerateInstaller.Gate(settings, settings.Name, doc);
+            if (gate.Failure is not null) return RenderHelpers.Render(kind, gate.Failure);
+
+            var res = GenerateInstaller.Write(gate, doc, outPath!, settings.Overwrite);
             return RenderHelpers.Render(kind, ToolResult<object>.Success(new
             {
                 kind = "AxSecurityRole",
@@ -581,7 +815,7 @@ public sealed class GenerateRoleCommand : Command<GenerateRoleCommand.Settings>
                 bytes = res.Bytes,
                 backup = res.BackupPath,
                 model = settings.InstallTo,
-            }));
+            }, gate.Warnings));
         }
         catch (Exception ex)
         {
@@ -809,17 +1043,23 @@ public sealed class GenerateReportCommand : Command<GenerateReportCommand.Settin
                 : null;
         }
 
+        var dpDoc = XppScaffolder.ReportDp(spec);
+
+        // Grounding gate (issue #161) — the DP class carries the report's X++.
+        var gate = GenerateInstaller.Gate(settings, spec.Name, dpDoc);
+        if (gate.Failure is not null) return RenderHelpers.Render(kind, gate.Failure);
+
         try
         {
-            var reportResult   = ScaffoldFileWriter.Write(XppScaffolder.Report(spec),   reportPath!,   settings.Overwrite);
-            var dpResult       = ScaffoldFileWriter.Write(XppScaffolder.ReportDp(spec), dpPath!,       settings.Overwrite);
+            var reportResult   = GenerateInstaller.Write(gate, XppScaffolder.Report(spec), reportPath!, settings.Overwrite);
+            var dpResult       = GenerateInstaller.Write(gate, dpDoc,                      dpPath!,     settings.Overwrite);
 
             ScaffoldFileWriter.WriteResult? contractResult = null;
             if (hasContract && contractPath is not null)
             {
                 var contractDoc = XppScaffolder.ReportContract(spec);
                 if (contractDoc is not null)
-                    contractResult = ScaffoldFileWriter.Write(contractDoc, contractPath, settings.Overwrite);
+                    contractResult = GenerateInstaller.Write(gate, contractDoc, contractPath, settings.Overwrite);
             }
 
             // The rest of the stack. A report is not one object: the DP declares and selects
@@ -836,7 +1076,7 @@ public sealed class GenerateReportCommand : Command<GenerateReportCommand.Settin
                 foreach (var ds in spec.EffectiveDatasets)
                 {
                     var tmpName = ds.DpClass + "Tmp";
-                    var written = ScaffoldFileWriter.Write(
+                    var written = GenerateInstaller.Write(gate,
                         XppScaffolder.ReportTmpTable(ds), SiblingOf(dpPath!, tmpName, Folders.Table), settings.Overwrite);
                     tmpTables.Add(new { name = tmpName, path = written.Path, bytes = written.Bytes });
                 }
@@ -845,7 +1085,7 @@ public sealed class GenerateReportCommand : Command<GenerateReportCommand.Settin
             ScaffoldFileWriter.WriteResult? controllerResult = null;
             if (!settings.NoController)
             {
-                controllerResult = ScaffoldFileWriter.Write(
+                controllerResult = GenerateInstaller.Write(gate,
                     XppScaffolder.ReportController(spec),
                     SiblingOf(dpPath!, spec.EffectiveController, Folders.Class),
                     settings.Overwrite);
@@ -859,7 +1099,7 @@ public sealed class GenerateReportCommand : Command<GenerateReportCommand.Settin
                 var target = settings.NoController ? spec.Name : spec.EffectiveController;
                 var targetType = settings.NoController ? MenuItemObjectType.Report : MenuItemObjectType.Class;
 
-                menuItemResult = ScaffoldFileWriter.Write(
+                menuItemResult = GenerateInstaller.Write(gate,
                     MenuItemScaffolder.MenuItem(
                         MenuItemKind.Output, spec.EffectiveMenuItem, target, targetType, spec.Caption),
                     SiblingOf(reportPath!, spec.EffectiveMenuItem, Folders.MenuItemOutput),
@@ -881,7 +1121,8 @@ public sealed class GenerateReportCommand : Command<GenerateReportCommand.Settin
                 menuItem    = menuItemResult is null ? null : new { name = spec.EffectiveMenuItem, path = menuItemResult.Path, bytes = menuItemResult.Bytes },
                 contract    = contractResult is null ? null : new { path = contractResult.Path, bytes = contractResult.Bytes, backup = contractResult.BackupPath },
                 model       = settings.InstallTo,
-            }));
+                grounding   = gate.Grounding,
+            }, gate.Warnings));
         }
         catch (Exception ex)
         {

--- a/src/D365FO.Cli/Commands/Generate/GenerateNumberSequenceCommand.cs
+++ b/src/D365FO.Cli/Commands/Generate/GenerateNumberSequenceCommand.cs
@@ -92,20 +92,26 @@ public sealed class GenerateNumberSequenceCommand : Command<GenerateNumberSequen
                 : settings.OutHandler ?? System.IO.Path.Combine(dir, handlerClass + ".xml");
         }
 
+        var moduleDoc = NumberSequenceScaffolder.ModuleExtension(settings.ModuleName, edtName, scope);
+        var edtDoc    = NumberSequenceScaffolder.Edt(edtName, settings.ModuleName, scope, settings.EdtLabel);
+
+        // Grounding gate (issue #161). The module extension names an existing module class and
+        // the optional form handler an existing table — both are claims about the real AOT.
+        var gate = GenerateInstaller.Gate(
+            settings, edtName, moduleDoc,
+            requiredSymbols: new[] { settings.ModuleName, settings.TableName }
+                .Where(n => !string.IsNullOrWhiteSpace(n)).Select(n => n!));
+        if (gate.Failure is not null) return RenderHelpers.Render(kind, gate.Failure);
+
         try
         {
-            var moduleResult = ScaffoldFileWriter.Write(
-                NumberSequenceScaffolder.ModuleExtension(settings.ModuleName, edtName, scope),
-                modulePath!, settings.Overwrite);
-
-            var edtResult = ScaffoldFileWriter.Write(
-                NumberSequenceScaffolder.Edt(edtName, settings.ModuleName, scope, settings.EdtLabel),
-                edtPath!, settings.Overwrite);
+            var moduleResult = GenerateInstaller.Write(gate, moduleDoc, modulePath!, settings.Overwrite);
+            var edtResult    = GenerateInstaller.Write(gate, edtDoc,    edtPath!,    settings.Overwrite);
 
             ScaffoldFileWriter.WriteResult? handlerResult = null;
             if (handlerClass is not null && handlerPath is not null)
             {
-                handlerResult = ScaffoldFileWriter.Write(
+                handlerResult = GenerateInstaller.Write(gate,
                     NumberSequenceScaffolder.FormHandler(settings.TableName!, edtName, handlerClass),
                     handlerPath, settings.Overwrite);
             }
@@ -120,7 +126,8 @@ public sealed class GenerateNumberSequenceCommand : Command<GenerateNumberSequen
                 edt          = new { path = edtResult.Path,     bytes = edtResult.Bytes,     backup = edtResult.BackupPath },
                 handler      = handlerResult is null ? null : new { path = handlerResult.Path, bytes = handlerResult.Bytes, backup = handlerResult.BackupPath },
                 model        = settings.InstallTo,
-            }));
+                grounding    = gate.Grounding,
+            }, gate.Warnings));
         }
         catch (Exception ex)
         {

--- a/src/D365FO.Cli/Commands/Generate/GenerateQueryCommand.cs
+++ b/src/D365FO.Cli/Commands/Generate/GenerateQueryCommand.cs
@@ -77,7 +77,11 @@ public sealed class GenerateQueryCommand : Command<GenerateQueryCommand.Settings
 
         try
         {
-            var res = ScaffoldFileWriter.Write(doc, outPath!, settings.Overwrite);
+            // Grounding gate (issue #161): uniform across every generate subcommand.
+            var gate = GenerateInstaller.Gate(settings, settings.Name, doc);
+            if (gate.Failure is not null) return RenderHelpers.Render(kind, gate.Failure);
+
+            var res = GenerateInstaller.Write(gate, doc, outPath!, settings.Overwrite);
             var roots = dsList.Where(d => string.IsNullOrEmpty(d.ParentDs)).Select(d => d.Table).ToList();
             var joins  = dsList.Where(d => !string.IsNullOrEmpty(d.ParentDs))
                                .Select(d => new { d.Table, d.JoinMode, parentDs = d.ParentDs }).ToList();
@@ -92,7 +96,7 @@ public sealed class GenerateQueryCommand : Command<GenerateQueryCommand.Settings
                 bytes       = res.Bytes,
                 backup      = res.BackupPath,
                 model       = settings.InstallTo,
-            }));
+            }, gate.Warnings));
         }
         catch (Exception ex)
         {

--- a/src/D365FO.Cli/Commands/Generate/GenerateRunBaseCommand.cs
+++ b/src/D365FO.Cli/Commands/Generate/GenerateRunBaseCommand.cs
@@ -53,7 +53,11 @@ public sealed class GenerateRunBaseCommand : Command<GenerateRunBaseCommand.Sett
         try
         {
             var doc = RunBaseScaffolder.RunBaseClass(settings.Name, settings.Batch, dialogParams);
-            var res = ScaffoldFileWriter.Write(doc, outPath!, settings.Overwrite);
+            // Grounding gate (issue #161): uniform across every generate subcommand.
+            var gate = GenerateInstaller.Gate(settings, settings.Name, doc);
+            if (gate.Failure is not null) return RenderHelpers.Render(kind, gate.Failure);
+
+            var res = GenerateInstaller.Write(gate, doc, outPath!, settings.Overwrite);
 
             return RenderHelpers.Render(kind, ToolResult<object>.Success(new
             {
@@ -67,7 +71,7 @@ public sealed class GenerateRunBaseCommand : Command<GenerateRunBaseCommand.Sett
                 bytes           = res.Bytes,
                 backup          = res.BackupPath,
                 model           = settings.InstallTo,
-            }));
+            }, gate.Warnings));
         }
         catch (Exception ex)
         {

--- a/src/D365FO.Cli/Commands/Generate/GenerateSecurityPolicyCommand.cs
+++ b/src/D365FO.Cli/Commands/Generate/GenerateSecurityPolicyCommand.cs
@@ -37,6 +37,18 @@ public sealed class GenerateSecurityPolicyCommand : Command<GenerateSecurityPoli
         [CommandOption("--context-value <VALUE>")]
         [System.ComponentModel.Description("Context value (role name or context string). Optional.")]
         public string? ContextValue { get; init; }
+
+        [CommandOption("--constrained <SPEC>")]
+        [System.ComponentModel.Description("Repeatable: <Table>[[/<Child>[[/<Grandchild>]]]][[:unconstrained]]. Tables the policy reaches beyond the primary one; '/' nests, ':unconstrained' marks a table the policy only traverses. Example: --constrained FmVehicleService/FmVehicleServiceLine")]
+        public string[] Constrained { get; init; } = Array.Empty<string>();
+
+        [CommandOption("--label <TEXT>")]
+        [System.ComponentModel.Description("Policy label.")]
+        public string? Label { get; init; }
+
+        [CommandOption("--use-not-exist-join")]
+        [System.ComponentModel.Description("Emit UseNotExistJoin=Yes — the policy excludes rows the query matches instead of restricting to them.")]
+        public bool UseNotExistJoin { get; init; }
     }
 
     public override int Execute(CommandContext ctx, Settings settings)
@@ -78,9 +90,16 @@ public sealed class GenerateSecurityPolicyCommand : Command<GenerateSecurityPoli
                 settings.PolicyQuery!,
                 operation,
                 contextType,
-                settings.ContextValue);
+                settings.ContextValue,
+                constrainedTables: ParseConstrained(settings.Constrained),
+                label: settings.Label,
+                useNotExistJoin: settings.UseNotExistJoin);
 
-            var res = ScaffoldFileWriter.Write(doc, outPath!, settings.Overwrite);
+            // Grounding gate (issue #161): uniform across every generate subcommand.
+            var gate = GenerateInstaller.Gate(settings, settings.Name, doc);
+            if (gate.Failure is not null) return RenderHelpers.Render(kind, gate.Failure);
+
+            var res = GenerateInstaller.Write(gate, doc, outPath!, settings.Overwrite);
 
             return RenderHelpers.Render(kind, ToolResult<object>.Success(new
             {
@@ -91,16 +110,62 @@ public sealed class GenerateSecurityPolicyCommand : Command<GenerateSecurityPoli
                 operation        = operation.ToString(),
                 contextType      = contextType.ToString(),
                 contextValue     = settings.ContextValue,
+                constrainedTables = settings.Constrained,
                 path             = res.Path,
                 bytes            = res.Bytes,
                 backup           = res.BackupPath,
                 model            = settings.InstallTo,
-            }));
+            }, gate.Warnings));
         }
         catch (Exception ex)
         {
             return RenderHelpers.Render(kind, ToolResult<object>.Fail(D365FoErrorCodes.WriteFailed, ex.Message));
         }
+    }
+
+    /// <summary>
+    /// Parse <c>--constrained &lt;Table&gt;[/&lt;Child&gt;…][:unconstrained]</c> into the
+    /// nested <c>ConstrainedTables</c> tree.
+    /// </summary>
+    /// <remarks>
+    /// A path rather than a flat list because <c>AxSecurityPolicyConstrainedEntity</c> nests: a
+    /// policy reaches a line table <em>through</em> its header, and flattening the two would
+    /// claim the line table is joined to the primary table directly. The <c>:unconstrained</c>
+    /// marker applies to the last segment — the common shape is traversing a header to
+    /// constrain its lines.
+    /// </remarks>
+    private static List<SecurityPolicyScaffolder.ConstrainedEntity> ParseConstrained(string[] raw)
+    {
+        var roots = new List<SecurityPolicyScaffolder.ConstrainedEntity>();
+
+        foreach (var spec in raw.Where(s => !string.IsNullOrWhiteSpace(s)))
+        {
+            var body = spec;
+            var constrained = true;
+            var marker = spec.LastIndexOf(':');
+            if (marker > 0 && spec[(marker + 1)..].Trim().Equals("unconstrained", StringComparison.OrdinalIgnoreCase))
+            {
+                body = spec[..marker];
+                constrained = false;
+            }
+
+            var segments = body.Split('/', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries);
+            if (segments.Length == 0) continue;
+
+            // Build from the leaf up: only the leaf carries the caller's constrained flag, the
+            // ancestors are the path taken to reach it.
+            SecurityPolicyScaffolder.ConstrainedEntity? node = null;
+            for (var i = segments.Length - 1; i >= 0; i--)
+            {
+                node = new SecurityPolicyScaffolder.ConstrainedEntity(
+                    segments[i],
+                    Constrained: node is null ? constrained : true,
+                    Children: node is null ? null : [node]);
+            }
+            roots.Add(node!);
+        }
+
+        return roots;
     }
 
     private static bool TryParseOperation(string raw, out PolicyOperation op)

--- a/src/D365FO.Cli/Commands/Generate/GenerateSysOperationCommand.cs
+++ b/src/D365FO.Cli/Commands/Generate/GenerateSysOperationCommand.cs
@@ -98,13 +98,18 @@ public sealed class GenerateSysOperationCommand : Command<GenerateSysOperationCo
 
         var parms = settings.Params.Select(ParseParam).ToList();
 
+        var serviceDoc = SysOperationScaffolder.Service(serviceName, contractName, settings.ServiceMethod, parms);
+
+        // Grounding gate (issue #161) — the service class is where this command's X++ lives.
+        var gate = GenerateInstaller.Gate(settings, settings.Name, serviceDoc);
+        if (gate.Failure is not null) return RenderHelpers.Render(kind, gate.Failure);
+
         try
         {
-            var contractResult    = ScaffoldFileWriter.Write(
+            var contractResult    = GenerateInstaller.Write(gate,
                 SysOperationScaffolder.Contract(contractName, parms), contractPath!, settings.Overwrite);
-            var serviceResult     = ScaffoldFileWriter.Write(
-                SysOperationScaffolder.Service(serviceName, contractName, settings.ServiceMethod, parms), servicePath!, settings.Overwrite);
-            var controllerResult  = ScaffoldFileWriter.Write(
+            var serviceResult     = GenerateInstaller.Write(gate, serviceDoc, servicePath!, settings.Overwrite);
+            var controllerResult  = GenerateInstaller.Write(gate,
                 SysOperationScaffolder.Controller(controllerName, serviceName, settings.ServiceMethod, mode), controllerPath!, settings.Overwrite);
 
             return RenderHelpers.Render(kind, ToolResult<object>.Success(new
@@ -121,7 +126,8 @@ public sealed class GenerateSysOperationCommand : Command<GenerateSysOperationCo
                 service        = new { path = serviceResult.Path,    bytes = serviceResult.Bytes,    backup = serviceResult.BackupPath },
                 controller     = new { path = controllerResult.Path, bytes = controllerResult.Bytes, backup = controllerResult.BackupPath },
                 model          = settings.InstallTo,
-            }));
+                grounding      = gate.Grounding,
+            }, gate.Warnings));
         }
         catch (Exception ex)
         {

--- a/src/D365FO.Cli/Commands/Generate/GenerateSysTestCommand.cs
+++ b/src/D365FO.Cli/Commands/Generate/GenerateSysTestCommand.cs
@@ -117,7 +117,11 @@ public sealed class GenerateSysTestCommand : Command<GenerateSysTestCommand.Sett
         try
         {
             var doc = SysTestScaffolder.TestClass(settings.Name, settings.DataAreaId, settings.Atl, subject);
-            var res = ScaffoldFileWriter.Write(doc, outPath!, settings.Overwrite);
+            // Grounding gate (issue #161): uniform across every generate subcommand.
+            var gate = GenerateInstaller.Gate(settings, settings.Name, doc);
+            if (gate.Failure is not null) return RenderHelpers.Render(kind, gate.Failure);
+
+            var res = GenerateInstaller.Write(gate, doc, outPath!, settings.Overwrite);
             var testMethodName = $"{subject ?? "subject"}_scenario_expectedResult";
 
             return RenderHelpers.Render(kind, ToolResult<object>.Success(new
@@ -133,7 +137,7 @@ public sealed class GenerateSysTestCommand : Command<GenerateSysTestCommand.Sett
                 bytes      = res.Bytes,
                 backup     = res.BackupPath,
                 model      = settings.InstallTo,
-            }));
+            }, gate.Warnings));
         }
         catch (Exception ex)
         {

--- a/src/D365FO.Cli/Commands/Generate/GenerateViewMapCommands.cs
+++ b/src/D365FO.Cli/Commands/Generate/GenerateViewMapCommands.cs
@@ -92,7 +92,11 @@ public sealed class GenerateViewCommand : Command<GenerateViewCommand.Settings>
 
         try
         {
-            var res = ScaffoldFileWriter.Write(doc, outPath!, settings.Overwrite);
+            // Grounding gate (issue #161): uniform across every generate subcommand.
+            var gate = GenerateInstaller.Gate(settings, settings.Name, doc);
+            if (gate.Failure is not null) return RenderHelpers.Render(kind, gate.Failure);
+
+            var res = GenerateInstaller.Write(gate, doc, outPath!, settings.Overwrite);
             return RenderHelpers.Render(kind, ToolResult<object>.Success(new
             {
                 kind = "AxView",
@@ -105,7 +109,7 @@ public sealed class GenerateViewCommand : Command<GenerateViewCommand.Settings>
                 bytes = res.Bytes,
                 backup = res.BackupPath,
                 model = settings.InstallTo,
-            }));
+            }, gate.Warnings));
         }
         catch (Exception ex)
         {
@@ -235,7 +239,11 @@ public sealed class GenerateMapCommand : Command<GenerateMapCommand.Settings>
 
         try
         {
-            var res = ScaffoldFileWriter.Write(doc, outPath!, settings.Overwrite);
+            // Grounding gate (issue #161): uniform across every generate subcommand.
+            var gate = GenerateInstaller.Gate(settings, settings.Name, doc);
+            if (gate.Failure is not null) return RenderHelpers.Render(kind, gate.Failure);
+
+            var res = GenerateInstaller.Write(gate, doc, outPath!, settings.Overwrite);
             return RenderHelpers.Render(kind, ToolResult<object>.Success(new
             {
                 kind = "AxMap",
@@ -246,7 +254,7 @@ public sealed class GenerateMapCommand : Command<GenerateMapCommand.Settings>
                 bytes = res.Bytes,
                 backup = res.BackupPath,
                 model = settings.InstallTo,
-            }));
+            }, gate.Warnings));
         }
         catch (Exception ex)
         {

--- a/src/D365FO.Cli/Commands/Generate/GenerateWorkflowCommand.cs
+++ b/src/D365FO.Cli/Commands/Generate/GenerateWorkflowCommand.cs
@@ -169,9 +169,18 @@ public sealed class GenerateWorkflowCommand : Command<GenerateWorkflowCommand.Se
                 : settings.OutQuery ?? System.IO.Path.Combine(dir, queryName + ".xml");
         }
 
+        var documentDoc = WorkflowScaffolder.WorkflowDocument(docClassName, queryName);
+
+        // Grounding gate (issue #161). The document class is the X++ here, and the driving
+        // table is the claim about the existing AOT.
+        var gate = GenerateInstaller.Gate(
+            settings, settings.Name, documentDoc,
+            requiredSymbols: string.IsNullOrWhiteSpace(settings.TableName) ? null : new[] { settings.TableName! });
+        if (gate.Failure is not null) return RenderHelpers.Render(kind, gate.Failure);
+
         try
         {
-            var workflowResult = ScaffoldFileWriter.Write(
+            var workflowResult = GenerateInstaller.Write(gate,
                 WorkflowScaffolder.WorkflowTemplate(
                     settings.Name,
                     docClassName,
@@ -182,14 +191,12 @@ public sealed class GenerateWorkflowCommand : Command<GenerateWorkflowCommand.Se
                     taskName),
                 workflowPath!, settings.Overwrite);
 
-            var documentResult = ScaffoldFileWriter.Write(
-                WorkflowScaffolder.WorkflowDocument(docClassName, queryName),
-                documentPath!, settings.Overwrite);
+            var documentResult = GenerateInstaller.Write(gate, documentDoc, documentPath!, settings.Overwrite);
 
             ScaffoldFileWriter.WriteResult? queryResult = null;
             if (generateQuery && queryPath is not null)
             {
-                queryResult = ScaffoldFileWriter.Write(
+                queryResult = GenerateInstaller.Write(gate,
                     QueryScaffolder.Query(queryName, [new QueryDataSourceSpec(settings.TableName!)]),
                     queryPath, settings.Overwrite);
             }
@@ -197,7 +204,7 @@ public sealed class GenerateWorkflowCommand : Command<GenerateWorkflowCommand.Se
             ScaffoldFileWriter.WriteResult? approvalResult = null;
             if (approvalName is not null && approvalPath is not null)
             {
-                approvalResult = ScaffoldFileWriter.Write(
+                approvalResult = GenerateInstaller.Write(gate,
                     WorkflowScaffolder.WorkflowApproval(approvalName, docClassName, docMenuItem),
                     approvalPath, settings.Overwrite);
             }
@@ -205,7 +212,7 @@ public sealed class GenerateWorkflowCommand : Command<GenerateWorkflowCommand.Se
             ScaffoldFileWriter.WriteResult? taskResult = null;
             if (taskName is not null && taskPath is not null)
             {
-                taskResult = ScaffoldFileWriter.Write(
+                taskResult = GenerateInstaller.Write(gate,
                     WorkflowScaffolder.WorkflowTask(taskName, docClassName, docMenuItem),
                     taskPath, settings.Overwrite);
             }
@@ -213,7 +220,7 @@ public sealed class GenerateWorkflowCommand : Command<GenerateWorkflowCommand.Se
             ScaffoldFileWriter.WriteResult? submitResult = null;
             if (generateSubmit && submitPath is not null)
             {
-                submitResult = ScaffoldFileWriter.Write(
+                submitResult = GenerateInstaller.Write(gate,
                     WorkflowScaffolder.CanSubmitExtension(settings.TableName!),
                     submitPath, settings.Overwrite);
             }
@@ -234,6 +241,7 @@ public sealed class GenerateWorkflowCommand : Command<GenerateWorkflowCommand.Se
             {
                 "Referenced but not generated — create these before building: " + string.Join("; ", pending),
             };
+            warnings.AddRange(gate.Warnings);
 
             return RenderHelpers.Render(kind, ToolResult<object>.Success(new
             {

--- a/src/D365FO.Cli/Commands/Generate/GroundingGate.cs
+++ b/src/D365FO.Cli/Commands/Generate/GroundingGate.cs
@@ -1,6 +1,7 @@
 using D365FO.Core;
 using D365FO.Core.Guardrails;
 using D365FO.Core.Index;
+using D365FO.Core.Scaffolding;
 using D365FO.Core.Validation;
 using System.Xml.Linq;
 
@@ -23,22 +24,78 @@ namespace D365FO.Cli.Commands.Generate;
 /// </summary>
 internal static class GroundingGate
 {
-    public sealed record GateResult(object Grounding, List<string> Warnings, ToolResult<object>? Failure);
+    /// <summary>
+    /// The verdict of one gate run, and the handle a command writes through.
+    /// </summary>
+    /// <remarks>
+    /// <see cref="GenerateInstaller.Write"/> takes one of these, so a generate command cannot
+    /// reach the writer without having gated first — the guarantee issue #161 asked for. It also
+    /// makes the object the natural place to hang the property-honesty report (R6): the gate
+    /// knows what was requested, and every document that reaches disk passes through here, so
+    /// the two halves of "did what I asked for survive?" meet without a command having to
+    /// arrange it.
+    /// </remarks>
+    public sealed record GateResult(object Grounding, List<string> Warnings, ToolResult<object>? Failure)
+    {
+        private readonly List<string> _written = [];
+        private readonly List<string> _honestyWarnings = [];
+
+        /// <summary>What the caller asked for, as option/value pairs.</summary>
+        internal IReadOnlyList<(string Option, string Value)> Requested { get; init; } = [];
+
+        /// <summary>Every document this gate has seen written, in order.</summary>
+        public IReadOnlyList<string> WrittenDocuments => _written;
+
+        /// <summary>Requested values that reached none of the written documents.</summary>
+        public IReadOnlyList<PropertyGap> PropertyGaps { get; private set; } = [];
+
+        /// <summary>
+        /// Record a document as written and re-run the honesty reconciliation over everything
+        /// written so far.
+        /// </summary>
+        /// <remarks>
+        /// Recomputed rather than accumulated, because a multi-document command legitimately
+        /// satisfies a request in its second file: <c>generate report --dataset X</c> puts the
+        /// dataset in the DP class, not in the AxReport. Judging each document alone would report
+        /// a gap that the next write fills. The previously reported gaps are removed from
+        /// <see cref="Warnings"/> before the new ones go in, so the list never accumulates
+        /// superseded findings.
+        /// </remarks>
+        internal void Observe(string xml)
+        {
+            if (string.IsNullOrWhiteSpace(xml)) return;
+            _written.Add(xml);
+
+            foreach (var stale in _honestyWarnings) Warnings.Remove(stale);
+            _honestyWarnings.Clear();
+
+            PropertyGaps = PropertyHonesty.Reconcile(Requested, string.Join('\n', _written));
+            _honestyWarnings.AddRange(PropertyGaps.Select(g => $"property-honesty: {g}"));
+            Warnings.AddRange(_honestyWarnings);
+        }
+    }
 
     /// <param name="token">Value of --grounding-token (may be null).</param>
     /// <param name="targetObject">The AOT object this write is bound to (CoC target, extension target…).</param>
     /// <param name="doc">Scaffolded XML; X++ inside Declaration/Source elements is validated.</param>
     /// <param name="requiredMethods">Methods that must exist on their owner (e.g. CoC-wrapped methods).</param>
     /// <param name="requiredSymbols">AOT names that must exist in the index (e.g. an extension's target object).</param>
+    /// <param name="requested">
+    /// Option/value pairs the caller supplied, for the property-honesty reconciliation (R6).
+    /// Empty means "do not reconcile" — the check is silent rather than reporting everything as
+    /// missing.
+    /// </param>
     public static GateResult Check(
         string? token,
         string targetObject,
         XDocument? doc,
         IEnumerable<(string Owner, string Method)>? requiredMethods = null,
-        IEnumerable<string>? requiredSymbols = null)
+        IEnumerable<string>? requiredSymbols = null,
+        IReadOnlyList<(string Option, string Value)>? requested = null)
     {
         var enforce = ProvenanceStore.EnforcementEnabled;
         var warnings = new List<string>();
+        var asked = requested ?? [];
 
         // ── 1. Grounding token ───────────────────────────────────────────────
         bool tokenValid = false;
@@ -53,7 +110,8 @@ internal static class GroundingGate
                 {
                     return new GateResult(new { enforced = true, tokenValid = false }, warnings,
                         ToolResult<object>.Fail("GROUNDING_REQUIRED", reason,
-                            $"Run `d365fo prepare change {targetObject}` (or `prepare create`) and pass the returned token via --grounding-token."));
+                            $"Run `d365fo prepare change {targetObject}` (or `prepare create`) and pass the returned token via --grounding-token."))
+                        { Requested = asked };
                 }
                 warnings.Add($"grounding: {reason}");
             }
@@ -155,13 +213,14 @@ internal static class GroundingGate
                     $"Generated code contains {refErrors} unresolved reference(s) and {bpErrors} BP error(s) (D365FO_GROUNDING_ENFORCE=true):\n" +
                     string.Join("\n", violationDetails),
                     "Fix the identifiers (use the suggested lookup commands), then retry. " +
-                    "Run `d365fo validate references` on the corrected code to confirm it is clean."));
+                    "Run `d365fo validate references` on the corrected code to confirm it is clean."))
+                { Requested = asked };
         }
 
         foreach (var detail in violationDetails)
             warnings.Add($"grounding: {detail}");
 
-        return new GateResult(grounding, warnings, null);
+        return new GateResult(grounding, warnings, null) { Requested = asked };
     }
 
     /// <summary>Concatenate X++ from Declaration/Source elements of a scaffolded AOT XML.</summary>

--- a/src/D365FO.Cli/Commands/Ops/BuildCommands.cs
+++ b/src/D365FO.Cli/Commands/Ops/BuildCommands.cs
@@ -232,19 +232,41 @@ public sealed class TestRunCommand : Command<TestRunCommand.Settings>
         var resultsWritten = !string.IsNullOrWhiteSpace(settings.ResultsPath)
                              && System.IO.File.Exists(settings.ResultsPath!);
 
-        return RenderHelpers.Render(kind, exit == 0
-            ? ToolResult<object>.Success(new
+        if (exit != 0)
+            return RenderHelpers.Render(kind, ToolResult<object>.Fail(
+                "TESTS_FAILED", $"Runner exited with {exit}.", string.Join('\n', stderr.Split('\n').TakeLast(5))));
+
+        // The verdict comes from the runner's own result document, not from its exit code: a
+        // run that dies half way still exits 0 with its remaining cases marked pending.
+        var results = D365FO.Core.Eval.SysTestResults.TryParseFile(settings.ResultsPath);
+
+        var warnings = new List<string>();
+        if (!resultsWritten && !string.IsNullOrWhiteSpace(settings.ResultsPath))
+            warnings.Add($"The runner exited cleanly but wrote no result document at {settings.ResultsPath}.");
+        else if (resultsWritten && results is null)
+            warnings.Add($"{settings.ResultsPath} is not a SysTest result document (expected a <test-results> root).");
+
+        var payload = ToolResult<object>.Success(new
+        {
+            exitCode = exit,
+            elapsedMs = (long)elapsed.TotalMilliseconds,
+            testClasses = classes,
+            resultsPath = resultsWritten ? settings.ResultsPath : null,
+            results = results is null ? null : new
             {
-                exitCode = exit,
-                elapsedMs = (long)elapsed.TotalMilliseconds,
-                testClasses = classes,
-                resultsPath = resultsWritten ? settings.ResultsPath : null,
-                tail = stdout.Split('\n').TakeLast(40).ToArray(),
+                clean = results.Clean,
+                passed = results.Passed,
+                failed = results.Failed,
+                skipped = results.Skipped,
+                pending = results.Pending,
+                failures = results.Failures.Select(f => new { name = f.Name, message = f.FailureMessage }).ToList(),
             },
-            resultsWritten || string.IsNullOrWhiteSpace(settings.ResultsPath)
-                ? null
-                : [$"The runner exited cleanly but wrote no result document at {settings.ResultsPath}."])
-            : ToolResult<object>.Fail("TESTS_FAILED", $"Runner exited with {exit}.", string.Join('\n', stderr.Split('\n').TakeLast(5))));
+            tail = stdout.Split('\n').TakeLast(40).ToArray(),
+        }, warnings.Count > 0 ? warnings : null);
+
+        var rc = RenderHelpers.Render(kind, payload);
+        // A parsed run that is not clean is a failed run, whatever the exit code said.
+        return rc != 0 ? rc : results is { Clean: false } ? 2 : 0;
     }
 }
 

--- a/src/D365FO.Cli/Commands/Ops/BuildCommands.cs
+++ b/src/D365FO.Cli/Commands/Ops/BuildCommands.cs
@@ -160,15 +160,52 @@ public sealed class SyncCommand : Command<SyncCommand.Settings>
     }
 }
 
+/// <summary>
+/// Runs SysTest tests through the platform's own console runner.
+/// </summary>
+/// <remarks>
+/// <para>
+/// Issue #160. This command used to default to <c>SysTestRunner.exe</c> and pass
+/// <c>--suite &lt;name&gt;</c>. Neither exists. The binary shipped in
+/// <c>PackagesLocalDirectory\bin</c> is <b>SysTestConsole.exe</b>, and its options are
+/// slash-prefixed and colon-joined — <c>/test:Class1,Class2</c>, <c>/xml:&lt;file&gt;</c>,
+/// <c>/granularity:</c>, <c>/parallel</c>. Ground-truthed by running the real binary's usage
+/// text on a D365FO host. The old defaults could never have worked, which is why nothing
+/// noticed: the command was never run against a real installation.
+/// </para>
+/// <para>
+/// <c>--results</c> asks the runner for its XML result document, which is the input an L4
+/// oracle needs. Without it the only output is a tail of console text, which is a log, not a
+/// result.
+/// </para>
+/// </remarks>
 public sealed class TestRunCommand : Command<TestRunCommand.Settings>
 {
     public sealed class Settings : D365OutputSettings
     {
         [CommandOption("--runner <PATH>")]
+        [System.ComponentModel.Description("Path to SysTestConsole.exe. Defaults to the one on PATH / in the packages bin folder.")]
         public string? RunnerPath { get; init; }
 
+        [CommandOption("--test <CLASS>")]
+        [System.ComponentModel.Description("Repeatable: test class to run. Maps to the runner's /test: option.")]
+        public string[] TestClasses { get; init; } = Array.Empty<string>();
+
         [CommandOption("--suite <NAME>")]
+        [System.ComponentModel.Description("Deprecated alias for --test; the runner has no notion of a suite.")]
         public string? Suite { get; init; }
+
+        [CommandOption("--granularity <LEVEL>")]
+        [System.ComponentModel.Description("Default | UnitTest | ScenarioTest.")]
+        public string? Granularity { get; init; }
+
+        [CommandOption("--results <PATH>")]
+        [System.ComponentModel.Description("Write the runner's XML result document here (/xml:). Required for any structured verdict.")]
+        public string? ResultsPath { get; init; }
+
+        [CommandOption("--parallel")]
+        [System.ComponentModel.Description("Run the tests through the batch framework in parallel.")]
+        public bool Parallel { get; init; }
     }
 
     public override int Execute(CommandContext ctx, Settings settings)
@@ -177,20 +214,36 @@ public sealed class TestRunCommand : Command<TestRunCommand.Settings>
         var guard = WindowsGuard.Check("d365fo test run");
         if (guard is not null) return RenderHelpers.Render(kind, guard);
 
-        var runner = settings.RunnerPath ?? "SysTestRunner.exe";
+        var runner = settings.RunnerPath ?? "SysTestConsole.exe";
+
+        var classes = settings.TestClasses
+            .Concat(string.IsNullOrWhiteSpace(settings.Suite) ? [] : new[] { settings.Suite! })
+            .Where(c => !string.IsNullOrWhiteSpace(c))
+            .ToList();
+
         var args = new List<string>();
-        if (!string.IsNullOrEmpty(settings.Suite))
-        {
-            // Two argv elements, not one. ProcessRunner passes each element through
-            // ArgumentList, so `args.Add($"--suite {suite}")` reaches the runner as the
-            // single literal argument "--suite MySuite" and is rejected. Nothing exercised
-            // --suite until the L4 oracle came to depend on it.
-            args.Add("--suite");
-            args.Add(settings.Suite!);
-        }
+        if (classes.Count > 0) args.Add("/test:" + string.Join(',', classes));
+        if (!string.IsNullOrWhiteSpace(settings.Granularity)) args.Add("/granularity:" + settings.Granularity);
+        if (!string.IsNullOrWhiteSpace(settings.ResultsPath)) args.Add("/xml:" + settings.ResultsPath);
+        if (settings.Parallel) args.Add("/parallel");
+
         var (exit, stdout, stderr, elapsed) = ProcessRunner.Run(runner, args);
+
+        var resultsWritten = !string.IsNullOrWhiteSpace(settings.ResultsPath)
+                             && System.IO.File.Exists(settings.ResultsPath!);
+
         return RenderHelpers.Render(kind, exit == 0
-            ? ToolResult<object>.Success(new { exitCode = exit, elapsedMs = (long)elapsed.TotalMilliseconds, tail = stdout.Split('\n').TakeLast(40).ToArray() })
+            ? ToolResult<object>.Success(new
+            {
+                exitCode = exit,
+                elapsedMs = (long)elapsed.TotalMilliseconds,
+                testClasses = classes,
+                resultsPath = resultsWritten ? settings.ResultsPath : null,
+                tail = stdout.Split('\n').TakeLast(40).ToArray(),
+            },
+            resultsWritten || string.IsNullOrWhiteSpace(settings.ResultsPath)
+                ? null
+                : [$"The runner exited cleanly but wrote no result document at {settings.ResultsPath}."])
             : ToolResult<object>.Fail("TESTS_FAILED", $"Runner exited with {exit}.", string.Join('\n', stderr.Split('\n').TakeLast(5))));
     }
 }

--- a/src/D365FO.Cli/Commands/Validate/ValidateXppCommand.cs
+++ b/src/D365FO.Cli/Commands/Validate/ValidateXppCommand.cs
@@ -52,7 +52,9 @@ public sealed class ValidateXppCommand : Command<ValidateXppCommand.Settings>
         }
         catch { /* no index — static defaults */ }
 
-        var violations = XppValidator.Validate(code!, codeType, stats);
+        // The path is passed through so XML013 can judge the folder the file sits in — it has
+        // nothing to say when the document arrived on stdin.
+        var violations = XppValidator.Validate(code!, codeType, stats, settings.File);
         var errors = violations.Count(v => v.Severity == "error");
         var warnings = violations.Count(v => v.Severity == "warning");
 

--- a/src/D365FO.Core/Eval/EvalScoreCard.cs
+++ b/src/D365FO.Core/Eval/EvalScoreCard.cs
@@ -14,7 +14,13 @@ namespace D365FO.Core.Eval;
 /// collected would be exactly the confident lie the triage rubric warns about.
 /// </para>
 /// <para>
-/// There is still no runtime/SysTest dimension: no oracle produces one yet.
+/// <see cref="RuntimeClean"/> is the L4 dimension (issue #160) and follows the same discipline
+/// one level further out: it is <c>null</c> unless a SysTest run actually happened and its
+/// results were read. No runner is wired to it yet — the platform's runner is
+/// <c>SysTestConsole.exe</c> and emits its verdict as an XML document via <c>/xml:</c>, but
+/// nothing in this repo parses that document, so nothing may claim a runtime verdict. The field
+/// exists so the scoring surface has one shape rather than growing a second one later; a
+/// scorecard where it is null means "not run", exactly as with <see cref="BuildClean"/>.
 /// </para>
 /// </remarks>
 public sealed record EvalScoreCard(
@@ -25,4 +31,6 @@ public sealed record EvalScoreCard(
     bool GoldenMatch,
     XmlGoldenDiff GoldenDiff,
     bool? BuildClean = null,
-    int BuildErrors = 0);
+    int BuildErrors = 0,
+    bool? RuntimeClean = null,
+    int RuntimeFailures = 0);

--- a/src/D365FO.Core/Eval/EvalScoreCard.cs
+++ b/src/D365FO.Core/Eval/EvalScoreCard.cs
@@ -16,11 +16,10 @@ namespace D365FO.Core.Eval;
 /// <para>
 /// <see cref="RuntimeClean"/> is the L4 dimension (issue #160) and follows the same discipline
 /// one level further out: it is <c>null</c> unless a SysTest run actually happened and its
-/// results were read. No runner is wired to it yet — the platform's runner is
-/// <c>SysTestConsole.exe</c> and emits its verdict as an XML document via <c>/xml:</c>, but
-/// nothing in this repo parses that document, so nothing may claim a runtime verdict. The field
-/// exists so the scoring surface has one shape rather than growing a second one later; a
-/// scorecard where it is null means "not run", exactly as with <see cref="BuildClean"/>.
+/// results were read. <see cref="SysTestResults"/> reads the document
+/// <c>SysTestConsole.exe /xml:</c> writes, so a caller that ran tests can fill this in; nothing
+/// fills it in from an exit code or an absent file. A scorecard where it is null means "not
+/// run", exactly as with <see cref="BuildClean"/> — never "passed".
 /// </para>
 /// </remarks>
 public sealed record EvalScoreCard(

--- a/src/D365FO.Core/Eval/SysTestResults.cs
+++ b/src/D365FO.Core/Eval/SysTestResults.cs
@@ -1,0 +1,153 @@
+using System.Xml;
+using System.Xml.Linq;
+
+namespace D365FO.Core.Eval;
+
+/// <summary>One test case from a SysTest run.</summary>
+/// <param name="Name">Fully qualified test-case name as the runner reports it.</param>
+/// <param name="Passed">The run finished and did not fail.</param>
+/// <param name="Skipped">The runner skipped it (an unmet dependency attribute, usually).</param>
+/// <param name="Pending">
+/// The case was registered and never executed — the run died, or was cut short. Distinct from
+/// skipped, and emphatically not a pass.
+/// </param>
+/// <param name="TimeMs">Reported duration, when the runner recorded one.</param>
+/// <param name="FailureMessage">The failure text, when it failed.</param>
+public sealed record SysTestCaseResult(
+    string Name,
+    bool Passed,
+    bool Skipped,
+    bool Pending,
+    int? TimeMs,
+    string? FailureMessage);
+
+/// <summary>The outcome of one SysTest run.</summary>
+public sealed record SysTestRunResults(
+    IReadOnlyList<SysTestCaseResult> Cases,
+    int Passed,
+    int Failed,
+    int Skipped,
+    int Pending)
+{
+    /// <summary>
+    /// Every case that was supposed to run did, and none failed.
+    /// </summary>
+    /// <remarks>
+    /// A run with no cases is not clean — it is a run that tested nothing, and reporting that as
+    /// a pass is how a broken harness looks healthy. Pending cases are not clean either: the
+    /// runner registered them and never got to them.
+    /// </remarks>
+    public bool Clean => Cases.Count > 0 && Failed == 0 && Pending == 0;
+
+    /// <summary>Cases that failed, for a caller that wants to name them.</summary>
+    public IEnumerable<SysTestCaseResult> Failures => Cases.Where(c => !c.Passed && !c.Skipped && !c.Pending);
+}
+
+/// <summary>
+/// Reads the XML document <c>SysTestConsole.exe /xml:&lt;file&gt;</c> writes.
+/// </summary>
+/// <remarks>
+/// <para>
+/// Issue #160 — the L4 oracle's missing half. <c>d365fo test run</c> returned a tail of console
+/// text, which is a log, not a result: nothing could say whether a generated object actually
+/// runs.
+/// </para>
+/// <para>
+/// <b>The schema is ground truth, not a guess.</b> It is not discoverable from the runner
+/// binary — not in its strings, its XML doc, or an embedded stylesheet — but the writer is X++
+/// and ships as source on every installation:
+/// <c>ApplicationFoundation\AxClass\SysTestListenerXML.xml</c>. Its element names are
+/// <c>#define</c>s at the top of the class and its attributes are literal
+/// <c>setAttribute</c> calls:
+/// </para>
+/// <code>
+/// #define.TestResults('test-results')   #define.TestSuite('test-suite')
+/// #define.Results('results')            #define.TestCase('test-case')
+/// #define.Failure('failure')            #define.Message('message')
+/// #define.execution('execution')        #define.executionPending('pending')
+/// </code>
+/// <para>
+/// The one trap is the <c>success</c> attribute, which does not mean what the method producing
+/// it is called. <c>SysTestListenerXML.isFailure()</c> returns <c>'false'</c> when the status is
+/// <c>Failed</c> and <c>'true'</c> otherwise — so <c>success</c> is a plain pass flag, and
+/// reading it as "is this a failure?" inverts every verdict in the file.
+/// </para>
+/// </remarks>
+public static class SysTestResults
+{
+    private const string RootElement = "test-results";
+    private const string CaseElement = "test-case";
+    private const string PendingExecution = "pending";
+
+    /// <summary>
+    /// Parse a result document. Returns null when <paramref name="xml"/> is not one — a caller
+    /// holding the wrong file must not receive an empty-but-successful run.
+    /// </summary>
+    public static SysTestRunResults? Parse(string? xml)
+    {
+        if (string.IsNullOrWhiteSpace(xml)) return null;
+
+        XDocument doc;
+        try
+        {
+            using var reader = XmlReader.Create(new StringReader(xml),
+                new XmlReaderSettings { DtdProcessing = DtdProcessing.Prohibit, XmlResolver = null });
+            doc = XDocument.Load(reader);
+        }
+        catch (XmlException)
+        {
+            return null;
+        }
+
+        if (doc.Root is null || doc.Root.Name.LocalName != RootElement) return null;
+
+        var cases = doc.Root
+            .Descendants()
+            .Where(e => e.Name.LocalName == CaseElement)
+            .Select(ReadCase)
+            .ToList();
+
+        return new SysTestRunResults(
+            cases,
+            Passed: cases.Count(c => c.Passed),
+            Failed: cases.Count(c => !c.Passed && !c.Skipped && !c.Pending),
+            Skipped: cases.Count(c => c.Skipped),
+            Pending: cases.Count(c => c.Pending));
+    }
+
+    /// <summary>Parse the document at <paramref name="path"/>, or null when it cannot be read.</summary>
+    public static SysTestRunResults? TryParseFile(string? path)
+    {
+        if (string.IsNullOrWhiteSpace(path) || !File.Exists(path)) return null;
+        try { return Parse(File.ReadAllText(path)); }
+        catch (IOException) { return null; }
+        catch (UnauthorizedAccessException) { return null; }
+    }
+
+    private static SysTestCaseResult ReadCase(XElement el)
+    {
+        var pending = string.Equals(Attr(el, "execution"), PendingExecution, StringComparison.OrdinalIgnoreCase);
+        var skipped = IsTrue(Attr(el, "skipped"));
+
+        // `success` is a pass flag despite the name of the method that writes it.
+        var success = IsTrue(Attr(el, "success"));
+
+        var failure = el.Elements().FirstOrDefault(e => e.Name.LocalName == "failure");
+        var message = failure?.Elements().FirstOrDefault(e => e.Name.LocalName == "message")?.Value.Trim()
+                      ?? failure?.Value.Trim();
+
+        return new SysTestCaseResult(
+            Name: Attr(el, "name") ?? "(unnamed)",
+            Passed: success && !skipped && !pending,
+            Skipped: skipped,
+            Pending: pending,
+            TimeMs: int.TryParse(Attr(el, "time"), out var t) ? t : null,
+            FailureMessage: string.IsNullOrWhiteSpace(message) ? null : message);
+    }
+
+    private static string? Attr(XElement el, string name) =>
+        el.Attributes().FirstOrDefault(a => a.Name.LocalName == name)?.Value;
+
+    private static bool IsTrue(string? value) =>
+        string.Equals(value, "true", StringComparison.OrdinalIgnoreCase);
+}

--- a/src/D365FO.Core/FormPatterns/FieldControlTypes.cs
+++ b/src/D365FO.Core/FormPatterns/FieldControlTypes.cs
@@ -1,0 +1,120 @@
+namespace D365FO.Core.FormPatterns;
+
+/// <summary>
+/// The control type a bound field gets, derived from the field's own concrete
+/// <c>AxTableField*</c> type rather than guessed from its EDT's name.
+/// </summary>
+/// <remarks>
+/// <para>
+/// Issue #164 / R5, the one item of the predecessor's form-engine material that was a real
+/// defect rather than a missing convenience. Every field control the form templates emitted was
+/// an <c>AxFormStringControl</c> with <c>&lt;Type&gt;String&lt;/Type&gt;</c>, whatever the field
+/// actually was: a quantity, a date, a status enum. The form loads, and then the control renders
+/// and validates as text — a `Qty` field that accepts "abc", a date with no picker, an enum with
+/// no list.
+/// </para>
+/// <para>
+/// <b>Where the mapping comes from.</b> Mined from 1,200 shipped <c>AxForm</c> files against
+/// 1,500 shipped <c>AxTable</c> files on a live installation, joining each bound control to the
+/// field it names through its datasource. The result is not a judgement call — every non-enum
+/// case is unanimous or near-unanimous in the sample:
+/// </para>
+/// <list type="table">
+/// <item><description><c>AxTableFieldString</c> → <c>AxFormStringControl</c> (518 of 518)</description></item>
+/// <item><description><c>AxTableFieldReal</c> → <c>AxFormRealControl</c> (119 of 119)</description></item>
+/// <item><description><c>AxTableFieldDate</c> → <c>AxFormDateControl</c> (55 of 55)</description></item>
+/// <item><description><c>AxTableFieldInt</c> → <c>AxFormIntegerControl</c> (26 of 27)</description></item>
+/// <item><description><c>AxTableFieldUtcDateTime</c> → <c>AxFormDateTimeControl</c> (20 of 20)</description></item>
+/// <item><description><c>AxTableFieldTime</c> → <c>AxFormTimeControl</c> (9 of 9)</description></item>
+/// <item><description><c>AxTableFieldInt64</c> → <c>AxFormInt64Control</c> (6 of 6)</description></item>
+/// <item><description><c>AxTableFieldGuid</c> → <c>AxFormGuidControl</c> (2 of 2)</description></item>
+/// </list>
+/// <para>
+/// The enum case is the only one that splits, and it splits cleanly along a line that is worth
+/// knowing: a <c>NoYes</c>-typed field is a <c>CheckBox</c> (111 of 111) and every other enum is
+/// a <c>ComboBox</c> (106 of 108, the remaining two being <c>RadioButton</c>). So the enum's
+/// identity, not just its kind, decides the control.
+/// </para>
+/// </remarks>
+public static class FieldControlTypes
+{
+    /// <summary>What the templates emitted for every field before this existed.</summary>
+    public const string DefaultControl = "AxFormStringControl";
+
+    private static readonly IReadOnlyDictionary<string, (string AxType, string TypeElement)> ByFieldType =
+        new Dictionary<string, (string, string)>(StringComparer.Ordinal)
+        {
+            ["AxTableFieldString"] = ("AxFormStringControl", "String"),
+            ["AxTableFieldMemo"] = ("AxFormStringControl", "String"),
+            ["AxTableFieldReal"] = ("AxFormRealControl", "Real"),
+            ["AxTableFieldDate"] = ("AxFormDateControl", "Date"),
+            ["AxTableFieldInt"] = ("AxFormIntegerControl", "Integer"),
+            ["AxTableFieldInt64"] = ("AxFormInt64Control", "Int64"),
+            ["AxTableFieldUtcDateTime"] = ("AxFormDateTimeControl", "DateTime"),
+            ["AxTableFieldTime"] = ("AxFormTimeControl", "Time"),
+            ["AxTableFieldGuid"] = ("AxFormGuidControl", "Guid"),
+            ["AxTableFieldContainer"] = ("AxFormImageControl", "Image"),
+        };
+
+    /// <summary>
+    /// Enums whose fields are rendered as a checkbox rather than a drop-down.
+    /// </summary>
+    /// <remarks>
+    /// Two-valued yes/no enums only. This is a list rather than "any enum with two values"
+    /// because the platform has plenty of two-valued enums that are genuinely drop-downs
+    /// (<c>Gender</c>, <c>DebCredProposal</c>) — the checkbox is about the enum <em>meaning</em>
+    /// a boolean, which is a naming convention the platform holds to.
+    /// </remarks>
+    private static readonly IReadOnlySet<string> CheckBoxEnums =
+        new HashSet<string>(StringComparer.OrdinalIgnoreCase) { "NoYes", "NoYesId", "NoYesCombo" };
+
+    /// <summary>
+    /// The concrete form-control type and its <c>&lt;Type&gt;</c> value for a bound field.
+    /// </summary>
+    /// <param name="axTableFieldType">
+    /// The field's <c>i:type</c> (<c>AxTableFieldString</c>, <c>AxTableFieldEnum</c>, …), or null
+    /// when the caller could not resolve it.
+    /// </param>
+    /// <param name="enumType">
+    /// The enum the field is typed as, when <paramref name="axTableFieldType"/> is
+    /// <c>AxTableFieldEnum</c>. Decides checkbox versus combo box.
+    /// </param>
+    /// <returns>
+    /// The control to emit. Falls back to a string control when the field type is unknown —
+    /// the same thing the templates always did, so an unresolvable field is no worse off than
+    /// before, and a resolvable one is now right.
+    /// </returns>
+    public static (string AxType, string TypeElement) For(string? axTableFieldType, string? enumType = null)
+    {
+        if (string.IsNullOrWhiteSpace(axTableFieldType)) return (DefaultControl, "String");
+
+        if (string.Equals(axTableFieldType, "AxTableFieldEnum", StringComparison.Ordinal))
+        {
+            return !string.IsNullOrWhiteSpace(enumType) && CheckBoxEnums.Contains(enumType!)
+                ? ("AxFormCheckBoxControl", "CheckBox")
+                : ("AxFormComboBoxControl", "ComboBox");
+        }
+
+        return ByFieldType.TryGetValue(axTableFieldType!, out var hit) ? hit : (DefaultControl, "String");
+    }
+
+    /// <summary>
+    /// The same answer from an EDT's primitive base type, for callers that have the index but
+    /// not the field element.
+    /// </summary>
+    /// <remarks>
+    /// The index records an EDT's <c>BaseType</c> (String, Integer, Real, Date, …), which is the
+    /// same fact the field's <c>i:type</c> encodes — <c>XppScaffolder</c> already uses it to pin
+    /// <c>AxTableField{Suffix}</c> when it generates a table. Going through the field type keeps
+    /// one mapping rather than two that can disagree.
+    /// </remarks>
+    public static (string AxType, string TypeElement) ForEdtBaseType(string? edtBaseType, string? enumType = null)
+        => For(edtBaseType is null ? null : "AxTableField" + NormalizeBaseType(edtBaseType), enumType);
+
+    private static string NormalizeBaseType(string baseType) => baseType.Trim() switch
+    {
+        "Integer" => "Int",
+        "DateTime" => "UtcDateTime",
+        var other => other,
+    };
+}

--- a/src/D365FO.Core/Scaffolding/FormPatternTemplates.cs
+++ b/src/D365FO.Core/Scaffolding/FormPatternTemplates.cs
@@ -1,4 +1,5 @@
 using System.Text;
+using D365FO.Core.FormPatterns;
 
 namespace D365FO.Core.Scaffolding;
 
@@ -32,6 +33,16 @@ public sealed record FormTemplateOptions
 
     /// <summary>Lines datasource table for <see cref="FormPattern.DetailsTransaction"/>. Defaults to <see cref="LinesDsName"/>.</summary>
     public string? LinesDsTable { get; init; }
+
+    /// <summary>
+    /// Field name → the form control it should be rendered as (issue #164 / R5).
+    /// </summary>
+    /// <remarks>
+    /// Supplied by the caller because resolving it needs the index, which this assembly's
+    /// rendering layer has no business opening. Absent, every field falls back to a string
+    /// control — which is what these templates always emitted, whatever the field really was.
+    /// </remarks>
+    public Func<string, (string AxType, string TypeElement)>? ControlTypeResolver { get; init; }
 }
 
 /// <summary>A named TabPage / section used by Dialog, TableOfContents, Workspace.</summary>
@@ -81,7 +92,7 @@ public static class FormPatternTemplates
     public static string BuildSimpleList(FormTemplateOptions opt)
     {
         var (dsName, dsTable) = ResolveDs(opt);
-        var grid = string.Concat(opt.GridFields.Select(f => RenderGridFieldControl("Grid", f, dsName, indent: 10)));
+        var grid = string.Concat(opt.GridFields.Select(f => RenderGridFieldControl("Grid", f, dsName, 10, opt.ControlTypeResolver)));
         return Fill("SimpleList.template.xml", new()
         {
             ["FormName"]          = opt.FormName,
@@ -97,8 +108,8 @@ public static class FormPatternTemplates
     public static string BuildSimpleListDetails(FormTemplateOptions opt)
     {
         var (dsName, dsTable) = ResolveDs(opt);
-        var listFields = string.Concat(opt.GridFields.Take(3).Select(f => RenderGridFieldControl("Grid", f, dsName, indent: 14)));
-        var detail = string.Concat(opt.GridFields.Select(f => RenderGridFieldControl("Overview", f, dsName, indent: 20)));
+        var listFields = string.Concat(opt.GridFields.Take(3).Select(f => RenderGridFieldControl("Grid", f, dsName, 14, opt.ControlTypeResolver)));
+        var detail = string.Concat(opt.GridFields.Select(f => RenderGridFieldControl("Overview", f, dsName, 20, opt.ControlTypeResolver)));
         return Fill("SimpleListDetails.template.xml", new()
         {
             ["FormName"]            = opt.FormName,
@@ -114,7 +125,7 @@ public static class FormPatternTemplates
     public static string BuildDetailsMaster(FormTemplateOptions opt)
     {
         var (dsName, dsTable) = ResolveDs(opt);
-        var overview = string.Concat(opt.GridFields.Select(f => RenderGridFieldControl("Overview", f, dsName, indent: 24)));
+        var overview = string.Concat(opt.GridFields.Select(f => RenderGridFieldControl("Overview", f, dsName, 24, opt.ControlTypeResolver)));
 
         // The pattern's title group requires a HeaderTitle control — the field shown as
         // the record's title on the details panel. The first requested field is the
@@ -138,7 +149,7 @@ public static class FormPatternTemplates
         var (dsName, dsTable) = ResolveDs(opt);
         var linesDs = string.IsNullOrEmpty(opt.LinesDsName) ? $"{dsName}Lines" : opt.LinesDsName!;
         var linesTable = string.IsNullOrEmpty(opt.LinesDsTable) ? linesDs : opt.LinesDsTable!;
-        var header = string.Concat(opt.GridFields.Select(f => RenderGridFieldControl("Header", f, dsName, indent: 34)));
+        var header = string.Concat(opt.GridFields.Select(f => RenderGridFieldControl("Header", f, dsName, 34, opt.ControlTypeResolver)));
         var headerTitle = RenderHeaderTitle(opt.GridFields.FirstOrDefault(), dsName, indent: 16);
 
         return Fill("DetailsTransaction.template.xml", new()
@@ -173,11 +184,11 @@ public static class FormPatternTemplates
         if (opt.Sections.Count > 0)
         {
             body = string.Concat(opt.Sections.Select(s =>
-                RenderDialogFieldGroup(s, opt.GridFields, dsName, indent: 10)));
+                RenderDialogFieldGroup(s, opt.GridFields, dsName, 10, opt.ControlTypeResolver)));
         }
         else
         {
-            body = string.Concat(opt.GridFields.Select(f => RenderDialogField(f, dsName, indent: 10)));
+            body = string.Concat(opt.GridFields.Select(f => RenderDialogField(f, dsName, 10, opt.ControlTypeResolver)));
         }
 
         return Fill("Dialog.template.xml", new()
@@ -204,7 +215,7 @@ public static class FormPatternTemplates
         // before) silently discarded --field while the command still reported
         // fieldCount = N.
         var pages = string.Concat(sections.Select((s, i) =>
-            RenderTocTabPage(s, i == 0 ? opt.GridFields : Array.Empty<string>(), opt.DsName, indent: 8)));
+            RenderTocTabPage(s, i == 0 ? opt.GridFields : Array.Empty<string>(), opt.DsName, 8, opt.ControlTypeResolver)));
 
         var (dsName, dsTable) = (opt.DsName, opt.DsTable);
         var dsXml = !string.IsNullOrEmpty(dsName) && !string.IsNullOrEmpty(dsTable)
@@ -225,7 +236,7 @@ public static class FormPatternTemplates
     public static string BuildLookup(FormTemplateOptions opt)
     {
         var (dsName, dsTable) = ResolveDs(opt);
-        var grid = string.Concat(opt.GridFields.Select(f => RenderGridFieldControl("Grid", f, dsName, indent: 10)));
+        var grid = string.Concat(opt.GridFields.Select(f => RenderGridFieldControl("Grid", f, dsName, 10, opt.ControlTypeResolver)));
         return Fill("Lookup.template.xml", new()
         {
             ["FormName"]          = opt.FormName,
@@ -240,7 +251,7 @@ public static class FormPatternTemplates
     public static string BuildListPage(FormTemplateOptions opt)
     {
         var (dsName, dsTable) = ResolveDs(opt);
-        var grid = string.Concat(opt.GridFields.Select(f => RenderGridFieldControl("Grid", f, dsName, indent: 10)));
+        var grid = string.Concat(opt.GridFields.Select(f => RenderGridFieldControl("Grid", f, dsName, 10, opt.ControlTypeResolver)));
         return Fill("ListPage.template.xml", new()
         {
             ["FormName"]          = opt.FormName,
@@ -289,6 +300,31 @@ public static class FormPatternTemplates
     private static string RenderCaption(string? caption) =>
         string.IsNullOrEmpty(caption) ? string.Empty : $"    <Caption xmlns=\"\">{caption}</Caption>\n";
 
+    /// <summary>
+    /// The control a bound field gets, or a string control when nothing can say otherwise.
+    /// </summary>
+    /// <remarks>
+    /// A resolver that throws must not take the generation down with it: the index is a cache,
+    /// and a form scaffolded against a stale one should still be a form. Falling back leaves the
+    /// caller exactly where they were before <see cref="FieldControlTypes"/> existed.
+    /// </remarks>
+    private static (string AxType, string TypeElement) Resolve(
+        Func<string, (string AxType, string TypeElement)>? resolve, string field)
+    {
+        if (resolve is null) return (FieldControlTypes.DefaultControl, "String");
+        try
+        {
+            var (axType, typeElement) = resolve(SplitTypedName(field));
+            return string.IsNullOrWhiteSpace(axType)
+                ? (FieldControlTypes.DefaultControl, "String")
+                : (axType, typeElement);
+        }
+        catch
+        {
+            return (FieldControlTypes.DefaultControl, "String");
+        }
+    }
+
     private static string RenderDsFields(IReadOnlyList<string> fields, int indent)
     {
         if (fields.Count == 0) return new string(' ', indent) + "<Fields />\n";
@@ -298,13 +334,16 @@ public static class FormPatternTemplates
         return $"{pad}<Fields>\n{inner}{pad}</Fields>\n";
     }
 
-    private static string RenderGridFieldControl(string namePrefix, string field, string ds, int indent)
+    private static string RenderGridFieldControl(
+        string namePrefix, string field, string ds, int indent,
+        Func<string, (string AxType, string TypeElement)>? resolve = null)
     {
         var pad = new string(' ', indent);
+        var (axType, typeElement) = Resolve(resolve, field);
         var sb = new StringBuilder();
-        sb.Append(pad).Append("<AxFormControl xmlns=\"\" i:type=\"AxFormStringControl\">\n");
+        sb.Append(pad).Append("<AxFormControl xmlns=\"\" i:type=\"").Append(axType).Append("\">\n");
         sb.Append(pad).Append("  <Name>").Append(namePrefix).Append('_').Append(field).Append("</Name>\n");
-        sb.Append(pad).Append("  <Type>String</Type>\n");
+        sb.Append(pad).Append("  <Type>").Append(typeElement).Append("</Type>\n");
         sb.Append(pad).Append("  <FormControlExtension i:nil=\"true\" />\n");
         sb.Append(pad).Append("  <DataField>").Append(field).Append("</DataField>\n");
         sb.Append(pad).Append("  <DataSource>").Append(ds).Append("</DataSource>\n");
@@ -312,13 +351,16 @@ public static class FormPatternTemplates
         return sb.ToString();
     }
 
-    private static string RenderDialogField(string field, string? ds, int indent)
+    private static string RenderDialogField(
+        string field, string? ds, int indent,
+        Func<string, (string AxType, string TypeElement)>? resolve = null)
     {
         var pad = new string(' ', indent);
+        var (axType, typeElement) = Resolve(resolve, field);
         var sb = new StringBuilder();
-        sb.Append(pad).Append("<AxFormControl xmlns=\"\" i:type=\"AxFormStringControl\">\n");
+        sb.Append(pad).Append("<AxFormControl xmlns=\"\" i:type=\"").Append(axType).Append("\">\n");
         sb.Append(pad).Append("  <Name>").Append(field).Append("</Name>\n");
-        sb.Append(pad).Append("  <Type>String</Type>\n");
+        sb.Append(pad).Append("  <Type>").Append(typeElement).Append("</Type>\n");
         sb.Append(pad).Append("  <FormControlExtension i:nil=\"true\" />\n");
         if (!string.IsNullOrEmpty(ds))
         {
@@ -334,7 +376,8 @@ public static class FormPatternTemplates
     /// fields — the deepest nesting the FieldsFieldGroups sub-pattern permits.
     /// </summary>
     private static string RenderDialogFieldGroup(
-        FormSectionSpec s, IReadOnlyList<string> fields, string? ds, int indent)
+        FormSectionSpec s, IReadOnlyList<string> fields, string? ds, int indent,
+        Func<string, (string AxType, string TypeElement)>? resolve = null)
     {
         var pad = new string(' ', indent);
         var sb = new StringBuilder();
@@ -350,7 +393,7 @@ public static class FormPatternTemplates
         else
         {
             sb.Append(pad).Append("  <Controls>\n");
-            foreach (var f in fields) sb.Append(RenderDialogField(f, ds, indent + 4));
+            foreach (var f in fields) sb.Append(RenderDialogField(f, ds, indent + 4, resolve));
             sb.Append(pad).Append("  </Controls>\n");
         }
         sb.Append(pad).Append("  <FrameType>None</FrameType>\n");
@@ -388,7 +431,8 @@ public static class FormPatternTemplates
         field.Split(':', 2)[0].Trim();
 
     private static string RenderTocTabPage(
-        FormSectionSpec s, IReadOnlyList<string> fields, string? ds, int indent)
+        FormSectionSpec s, IReadOnlyList<string> fields, string? ds, int indent,
+        Func<string, (string AxType, string TypeElement)>? resolve = null)
     {
         var pad = new string(' ', indent);
         var sb = new StringBuilder();
@@ -457,7 +501,7 @@ public static class FormPatternTemplates
         else
         {
             sb.Append(pad).Append("      <Controls>\n");
-            foreach (var f in fields) sb.Append(RenderDialogField(f, ds, indent + 8));
+            foreach (var f in fields) sb.Append(RenderDialogField(f, ds, indent + 8, resolve));
             sb.Append(pad).Append("      </Controls>\n");
         }
         sb.Append(pad).Append("      <FrameType>None</FrameType>\n");
@@ -477,7 +521,8 @@ public static class FormPatternTemplates
     }
 
     private static string RenderWorkspaceListSection(
-        FormSectionSpec s, int idx, string dsName, IReadOnlyList<string> fields, int indent)
+        FormSectionSpec s, int idx, string dsName, IReadOnlyList<string> fields, int indent,
+        Func<string, (string AxType, string TypeElement)>? resolve = null)
     {
         // ElementPosition follows MCP's heuristic: 536870912 * (idx + 2)
         var pos = 536870912L * (idx + 2);
@@ -535,7 +580,7 @@ public static class FormPatternTemplates
         {
             sb.Append(pad).Append("      <Controls>\n");
             foreach (var f in fields)
-                sb.Append(RenderGridFieldControl($"{s.Name}Grid", f, dsName, indent + 8));
+                sb.Append(RenderGridFieldControl($"{s.Name}Grid", f, dsName, indent + 8, resolve));
             sb.Append(pad).Append("      </Controls>\n");
         }
         sb.Append(pad).Append("      <DataSource>").Append(dsName).Append("</DataSource>\n");

--- a/src/D365FO.Core/Scaffolding/PropertyHonesty.cs
+++ b/src/D365FO.Core/Scaffolding/PropertyHonesty.cs
@@ -1,0 +1,127 @@
+using System.Xml.Linq;
+
+namespace D365FO.Core.Scaffolding;
+
+/// <summary>One thing the caller asked for that is not in the document that was written.</summary>
+/// <param name="Option">The option the value came from, e.g. <c>--label</c>.</param>
+/// <param name="Value">The value as the caller wrote it.</param>
+/// <param name="Missing">The part of it that could not be found in the written document.</param>
+public sealed record PropertyGap(string Option, string Value, string Missing)
+{
+    /// <summary>Sentence for a warnings list.</summary>
+    public override string ToString()
+        => $"{Option} {Value} — \"{Missing}\" is not in the generated object. The scaffolder either " +
+           $"does not carry that option onto this AOT type, or the value was dropped on the way to disk.";
+}
+
+/// <summary>
+/// Reconciles what a generate call requested against what actually reached the document.
+/// </summary>
+/// <remarks>
+/// <para>
+/// Issue #161 / R6, ported in spirit from the predecessor's
+/// <c>createTablePropertyHonesty.ts</c>. The defect class it exists for is silent: an option is
+/// accepted, the command reports success, and the property is simply not in the file — because
+/// the scaffolder never carried it onto that AOT type, or because something between the
+/// scaffolder and disk discarded it. Every other check in this repo judges the document on its
+/// own terms and therefore cannot see this: a document missing a property the caller asked for
+/// is a perfectly valid document.
+/// </para>
+/// <para>
+/// The comparison is deliberately blunt — a case-insensitive search of the whole written
+/// document for each requested value. It is a claim about presence, not about which member the
+/// value should have landed in, because mapping option → AOT member per command is exactly the
+/// hand-maintained table that drifts and would have to be right for the check to be worth
+/// anything. Blunt makes it wrong in one direction only: it can miss a value that coincidentally
+/// appears elsewhere, but it never invents a gap for a value that really is in the file.
+/// </para>
+/// </remarks>
+public static class PropertyHonesty
+{
+    /// <summary>
+    /// Values that carry a request but never survive as text: they select a shape rather than
+    /// supply a value, so their absence from the document says nothing.
+    /// </summary>
+    private static readonly HashSet<string> Untraceable = new(StringComparer.OrdinalIgnoreCase)
+    {
+        "true", "false", "yes", "no", "none", "default", "auto",
+    };
+
+    private static readonly char[] CompositeSeparators = [':', ',', ';', '|', '=', '/'];
+
+    /// <summary>
+    /// Requested values that did not reach <paramref name="writtenXml"/>.
+    /// </summary>
+    /// <param name="requested">Option name → value, as supplied on the command line.</param>
+    /// <param name="writtenXml">The document as it was written (or handed to the provider).</param>
+    public static IReadOnlyList<PropertyGap> Reconcile(
+        IEnumerable<(string Option, string Value)> requested, string writtenXml)
+    {
+        ArgumentNullException.ThrowIfNull(requested);
+        if (string.IsNullOrWhiteSpace(writtenXml)) return Array.Empty<PropertyGap>();
+
+        var haystack = Haystack(writtenXml);
+        var gaps = new List<PropertyGap>();
+
+        foreach (var (option, value) in requested)
+        {
+            if (string.IsNullOrWhiteSpace(value)) continue;
+
+            foreach (var part in Parts(value))
+            {
+                if (haystack.Contains(part, StringComparison.OrdinalIgnoreCase)) continue;
+                gaps.Add(new PropertyGap(option, value, part));
+            }
+        }
+
+        return gaps;
+    }
+
+    /// <summary>
+    /// Everything the document says, as one string: element names, element text and attribute
+    /// values.
+    /// </summary>
+    /// <remarks>
+    /// Names matter as much as values. <c>--field Plate:Name:mandatory</c> asks for three things
+    /// and only two of them are text — "mandatory" arrives as the <c>&lt;Mandatory&gt;</c>
+    /// element, whose value is "Yes". Searching the raw XML rather than the parsed values covers
+    /// both without having to know which is which. It falls back to the raw string when the
+    /// document does not parse, because a caller holding unparseable XML has a bigger problem
+    /// than this and should not also get a wall of spurious gaps.
+    /// </remarks>
+    private static string Haystack(string writtenXml)
+    {
+        try
+        {
+            var doc = XDocument.Parse(writtenXml);
+            return doc.ToString(SaveOptions.DisableFormatting);
+        }
+        catch (System.Xml.XmlException)
+        {
+            return writtenXml;
+        }
+    }
+
+    /// <summary>
+    /// The traceable pieces of one option value.
+    /// </summary>
+    /// <remarks>
+    /// Repeatable options carry composite specs — <c>--field AccountNum:CustAccount:mandatory</c>,
+    /// <c>--relation Vehicle=VehicleId</c>, <c>--constrained Header/Line</c> — and each piece is a
+    /// separate request that can be separately dropped. Splitting them is what turns "the field
+    /// arrived" into "the field arrived but its EDT did not", which is the interesting half; not
+    /// splitting them is what made <c>--constrained Header/Line</c> report a gap for a policy
+    /// that had both tables, because no single element holds the path as written.
+    /// </remarks>
+    private static IEnumerable<string> Parts(string value)
+    {
+        foreach (var raw in value.Split(CompositeSeparators, StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries))
+        {
+            // A label key is written as-is; anything shorter than two characters matches too
+            // much to mean anything.
+            if (raw.Length < 2) continue;
+            if (Untraceable.Contains(raw)) continue;
+            yield return raw;
+        }
+    }
+}

--- a/src/D365FO.Core/Scaffolding/SecurityPolicyScaffolder.cs
+++ b/src/D365FO.Core/Scaffolding/SecurityPolicyScaffolder.cs
@@ -22,16 +22,48 @@ public enum PolicyContextType { RoleName, ContextString }
 public static class SecurityPolicyScaffolder
 {
     /// <summary>
+    /// One entry in a policy's <c>ConstrainedTables</c> tree.
+    /// </summary>
+    /// <param name="Name">The table (or entity) the policy reaches.</param>
+    /// <param name="Constrained">
+    /// Whether the policy actually restricts this table, or merely traverses it to get to one
+    /// that is. A tree of tables all marked constrained is not the same policy as a tree where
+    /// only the leaves are.
+    /// </param>
+    /// <param name="Children">Tables reached through this one — the collection nests.</param>
+    public sealed record ConstrainedEntity(
+        string Name,
+        bool Constrained = true,
+        IReadOnlyList<ConstrainedEntity>? Children = null);
+
+    /// <summary>
     /// Generates a minimal but valid <c>AxSecurityPolicy</c> document.
     /// </summary>
     /// <param name="constrainedTable">Table the policy constrains — emitted as <c>PrimaryTable</c>.</param>
+    /// <param name="constrainedTables">
+    /// The tables the policy reaches beyond the primary one (issue #162). Previously
+    /// <c>&lt;ConstrainedTables&gt;</c> was always emitted empty, so a policy could constrain
+    /// exactly one table and there was no way to express the rest of the tree.
+    /// </param>
+    /// <remarks>
+    /// There is deliberately no <c>PolicyGroup</c>. It was on the list of things this scaffolder
+    /// was missing, but <c>AxSecurityPolicy</c> has no such member — the contract catalog
+    /// generated from <c>Microsoft.Dynamics.AX.Metadata.dll</c> lists ConstrainedTable,
+    /// ContextString, ContextType, Enabled, HelpText, IsObsolete, Label, Operation, PrimaryTable,
+    /// Query, RoleName, Tags, UseNotExistJoin, Visibility and ConstrainedTables, and nothing
+    /// else. Emitting a <c>PolicyGroup</c> element would be silently dropped on read (XML007),
+    /// which is precisely the defect class this repo exists to stop.
+    /// </remarks>
     public static XDocument Policy(
         string name,
         string constrainedTable,
         string policyQuery,
         PolicyOperation operation = PolicyOperation.Select,
         PolicyContextType contextType = PolicyContextType.RoleName,
-        string? contextValue = null)
+        string? contextValue = null,
+        IEnumerable<ConstrainedEntity>? constrainedTables = null,
+        string? label = null,
+        bool useNotExistJoin = false)
     {
         var operationStr   = operation   == PolicyOperation.All            ? "AllOperations" : "Select";
         var contextTypeStr = contextType == PolicyContextType.ContextString ? "ContextString" : "RoleName";
@@ -47,11 +79,31 @@ public static class SecurityPolicyScaffolder
             root.Add(new XElement("ContextString", contextValue));
         root.Add(new XElement("ContextType", contextTypeStr));
         root.Add(new XElement("Enabled", "Yes"));
+        if (!string.IsNullOrWhiteSpace(label)) root.Add(new XElement("Label", label));
         root.Add(new XElement("Operation", operationStr));
         root.Add(new XElement("PrimaryTable", constrainedTable));
         root.Add(new XElement("Query", policyQuery));
-        root.Add(new XElement("ConstrainedTables"));
+        if (useNotExistJoin) root.Add(new XElement("UseNotExistJoin", "Yes"));
+        root.Add(new XElement("ConstrainedTables",
+            (constrainedTables ?? []).Select(ConstrainedEntityElement)));
 
         return new XDocument(root);
     }
+
+    /// <summary>
+    /// One <c>AxSecurityPolicyConstrainedEntity</c>, nesting its children under the collection
+    /// of the same name.
+    /// </summary>
+    /// <remarks>
+    /// Member order is Constrained, Name, Tags, ConstrainedTables — the flag comes first, so an
+    /// entity written Name-first loses it and every table in the tree reads back as
+    /// unconstrained.
+    /// </remarks>
+    private static XElement ConstrainedEntityElement(ConstrainedEntity entity)
+        => new("AxSecurityPolicyConstrainedEntity",
+            new XElement("Constrained", entity.Constrained ? "Yes" : "No"),
+            new XElement("Name", entity.Name),
+            entity.Children is { Count: > 0 }
+                ? new XElement("ConstrainedTables", entity.Children.Select(ConstrainedEntityElement))
+                : null);
 }

--- a/src/D365FO.Core/Scaffolding/XppScaffolder.cs
+++ b/src/D365FO.Core/Scaffolding/XppScaffolder.cs
@@ -1693,6 +1693,20 @@ public static class ScaffoldFileWriter
     {
         var violations = new List<XppViolation>();
         ContractShapeRules.Check(xml, violations);
+
+        // The root's own shape, from the same catalog (issue #163). Only the two rules nothing
+        // else on this path covers: an unreal root (XML009) and the wrong contract namespace
+        // (XML012) — ContractNamespaceApplier *fixes* a missing namespace but stands aside when
+        // the document already declares one, so a document carrying the wrong one used to be
+        // written unchallenged. The abstract-root and xmlns:i policies (XML010/XML011) are left
+        // to EnsureConcreteAxRoot / EnsureXsiNamespaceDeclared above, whose messages name the
+        // concrete EDT subtype to use; the folder rule (XML013) belongs to `validate xpp`, where
+        // a wrong guess is advice rather than a refused write.
+        var rootShape = new List<XppViolation>();
+        ObjectShapeRules.Check(xml, rootShape);
+        violations.AddRange(rootShape.Where(v =>
+            v.Rule is ObjectShapeRules.RuleUnknownRoot or ObjectShapeRules.RuleContractNamespace));
+
         if (violations.Count == 0) return;
 
         var first = violations[0];

--- a/src/D365FO.Core/Scaffolding/XppScaffolder.cs
+++ b/src/D365FO.Core/Scaffolding/XppScaffolder.cs
@@ -1795,7 +1795,13 @@ public static class ScaffoldFileWriter
             File.Move(full, backup);
         }
 
-        var tmp = full + ".tmp";
+        // The staging name is unique per call, not the deterministic "<target>.tmp" it used to
+        // be (issue #158). Two writers aiming at the same path shared that sibling: the second
+        // File.Create truncated the first one's staged bytes, so whichever move landed first
+        // published the *other* writer's content, and the loser threw a FileNotFoundException
+        // from a path that looks like a successful atomic write. A per-call name makes the
+        // stage-then-rename genuinely private to the call, which is what "atomic" claimed.
+        var tmp = full + "." + Guid.NewGuid().ToString("N") + ".tmp";
         try
         {
             if (declarationOnSaveFromXDoc && doc is not null)
@@ -1808,7 +1814,7 @@ public static class ScaffoldFileWriter
                 File.WriteAllText(tmp, xml);
             }
 
-            File.Move(tmp, full);
+            MoveOntoTarget(tmp, full);
         }
         catch
         {
@@ -1829,6 +1835,63 @@ public static class ScaffoldFileWriter
         var bytes = new FileInfo(full).Length;
         RecordJournalEntry(full, preImage, preImageHadBom);
         return new WriteResult(full, bytes, backup);
+    }
+
+    /// <summary>
+    /// Publish the staged file onto its target, and refuse to report success unless the target
+    /// is actually there afterwards.
+    /// </summary>
+    /// <remarks>
+    /// Issue #158: a scaffold write returned normally and the file was gone by the time the
+    /// caller looked. <c>File.Move</c> is the only step that can fail without an exception in
+    /// practice — a scanner or indexer holding the source or the target makes the rename fail
+    /// transiently, and the surrounding code treated "no exception" as "written". Retrying a
+    /// handful of times covers the transient case; a post-move existence check turns the
+    /// non-transient case into a loud error at the write, naming the directory's real contents,
+    /// instead of a mystery count mismatch somewhere downstream.
+    /// </remarks>
+    private static void MoveOntoTarget(string tmp, string full)
+    {
+        const int attempts = 5;
+        for (var attempt = 1; ; attempt++)
+        {
+            try
+            {
+                File.Move(tmp, full);
+                if (File.Exists(full)) return;
+            }
+            catch (IOException) when (attempt < attempts)
+            {
+                // Transient sharing violation — fall through to the backoff below.
+            }
+            catch (UnauthorizedAccessException) when (attempt < attempts)
+            {
+                // Same shape, different exception type depending on who holds the handle.
+            }
+
+            if (attempt >= attempts)
+            {
+                var dir = Path.GetDirectoryName(full);
+                var siblings = SafeListDirectory(dir);
+                throw new IOException(
+                    $"Wrote the staged file but '{full}' is not on disk afterwards. " +
+                    $"Staged file {(File.Exists(tmp) ? "still present" : "gone")}: {tmp}. " +
+                    $"Directory now contains [{siblings}].");
+            }
+
+            Thread.Sleep(20 * attempt);
+        }
+    }
+
+    private static string SafeListDirectory(string? dir)
+    {
+        try
+        {
+            return string.IsNullOrEmpty(dir)
+                ? "<no directory>"
+                : string.Join(", ", Directory.EnumerateFileSystemEntries(dir).Select(Path.GetFileName));
+        }
+        catch (Exception ex) { return $"<unreadable: {ex.GetType().Name}>"; }
     }
 
     /// <summary>

--- a/src/D365FO.Core/Scaffolding/XppScaffolder.cs
+++ b/src/D365FO.Core/Scaffolding/XppScaffolder.cs
@@ -260,6 +260,10 @@ public static class XppScaffolder
     /// <param name="gridFields">Field names rendered as grid / detail columns.</param>
     /// <param name="sections">Sections for <c>TableOfContents</c> / <c>Dialog</c> / <c>Workspace</c>.</param>
     /// <param name="linesTable">Lines datasource table for <see cref="FormPattern.DetailsTransaction"/>.</param>
+    /// <param name="controlTypeResolver">
+    /// Field name → form control type (issue #164 / R5). Without it every bound field is
+    /// rendered as a string control, whatever the field really is.
+    /// </param>
     public static string Form(
         string formName,
         string? dataSourceTable = null,
@@ -267,7 +271,8 @@ public static class XppScaffolder
         string? caption = null,
         IReadOnlyList<string>? gridFields = null,
         IReadOnlyList<FormSectionSpec>? sections = null,
-        string? linesTable = null)
+        string? linesTable = null,
+        Func<string, (string AxType, string TypeElement)>? controlTypeResolver = null)
     {
         var opt = new FormTemplateOptions
         {
@@ -279,6 +284,7 @@ public static class XppScaffolder
             Sections     = sections ?? Array.Empty<FormSectionSpec>(),
             LinesDsName  = linesTable,
             LinesDsTable = linesTable,
+            ControlTypeResolver = controlTypeResolver,
         };
         return FormPatternTemplates.Build(pattern, opt);
     }

--- a/src/D365FO.Core/Scaffolding/XppScaffolder.cs
+++ b/src/D365FO.Core/Scaffolding/XppScaffolder.cs
@@ -314,6 +314,14 @@ public static class XppScaffolder
     /// the staging table existing (create it as its own table).
     /// </para>
     /// </summary>
+    /// <param name="relations">
+    /// Relations to other entities (issue #162). An entity's relations are what make it
+    /// navigable over OData and what the DMF uses to resolve a lookup to a surrogate key;
+    /// without them the entity is an isolated table projection.
+    /// </param>
+    /// <param name="computedFields">
+    /// Unmapped fields whose value comes from a static X++ method rather than a column.
+    /// </param>
     public static XDocument DataEntity(
         string entityName,
         string table,
@@ -323,7 +331,9 @@ public static class XppScaffolder
         bool dataManagementEnabled = false,
         string? dataManagementStagingTable = null,
         string? entityCategory = null,
-        IEnumerable<string>? keyFields = null)
+        IEnumerable<string>? keyFields = null,
+        IEnumerable<EntityRelationSpec>? relations = null,
+        IEnumerable<EntityComputedFieldSpec>? computedFields = null)
     {
         var pubEntity = string.IsNullOrEmpty(publicEntityName) ? entityName : publicEntityName;
         var pubColl = string.IsNullOrEmpty(publicCollectionName) ? pubEntity + "s" : publicCollectionName;
@@ -340,7 +350,8 @@ public static class XppScaffolder
                 // The member is Mandatory; IsMandatory is not one, and was silently discarded.
                 f.IsMandatory ? new XElement("Mandatory", "Yes") : null,
                 new XElement("DataField", f.DataField ?? f.Name),
-                new XElement("DataSource", table)));
+                new XElement("DataSource", table)))
+            .Concat((computedFields ?? []).Select(ComputedFieldElement));
 
         var keys = keyFields?.ToList() ?? [];
         XElement? keysEl = null;
@@ -369,6 +380,13 @@ public static class XppScaffolder
 
         return new XDocument(
             new XElement("AxDataEntityView",
+                // Every field here carries an i:type, and a discriminator with no namespace in
+                // scope is just an unknown attribute — the mapped fields read back as the plain
+                // field type with DataField/DataSource gone. The write path hoists the
+                // declaration, but a scaffolder that only produces a readable document once
+                // something else has fixed it is a scaffolder whose output cannot be trusted on
+                // its own (XML011, issue #163).
+                new XAttribute(XNamespace.Xmlns + "i", Xsi.NamespaceName),
                 new XElement("Name", entityName),
                 string.IsNullOrEmpty(entityCategory) ? null : new XElement("EntityCategory", entityCategory),
                 new XElement("PublicEntityName", pubEntity),
@@ -379,6 +397,7 @@ public static class XppScaffolder
                 isPublic ? new XElement("PrimaryKey", "EntityKey") : null,
                 new XElement("Fields", fieldEls),
                 keysEl,
+                RelationsElement(relations),
                 // An entity's data sources are not its own member — they belong to the embedded
                 // query in ViewMetadata. A <DataSources> element on the entity is discarded, and
                 // the entity loads with nothing to select from.
@@ -389,6 +408,150 @@ public static class XppScaffolder
                             new XElement("Name", table),
                             new XElement("DynamicFields", "Yes"),
                             new XElement("Table", table))))));
+    }
+
+    /// <summary>
+    /// An unmapped field whose value comes from a static X++ method on the entity.
+    /// </summary>
+    /// <remarks>
+    /// Issue #162. The concrete type is <c>AxDataEntityViewUnmappedField</c> — the only one of
+    /// the two <c>AxDataEntityViewField</c> subtypes that declares <c>ComputedFieldMethod</c>
+    /// and <c>IsComputedField</c>. Written without the discriminator the reader instantiates
+    /// the plain field type, and both of those members are gone: the entity exposes a column
+    /// that is always null, with nothing in the file to explain why. The method itself must
+    /// exist on the entity's <c>SourceCode</c> and return the SQL text of the expression —
+    /// that is the developer's to write; this only wires the field to it.
+    /// </remarks>
+    private static XElement ComputedFieldElement(EntityComputedFieldSpec spec)
+        => new("AxDataEntityViewField",
+            new XAttribute(Xsi + "type", "AxDataEntityViewUnmappedField"),
+            new XElement("Name", spec.Name),
+            string.IsNullOrWhiteSpace(spec.Label) ? null : new XElement("Label", spec.Label),
+            new XElement("ComputedFieldMethod", spec.Method),
+            string.IsNullOrWhiteSpace(spec.Edt) ? null : new XElement("ExtendedDataType", spec.Edt),
+            new XElement("IsComputedField", "Yes"));
+
+    private static XElement? RelationsElement(IEnumerable<EntityRelationSpec>? relations)
+    {
+        var list = (relations ?? []).Where(r => !string.IsNullOrWhiteSpace(r.Name)).ToList();
+        return list.Count == 0 ? null : new XElement("Relations", list.Select(RelationElement));
+    }
+
+    /// <summary>
+    /// One <c>AxDataEntityViewRelation</c> and its field constraints.
+    /// </summary>
+    /// <remarks>
+    /// The constraint items are polymorphic: <c>AxDataEntityViewRelationConstraint</c> is the
+    /// element name, and the concrete subtype (<c>…ConstraintField</c> for a field-to-field
+    /// link, <c>…ConstraintFixed</c> / <c>…ConstraintRelatedFixed</c> for a literal) has to be
+    /// pinned via <c>i:type</c> — the base declares only Name and Tags, so an unpinned
+    /// constraint reads back with neither field and the relation joins on nothing.
+    /// </remarks>
+    private static XElement RelationElement(EntityRelationSpec spec)
+        => new("AxDataEntityViewRelation",
+            new XElement("Name", spec.Name),
+            string.IsNullOrWhiteSpace(spec.Cardinality) ? null : new XElement("Cardinality", spec.Cardinality),
+            new XElement("RelatedDataEntity", spec.RelatedDataEntity),
+            string.IsNullOrWhiteSpace(spec.RelatedCardinality) ? null : new XElement("RelatedDataEntityCardinality", spec.RelatedCardinality),
+            string.IsNullOrWhiteSpace(spec.RelatedRole) ? null : new XElement("RelatedDataEntityRole", spec.RelatedRole),
+            string.IsNullOrWhiteSpace(spec.RelationshipType) ? null : new XElement("RelationshipType", spec.RelationshipType),
+            string.IsNullOrWhiteSpace(spec.Role) ? null : new XElement("Role", spec.Role),
+            new XElement("Constraints",
+                spec.Constraints.Select(c =>
+                    new XElement("AxDataEntityViewRelationConstraint",
+                        new XAttribute(Xsi + "type", "AxDataEntityViewRelationConstraintField"),
+                        new XElement("Name", c.Field),
+                        new XElement("Field", c.Field),
+                        new XElement("RelatedField", c.RelatedField)))));
+
+    /// <summary>
+    /// The DMF staging table that goes with a data-management-enabled entity.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// Issue #162. <c>DataManagementEnabled=Yes</c> names a staging table, and the build fails
+    /// on the very next compile if that table does not exist — so an entity generated with data
+    /// management on used to be a guaranteed broken build unless the developer knew to hand-write
+    /// the table. This emits it.
+    /// </para>
+    /// <para>
+    /// The shape is not a guess and not a copy of the entity. It is what 398 of the 400 shipped
+    /// <c>*Staging</c> tables sampled from <c>PackagesLocalDirectory</c> on a real AOS all do:
+    /// <c>TableGroup=Staging</c>, <c>SaveDataPerCompany=No</c>, the four DMF bookkeeping columns
+    /// (<c>DefinitionGroup</c> / <c>ExecutionId</c> as <c>DMF*</c> string EDTs, <c>IsSelected</c>
+    /// and <c>TransferStatus</c> as the <c>DMFIsSelected</c> / <c>DMFTransferStatus</c> enums),
+    /// and a <c>StagingIdx</c> alternate key over
+    /// <c>DefinitionGroup, ExecutionId, &lt;business key&gt;</c> that is also the primary index
+    /// and the replacement key. A staging table missing those columns compiles and is then
+    /// rejected by the framework at run time, which is the worst place to find out.
+    /// </para>
+    /// </remarks>
+    public static XDocument EntityStagingTable(
+        string stagingTableName, IEnumerable<EntityFieldSpec>? fields = null, string? label = null)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(stagingTableName);
+
+        var entityFields = (fields ?? [])
+            .Where(f => !string.IsNullOrWhiteSpace(f.Name))
+            .Select(f => new TableFieldSpec(f.Name, null, null, Mandatory: false))
+            .ToList();
+
+        var framework = new List<TableFieldSpec>
+        {
+            new("DefinitionGroup", "DMFDefinitionGroupName", null, false),
+            new("ExecutionId", "DMFExecutionId", null, false),
+            new("IsSelected", "DMFIsSelected", null, false),
+            new("TransferStatus", "DMFTransferStatus", null, false),
+        };
+
+        var doc = Table(
+            stagingTableName,
+            label,
+            entityFields.Concat(framework).ToList(),
+            TablePattern.None);
+
+        var root = doc.Root!;
+        var fieldEls = root.Element("Fields")!.Elements().ToList();
+
+        // IsSelected and TransferStatus are enum columns. The table scaffolder types fields from
+        // their EDT, and neither of those names an EDT — so the discriminator and EnumType are
+        // corrected here rather than smuggled through a fake EDT name.
+        foreach (var (fieldName, enumName) in new[] { ("IsSelected", "DMFIsSelected"), ("TransferStatus", "DMFTransferStatus") })
+        {
+            var el = fieldEls.FirstOrDefault(f => f.Element("Name")?.Value == fieldName);
+            if (el is null) continue;
+            el.SetAttributeValue(Xsi + "type", "AxTableFieldEnum");
+            el.Element("ExtendedDataType")?.Remove();
+            el.Add(new XElement("EnumType", enumName));
+        }
+
+        // StagingIdx, not the generic PrimaryIdx the table scaffolder emits: the DMF looks the
+        // index up by name, and it keys on the run (DefinitionGroup + ExecutionId) before the
+        // entity's own key — a staging row is unique within a run, not across the table.
+        var businessKey = entityFields.Select(f => f.Name).FirstOrDefault();
+        var indexFields = new List<string> { "DefinitionGroup", "ExecutionId" };
+        if (businessKey is not null) indexFields.Add(businessKey);
+
+        root.Element("Indexes")?.Remove();
+        root.Element("ClusteredIndex")?.Remove();
+        root.Add(
+            new XElement("TableGroup", "Staging"),
+            new XElement("SaveDataPerCompany", "No"),
+            new XElement("PrimaryIndex", "StagingIdx"),
+            new XElement("ReplacementKey", "StagingIdx"),
+            new XElement("ClusteredIndex", "StagingIdx"),
+            new XElement("Indexes",
+                new XElement("AxTableIndex",
+                    new XElement("Name", "StagingIdx"),
+                    new XElement("AlternateKey", "Yes"),
+                    new XElement("AllowDuplicates", "No"),
+                    new XElement("Fields",
+                        indexFields.Select(n => new XElement("AxTableIndexField", new XElement("DataField", n)))))));
+
+        // Members were appended, so put the document back into contract order before anyone
+        // sees it — a misordered member is dropped on read and the file still looks right.
+        ContractOrderCanonicalizer.Apply(doc);
+        return doc;
     }
 
     /// <summary>
@@ -456,8 +619,16 @@ public static class XppScaffolder
     /// the dot-notation convention <c>&lt;BaseDuty&gt;.&lt;Suffix&gt;</c>, same
     /// as table/menu extensions.
     /// </summary>
+    /// <remarks>
+    /// Issue #162: <c>PropertyModifications</c> was emitted as an empty element and could not be
+    /// filled. That collection is the only way an extension can change a property of the base
+    /// duty — switch a Microsoft duty off, relabel it, retarget its context string — without
+    /// overlaying the object. Each entry is an <c>AxPropertyModification</c> naming a member of
+    /// the base <c>AxSecurityDuty</c> and the value to put there.
+    /// </remarks>
     public static XDocument SecurityDutyExtension(
-        string targetDuty, string suffix, IEnumerable<string>? privileges = null)
+        string targetDuty, string suffix, IEnumerable<string>? privileges = null,
+        IEnumerable<PropertyModificationSpec>? propertyModifications = null)
     {
         return new XDocument(
             new XElement("AxSecurityDutyExtension",
@@ -466,7 +637,7 @@ public static class XppScaffolder
                     (privileges ?? Enumerable.Empty<string>())
                         .Where(p => !string.IsNullOrWhiteSpace(p))
                         .Select(p => new XElement("AxSecurityPrivilegeReference", new XElement("Name", p)))),
-                new XElement("PropertyModifications")));
+                PropertyModifications(propertyModifications)));
     }
 
     /// <summary>
@@ -474,9 +645,16 @@ public static class XppScaffolder
     /// privileges to an EXISTING (often Microsoft-owned) role without
     /// overlaying it. Name follows <c>&lt;BaseRole&gt;.&lt;Suffix&gt;</c>.
     /// </summary>
+    /// <remarks>
+    /// Issue #162, same as the duty extension: <c>PropertyModifications</c> is what lets an
+    /// extension change the base role rather than only add to it. <c>AxSecurityRoleExtension</c>
+    /// has no <c>SubRoles</c> member — role composition is expressible on the role itself but
+    /// not through an extension, so asking for it here would write an element the reader drops.
+    /// </remarks>
     public static XDocument SecurityRoleExtension(
         string targetRole, string suffix,
-        IEnumerable<string>? duties = null, IEnumerable<string>? privileges = null)
+        IEnumerable<string>? duties = null, IEnumerable<string>? privileges = null,
+        IEnumerable<PropertyModificationSpec>? propertyModifications = null)
     {
         return new XDocument(
             new XElement("AxSecurityRoleExtension",
@@ -490,7 +668,7 @@ public static class XppScaffolder
                     (privileges ?? Enumerable.Empty<string>())
                         .Where(p => !string.IsNullOrWhiteSpace(p))
                         .Select(p => new XElement("AxSecurityPrivilegeReference", new XElement("Name", p)))),
-                new XElement("PropertyModifications")));
+                PropertyModifications(propertyModifications)));
     }
 
     /// <summary>
@@ -620,20 +798,77 @@ public static class XppScaffolder
         return new XElement("Grant", allow.Select(p => new XElement(p, "Allow")));
     }
 
-    /// <summary>Scaffolds an <c>AxSecurityDuty</c> grouping given privileges.</summary>
-    public static XDocument Duty(string name, IEnumerable<string> privileges, string? label = null)
+    /// <summary>
+    /// A reference from a duty/role to another security object.
+    /// </summary>
+    /// <param name="Name">The referenced object.</param>
+    /// <param name="Enabled">
+    /// Whether the reference is live. <c>AxSecurity*Reference</c> carries an <c>Enabled</c> of
+    /// its own, which is how a shipped role keeps a duty listed but switched off — omitted here
+    /// unless asked for, because the AOT default is enabled and writing it everywhere makes
+    /// every generated file differ from the shipped ones for no reason.
+    /// </param>
+    public sealed record SecurityReferenceSpec(string Name, bool? Enabled = null);
+
+    /// <summary>A single property override carried by a duty/role extension.</summary>
+    public sealed record PropertyModificationSpec(string Name, string Value);
+
+    private static XElement SecurityReference(string itemType, SecurityReferenceSpec spec)
+        => new(itemType,
+            // Contract order for AxSecurity*Reference is Enabled, Name, Tags — a reference that
+            // lists Name first loses its Enabled on read.
+            spec.Enabled is null ? null : new XElement("Enabled", spec.Enabled.Value ? "Yes" : "No"),
+            new XElement("Name", spec.Name));
+
+    private static List<XElement> SecurityReferences(string itemType, IEnumerable<SecurityReferenceSpec>? specs)
+        => (specs ?? [])
+            .Where(s => !string.IsNullOrWhiteSpace(s.Name))
+            .Select(s => SecurityReference(itemType, s))
+            .ToList();
+
+    private static XElement? PropertyModifications(IEnumerable<PropertyModificationSpec>? mods)
     {
+        var items = (mods ?? [])
+            .Where(m => !string.IsNullOrWhiteSpace(m.Name))
+            .Select(m => new XElement("AxPropertyModification",
+                new XElement("Name", m.Name),
+                new XElement("Value", m.Value)))
+            .ToList();
+        return new XElement("PropertyModifications", items);
+    }
+
+    /// <summary>Scaffolds an <c>AxSecurityDuty</c> grouping given privileges.</summary>
+    /// <remarks>
+    /// Issue #162: a duty is more than a list of privileges. <c>Description</c> is what the
+    /// security-configuration UI shows an administrator, <c>Enabled</c> is how a duty ships
+    /// switched off, and <c>ContextString</c> is the string the role-assignment rules match on.
+    /// All three are members of <c>AxSecurityDuty</c> and none of them could be generated.
+    /// </remarks>
+    public static XDocument Duty(
+        string name,
+        IEnumerable<string> privileges,
+        string? label = null,
+        string? description = null,
+        bool? enabled = null,
+        string? contextString = null,
+        IEnumerable<SecurityReferenceSpec>? privilegeRefs = null)
+    {
+        var refs = privilegeRefs is not null
+            ? SecurityReferences("AxSecurityPrivilegeReference", privilegeRefs)
+            : SecurityReferences("AxSecurityPrivilegeReference",
+                (privileges ?? []).Select(p => new SecurityReferenceSpec(p)));
+
         return new XDocument(
             new XElement("AxSecurityDuty",
                 new XElement("Name", name),
+                string.IsNullOrEmpty(contextString) ? null : new XElement("ContextString", contextString),
+                string.IsNullOrEmpty(description) ? null : new XElement("Description", description),
+                enabled is null ? null : new XElement("Enabled", enabled.Value ? "Yes" : "No"),
                 string.IsNullOrEmpty(label) ? null : new XElement("Label", label),
                 // AxSecurityDuty's collection is Privileges; "PrivilegeReferences" (the item
                 // type's name, near enough to look right) is not a member, so every privilege
                 // listed here was discarded when the AOT read the duty back.
-                new XElement("Privileges",
-                    privileges.Select(p =>
-                        new XElement("AxSecurityPrivilegeReference",
-                            new XElement("Name", p))))));
+                new XElement("Privileges", refs)));
     }
 
     /// <summary>
@@ -641,29 +876,41 @@ public static class XppScaffolder
     /// privileges. D365FO best practice is to prefer duties, but a role may
     /// reference privileges directly for narrow use-cases.
     /// </summary>
+    /// <remarks>
+    /// Issue #162. Beyond the two reference lists, <c>AxSecurityRole</c> carries
+    /// <c>SubRoles</c> — role composition, which is how the shipped roles are actually built —
+    /// plus <c>ContextString</c>, <c>Enabled</c> and <c>CanBeDeletedFromUI</c>. A role that can
+    /// only list duties and privileges cannot express any of that.
+    /// </remarks>
     public static XDocument Role(
         string name,
         IEnumerable<string>? duties = null,
         IEnumerable<string>? privileges = null,
         string? label = null,
-        string? description = null)
+        string? description = null,
+        IEnumerable<string>? subRoles = null,
+        string? contextString = null,
+        bool? enabled = null,
+        bool? canBeDeletedFromUI = null)
     {
-        var dutyRefs = (duties ?? Enumerable.Empty<string>())
-            .Where(d => !string.IsNullOrWhiteSpace(d))
-            .Select(d => new XElement("AxSecurityDutyReference", new XElement("Name", d)))
-            .ToList();
-        var privRefs = (privileges ?? Enumerable.Empty<string>())
-            .Where(p => !string.IsNullOrWhiteSpace(p))
-            .Select(p => new XElement("AxSecurityPrivilegeReference", new XElement("Name", p)))
-            .ToList();
+        var dutyRefs = SecurityReferences("AxSecurityDutyReference",
+            (duties ?? []).Select(d => new SecurityReferenceSpec(d)));
+        var privRefs = SecurityReferences("AxSecurityPrivilegeReference",
+            (privileges ?? []).Select(p => new SecurityReferenceSpec(p)));
+        var subRoleRefs = SecurityReferences("AxSecurityRoleReference",
+            (subRoles ?? []).Select(r => new SecurityReferenceSpec(r)));
 
         return new XDocument(
             new XElement("AxSecurityRole",
                 new XElement("Name", name),
-                string.IsNullOrEmpty(label) ? null : new XElement("Label", label),
+                canBeDeletedFromUI is null ? null : new XElement("CanBeDeletedFromUI", canBeDeletedFromUI.Value ? "Yes" : "No"),
+                string.IsNullOrEmpty(contextString) ? null : new XElement("ContextString", contextString),
                 string.IsNullOrEmpty(description) ? null : new XElement("Description", description),
+                enabled is null ? null : new XElement("Enabled", enabled.Value ? "Yes" : "No"),
+                string.IsNullOrEmpty(label) ? null : new XElement("Label", label),
                 dutyRefs.Count == 0 ? null : new XElement("Duties", dutyRefs),
-                privRefs.Count == 0 ? null : new XElement("Privileges", privRefs)));
+                privRefs.Count == 0 ? null : new XElement("Privileges", privRefs),
+                subRoleRefs.Count == 0 ? null : new XElement("SubRoles", subRoleRefs)));
     }
 
     /// <summary>
@@ -1358,6 +1605,39 @@ public static class XppScaffolder
 }
 
 public sealed record EntityFieldSpec(string Name, string? DataField, bool IsMandatory);
+
+/// <summary>One field-to-field constraint of a data-entity relation.</summary>
+public sealed record EntityRelationConstraintSpec(string Field, string RelatedField);
+
+/// <summary>
+/// A relation from a data entity to another entity (issue #162).
+/// </summary>
+/// <param name="Name">Relation name — conventionally the related entity's role.</param>
+/// <param name="RelatedDataEntity">The entity on the other end.</param>
+/// <param name="Constraints">Field pairs that join the two.</param>
+/// <param name="Cardinality">
+/// This entity's side: ExactlyOne | NotSpecified | OneMore | ZeroMore | ZeroOne.
+/// </param>
+/// <param name="RelatedCardinality">The other side: ExactlyOne | NotSpecified | ZeroOne.</param>
+/// <param name="RelationshipType">
+/// Aggregation | Association | Composition | Link | NotSpecified | Specialization.
+/// </param>
+/// <param name="Role">Role name on this side; <paramref name="RelatedRole"/> is the other.</param>
+public sealed record EntityRelationSpec(
+    string Name,
+    string RelatedDataEntity,
+    IReadOnlyList<EntityRelationConstraintSpec> Constraints,
+    string? Cardinality = null,
+    string? RelatedCardinality = null,
+    string? RelationshipType = null,
+    string? Role = null,
+    string? RelatedRole = null);
+
+/// <summary>
+/// A computed (unmapped) data-entity column, backed by a static X++ method that returns the
+/// SQL text of its expression.
+/// </summary>
+public sealed record EntityComputedFieldSpec(string Name, string Method, string? Edt = null, string? Label = null);
 
 /// <summary>One dataset within an <c>AxReport</c>, bound to a DP class.</summary>
 public sealed record ReportDatasetSpec(

--- a/src/D365FO.Core/Validation/ObjectShapeRules.cs
+++ b/src/D365FO.Core/Validation/ObjectShapeRules.cs
@@ -1,0 +1,309 @@
+using System.Xml;
+using System.Xml.Linq;
+using D365FO.Core.Metadata;
+using D365FO.Core.ObjectTypes;
+
+namespace D365FO.Core.Validation;
+
+/// <summary>
+/// Per-family structural rules for an AOT document's <em>root</em>: is this a real AOT type,
+/// is the polymorphism pinned, is the schema-instance namespace declared, is the document in
+/// the namespace its contract declares, and does the file sit in the folder its family owns.
+/// </summary>
+/// <remarks>
+/// <para>
+/// Issue #163 (audit plan §1.4 / finding G9). <see cref="ContractShapeRules"/> already speaks
+/// for every family about what is <em>inside</em> a document — XML007 for a member the type
+/// does not declare, XML008 for a value outside its enum. Nothing spoke about the root itself
+/// except the write path, which threw from inside <c>ScaffoldFileWriter</c>. That made the
+/// knowledge unavailable to anything that is not writing a file: an eval golden, a CI sweep
+/// over a directory, an agent asking "would this be accepted?" before it commits.
+/// </para>
+/// <para>
+/// These four rules are the offline approximation of what the bridge's
+/// <c>Handlers.WriteArtifact</c> rejects before it ever reaches the provider —
+/// <c>TYPE_NOT_FOUND</c> (XML009), <c>ABSTRACT_TYPE</c> (XML010), and the two
+/// <c>XML_DESERIALIZE_FAILED</c> shapes that a missing <c>xmlns:i</c> (XML011) or the wrong
+/// contract namespace (XML012) produce. They are driven by
+/// <see cref="ObjectTypeRegistry"/> and the <see cref="MetadataContracts"/> catalog, so they
+/// cover every family the AOT has rather than the AxTable-only set XML001–XML005 covered.
+/// </para>
+/// <para>
+/// <b>What is deliberately not here:</b> a member-order lint. Order genuinely matters — the
+/// writer canonicalises it — but shipped Microsoft files deviate from contract order in places
+/// and the provider still reads them back without loss, so flagging deviation in other
+/// people's files would be asserting a defect the evidence does not support. The reasoning is
+/// recorded in full on <see cref="ContractShapeRules"/>.
+/// </para>
+/// </remarks>
+public static class ObjectShapeRules
+{
+    private const string XsiNamespace = "http://www.w3.org/2001/XMLSchema-instance";
+
+    /// <summary>Root element that names no AOT type — the provider cannot construct anything.</summary>
+    public const string RuleUnknownRoot = "XML009";
+
+    /// <summary>Abstract root with no concrete <c>i:type</c> pinned.</summary>
+    public const string RuleAbstractRoot = "XML010";
+
+    /// <summary>The XMLSchema-instance namespace is used, or required, but not declared on the root.</summary>
+    public const string RuleXsiNamespace = "XML011";
+
+    /// <summary>The document is not in the XML namespace its contract declares.</summary>
+    public const string RuleContractNamespace = "XML012";
+
+    /// <summary>The file sits in an AOT folder that belongs to a different family.</summary>
+    public const string RuleFolderMismatch = "XML013";
+
+    /// <summary>
+    /// Appends any root-shape violations found in <paramref name="xml"/>.
+    /// </summary>
+    /// <param name="xml">The document as it would be written.</param>
+    /// <param name="violations">Collector.</param>
+    /// <param name="sourcePath">
+    /// Where the document lives, when that is known. Only used by <see cref="RuleFolderMismatch"/>,
+    /// which has nothing to say about a document that came from stdin.
+    /// </param>
+    public static void Check(string xml, List<XppViolation> violations, string? sourcePath = null)
+    {
+        XDocument doc;
+        try
+        {
+            doc = XDocument.Parse(xml, LoadOptions.SetLineInfo);
+        }
+        catch (XmlException)
+        {
+            return; // Not well-formed — the parser and the other rules report that.
+        }
+
+        if (doc.Root is not null) Check(doc.Root, violations, sourcePath);
+    }
+
+    /// <summary>Root-shape rules against an already-parsed document.</summary>
+    public static void Check(XElement root, List<XppViolation> violations, string? sourcePath = null)
+    {
+        ArgumentNullException.ThrowIfNull(root);
+        ArgumentNullException.ThrowIfNull(violations);
+
+        var name = root.Name.LocalName;
+
+        // Only AOT documents are in scope. A form-pattern fragment, a .rnrproj, an arbitrary
+        // XML file the user pointed at — none of those name an Ax* type, and guessing at them
+        // would make the rule useless noise.
+        if (!name.StartsWith("Ax", StringComparison.Ordinal)) return;
+
+        var line = (root as IXmlLineInfo)?.LineNumber;
+        var contract = MetadataContracts.Find(name);
+        var registered = ObjectTypeRegistry.Find(name);
+
+        if (!CheckRootIsReal(name, contract, registered, line, violations)) return;
+
+        CheckAbstractRoot(root, name, contract, registered, line, violations);
+        CheckXsiDeclaration(root, name, registered, line, violations);
+        CheckContractNamespace(root, name, contract, registered, line, violations);
+        CheckFolder(name, registered, sourcePath, line, violations);
+    }
+
+    /// <summary>
+    /// The root has to name a type the metadata assemblies actually define.
+    /// </summary>
+    /// <remarks>
+    /// Two authorities, because they answer different questions. The contract catalog knows all
+    /// 565 MetaModel types including the ones that are never a file's root
+    /// (<c>AxTableField</c>) and the concrete subtypes a registry family collapses
+    /// (<c>AxEdtString</c>). The registry knows which of those are top-level AOT families, and
+    /// carries <c>ExistsInStandardAot</c> — the flag that exists because
+    /// <c>AxWorkflowType</c> was read for years and matches no folder on any AOS (finding G1).
+    /// A name unknown to both is the failure the bridge reports as <c>TYPE_NOT_FOUND</c>.
+    /// </remarks>
+    private static bool CheckRootIsReal(
+        string name, MetadataContract? contract, ObjectTypeInfo? registered, int? line, List<XppViolation> violations)
+    {
+        if (contract is null && registered is null)
+        {
+            violations.Add(new XppViolation(
+                RuleUnknownRoot, "error", line, $"<{name}>",
+                $"No AOT type is named {name}. The metadata provider cannot construct a root it does " +
+                $"not know, so the file is unreadable end to end. {NearestRoots(name)}"));
+            return false;
+        }
+
+        if (registered is not null && !registered.ExistsInStandardAot)
+        {
+            violations.Add(new XppViolation(
+                RuleUnknownRoot, "error", line, $"<{name}>",
+                $"{name} is a plausible-looking name that matches no folder on any shipped D365FO " +
+                $"installation, so an object written as one is invisible to the index and to Visual " +
+                $"Studio. Use the real root for this family instead."));
+            return false;
+        }
+
+        return true;
+    }
+
+    /// <summary>
+    /// An abstract root is only writable when the concrete subtype is pinned via <c>i:type</c> —
+    /// the escape hatch <c>Handlers.WriteArtifact</c> honours for
+    /// <c>&lt;AxEdt i:type="AxEdtString"&gt;</c>.
+    /// </summary>
+    private static void CheckAbstractRoot(
+        XElement root, string name, MetadataContract? contract, ObjectTypeInfo? registered,
+        int? line, List<XppViolation> violations)
+    {
+        var isAbstract = contract?.IsAbstract == true || registered?.AbstractRoot == true;
+        var pinned = root.Attribute(XName.Get("type", XsiNamespace))?.Value;
+
+        if (isAbstract && string.IsNullOrWhiteSpace(pinned))
+        {
+            violations.Add(new XppViolation(
+                RuleAbstractRoot, "error", line, $"<{name}>",
+                $"{name} is an abstract MetaModel type. Opening the file throws \"Cannot create an " +
+                $"abstract class\" unless a concrete subtype is pinned. Either write the concrete root " +
+                $"directly or add i:type — {ConcreteSubtypes(name)}"));
+            return;
+        }
+
+        if (string.IsNullOrWhiteSpace(pinned)) return;
+
+        if (MetadataContracts.Find(pinned) is null)
+        {
+            violations.Add(new XppViolation(
+                RuleAbstractRoot, "error", line, $"<{name} i:type=\"{pinned}\">",
+                $"No AOT type is named {pinned}, so the discriminator resolves to nothing and the " +
+                $"read fails. {ConcreteSubtypes(name)}"));
+            return;
+        }
+
+        // A discriminator that names a real type from a different branch is worse than an
+        // unknown one: it deserializes into the wrong shape rather than failing.
+        var subtypes = MetadataContracts.DerivedFrom(name);
+        if (subtypes.Count > 0 && !subtypes.Any(s => string.Equals(s.Name, pinned, StringComparison.Ordinal))
+            && !string.Equals(pinned, name, StringComparison.Ordinal))
+        {
+            violations.Add(new XppViolation(
+                RuleAbstractRoot, "error", line, $"<{name} i:type=\"{pinned}\">",
+                $"{pinned} does not derive from {name}, so the discriminator cannot select it. " +
+                $"{ConcreteSubtypes(name)}"));
+        }
+    }
+
+    /// <summary>
+    /// Roots that carry <c>i:type</c> anywhere, and the families the registry marks as
+    /// requiring it, need the XMLSchema-instance namespace declared on the root element.
+    /// </summary>
+    /// <remarks>
+    /// Two reasons, and both were shipped defects. A discriminator with no namespace in scope
+    /// is not a discriminator at all — it is an unknown attribute, and the polymorphic member it
+    /// was pinning silently reads as its base type (issue #91, every <c>AxTableField</c>). And
+    /// for <c>AxEnum</c> Visual Studio's reader refuses the file outright when the declaration
+    /// is absent even though nothing in it uses the prefix (issue #70), which is why the policy
+    /// is a per-family registry flag and not something derived from the document alone.
+    /// </remarks>
+    private static void CheckXsiDeclaration(
+        XElement root, string name, ObjectTypeInfo? registered, int? line, List<XppViolation> violations)
+    {
+        var usesXsi = root.DescendantsAndSelf()
+            .Any(e => e.Attributes().Any(a => a.Name.NamespaceName == XsiNamespace));
+        var requiredByFamily = registered?.RequiresXsiNamespace == true
+                               || name.StartsWith("AxEdt", StringComparison.Ordinal);
+        if (!usesXsi && !requiredByFamily) return;
+
+        // Any prefix bound to the URI counts; Visual Studio always writes "i", but the prefix
+        // carries no meaning of its own.
+        var declared = root.Attributes()
+            .Any(a => a.IsNamespaceDeclaration && string.Equals(a.Value, XsiNamespace, StringComparison.Ordinal));
+        if (declared) return;
+
+        violations.Add(new XppViolation(
+            RuleXsiNamespace, "error", line, $"<{name}>",
+            $"Declare xmlns:i=\"{XsiNamespace}\" on the root. " +
+            (usesXsi
+                ? "Without it the i:type discriminators in this document are just unknown attributes, " +
+                  "and every polymorphic member reads back as its base type with its extra properties gone."
+                : $"Visual Studio's metadata reader refuses to open an {name} file whose root does not " +
+                  "declare it, whether or not the document uses the prefix.")));
+    }
+
+    /// <summary>
+    /// The document has to be in the XML namespace its DataContract declares.
+    /// </summary>
+    /// <remarks>
+    /// Finding G3: menu items and tiles contract into <c>…Metadata.V1</c>, reports and workflow
+    /// objects into <c>V2</c>, forms into <c>V6</c>, and everything else into the empty
+    /// namespace. Getting it wrong is not cosmetic — the reader fails with "Expecting element X
+    /// from namespace Y" before it looks at a single property, which is how menu items, reports
+    /// and workflow objects shipped unreadable until the namespaces were ground-truthed.
+    /// </remarks>
+    private static void CheckContractNamespace(
+        XElement root, string name, MetadataContract? contract, ObjectTypeInfo? registered,
+        int? line, List<XppViolation> violations)
+    {
+        var expected = contract?.Namespace ?? registered?.ContractNamespace ?? string.Empty;
+        var actual = root.Name.NamespaceName;
+        if (string.Equals(expected, actual, StringComparison.Ordinal)) return;
+
+        violations.Add(new XppViolation(
+            RuleContractNamespace, "error", line, $"<{name} xmlns=\"{actual}\">",
+            expected.Length == 0
+                ? $"{name} contracts into the empty namespace, so a default namespace on the root makes " +
+                  $"the reader fail with \"Expecting element {name} from namespace ''\". Drop the xmlns."
+                : $"{name} contracts into \"{expected}\". The reader fails with \"Expecting element {name} " +
+                  $"from namespace {expected}\" before it reads a single property. Set xmlns=\"{expected}\" " +
+                  $"on the root."));
+    }
+
+    /// <summary>
+    /// A family owns exactly one AOT folder, and the folder is how the extractor, Visual Studio
+    /// and the build tools decide what a file is.
+    /// </summary>
+    /// <remarks>
+    /// Path-aware, so it only speaks when the caller knows where the document lives. The parent
+    /// folder has to be an AOT folder some family owns before this says anything — a scaffold
+    /// parked at an arbitrary <c>--out</c> path is not in the AOT at all and is not a defect.
+    /// </remarks>
+    private static void CheckFolder(
+        string name, ObjectTypeInfo? registered, string? sourcePath, int? line, List<XppViolation> violations)
+    {
+        if (registered is null || string.IsNullOrWhiteSpace(sourcePath)) return;
+
+        var folder = Path.GetFileName(Path.GetDirectoryName(Path.GetFullPath(sourcePath)));
+        if (string.IsNullOrEmpty(folder)) return;
+
+        var owner = ObjectTypeRegistry.Find(folder);
+        if (owner is null || !string.Equals(owner.AotSubfolder, folder, StringComparison.OrdinalIgnoreCase)) return;
+        if (string.Equals(owner.AotSubfolder, registered.AotSubfolder, StringComparison.OrdinalIgnoreCase)) return;
+
+        violations.Add(new XppViolation(
+            RuleFolderMismatch, "error", line, $"{folder}/{Path.GetFileName(sourcePath)}",
+            $"A <{name}> document is sitting in the {folder} folder, which belongs to " +
+            $"{owner.RootElement}. The extractor and the build tools read a file's type from its " +
+            $"folder, so this object is indexed as the wrong kind — or not at all. Move it to " +
+            $"{registered.AotSubfolder}."));
+    }
+
+    private static string ConcreteSubtypes(string abstractName)
+    {
+        var concrete = MetadataContracts.DerivedFrom(abstractName)
+            .Where(c => !c.IsAbstract)
+            .Select(c => c.Name)
+            .Take(8)
+            .ToList();
+
+        return concrete.Count == 0
+            ? "the metadata catalog lists no concrete subtype for it."
+            : $"concrete subtypes: {string.Join(", ", concrete)}.";
+    }
+
+    private static string NearestRoots(string written)
+    {
+        var prefix = written[..Math.Min(5, written.Length)];
+        var near = MetadataContracts.All.Keys
+            .Where(k => k.StartsWith(prefix, StringComparison.OrdinalIgnoreCase))
+            .Take(6)
+            .ToList();
+
+        return near.Count > 0
+            ? $"Did you mean one of: {string.Join(", ", near)}?"
+            : "Run `d365fo get object-types` for the AOT families this tool knows.";
+    }
+}

--- a/src/D365FO.Core/Validation/XppValidator.cs
+++ b/src/D365FO.Core/Validation/XppValidator.cs
@@ -41,11 +41,21 @@ public interface IPropertyStatsProvider
 ///   XML004  AxTableField without &lt;ExtendedDataType&gt;/&lt;EnumType&gt; (data-driven)
 ///   XML005  AxTable missing &lt;ClusteredIndex&gt;   (only when standard usage ≥ threshold)
 ///   XML007  Member the AOT type does not declare — silently dropped when the file is read
+///   XML008  Value outside the enum its member is typed as — the whole document fails to load
+///   XML009  Root element names no AOT type
+///   XML010  Abstract root with no concrete &lt;c&gt;i:type&lt;/c&gt; pinned
+///   XML011  XMLSchema-instance namespace used or required but not declared on the root
+///   XML012  Document not in the XML namespace its contract declares
+///   XML013  File sitting in an AOT folder another family owns (path-aware)
 /// </summary>
 /// <remarks>
-/// XML007 comes from <see cref="D365FO.Core.Metadata.MetadataContracts"/> and applies to every
-/// AOT family, not just tables. It is the offline counterpart of <c>validate metadata</c>,
-/// which asks the live provider the same question.
+/// XML001–XML005 are AxTable-only by nature — they are property-presence rules mined from
+/// standard tables. XML007–XML013 are not: they come from
+/// <see cref="D365FO.Core.Metadata.MetadataContracts"/> (565 types) and
+/// <see cref="D365FO.Core.ObjectTypes.ObjectTypeRegistry"/>, so they apply to every AOT family.
+/// Together they are the offline counterpart of <c>validate metadata</c>, which asks the live
+/// provider the same questions — see <see cref="ObjectShapeRules"/> for the mapping onto the
+/// bridge's own rejection codes.
 /// </remarks>
 public static class XppValidator
 {
@@ -75,7 +85,12 @@ public static class XppValidator
         "menuitemoutputstr", "varstr", "con2str", "int2str", "num2str",
     };
 
-    public static IReadOnlyList<XppViolation> Validate(string code, string codeType = CodeTypeXpp, IPropertyStatsProvider? stats = null)
+    /// <param name="sourcePath">
+    /// Where the document came from, when the caller knows. Only XML013 uses it — a file in the
+    /// wrong AOT folder is not something stdin can be guilty of.
+    /// </param>
+    public static IReadOnlyList<XppViolation> Validate(
+        string code, string codeType = CodeTypeXpp, IPropertyStatsProvider? stats = null, string? sourcePath = null)
     {
         var violations = new List<XppViolation>();
         var normalized = NormalizeCodeType(codeType);
@@ -89,17 +104,28 @@ public static class XppValidator
             CheckMissingAlternateKey(code, violations);
             CheckTableProperties(code, stats, violations);
             CheckFieldEdt(code, stats, violations);
-            ContractShapeRules.Check(code, violations);
+            RunXmlShapeRules(code, sourcePath, violations);
         }
         else
         {
             CheckMissingAlternateKey(code, violations);
             CheckTableProperties(code, stats, violations);
             CheckFieldEdt(code, stats, violations);
-            // Applies to every AOT family, not just tables: the contract catalog knows them all.
-            ContractShapeRules.Check(code, violations);
+            RunXmlShapeRules(code, sourcePath, violations);
         }
         return violations;
+    }
+
+    /// <summary>
+    /// The family-agnostic half of the XML rules: the root's own shape (XML009–XML013) and
+    /// everything inside it (XML007–XML008). Both are driven by the contract catalog and the
+    /// object-type registry, so they apply to every AOT family rather than the AxTable-only set
+    /// XML001–XML005 covers (issue #163).
+    /// </summary>
+    private static void RunXmlShapeRules(string code, string? sourcePath, List<XppViolation> violations)
+    {
+        ObjectShapeRules.Check(code, violations, sourcePath);
+        ContractShapeRules.Check(code, violations);
     }
 
     public static string NormalizeCodeType(string? codeType) => codeType?.ToLowerInvariant() switch

--- a/src/D365FO.Mcp/ToolCatalog.cs
+++ b/src/D365FO.Mcp/ToolCatalog.cs
@@ -268,15 +268,17 @@ public static class ToolCatalog
 
         new Descriptor("validate",
             "Check an artifact before it is written. `mode`:\n" +
-            "• xpp — the offline X++/XML best-practice validator (XML001-XML008, BP rules). `codeType` " +
+            "• xpp — the offline X++/XML best-practice validator (XML001-XML013, BP rules). `codeType` " +
             "xpp | xml-table | xml-any, auto-detected when omitted.\n" +
             "• references — every identifier in the code must exist in the index; the anti-hallucination gate. " +
             "Requires an index.\n" +
             "• form-pattern — structural AxForm pattern rules FP001-FP010, the same gate generate_object(form) enforces.\n" +
-            "• metadata-shape — judges AOT XML against the serialization contract the AOT reader is generated from: " +
-            "XML007 (a member the type does not declare, silently dropped on read) and XML008 (a value outside its " +
-            "enum, which stops the read outright). Needs no bridge and no VM; this is the offline half of the CLI's " +
-            "`validate metadata`.",
+            "• metadata-shape — judges AOT XML against the serialization contract the AOT reader is generated from. " +
+            "Inside the document: XML007 (a member the type does not declare, silently dropped on read) and XML008 " +
+            "(a value outside its enum, which stops the read outright). The root itself: XML009 (names no AOT type), " +
+            "XML010 (abstract root with no concrete i:type), XML011 (missing xmlns:i), XML012 (wrong contract " +
+            "namespace). Every AOT family, not just tables. Needs no bridge and no VM; this is the offline half of " +
+            "the CLI's `validate metadata`.",
             Schema(("mode", "string", true), ("code", "string", true),
                    ("context", "string", false), ("codeType", "string", false)),
             (h, p) => h.Validate(Str(p, "mode"), Str(p, "code"), StrOrNull(p, "context"), StrOrNull(p, "codeType"))),

--- a/src/D365FO.Mcp/ToolHandlers.cs
+++ b/src/D365FO.Mcp/ToolHandlers.cs
@@ -1539,6 +1539,11 @@ public sealed class ToolHandlers
     private static ToolResult<object> ValidateMetadataShape(string xml, string? context)
     {
         var violations = new List<D365FO.Core.Validation.XppViolation>();
+        // The root's own shape first (issue #163), then everything inside it. Both are driven by
+        // the same catalog, and both speak for every AOT family — an agent that asks about a
+        // document whose root the provider cannot even construct should hear that before it
+        // hears about the members inside it.
+        D365FO.Core.Validation.ObjectShapeRules.Check(xml, violations);
         D365FO.Core.Validation.ContractShapeRules.Check(xml, violations);
 
         return ValidationEnvelope(context, "metadata-shape", violations.Select(v =>

--- a/tests/D365FO.Cli.Tests/GenerateGateSurfaceTests.cs
+++ b/tests/D365FO.Cli.Tests/GenerateGateSurfaceTests.cs
@@ -1,0 +1,130 @@
+using System.Reflection;
+using System.Text.RegularExpressions;
+using D365FO.Cli.Commands.Generate;
+using Xunit;
+
+namespace D365FO.Cli.Tests;
+
+/// <summary>
+/// The structural half of issue #161: no <c>generate</c> subcommand can reach disk without
+/// having run the grounding gate.
+/// </summary>
+/// <remarks>
+/// <para>
+/// The gate is enforced by the type system as far as it can be —
+/// <c>GenerateInstaller.Write</c> takes a <c>GateResult</c>, so a caller that has not gated has
+/// nothing to pass it. What the type system cannot prevent is a command calling
+/// <c>ScaffoldFileWriter.Write</c> directly, which is exactly how the gate came to be wired
+/// into three subcommands out of twenty-nine. This suite is that guard: it reads the command
+/// sources and fails if one of them writes around the shared path.
+/// </para>
+/// <para>
+/// A source scan rather than a reflection check, because the property under test is "which API
+/// does this code call", and that is not observable on the compiled surface.
+/// </para>
+/// </remarks>
+public class GenerateGateSurfaceTests
+{
+    private static string GenerateCommandsDirectory()
+    {
+        var dir = new DirectoryInfo(AppContext.BaseDirectory);
+        while (dir is not null && !Directory.Exists(Path.Combine(dir.FullName, "src", "D365FO.Cli")))
+            dir = dir.Parent;
+
+        Assert.NotNull(dir);
+        return Path.Combine(dir!.FullName, "src", "D365FO.Cli", "Commands", "Generate");
+    }
+
+    /// <summary>Source files holding the generate subcommands, minus the shared installer itself.</summary>
+    private static IEnumerable<(string Name, string Source)> CommandSources()
+        => Directory.EnumerateFiles(GenerateCommandsDirectory(), "*.cs")
+            .Where(f => Path.GetFileName(f) != "GenerateCommands.cs")
+            .Select(f => (Path.GetFileName(f), File.ReadAllText(f)));
+
+    [Fact]
+    public void No_generate_command_calls_the_scaffold_writer_directly()
+    {
+        var offenders = CommandSources()
+            .Where(f => Regex.IsMatch(f.Source, @"ScaffoldFileWriter\s*\.\s*Write\s*\("))
+            .Select(f => f.Name)
+            .ToArray();
+
+        Assert.Empty(offenders);
+    }
+
+    [Fact]
+    public void Every_generate_command_source_that_writes_also_gates()
+    {
+        var offenders = new List<string>();
+
+        foreach (var (name, source) in CommandSources())
+        {
+            var writes = Regex.IsMatch(source, @"GenerateInstaller\s*\.\s*(Write|Emit|EmitString)\s*\(")
+                         || source.Contains("AtomicSave(", StringComparison.Ordinal);
+            if (!writes) continue;
+
+            if (!Regex.IsMatch(source, @"GenerateInstaller\s*\.\s*Gate\s*\("))
+                offenders.Add(name);
+        }
+
+        Assert.Empty(offenders);
+    }
+
+    [Fact]
+    public void The_shared_installer_is_the_only_place_that_names_the_scaffold_writer()
+    {
+        // GenerateCommands.cs holds GenerateInstaller. It is allowed to call the writer —
+        // that is the whole point of a choke point — but it must do so from the gated
+        // wrappers, so every call site there sits inside a method taking a GateResult.
+        var installer = File.ReadAllText(Path.Combine(GenerateCommandsDirectory(), "GenerateCommands.cs"));
+        var calls = Regex.Matches(installer, @"ScaffoldFileWriter\s*\.\s*Write\s*\(\s*(doc|xml)\s*,").Count;
+
+        Assert.Equal(2, calls); // the XDocument overload and the string one
+    }
+
+    [Fact]
+    public void Requested_values_come_from_the_command_s_own_options_only()
+    {
+        // The honesty report must not treat plumbing as a request: --out is not a property of
+        // the generated object, and reporting it as "missing from the document" every time
+        // would bury the findings that matter.
+        var settings = new GenerateTableCommand.Settings
+        {
+            Name = "ConVehicle",
+            Out = @"C:\scratch\ConVehicle.xml",
+            InstallTo = "ConModel",
+            GroundingToken = "deadbeef",
+            Pattern = "main",
+            Fields = ["Plate:Name:mandatory"],
+        };
+
+        var requested = GenerateInstaller.RequestedValues(settings);
+        var options = requested.Select(r => r.Option).ToArray();
+
+        Assert.Contains("<NAME>", options);
+        Assert.Contains("--pattern", options);
+        Assert.Contains("--field", options);
+        Assert.DoesNotContain("--out", options);
+        Assert.DoesNotContain("--install-to", options);
+        Assert.DoesNotContain("--grounding-token", options);
+        Assert.DoesNotContain("--output", options);
+    }
+
+    [Fact]
+    public void Every_generate_settings_type_derives_from_the_gated_base()
+    {
+        // A command whose settings do not derive from GenerateSettings cannot be gated by
+        // GenerateInstaller.Gate at all, so it would silently sit outside the guarantee.
+        var offenders = typeof(GenerateInstaller).Assembly.GetTypes()
+            .Where(t => t is { IsAbstract: false, IsClass: true }
+                        && t.Namespace == "D365FO.Cli.Commands.Generate"
+                        && t.Name.StartsWith("Generate", StringComparison.Ordinal)
+                        && t.Name.EndsWith("Command", StringComparison.Ordinal))
+            .Select(t => (Command: t, Settings: t.GetNestedType("Settings", BindingFlags.Public | BindingFlags.NonPublic)))
+            .Where(x => x.Settings is not null && !typeof(GenerateSettings).IsAssignableFrom(x.Settings))
+            .Select(x => x.Command.Name)
+            .ToArray();
+
+        Assert.Empty(offenders);
+    }
+}

--- a/tests/D365FO.Cli.Tests/PropertyHonestyReportingTests.cs
+++ b/tests/D365FO.Cli.Tests/PropertyHonestyReportingTests.cs
@@ -1,0 +1,106 @@
+using D365FO.Cli.Commands.Generate;
+using Xunit;
+
+namespace D365FO.Cli.Tests;
+
+/// <summary>
+/// R6 (issue #161) end to end: a generate call reports any requested value that did not survive
+/// to disk.
+/// </summary>
+/// <remarks>
+/// The Core-level rules live in <c>PropertyHonestyTests</c>; what is checked here is that the
+/// wiring is live — that a real command, run normally, actually reconciles its own options
+/// against the document it wrote. A check like this is worth nothing if it silently becomes a
+/// no-op, and the failure mode of a reflection-driven request list is exactly that.
+/// </remarks>
+[Collection("EnvIndexDb")]
+public sealed class PropertyHonestyReportingTests : IDisposable
+{
+    private readonly string _dir = Path.Combine(Path.GetTempPath(), $"d365fo-honesty-{Guid.NewGuid():N}");
+
+    public PropertyHonestyReportingTests() => Directory.CreateDirectory(_dir);
+
+    public void Dispose()
+    {
+        try { Directory.Delete(_dir, recursive: true); } catch { }
+    }
+
+    private string Out(string name) => Path.Combine(_dir, name + ".xml");
+
+    [Fact]
+    public void A_requested_value_the_scaffolder_discards_is_reported()
+    {
+        // --primary-key names the fields of the alternate-key index, and the scaffolder builds
+        // that index from the fields it was actually given. A name that is not one of them is
+        // dropped in silence: the command succeeds and the index does not mention it.
+        var settings = new GenerateTableCommand.Settings
+        {
+            Name = "ConHonestyVehicle",
+            Fields = ["Plate:Name"],
+            PrimaryKey = ["NotAFieldOfThisTable"],
+            Out = Out("ConHonestyVehicle"),
+            Overwrite = true,
+            Output = "json",
+        };
+
+        var exit = new GenerateTableCommand().Execute(null!, settings);
+        Assert.Equal(0, exit);
+
+        var written = File.ReadAllText(settings.Out!);
+        Assert.DoesNotContain("NotAFieldOfThisTable", written, StringComparison.OrdinalIgnoreCase);
+
+        // The same reconciliation the command runs, over the document it produced.
+        var gaps = D365FO.Core.Scaffolding.PropertyHonesty.Reconcile(
+            GenerateInstaller.RequestedValues(settings), written);
+
+        var gap = Assert.Single(gaps);
+        Assert.Equal("--primary-key", gap.Option);
+        Assert.Equal("NotAFieldOfThisTable", gap.Missing);
+    }
+
+    [Fact]
+    public void A_call_whose_options_all_survive_reports_nothing()
+    {
+        var settings = new GenerateTableCommand.Settings
+        {
+            Name = "ConHonestyClean",
+            Fields = ["Plate:Name:mandatory", "Colour:ConColour"],
+            Pattern = "main",
+            ConfigurationKey = "ConFleetKey",
+            FormRef = "ConHonestyCleanMenuItem",
+            Out = Out("ConHonestyClean"),
+            Overwrite = true,
+            Output = "json",
+        };
+
+        var exit = new GenerateTableCommand().Execute(null!, settings);
+        Assert.Equal(0, exit);
+
+        var gaps = D365FO.Core.Scaffolding.PropertyHonesty.Reconcile(
+            GenerateInstaller.RequestedValues(settings), File.ReadAllText(settings.Out!));
+
+        Assert.Empty(gaps);
+    }
+
+    [Fact]
+    public void The_reconciliation_reads_the_command_s_real_options()
+    {
+        // The list is derived by reflection, so the thing that can rot is the derivation
+        // itself: an empty list makes every honesty check pass for the wrong reason.
+        var settings = new GenerateEnumCommand.Settings
+        {
+            Name = "ConHonestyStatus",
+            Values = ["None:0", "Active:1"],
+            Label = "@Con:StatusLabel",
+            Out = Out("ConHonestyStatus"),
+            Overwrite = true,
+            Output = "json",
+        };
+
+        var requested = GenerateInstaller.RequestedValues(settings);
+
+        Assert.Contains(requested, r => r is { Option: "<NAME>", Value: "ConHonestyStatus" });
+        Assert.Contains(requested, r => r is { Option: "--label", Value: "@Con:StatusLabel" });
+        Assert.Equal(2, requested.Count(r => r.Option == "--value"));
+    }
+}

--- a/tests/D365FO.Core.Tests/D365FoSettingsResolveTests.cs
+++ b/tests/D365FO.Core.Tests/D365FoSettingsResolveTests.cs
@@ -2,6 +2,7 @@ using Xunit;
 
 namespace D365FO.Core.Tests;
 
+[Collection(EnvironmentCollectionDefinition.Name)]
 public class D365FoSettingsResolveTests
 {
     // Use unlikely key names so a real settings.json on the test host cannot

--- a/tests/D365FO.Core.Tests/DataEntityDepthTests.cs
+++ b/tests/D365FO.Core.Tests/DataEntityDepthTests.cs
@@ -1,0 +1,209 @@
+using System.Xml.Linq;
+using D365FO.Core.Metadata;
+using D365FO.Core.Scaffolding;
+using D365FO.Core.Validation;
+using Xunit;
+
+namespace D365FO.Core.Tests;
+
+/// <summary>
+/// Issue #162, data-entity half: relations, computed columns, and the DMF staging table that
+/// <c>DataManagementEnabled=Yes</c> promises and nothing used to generate.
+/// </summary>
+public class DataEntityDepthTests
+{
+    private static readonly XNamespace Xsi = "http://www.w3.org/2001/XMLSchema-instance";
+
+    private static IReadOnlyList<XppViolation> Shape(XDocument doc)
+    {
+        var v = new List<XppViolation>();
+        var xml = doc.ToString(SaveOptions.DisableFormatting);
+        ObjectShapeRules.Check(xml, v);
+        ContractShapeRules.Check(xml, v);
+        return v;
+    }
+
+    private static XDocument Entity(
+        IEnumerable<EntityRelationSpec>? relations = null,
+        IEnumerable<EntityComputedFieldSpec>? computed = null)
+        => XppScaffolder.DataEntity(
+            "ConVehicleEntity", "FmVehicle",
+            fields: [new EntityFieldSpec("VehicleId", "VehicleId", true)],
+            keyFields: ["VehicleId"],
+            relations: relations,
+            computedFields: computed);
+
+    // ── relations ────────────────────────────────────────────────────────────
+
+    [Fact]
+    public void A_relation_joins_two_entities_on_a_field_pair()
+    {
+        var doc = Entity(relations: [
+            new EntityRelationSpec(
+                "Customer", "CustCustomerV3Entity",
+                [new EntityRelationConstraintSpec("CustomerAccount", "CustomerAccount")],
+                Cardinality: "ZeroOne",
+                RelationshipType: "Association"),
+        ]);
+
+        var relation = Assert.Single(doc.Root!.Element("Relations")!.Elements());
+        Assert.Equal("AxDataEntityViewRelation", relation.Name.LocalName);
+        Assert.Equal("Customer", relation.Element("Name")!.Value);
+        Assert.Equal("CustCustomerV3Entity", relation.Element("RelatedDataEntity")!.Value);
+        Assert.Equal("ZeroOne", relation.Element("Cardinality")!.Value);
+        Assert.Equal("Association", relation.Element("RelationshipType")!.Value);
+
+        var constraint = Assert.Single(relation.Element("Constraints")!.Elements());
+        Assert.Equal("AxDataEntityViewRelationConstraint", constraint.Name.LocalName);
+        Assert.Equal("AxDataEntityViewRelationConstraintField", constraint.Attribute(Xsi + "type")!.Value);
+        Assert.Equal("CustomerAccount", constraint.Element("Field")!.Value);
+        Assert.Equal("CustomerAccount", constraint.Element("RelatedField")!.Value);
+
+        Assert.Empty(Shape(doc));
+    }
+
+    [Fact]
+    public void A_constraint_without_its_discriminator_would_lose_both_fields()
+    {
+        // The reason the i:type above is not decoration: the base constraint declares Name and
+        // Tags only, so an unpinned constraint reads back joining on nothing.
+        var baseContract = MetadataContracts.Find("AxDataEntityViewRelationConstraint")!;
+        Assert.False(MetadataContracts.AcceptsMember(baseContract, "Field"));
+        Assert.False(MetadataContracts.AcceptsMember(baseContract, "RelatedField"));
+
+        var fieldContract = MetadataContracts.Find("AxDataEntityViewRelationConstraintField")!;
+        Assert.True(MetadataContracts.AcceptsMember(fieldContract, "Field"));
+        Assert.True(MetadataContracts.AcceptsMember(fieldContract, "RelatedField"));
+    }
+
+    [Fact]
+    public void An_entity_with_no_relations_emits_no_collection()
+    {
+        Assert.Null(Entity().Root!.Element("Relations"));
+    }
+
+    // ── computed columns ─────────────────────────────────────────────────────
+
+    [Fact]
+    public void A_computed_field_is_an_unmapped_field_bound_to_a_method()
+    {
+        var doc = Entity(computed: [
+            new EntityComputedFieldSpec("VehicleDisplayName", "computeVehicleDisplayName", "Name"),
+        ]);
+
+        var computed = doc.Root!.Element("Fields")!.Elements()
+            .Single(f => f.Element("Name")!.Value == "VehicleDisplayName");
+
+        Assert.Equal("AxDataEntityViewUnmappedField", computed.Attribute(Xsi + "type")!.Value);
+        Assert.Equal("computeVehicleDisplayName", computed.Element("ComputedFieldMethod")!.Value);
+        Assert.Equal("Name", computed.Element("ExtendedDataType")!.Value);
+        Assert.Equal("Yes", computed.Element("IsComputedField")!.Value);
+
+        // And the mapped field beside it is untouched.
+        var mapped = doc.Root.Element("Fields")!.Elements()
+            .Single(f => f.Element("Name")!.Value == "VehicleId");
+        Assert.Equal("AxDataEntityViewMappedField", mapped.Attribute(Xsi + "type")!.Value);
+
+        Assert.Empty(Shape(doc));
+    }
+
+    [Fact]
+    public void The_mapped_field_type_has_no_computed_members_at_all()
+    {
+        // Which is why the computed field has to be the unmapped subtype rather than a mapped
+        // field with extra elements: on AxDataEntityViewMappedField those members do not exist.
+        var mapped = MetadataContracts.Find("AxDataEntityViewMappedField")!;
+        Assert.False(MetadataContracts.AcceptsMember(mapped, "ComputedFieldMethod"));
+        Assert.False(MetadataContracts.AcceptsMember(mapped, "IsComputedField"));
+    }
+
+    // ── staging table ────────────────────────────────────────────────────────
+
+    [Fact]
+    public void The_staging_table_carries_the_entity_fields_and_the_DMF_bookkeeping_columns()
+    {
+        var doc = XppScaffolder.EntityStagingTable(
+            "ConVehicleEntityStaging",
+            [new EntityFieldSpec("VehicleId", "VehicleId", true), new EntityFieldSpec("Plate", null, false)]);
+
+        Assert.Equal("AxTable", doc.Root!.Name.LocalName);
+
+        var names = doc.Root.Element("Fields")!.Elements()
+            .Select(f => f.Element("Name")!.Value).ToArray();
+
+        Assert.Contains("VehicleId", names);
+        Assert.Contains("Plate", names);
+        foreach (var required in new[] { "DefinitionGroup", "ExecutionId", "IsSelected", "TransferStatus" })
+            Assert.Contains(required, names);
+
+        Assert.Empty(Shape(doc));
+    }
+
+    [Fact]
+    public void The_staging_table_types_its_framework_columns_the_way_the_DMF_expects()
+    {
+        // Ground-truthed against 398 of 400 shipped *Staging tables sampled from
+        // PackagesLocalDirectory on a real AOS.
+        var doc = XppScaffolder.EntityStagingTable("ConVehicleEntityStaging", []);
+        var fields = doc.Root!.Element("Fields")!.Elements()
+            .ToDictionary(f => f.Element("Name")!.Value);
+
+        Assert.Equal("DMFDefinitionGroupName", fields["DefinitionGroup"].Element("ExtendedDataType")!.Value);
+        Assert.Equal("AxTableFieldString", fields["DefinitionGroup"].Attribute(Xsi + "type")!.Value);
+        Assert.Equal("DMFExecutionId", fields["ExecutionId"].Element("ExtendedDataType")!.Value);
+
+        // IsSelected and TransferStatus are enum columns, not EDT ones.
+        foreach (var (field, enumName) in new[] { ("IsSelected", "DMFIsSelected"), ("TransferStatus", "DMFTransferStatus") })
+        {
+            Assert.Equal("AxTableFieldEnum", fields[field].Attribute(Xsi + "type")!.Value);
+            Assert.Equal(enumName, fields[field].Element("EnumType")!.Value);
+            Assert.Null(fields[field].Element("ExtendedDataType"));
+        }
+    }
+
+    [Fact]
+    public void The_staging_table_carries_the_shape_the_DMF_looks_for()
+    {
+        var doc = XppScaffolder.EntityStagingTable(
+            "ConVehicleEntityStaging", [new EntityFieldSpec("VehicleId", "VehicleId", true)]);
+        var root = doc.Root!;
+
+        Assert.Equal("Staging", root.Element("TableGroup")!.Value);
+        Assert.Equal("No", root.Element("SaveDataPerCompany")!.Value);
+        Assert.Equal("StagingIdx", root.Element("PrimaryIndex")!.Value);
+        Assert.Equal("StagingIdx", root.Element("ReplacementKey")!.Value);
+
+        var index = Assert.Single(root.Element("Indexes")!.Elements());
+        Assert.Equal("StagingIdx", index.Element("Name")!.Value);
+        Assert.Equal("Yes", index.Element("AlternateKey")!.Value);
+
+        // The run comes before the entity's own key: a staging row is unique within a run.
+        Assert.Equal(
+            new[] { "DefinitionGroup", "ExecutionId", "VehicleId" },
+            index.Element("Fields")!.Elements().Select(f => f.Element("DataField")!.Value).ToArray());
+
+        Assert.Empty(Shape(doc));
+    }
+
+    [Fact]
+    public void The_staging_table_refuses_an_empty_name()
+    {
+        Assert.Throws<ArgumentException>(() => XppScaffolder.EntityStagingTable("  "));
+    }
+
+    [Fact]
+    public void The_entity_and_its_staging_table_agree_on_the_name()
+    {
+        var entity = XppScaffolder.DataEntity(
+            "ConVehicleEntity", "FmVehicle",
+            fields: [new EntityFieldSpec("VehicleId", "VehicleId", true)],
+            keyFields: ["VehicleId"],
+            dataManagementEnabled: true);
+
+        var declared = entity.Root!.Element("DataManagementStagingTable")!.Value;
+        Assert.Equal("ConVehicleEntityStaging", declared);
+
+        var staging = XppScaffolder.EntityStagingTable(declared);
+        Assert.Equal(declared, staging.Root!.Element("Name")!.Value);
+    }
+}

--- a/tests/D365FO.Core.Tests/EnvironmentCollection.cs
+++ b/tests/D365FO.Core.Tests/EnvironmentCollection.cs
@@ -1,0 +1,23 @@
+namespace D365FO.Core.Tests;
+
+/// <summary>
+/// The one collection every test that mutates process-wide environment state belongs to.
+/// </summary>
+/// <remarks>
+/// Issue #158. Environment variables are process-wide, and <c>D365FoSettings.FromEnvironment()</c>
+/// is read on every scaffold write, every journal append and every index open — so a class that
+/// sets <c>D365FO_INDEX_DB</c> / <c>D365FO_HOME</c> / <c>D365FO_CUSTOM_MODELS</c> in its
+/// constructor and restores it in <c>Dispose</c> is, for the duration of that test class,
+/// redefining where every *other* concurrently running test writes. xUnit runs separate
+/// collections in parallel by default, so grouping the mutators without
+/// <c>DisableParallelization</c> would only stop them racing each other, not the readers.
+///
+/// <c>DisableParallelization = true</c> is what actually closes it: this collection never runs
+/// alongside another collection, so no test outside it can observe a half-applied environment.
+/// The sibling <c>D365FO.Cli.Tests</c> assembly does the same thing under the name "EnvIndexDb".
+/// </remarks>
+[CollectionDefinition(Name, DisableParallelization = true)]
+public sealed class EnvironmentCollectionDefinition
+{
+    public const string Name = "Environment";
+}

--- a/tests/D365FO.Core.Tests/Eval/SysTestResultsTests.cs
+++ b/tests/D365FO.Core.Tests/Eval/SysTestResultsTests.cs
@@ -1,0 +1,177 @@
+using D365FO.Core.Eval;
+using Xunit;
+
+namespace D365FO.Core.Tests.Eval;
+
+/// <summary>
+/// Issue #160 — reading the document <c>SysTestConsole.exe /xml:</c> writes.
+/// </summary>
+/// <remarks>
+/// The fixtures below are built to the schema <c>SysTestListenerXML</c> actually emits, taken
+/// from its X++ source on a live installation: element names are <c>#define</c>s at the top of
+/// that class, attributes are literal <c>setAttribute</c> calls. The polarity of
+/// <c>success</c> is the trap and is pinned first.
+/// </remarks>
+public class SysTestResultsTests
+{
+    private const string Run = """
+        <?xml version="1.0" encoding="utf-8" standalone="yes"?>
+        <!-- Created by SysTestListenerXML -->
+        <test-results date="2026-08-06" time="14:22:01">
+          <environment user="admin" machine="AOS1" company="DAT" layer="usr" />
+          <test-suite name="ConVehicleTest" time="412" success="true">
+            <results>
+              <test-case name="ConVehicleTest.testPlateIsMandatory" time="120"
+                         starttime="2026-08-06T14:22:01" endtime="2026-08-06T14:22:01"
+                         success="true" skipped="false" />
+              <test-case name="ConVehicleTest.testMileageRejectsNegative" time="292"
+                         success="false" skipped="false">
+                <failure>
+                  <message>Assert.isTrue failed: mileage -1 was accepted</message>
+                </failure>
+              </test-case>
+              <test-case name="ConVehicleTest.testNeedsDemoData" success="true" skipped="true" />
+              <test-case name="ConVehicleTest.testNeverGotThere" success="true" execution="pending" />
+            </results>
+          </test-suite>
+        </test-results>
+        """;
+
+    [Fact]
+    public void Success_is_a_pass_flag_not_a_failure_flag()
+    {
+        // SysTestListenerXML.isFailure() returns 'false' when the status is Failed and 'true'
+        // otherwise. Reading it the way its name suggests inverts every verdict in the file.
+        var results = SysTestResults.Parse(Run)!;
+
+        Assert.True(results.Cases.Single(c => c.Name.EndsWith("testPlateIsMandatory")).Passed);
+        Assert.False(results.Cases.Single(c => c.Name.EndsWith("testMileageRejectsNegative")).Passed);
+    }
+
+    [Fact]
+    public void Every_case_is_counted_into_exactly_one_bucket()
+    {
+        var results = SysTestResults.Parse(Run)!;
+
+        Assert.Equal(4, results.Cases.Count);
+        Assert.Equal(1, results.Passed);
+        Assert.Equal(1, results.Failed);
+        Assert.Equal(1, results.Skipped);
+        Assert.Equal(1, results.Pending);
+    }
+
+    [Fact]
+    public void A_skipped_case_is_neither_passed_nor_failed()
+    {
+        var skipped = SysTestResults.Parse(Run)!.Cases.Single(c => c.Name.EndsWith("testNeedsDemoData"));
+
+        Assert.True(skipped.Skipped);
+        Assert.False(skipped.Passed);
+    }
+
+    [Fact]
+    public void A_pending_case_is_not_a_pass_however_it_is_marked()
+    {
+        // execution="pending" means the runner registered the case and never executed it. The
+        // document still carries success="true", which is exactly the trap: a run that died
+        // half way would otherwise read as a clean run.
+        var pending = SysTestResults.Parse(Run)!.Cases.Single(c => c.Name.EndsWith("testNeverGotThere"));
+
+        Assert.True(pending.Pending);
+        Assert.False(pending.Passed);
+    }
+
+    [Fact]
+    public void The_failure_message_survives()
+    {
+        var failed = SysTestResults.Parse(Run)!.Failures.Single();
+
+        Assert.Equal("ConVehicleTest.testMileageRejectsNegative", failed.Name);
+        Assert.Equal("Assert.isTrue failed: mileage -1 was accepted", failed.FailureMessage);
+        Assert.Equal(292, failed.TimeMs);
+    }
+
+    [Fact]
+    public void A_run_is_clean_only_when_everything_that_should_have_run_did_and_passed()
+    {
+        Assert.False(SysTestResults.Parse(Run)!.Clean);
+
+        const string allGood = """
+            <test-results date="2026-08-06" time="14:22:01">
+              <test-suite name="ConVehicleTest" success="true">
+                <results>
+                  <test-case name="ConVehicleTest.testOne" success="true" skipped="false" />
+                  <test-case name="ConVehicleTest.testTwo" success="true" skipped="true" />
+                </results>
+              </test-suite>
+            </test-results>
+            """;
+        Assert.True(SysTestResults.Parse(allGood)!.Clean);
+    }
+
+    [Fact]
+    public void A_run_that_tested_nothing_is_not_a_clean_run()
+    {
+        // Reporting an empty run as a pass is how a broken harness looks healthy.
+        const string empty = """
+            <test-results date="2026-08-06" time="14:22:01">
+              <test-suite name="ConVehicleTest" success="true"><results /></test-suite>
+            </test-results>
+            """;
+
+        var results = SysTestResults.Parse(empty)!;
+        Assert.Empty(results.Cases);
+        Assert.False(results.Clean);
+    }
+
+    [Fact]
+    public void Nested_suites_are_walked()
+    {
+        const string nested = """
+            <test-results date="2026-08-06" time="14:22:01">
+              <test-suite name="Outer" success="true">
+                <results>
+                  <test-suite name="Inner" success="true">
+                    <results>
+                      <test-case name="Inner.testOne" success="true" skipped="false" />
+                    </results>
+                  </test-suite>
+                </results>
+              </test-suite>
+            </test-results>
+            """;
+
+        Assert.Equal(1, SysTestResults.Parse(nested)!.Passed);
+    }
+
+    [Theory]
+    [InlineData(null)]
+    [InlineData("")]
+    [InlineData("   ")]
+    [InlineData("not xml at all")]
+    [InlineData("<TestRun><Results /></TestRun>")]     // a .trx, not a SysTest document
+    public void Anything_that_is_not_a_result_document_is_refused(string? xml)
+        => Assert.Null(SysTestResults.Parse(xml));
+
+    [Fact]
+    public void A_missing_file_is_refused_rather_than_read_as_an_empty_run()
+    {
+        Assert.Null(SysTestResults.TryParseFile(Path.Combine(Path.GetTempPath(), $"no-such-{Guid.NewGuid():N}.xml")));
+        Assert.Null(SysTestResults.TryParseFile(null));
+    }
+
+    [Fact]
+    public void A_document_on_disk_reads_the_same_as_one_in_memory()
+    {
+        var path = Path.Combine(Path.GetTempPath(), $"systest-{Guid.NewGuid():N}.xml");
+        try
+        {
+            File.WriteAllText(path, Run);
+            Assert.Equal(SysTestResults.Parse(Run)!.Failed, SysTestResults.TryParseFile(path)!.Failed);
+        }
+        finally
+        {
+            try { File.Delete(path); } catch { }
+        }
+    }
+}

--- a/tests/D365FO.Core.Tests/ExtractPipelineTests.cs
+++ b/tests/D365FO.Core.Tests/ExtractPipelineTests.cs
@@ -6,10 +6,13 @@ using Xunit;
 
 namespace D365FO.Core.Tests;
 
-// Shares a collection with ScaffoldFileWriterJournalTests: both call ScaffoldFileWriter.Write,
-// which (issue #113) journals via the process-wide D365FO_INDEX_DB env var that the journal
-// test overrides — running them in parallel would race on that global state.
-[Collection("ScaffoldFileWriter")]
+// Both this class and ScaffoldFileWriterJournalTests call ScaffoldFileWriter.Write, which
+// (issue #113) journals via the process-wide D365FO_INDEX_DB env var that the journal test
+// overrides. A private collection only stopped those two racing each other — separate xUnit
+// collections still run in parallel, so any other test writing a scaffold could still observe
+// the overridden variable. They now share the assembly-wide, non-parallel Environment
+// collection (issue #158).
+[Collection(EnvironmentCollectionDefinition.Name)]
 public class ExtractPipelineTests : IDisposable
 {
     private readonly string _dbPath = Path.Combine(Path.GetTempPath(), $"d365fo-extract-{Guid.NewGuid():N}.sqlite");

--- a/tests/D365FO.Core.Tests/FieldControlTypesTests.cs
+++ b/tests/D365FO.Core.Tests/FieldControlTypesTests.cs
@@ -1,0 +1,106 @@
+using D365FO.Core.FormPatterns;
+using D365FO.Core.Scaffolding;
+using Xunit;
+
+namespace D365FO.Core.Tests;
+
+/// <summary>
+/// Issue #164 / R5 — the control type a bound field gets, derived from the field's own type.
+/// </summary>
+/// <remarks>
+/// The mapping is mined from shipped forms (see <see cref="FieldControlTypes"/> for the sample
+/// sizes). What is pinned here is the mapping itself and, more importantly, the fallback: a
+/// field the caller cannot resolve must still produce a form, because the index is a cache and
+/// generation has to work without one.
+/// </remarks>
+public class FieldControlTypesTests
+{
+    [Theory]
+    [InlineData("AxTableFieldString", "AxFormStringControl", "String")]
+    [InlineData("AxTableFieldReal", "AxFormRealControl", "Real")]
+    [InlineData("AxTableFieldDate", "AxFormDateControl", "Date")]
+    [InlineData("AxTableFieldInt", "AxFormIntegerControl", "Integer")]
+    [InlineData("AxTableFieldInt64", "AxFormInt64Control", "Int64")]
+    [InlineData("AxTableFieldUtcDateTime", "AxFormDateTimeControl", "DateTime")]
+    [InlineData("AxTableFieldTime", "AxFormTimeControl", "Time")]
+    [InlineData("AxTableFieldGuid", "AxFormGuidControl", "Guid")]
+    public void A_field_gets_the_control_shipped_forms_give_it(string fieldType, string axType, string typeElement)
+        => Assert.Equal((axType, typeElement), FieldControlTypes.For(fieldType));
+
+    [Fact]
+    public void A_NoYes_enum_is_a_checkbox_and_every_other_enum_is_a_combo_box()
+    {
+        Assert.Equal(("AxFormCheckBoxControl", "CheckBox"), FieldControlTypes.For("AxTableFieldEnum", "NoYes"));
+        Assert.Equal(("AxFormCheckBoxControl", "CheckBox"), FieldControlTypes.For("AxTableFieldEnum", "NoYesId"));
+        Assert.Equal(("AxFormComboBoxControl", "ComboBox"), FieldControlTypes.For("AxTableFieldEnum", "SalesStatus"));
+
+        // An enum field whose enum we could not resolve is still not a text box.
+        Assert.Equal(("AxFormComboBoxControl", "ComboBox"), FieldControlTypes.For("AxTableFieldEnum"));
+    }
+
+    [Theory]
+    [InlineData(null)]
+    [InlineData("")]
+    [InlineData("AxTableFieldSomethingNew")]
+    public void An_unresolvable_field_falls_back_to_the_string_control(string? fieldType)
+        => Assert.Equal((FieldControlTypes.DefaultControl, "String"), FieldControlTypes.For(fieldType));
+
+    [Theory]
+    [InlineData("String", "AxFormStringControl")]
+    [InlineData("Integer", "AxFormIntegerControl")]
+    [InlineData("Real", "AxFormRealControl")]
+    [InlineData("Date", "AxFormDateControl")]
+    [InlineData("DateTime", "AxFormDateTimeControl")]
+    [InlineData("Int64", "AxFormInt64Control")]
+    [InlineData("Guid", "AxFormGuidControl")]
+    public void An_EDT_base_type_resolves_the_same_way_a_field_type_does(string baseType, string expected)
+        => Assert.Equal(expected, FieldControlTypes.ForEdtBaseType(baseType).AxType);
+
+    // ── the templates actually use it ────────────────────────────────────────
+
+    [Fact]
+    public void A_generated_form_types_its_controls_from_the_resolver()
+    {
+        var xml = XppScaffolder.Form(
+            "ConVehicleListPage", "FmVehicle", FormPattern.SimpleList,
+            gridFields: ["VehicleId", "PurchaseDate", "IsActive", "Mileage"],
+            controlTypeResolver: field => field switch
+            {
+                "PurchaseDate" => FieldControlTypes.For("AxTableFieldDate"),
+                "IsActive" => FieldControlTypes.For("AxTableFieldEnum", "NoYes"),
+                "Mileage" => FieldControlTypes.For("AxTableFieldReal"),
+                _ => FieldControlTypes.For("AxTableFieldString"),
+            });
+
+        Assert.Contains("i:type=\"AxFormDateControl\"", xml);
+        Assert.Contains("<Type>Date</Type>", xml);
+        Assert.Contains("i:type=\"AxFormCheckBoxControl\"", xml);
+        Assert.Contains("<Type>CheckBox</Type>", xml);
+        Assert.Contains("i:type=\"AxFormRealControl\"", xml);
+        Assert.Contains("i:type=\"AxFormStringControl\"", xml);
+    }
+
+    [Fact]
+    public void Without_a_resolver_a_generated_form_is_byte_for_byte_what_it_always_was()
+    {
+        // The resolver is additive: no index, no change. Anything else would make every
+        // existing golden move for a feature that could not be applied.
+        var before = XppScaffolder.Form(
+            "ConVehicleListPage", "FmVehicle", FormPattern.SimpleList,
+            gridFields: ["VehicleId", "PurchaseDate"]);
+
+        Assert.Contains("i:type=\"AxFormStringControl\"", before);
+        Assert.DoesNotContain("AxFormDateControl", before);
+    }
+
+    [Fact]
+    public void A_resolver_that_throws_does_not_take_the_form_down_with_it()
+    {
+        var xml = XppScaffolder.Form(
+            "ConVehicleListPage", "FmVehicle", FormPattern.SimpleList,
+            gridFields: ["VehicleId"],
+            controlTypeResolver: _ => throw new InvalidOperationException("index is gone"));
+
+        Assert.Contains("i:type=\"AxFormStringControl\"", xml);
+    }
+}

--- a/tests/D365FO.Core.Tests/ObjectModifyEngineTests.cs
+++ b/tests/D365FO.Core.Tests/ObjectModifyEngineTests.cs
@@ -23,6 +23,7 @@ namespace D365FO.Core.Tests;
 ///
 /// Exercised against a fake in-process bridge, so no D365FO VM is involved.
 /// </summary>
+[Collection(EnvironmentCollectionDefinition.Name)]
 public sealed class ObjectModifyEngineTests : IDisposable
 {
     private readonly string _dbPath = Path.Combine(Path.GetTempPath(), $"objmodify-{Guid.NewGuid():N}.sqlite");

--- a/tests/D365FO.Core.Tests/ObjectShapeRulesTests.cs
+++ b/tests/D365FO.Core.Tests/ObjectShapeRulesTests.cs
@@ -1,0 +1,243 @@
+using D365FO.Core.Eval;
+using D365FO.Core.Validation;
+using Xunit;
+
+namespace D365FO.Core.Tests;
+
+/// <summary>
+/// XML009–XML013 — the per-family root-shape rules that close audit plan §1.4 / finding G9
+/// (issue #163): the offline approximation of what the bridge's <c>Handlers.WriteArtifact</c>
+/// rejects, driven by the object-type registry and the contract catalog rather than by an
+/// AxTable-shaped hand-written list.
+/// </summary>
+public class ObjectShapeRulesTests
+{
+    private static IReadOnlyList<XppViolation> Check(string xml, string? path = null)
+    {
+        var v = new List<XppViolation>();
+        ObjectShapeRules.Check(xml, v, path);
+        return v;
+    }
+
+    private static string[] Rules(IReadOnlyList<XppViolation> v) => v.Select(x => x.Rule).Distinct().Order().ToArray();
+
+    // ── XML009: the root has to name a real AOT type ─────────────────────────
+
+    [Theory]
+    [InlineData("AxTable")]
+    [InlineData("AxClass")]
+    [InlineData("AxEnum")]
+    [InlineData("AxQuerySimple")]
+    [InlineData("AxSecurityDuty")]
+    [InlineData("AxSecurityRole")]
+    [InlineData("AxSecurityPrivilege")]
+    [InlineData("AxDataEntityView")]
+    [InlineData("AxMap")]
+    [InlineData("AxView")]
+    public void Real_roots_are_accepted(string root)
+    {
+        var xsi = " xmlns:i=\"http://www.w3.org/2001/XMLSchema-instance\"";
+        Assert.Empty(Check($"<{root}{xsi}><Name>ConThing</Name></{root}>"));
+    }
+
+    [Fact]
+    public void An_invented_root_is_XML009()
+    {
+        var v = Check("<AxTabel><Name>ConThing</Name></AxTabel>");
+
+        Assert.Equal([ObjectShapeRules.RuleUnknownRoot], Rules(v));
+        Assert.Contains("AxTable", v[0].Fix);
+    }
+
+    [Fact]
+    public void A_root_the_registry_marks_as_absent_from_any_shipped_AOT_is_XML009()
+    {
+        // The G1 failure mode: a name that reads perfectly well and matches no folder on any
+        // AOS. A workspace is an AxForm carrying the Workspace pattern — there is no AxWorkspace
+        // folder to put one in, so an object written as one is invisible to everything.
+        var v = Check("<AxWorkspace><Name>ConVehicleWorkspace</Name></AxWorkspace>");
+
+        Assert.Equal([ObjectShapeRules.RuleUnknownRoot], Rules(v));
+        Assert.Contains("matches no folder", v[0].Fix);
+    }
+
+    [Fact]
+    public void The_root_G1_actually_shipped_is_XML009()
+    {
+        // AxWorkflowType was generated and read for years and names no MetaModel type at all.
+        var v = Check("<AxWorkflowType><Name>ConVehicleReview</Name></AxWorkflowType>");
+
+        Assert.Equal([ObjectShapeRules.RuleUnknownRoot], Rules(v));
+        Assert.Contains("No AOT type is named AxWorkflowType", v[0].Fix);
+    }
+
+    [Fact]
+    public void A_non_Ax_root_is_left_alone()
+    {
+        // Form-pattern fragments, .rnrproj files, anything the user pipes in — not AOT
+        // documents, so the rules have nothing to say about them.
+        Assert.Empty(Check("<Project><ItemGroup /></Project>"));
+    }
+
+    // ── XML010: abstract roots need a concrete i:type ────────────────────────
+
+    [Fact]
+    public void An_abstract_root_without_a_discriminator_is_XML010()
+    {
+        var v = Check("<AxEdt xmlns:i=\"http://www.w3.org/2001/XMLSchema-instance\"><Name>ConPlate</Name></AxEdt>");
+
+        Assert.Contains(ObjectShapeRules.RuleAbstractRoot, Rules(v));
+        Assert.Contains("AxEdtString", v.First(x => x.Rule == ObjectShapeRules.RuleAbstractRoot).Fix);
+    }
+
+    [Fact]
+    public void An_abstract_root_with_a_concrete_discriminator_is_accepted()
+    {
+        Assert.Empty(Check(
+            "<AxEdt xmlns:i=\"http://www.w3.org/2001/XMLSchema-instance\" i:type=\"AxEdtString\">" +
+            "<Name>ConPlate</Name></AxEdt>"));
+    }
+
+    [Fact]
+    public void A_discriminator_naming_no_type_is_XML010()
+    {
+        var v = Check(
+            "<AxEdt xmlns:i=\"http://www.w3.org/2001/XMLSchema-instance\" i:type=\"AxEdtText\">" +
+            "<Name>ConPlate</Name></AxEdt>");
+
+        Assert.Contains(ObjectShapeRules.RuleAbstractRoot, Rules(v));
+        Assert.Contains("No AOT type is named AxEdtText", v.First(x => x.Rule == ObjectShapeRules.RuleAbstractRoot).Fix);
+    }
+
+    [Fact]
+    public void A_discriminator_from_another_branch_is_XML010()
+    {
+        // AxTable is a real type, and it is not an EDT — a discriminator the reader cannot use
+        // to select anything under AxEdt.
+        var v = Check(
+            "<AxEdt xmlns:i=\"http://www.w3.org/2001/XMLSchema-instance\" i:type=\"AxTable\">" +
+            "<Name>ConPlate</Name></AxEdt>");
+
+        Assert.Contains(ObjectShapeRules.RuleAbstractRoot, Rules(v));
+        Assert.Contains("does not derive from AxEdt", v.First(x => x.Rule == ObjectShapeRules.RuleAbstractRoot).Fix);
+    }
+
+    // ── XML011: the schema-instance declaration ──────────────────────────────
+
+    [Fact]
+    public void An_i_type_with_no_namespace_in_scope_is_XML011()
+    {
+        // Written without xmlns:i the discriminators are unknown attributes and every field
+        // reads back as the abstract base (issue #91).
+        var v = Check(
+            "<AxTable><Name>ConVehicle</Name><Fields>" +
+            "<AxTableField xmlns:z=\"http://www.w3.org/2001/XMLSchema-instance\" z:type=\"AxTableFieldString\">" +
+            "<Name>Plate</Name></AxTableField></Fields></AxTable>");
+
+        Assert.Contains(ObjectShapeRules.RuleXsiNamespace, Rules(v));
+    }
+
+    [Fact]
+    public void An_enum_without_the_declaration_is_XML011_even_though_nothing_uses_it()
+    {
+        // Issue #70: the reader refuses the file outright, with no i:type anywhere in it.
+        var v = Check("<AxEnum><Name>ConVehicleStatus</Name></AxEnum>");
+
+        Assert.Equal([ObjectShapeRules.RuleXsiNamespace], Rules(v));
+        Assert.Contains("refuses to open", v[0].Fix);
+    }
+
+    [Fact]
+    public void Any_prefix_bound_to_the_schema_instance_uri_satisfies_XML011()
+    {
+        Assert.Empty(Check("<AxEnum xmlns:whatever=\"http://www.w3.org/2001/XMLSchema-instance\"><Name>ConVehicleStatus</Name></AxEnum>"));
+    }
+
+    // ── XML012: the contract namespace ───────────────────────────────────────
+
+    [Fact]
+    public void A_menu_item_outside_its_V1_namespace_is_XML012()
+    {
+        var v = Check("<AxMenuItemDisplay><Name>ConVehicleMenuItem</Name></AxMenuItemDisplay>");
+
+        Assert.Equal([ObjectShapeRules.RuleContractNamespace], Rules(v));
+        Assert.Contains("Microsoft.Dynamics.AX.Metadata.V1", v[0].Fix);
+    }
+
+    [Fact]
+    public void A_menu_item_in_its_V1_namespace_is_accepted()
+    {
+        Assert.Empty(Check(
+            "<AxMenuItemDisplay xmlns=\"Microsoft.Dynamics.AX.Metadata.V1\"><Name>ConVehicleMenuItem</Name></AxMenuItemDisplay>"));
+    }
+
+    [Fact]
+    public void A_table_carrying_a_namespace_it_does_not_contract_into_is_XML012()
+    {
+        var v = Check(
+            "<AxTable xmlns=\"Microsoft.Dynamics.AX.Metadata.V2\" xmlns:i=\"http://www.w3.org/2001/XMLSchema-instance\">" +
+            "<Name>ConVehicle</Name></AxTable>");
+
+        Assert.Equal([ObjectShapeRules.RuleContractNamespace], Rules(v));
+        Assert.Contains("Drop the xmlns", v[0].Fix);
+    }
+
+    // ── XML013: the AOT folder a file sits in ────────────────────────────────
+
+    [Fact]
+    public void A_class_document_in_the_AxTable_folder_is_XML013()
+    {
+        var path = Path.Combine("C:", "Model", "Model", "AxTable", "ConVehicleHelper.xml");
+        var v = Check("<AxClass><Name>ConVehicleHelper</Name></AxClass>", path);
+
+        Assert.Equal([ObjectShapeRules.RuleFolderMismatch], Rules(v));
+        Assert.Contains("AxClass", v[0].Fix);
+    }
+
+    [Fact]
+    public void A_document_in_its_own_folder_is_accepted()
+    {
+        var path = Path.Combine("C:", "Model", "Model", "AxClass", "ConVehicleHelper.xml");
+        Assert.Empty(Check("<AxClass><Name>ConVehicleHelper</Name></AxClass>", path));
+    }
+
+    [Fact]
+    public void A_document_outside_the_AOT_says_nothing_about_its_folder()
+    {
+        // A scaffold parked at an arbitrary --out path is not in the AOT and is not a defect.
+        var path = Path.Combine("C:", "scratch", "ConVehicleHelper.xml");
+        Assert.Empty(Check("<AxClass><Name>ConVehicleHelper</Name></AxClass>", path));
+    }
+
+    [Fact]
+    public void A_document_with_no_path_says_nothing_about_its_folder()
+    {
+        Assert.Empty(Check("<AxClass><Name>ConVehicleHelper</Name></AxClass>"));
+    }
+
+    // ── The CI sweep §1.4 actually asked for ─────────────────────────────────
+
+    [Fact]
+    public void Every_reviewed_golden_passes_the_per_family_root_rules()
+    {
+        var root = EvalPaths.FindRepoRoot();
+        Assert.NotNull(root);
+        var goldens = Path.Combine(EvalPaths.GoldensDir(root!));
+        Assert.True(Directory.Exists(goldens), $"goldens directory not found at {goldens}");
+
+        var offenders = new List<string>();
+        var checkedFiles = 0;
+
+        foreach (var file in Directory.EnumerateFiles(goldens, "*.xml", SearchOption.AllDirectories))
+        {
+            checkedFiles++;
+            var violations = new List<XppViolation>();
+            ObjectShapeRules.Check(File.ReadAllText(file), violations, file);
+            foreach (var v in violations)
+                offenders.Add($"{Path.GetRelativePath(goldens, file)}: {v.Rule} {v.Excerpt} — {v.Fix}");
+        }
+
+        Assert.True(checkedFiles > 0, "no golden documents were found to check");
+        Assert.Empty(offenders);
+    }
+}

--- a/tests/D365FO.Core.Tests/PropertyHonestyTests.cs
+++ b/tests/D365FO.Core.Tests/PropertyHonestyTests.cs
@@ -1,0 +1,87 @@
+using D365FO.Core.Scaffolding;
+using Xunit;
+
+namespace D365FO.Core.Tests;
+
+/// <summary>
+/// R6 (issue #161) — the request-vs-written diff. The defect class it exists for is an option
+/// that is accepted, reported as a success, and simply not in the file.
+/// </summary>
+public class PropertyHonestyTests
+{
+    private const string Table =
+        "<AxTable><Name>ConVehicle</Name><Label>@Con:VehicleLabel</Label><TableGroup>Main</TableGroup>" +
+        "<Fields><AxTableField><Name>Plate</Name><ExtendedDataType>Name</ExtendedDataType>" +
+        "<Mandatory>Yes</Mandatory></AxTableField></Fields></AxTable>";
+
+    [Fact]
+    public void A_value_that_reached_the_document_is_not_a_gap()
+    {
+        Assert.Empty(PropertyHonesty.Reconcile([("--label", "@Con:VehicleLabel")], Table));
+    }
+
+    [Fact]
+    public void A_value_that_reached_nothing_is_reported_with_its_option()
+    {
+        var gaps = PropertyHonesty.Reconcile([("--configuration-key", "ConFleetKey")], Table);
+
+        var gap = Assert.Single(gaps);
+        Assert.Equal("--configuration-key", gap.Option);
+        Assert.Equal("ConFleetKey", gap.Missing);
+        Assert.Contains("not in the generated object", gap.ToString());
+    }
+
+    [Fact]
+    public void A_composite_spec_is_judged_piece_by_piece()
+    {
+        // The field arrived and so did its EDT — but nothing carried the second field.
+        var gaps = PropertyHonesty.Reconcile(
+            [("--field", "Plate:Name:mandatory"), ("--field", "Colour:ConColour")],
+            Table);
+
+        Assert.Equal(
+            new[] { "Colour", "ConColour" },
+            gaps.Select(g => g.Missing).Order().ToArray());
+    }
+
+    [Fact]
+    public void Element_names_count_as_much_as_values()
+    {
+        // "mandatory" arrives as <Mandatory>, whose value is "Yes" — searching values alone
+        // would report a gap for a request that was honoured.
+        Assert.Empty(PropertyHonesty.Reconcile([("--field", "Plate:Name:mandatory")], Table));
+    }
+
+    [Fact]
+    public void Matching_ignores_case()
+    {
+        // --pattern main lands as <TableGroup>Main</TableGroup>.
+        Assert.Empty(PropertyHonesty.Reconcile([("--pattern", "main")], Table));
+    }
+
+    [Theory]
+    [InlineData("true")]
+    [InlineData("No")]
+    [InlineData("default")]
+    [InlineData("x")]
+    public void Values_that_select_a_shape_rather_than_supply_one_are_not_traced(string value)
+    {
+        Assert.Empty(PropertyHonesty.Reconcile([("--flagish", value)], Table));
+    }
+
+    [Fact]
+    public void An_empty_request_says_nothing()
+    {
+        Assert.Empty(PropertyHonesty.Reconcile([], Table));
+        Assert.Empty(PropertyHonesty.Reconcile([("--label", "  ")], Table));
+    }
+
+    [Fact]
+    public void An_unparseable_document_falls_back_to_its_raw_text()
+    {
+        // A caller holding broken XML has a bigger problem than this; it should not also get a
+        // wall of gaps for values that are plainly there.
+        const string broken = "<AxTable><Name>ConVehicle</Name>";
+        Assert.Empty(PropertyHonesty.Reconcile([("<NAME>", "ConVehicle")], broken));
+    }
+}

--- a/tests/D365FO.Core.Tests/ProvenanceStoreTests.cs
+++ b/tests/D365FO.Core.Tests/ProvenanceStoreTests.cs
@@ -3,6 +3,7 @@ using Xunit;
 
 namespace D365FO.Core.Tests;
 
+[Collection(EnvironmentCollectionDefinition.Name)]
 public class ProvenanceStoreTests : IDisposable
 {
     private readonly string _home = Path.Combine(Path.GetTempPath(), $"d365fo-home-{Guid.NewGuid():N}");

--- a/tests/D365FO.Core.Tests/ScaffoldFileWriterAtomicityTests.cs
+++ b/tests/D365FO.Core.Tests/ScaffoldFileWriterAtomicityTests.cs
@@ -1,0 +1,97 @@
+using System.Xml.Linq;
+using D365FO.Core.Scaffolding;
+using Xunit;
+
+namespace D365FO.Core.Tests;
+
+/// <summary>
+/// Pins the write path's "atomic" claim (issue #158): a <see cref="ScaffoldFileWriter.Write"/>
+/// that returns normally has left the file on disk, and concurrent writers do not interfere.
+/// </summary>
+/// <remarks>
+/// The reported symptom was a scaffold write that returned successfully and a file that was
+/// gone when the caller looked — three writes, two files. Two things made that possible and
+/// both are covered here: the staging sibling used to be the deterministic
+/// <c>&lt;target&gt;.tmp</c>, shared by every writer aiming at that target, and nothing checked
+/// that the rename had actually published the file.
+/// </remarks>
+// In the non-parallel Environment collection deliberately, and with the degree of parallelism
+// pinned. These tests exist to put the write path under contention, and an unbounded
+// Parallel.ForEach grows the shared thread pool — which then makes the *rest* of the suite run
+// at a concurrency it was never stable at. Measured: five clean full-suite runs before these
+// tests existed, two unrelated SQLite tests going red across seven runs after. Four writers is
+// already more than the one-writer-per-target race needs.
+[Collection(EnvironmentCollectionDefinition.Name)]
+public sealed class ScaffoldFileWriterAtomicityTests : IDisposable
+{
+    private readonly string _dir = Path.Combine(Path.GetTempPath(), $"sfw-atomic-{Guid.NewGuid():N}");
+
+    public ScaffoldFileWriterAtomicityTests() => Directory.CreateDirectory(_dir);
+
+    public void Dispose()
+    {
+        try { Directory.Delete(_dir, recursive: true); } catch { }
+    }
+
+    /// <summary>Enough writers to race, few enough not to reshape the thread pool.</summary>
+    private static readonly ParallelOptions Bounded = new() { MaxDegreeOfParallelism = 4 };
+
+    private static XDocument TableDoc(string name) => XDocument.Parse(
+        $"<AxTable xmlns:i=\"http://www.w3.org/2001/XMLSchema-instance\"><Name>{name}</Name></AxTable>");
+
+    [Fact]
+    public void A_successful_write_leaves_no_staging_file_behind()
+    {
+        ScaffoldFileWriter.Write(TableDoc("Solo"), Path.Combine(_dir, "Solo.xml"));
+
+        Assert.Empty(Directory.GetFiles(_dir, "*.tmp"));
+        Assert.True(File.Exists(Path.Combine(_dir, "Solo.xml")));
+    }
+
+    [Fact]
+    public void Concurrent_writes_into_one_directory_all_land()
+    {
+        var names = Enumerable.Range(0, 16).Select(i => $"ConVehicle{i:D2}").ToArray();
+
+        Parallel.ForEach(names, Bounded, name =>
+            ScaffoldFileWriter.Write(TableDoc(name), Path.Combine(_dir, name + ".xml")));
+
+        Assert.Equal(
+            names.Select(n => n + ".xml").Order().ToArray(),
+            Directory.GetFiles(_dir, "*.xml").Select(Path.GetFileName).Order().ToArray()!);
+        Assert.Empty(Directory.GetFiles(_dir, "*.tmp"));
+
+        // Every file holds its own document — not a neighbour's, which is what a shared
+        // staging name would produce.
+        foreach (var name in names)
+            Assert.Equal(name, XDocument.Load(Path.Combine(_dir, name + ".xml")).Root!.Element("Name")!.Value);
+    }
+
+    [Fact]
+    public void Concurrent_writers_racing_one_path_never_publish_a_torn_document()
+    {
+        var target = Path.Combine(_dir, "Contended.xml");
+        File.WriteAllText(target, "<AxTable><Name>Seed</Name></AxTable>");
+
+        // Writers that lose the race are allowed to fail — what is not allowed is a write that
+        // reports success while the file holds someone else's half-staged bytes, or no file at
+        // all. Before the fix each writer staged through the same "<target>.tmp".
+        //
+        // Both exception types count as losing. The .bak sibling deliberately keeps a fixed
+        // name — it exists so a human can find it — so concurrent overwrites of one path still
+        // contend there, and on Windows that contention surfaces as UnauthorizedAccessException
+        // rather than IOException. Only the staging file needed to become private.
+        Parallel.For(0, 24, Bounded, i =>
+        {
+            try { ScaffoldFileWriter.Write(TableDoc($"Racer{i:D2}"), target, overwrite: true); }
+            catch (IOException) { /* lost the rename race — acceptable */ }
+            catch (UnauthorizedAccessException) { /* lost the .bak race — acceptable */ }
+        });
+
+        Assert.True(File.Exists(target));
+        var name = XDocument.Load(target).Root!.Element("Name")!.Value;
+        Assert.True(name == "Seed" || name.StartsWith("Racer", StringComparison.Ordinal),
+            $"target holds an unexpected document: {name}");
+        Assert.Empty(Directory.GetFiles(_dir, "*.tmp"));
+    }
+}

--- a/tests/D365FO.Core.Tests/ScaffoldFileWriterJournalTests.cs
+++ b/tests/D365FO.Core.Tests/ScaffoldFileWriterJournalTests.cs
@@ -10,7 +10,7 @@ namespace D365FO.Core.Tests;
 /// <c>generate *</c> CLI command and the MCP <c>generate_object</c> tool funnel disk writes
 /// through — journals every write (issue #113) without the caller having to opt in.
 /// </summary>
-[Collection("ScaffoldFileWriter")]
+[Collection(EnvironmentCollectionDefinition.Name)]
 public sealed class ScaffoldFileWriterJournalTests : IDisposable
 {
     private readonly string _dir = Path.Combine(Path.GetTempPath(), $"sfw-journal-{Guid.NewGuid():N}");

--- a/tests/D365FO.Core.Tests/SecurityDepthTests.cs
+++ b/tests/D365FO.Core.Tests/SecurityDepthTests.cs
@@ -1,0 +1,209 @@
+using System.Xml.Linq;
+using D365FO.Core.Metadata;
+using D365FO.Core.Scaffolding;
+using D365FO.Core.Validation;
+using Xunit;
+
+namespace D365FO.Core.Tests;
+
+/// <summary>
+/// Issue #162, security half: duty and role depth beyond reference lists, the policy's
+/// <c>ConstrainedTables</c> tree, and the property-modification payloads that make a duty/role
+/// extension able to change the base object rather than only add to it.
+/// </summary>
+/// <remarks>
+/// Every assertion here is paired with a contract check: the point is not that the scaffolder
+/// emits some element, it is that the element is one the AOT type actually declares. An
+/// invented member is dropped in silence, so a test that only asserts on our own output would
+/// pass just as happily for a file the provider reads as empty.
+/// </remarks>
+public class SecurityDepthTests
+{
+    private static XElement Root(XDocument doc) => doc.Root!;
+
+    private static string? Value(XElement root, string name) =>
+        root.Elements().FirstOrDefault(e => e.Name.LocalName == name)?.Value;
+
+    private static IReadOnlyList<XppViolation> Shape(XDocument doc)
+    {
+        var v = new List<XppViolation>();
+        var xml = doc.ToString(SaveOptions.DisableFormatting);
+        ObjectShapeRules.Check(xml, v);
+        ContractShapeRules.Check(xml, v);
+        return v;
+    }
+
+    // ── duty depth ───────────────────────────────────────────────────────────
+
+    [Fact]
+    public void A_duty_carries_description_enabled_and_context_string()
+    {
+        var doc = XppScaffolder.Duty(
+            "ConVehicleMaintainDuty", ["ConVehiclePriv"], label: "@Con:Duty",
+            description: "Maintain fleet vehicles", enabled: false, contextString: "ConFleet");
+
+        var root = Root(doc);
+        Assert.Equal("Maintain fleet vehicles", Value(root, "Description"));
+        Assert.Equal("No", Value(root, "Enabled"));
+        Assert.Equal("ConFleet", Value(root, "ContextString"));
+        Assert.Equal("@Con:Duty", Value(root, "Label"));
+        Assert.Empty(Shape(doc));
+    }
+
+    [Fact]
+    public void Duty_depth_names_only_real_members()
+    {
+        var contract = MetadataContracts.Find("AxSecurityDuty")!;
+        foreach (var member in new[] { "Description", "Enabled", "ContextString", "Label", "Privileges" })
+            Assert.True(MetadataContracts.AcceptsMember(contract, member), member);
+    }
+
+    [Fact]
+    public void An_unasked_for_duty_property_is_left_out_entirely()
+    {
+        // The AOT default is enabled; writing Enabled=Yes everywhere would make every generated
+        // duty differ from the shipped ones for no reason.
+        var root = Root(XppScaffolder.Duty("ConVehicleDuty", ["ConVehiclePriv"]));
+
+        Assert.Null(Value(root, "Enabled"));
+        Assert.Null(Value(root, "Description"));
+        Assert.Null(Value(root, "ContextString"));
+    }
+
+    [Fact]
+    public void A_privilege_reference_can_be_listed_but_switched_off()
+    {
+        var doc = XppScaffolder.Duty(
+            "ConVehicleDuty", [],
+            privilegeRefs: [
+                new XppScaffolder.SecurityReferenceSpec("ConVehicleRead"),
+                new XppScaffolder.SecurityReferenceSpec("ConVehicleWrite", Enabled: false),
+            ]);
+
+        var refs = Root(doc).Element("Privileges")!.Elements().ToArray();
+        Assert.Equal(2, refs.Length);
+        Assert.Null(refs[0].Element("Enabled"));
+        Assert.Equal("No", refs[1].Element("Enabled")!.Value);
+
+        // Enabled precedes Name in AxSecurityPrivilegeReference's contract; the other order
+        // loses the flag on read.
+        Assert.Equal(["Enabled", "Name"], refs[1].Elements().Select(e => e.Name.LocalName).ToArray());
+        Assert.Empty(Shape(doc));
+    }
+
+    // ── role depth ───────────────────────────────────────────────────────────
+
+    [Fact]
+    public void A_role_can_compose_other_roles()
+    {
+        var doc = XppScaffolder.Role(
+            "ConFleetManager", duties: ["ConVehicleMaintainDuty"], subRoles: ["ConFleetViewer"],
+            contextString: "ConFleet", enabled: false, canBeDeletedFromUI: false);
+
+        var root = Root(doc);
+        var subRoles = root.Element("SubRoles")!.Elements().ToArray();
+        Assert.Equal("AxSecurityRoleReference", Assert.Single(subRoles).Name.LocalName);
+        Assert.Equal("ConFleetViewer", subRoles[0].Element("Name")!.Value);
+        Assert.Equal("ConFleet", Value(root, "ContextString"));
+        Assert.Equal("No", Value(root, "Enabled"));
+        Assert.Equal("No", Value(root, "CanBeDeletedFromUI"));
+        Assert.Empty(Shape(doc));
+    }
+
+    [Fact]
+    public void Role_depth_names_only_real_members()
+    {
+        var contract = MetadataContracts.Find("AxSecurityRole")!;
+        foreach (var member in new[] { "SubRoles", "ContextString", "Enabled", "CanBeDeletedFromUI", "Description" })
+            Assert.True(MetadataContracts.AcceptsMember(contract, member), member);
+    }
+
+    // ── extension property modifications ─────────────────────────────────────
+
+    [Fact]
+    public void A_duty_extension_can_override_a_property_of_the_base_duty()
+    {
+        var doc = XppScaffolder.SecurityDutyExtension(
+            "MaintainVehicleServiceDuty", "Con", ["ConVehiclePriv"],
+            [new XppScaffolder.PropertyModificationSpec("Enabled", "No")]);
+
+        var mods = Root(doc).Element("PropertyModifications")!.Elements().ToArray();
+        var mod = Assert.Single(mods);
+        Assert.Equal("AxPropertyModification", mod.Name.LocalName);
+        Assert.Equal("Enabled", mod.Element("Name")!.Value);
+        Assert.Equal("No", mod.Element("Value")!.Value);
+        Assert.Empty(Shape(doc));
+    }
+
+    [Fact]
+    public void A_role_extension_can_override_a_property_of_the_base_role()
+    {
+        var doc = XppScaffolder.SecurityRoleExtension(
+            "FleetManager", "Con", duties: ["ConVehicleDuty"], privileges: null,
+            propertyModifications: [
+                new XppScaffolder.PropertyModificationSpec("Description", "Contoso fleet manager"),
+                new XppScaffolder.PropertyModificationSpec("ContextString", "ConFleet"),
+            ]);
+
+        var mods = Root(doc).Element("PropertyModifications")!.Elements().ToArray();
+        Assert.Equal(2, mods.Length);
+        Assert.Equal(["Description", "ContextString"], mods.Select(m => m.Element("Name")!.Value).ToArray());
+        Assert.Empty(Shape(doc));
+    }
+
+    [Fact]
+    public void An_extension_with_no_overrides_still_emits_the_empty_collection()
+    {
+        // Shipped extensions carry the element; dropping it would make every generated file
+        // differ from the real ones without changing what the provider reads.
+        Assert.NotNull(Root(XppScaffolder.SecurityDutyExtension("D", "Con")).Element("PropertyModifications"));
+        Assert.NotNull(Root(XppScaffolder.SecurityRoleExtension("R", "Con")).Element("PropertyModifications"));
+    }
+
+    // ── policy constrained tables ────────────────────────────────────────────
+
+    [Fact]
+    public void A_policy_can_name_the_tables_it_reaches_beyond_the_primary_one()
+    {
+        var doc = SecurityPolicyScaffolder.Policy(
+            "ConFleetPolicy", "FmVehicle", "ConFleetPolicyQuery",
+            constrainedTables: [
+                new SecurityPolicyScaffolder.ConstrainedEntity("FmVehicleService", Constrained: false,
+                    Children: [new SecurityPolicyScaffolder.ConstrainedEntity("FmVehicleServiceLine")]),
+            ]);
+
+        var entities = Root(doc).Element("ConstrainedTables")!.Elements().ToArray();
+        var header = Assert.Single(entities);
+        Assert.Equal("AxSecurityPolicyConstrainedEntity", header.Name.LocalName);
+        Assert.Equal("No", header.Element("Constrained")!.Value);
+        Assert.Equal("FmVehicleService", header.Element("Name")!.Value);
+
+        var line = Assert.Single(header.Element("ConstrainedTables")!.Elements());
+        Assert.Equal("FmVehicleServiceLine", line.Element("Name")!.Value);
+        Assert.Equal("Yes", line.Element("Constrained")!.Value);
+
+        // Constrained precedes Name in the contract — the other order loses the flag.
+        Assert.Equal("Constrained", header.Elements().First().Name.LocalName);
+        Assert.Empty(Shape(doc));
+    }
+
+    [Fact]
+    public void A_policy_without_constrained_tables_is_unchanged()
+    {
+        var doc = SecurityPolicyScaffolder.Policy("ConFleetPolicy", "FmVehicle", "ConFleetPolicyQuery");
+        Assert.Empty(Root(doc).Element("ConstrainedTables")!.Elements());
+        Assert.Empty(Shape(doc));
+    }
+
+    [Fact]
+    public void AxSecurityPolicy_has_no_PolicyGroup_member()
+    {
+        // Recorded as a test, not a comment: "PolicyGroup" was on the list of things this
+        // scaffolder was missing, and the metadata assembly says the type has no such member.
+        // Emitting one would be XML007 — dropped on read, file still looks right.
+        var contract = MetadataContracts.Find("AxSecurityPolicy")!;
+
+        Assert.False(MetadataContracts.AcceptsMember(contract, "PolicyGroup"));
+        Assert.True(MetadataContracts.AcceptsMember(contract, "ConstrainedTables"));
+    }
+}

--- a/tests/D365FO.Core.Tests/WorkflowScaffolderTests.cs
+++ b/tests/D365FO.Core.Tests/WorkflowScaffolderTests.cs
@@ -186,7 +186,11 @@ public class WorkflowScaffolderTests
                 WorkflowScaffolder.WorkflowTask("ConVehicleTask", "ConVehicleReviewDocument"),
                 Path.Combine(dir, "ConVehicleTask.xml"));
 
-            Assert.Equal(3, Directory.GetFiles(dir, "*.xml").Length);
+            // Listed, not counted (issue #158): when this went red the message said
+            // "Expected 3, Actual 2" and nothing about which write was missing.
+            Assert.Equal(
+                new[] { "ConVehicleApproval.xml", "ConVehicleReview.xml", "ConVehicleTask.xml" },
+                Directory.GetFiles(dir, "*.xml").Select(Path.GetFileName).Order().ToArray());
         }
         finally
         {


### PR DESCRIPTION
Works every issue open on `main`. One commit per issue, each building standalone; full suite green (1148 tests, five consecutive clean runs — same as the pre-change baseline).

| Issue | State | Commit |
|-------|-------|--------|
| #158 flaky write path | **closed** | `b267ef7` |
| #163 per-family shape check | **closed** | `2edd59f` |
| #162 security / entity depth | **closed** | `ea4f84a` |
| #164 R5 form-engine extras | **partial** | `5377492` |
| #161 uniform grounding gate + property honesty | **closed** | `a0cee69` |
| #160 L4 runtime oracle | **partial** | `9a86005`, `1a9eac4` |

## What is actually fixed

**#158** was a real defect, not just contention. The staging sibling was the deterministic `<target>.tmp`, shared by every writer aiming at that target, and nothing checked that the rename had published anything. Both closed; the env-mutating test classes now share one non-parallel collection.

**#163** is closed by adding the checks rather than writing the confirmation. XML009–XML013 cover the document root for every AOT family, driven by `ObjectTypeRegistry` + the 565-type contract catalog, and map onto what the bridge's `WriteArtifact` rejects. A test runs them over all 60 reviewed goldens. No member-order lint — the evidence does not support one, and the reasoning is recorded in the code.

**#162** covers duty/role depth, `SubRoles`, extension `PropertyModifications`, the nested `ConstrainedTables` tree, entity relations, computed columns and the DMF staging table.

**#161** puts the gate on the shared path and makes `GenerateInstaller.Write` take the gate result, so bypassing it is not expressible. All 29 subcommands, up from 3. Property honesty (R6) is reflection-driven so it cannot go stale.

**#164** absorbs the one R5 item that was a defect rather than a convenience.

**#160** fixes the runner invocation *and* lands the result parser the issue said did not exist.

## Findings worth recording

**`AxSecurityPolicy` has no `PolicyGroup` member.** It was on #162's list. The catalog generated from `Microsoft.Dynamics.AX.Metadata.dll` lists `ConstrainedTable, ContextString, ContextType, Enabled, HelpText, IsObsolete, Label, Operation, PrimaryTable, Query, RoleName, Tags, UseNotExistJoin, Visibility, ConstrainedTables` and nothing else. Emitting a `PolicyGroup` would be XML007 — dropped on read, file still looks right. Pinned as a test. ([detail on #162](https://github.com/dynamics365ninja/d365fo-cli/issues/162#issuecomment-5208285714))

**`d365fo test run` invoked a binary that exists nowhere.** It defaulted to `SysTestRunner.exe --suite <name>`; the shipped runner is `SysTestConsole.exe` with `/test:`, `/xml:`, `/granularity:`, `/parallel`. The `--suite` argv fix noted in #160 was fixing the wrong tool.

**The SysTest result schema is discoverable from X++, not from the binary.** It is absent from the runner's string table, XML doc and any embedded stylesheet — but `ApplicationFoundation\AxClass\SysTestListenerXML.xml` ships as source and declares the element names as `#define`s. Two traps, both pinned by tests: `success` is a *pass* flag despite `isFailure()` producing it, and `execution="pending"` cases still carry `success="true"`, so a run that died half way would read as clean. ([detail on #160](https://github.com/dynamics365ninja/d365fo-cli/issues/160#issuecomment-5208328090))

## What is deliberately not here

- **#164 / R3 (RDL precision design)** — stays out. A wrong RDL renders wrongly rather than failing to load, so absorbing it needs a rendering oracle. That evidence base does not exist here, which is what the issue already said.
- **#164 / R5** — `formCloner` and `crossCheck` not ported.
- **#160 — the oracle itself.** The parser and the scorecard slot are here; provisioning a case's fixtures into a real model and scoring the catalog on a VM are not. One more blocker found on the way: `SysTestConsole.exe` calls `WaitForDebugger()` *before* parsing its arguments and throws on a redirected stdin, so it cannot be driven headless as shipped.

Suggest closing #158, #163, #162, #161 on merge and leaving #164 and #160 open with the remainder above.

## Ground truth used

This work was done on a host with a live D365FO installation, so several decisions are mined rather than reasoned:

- staging-table shape — 4,611 shipped `*Staging` tables, 400 sampled, 398 agreeing
- field → form control type — 1,200 shipped `AxForm` files joined against 1,500 `AxTable` files
- SysTest result schema — the X++ source of `SysTestListenerXML`
- `SysTestConsole.exe` options — the binary's own usage output
- suite stability — five clean full-suite runs on unmodified `main` as the baseline the branch is held to

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SuTvn5ymx3HAUtGjsxBuaA
