### PR TITLE
Fix the red eval gate, and the form-clone defect the stale row was hiding

### DIFF
--- a/eval/COVERAGE.md
+++ b/eval/COVERAGE.md
@@ -14,7 +14,7 @@ Every column is derived — families from `ObjectTypeRegistry`, capabilities fro
 file cannot claim coverage that no longer exists. Regenerate with
 `d365fo eval coverage --write`; CI runs `--check`.
 
-**42 of 70 leaves complete.**
+**42 of 71 leaves complete.**
 
 ## AOT families
 
@@ -30,7 +30,7 @@ file cannot claim coverage that no longer exists. Regenerate with
 | `AxEdtExtension` | edtextension | — | ✅ | ✅ | — | `L2-edt-extension` | generate extension |
 | `AxEnum` | enum | ✅ | ✅ | ✅ | `event-handler-authoring`, `object-extension-authoring` | `L0-enum-basic`, `L0-enum-non-extensible` | generate enum |
 | `AxEnumExtension` | enumextension | — | ✅ | ✅ | — | `L2-enum-extension` | generate extension |
-| `AxForm` | form | ✅ | ✅ | ✅ | `coc-extension-authoring`, `data-entity-scaffolding`, `event-handler-authoring`, `form-pattern-scaffolding`, `label-translation`, `model-dependency-and-coupling`, `object-extension-authoring`, `review-and-checkpoint-workflow`, `security-hierarchy-trace`, `table-scaffolding`, `x++-class-authoring`, `xpp-best-practice-rules`, `xpp-class-and-method-rules`, `xpp-database-queries`, `xpp-statement-and-type-rules` | `L1-form-basic`, `L1-form-details-master`, `L1-form-details-transaction`, `L1-form-dialog`, `L1-form-list-page`, `L1-form-lookup`, `L1-form-simplelist-details`, `L1-form-table-of-contents`, `L1-form-workspace`, `L2-control-method-basic`, `L2-datasource-method-basic` | generate form |
+| `AxForm` | form | ✅ | ✅ | ✅ | `coc-extension-authoring`, `data-entity-scaffolding`, `event-handler-authoring`, `form-pattern-scaffolding`, `label-translation`, `model-dependency-and-coupling`, `object-extension-authoring`, `review-and-checkpoint-workflow`, `security-hierarchy-trace`, `table-scaffolding`, `x++-class-authoring`, `xpp-best-practice-rules`, `xpp-class-and-method-rules`, `xpp-database-queries`, `xpp-statement-and-type-rules` | `L1-form-basic`, `L1-form-details-master`, `L1-form-details-transaction`, `L1-form-dialog`, `L1-form-list-page`, `L1-form-lookup`, `L1-form-simplelist-details`, `L1-form-table-of-contents`, `L1-form-workspace`, `L2-control-method-basic`, `L2-datasource-method-basic`, `L2-form-clone-basic` | generate form |
 | `AxFormExtension` | formextension | ✅ | ✅ | ✅ | `form-pattern-scaffolding`, `review-and-checkpoint-workflow` | `L2-form-extension-basic` | generate extension |
 | `AxFormPart` | formpart | — | — | — | — | — | — |
 | `AxLabelFile` | labelfile | ✅ | — | — | `label-translation` | — | — |
@@ -75,6 +75,7 @@ whether it is taught and proven.
 | `generate form` | AxForm | ✅ | ✅ | `form-pattern-scaffolding` | `L1-form-basic`, `L1-form-details-master`, `L1-form-details-transaction`, `L1-form-dialog`, `L1-form-list-page`, `L1-form-lookup`, `L1-form-simplelist-details`, `L1-form-table-of-contents`, `L1-form-workspace` |
 | `generate datasource-method` | AxForm | — | ✅ | — | `L2-datasource-method-basic` |
 | `generate control-method` | AxForm | — | ✅ | — | `L2-control-method-basic` |
+| `generate form-clone` | AxForm | — | ✅ | — | `L2-form-clone-basic` |
 | `generate simple-list` | deprecated alias | — | — | — | — |
 | `generate entity` | AxDataEntityView | ✅ | ✅ | `data-entity-scaffolding`, `integration-dmf-dualwrite`, `integration-patterns` | `L2-virtual-entity-basic` |
 | `generate extension` | AxTableExtension, AxFormExtension, AxEdtExtension, AxEnumExtension, AxViewExtension, AxQuerySimpleExtension, AxDataEntityViewExtension, AxSecurityDutyExtension, AxSecurityRoleExtension | ✅ | ✅ | `forms-and-navigation`, `object-extension-authoring`, `xpp-best-practice-rules` | `L2-edt-extension`, `L2-enum-extension`, `L2-form-extension-basic`, `L2-security-duty-extension`, `L2-security-role-extension`, `L2-table-extension` |
@@ -106,6 +107,7 @@ cannot build at all are omitted — they are a generation gap, not a coverage ga
 
 - **control-method** (capability) — no topic names it
 - **datasource-method** (capability) — no topic names it
+- **form-clone** (capability) — no topic names it
 - **map** (capability) — no topic names it
 - **simple-list** (capability) — no topic names it; no case with a reviewed golden
 - **systest** (capability) — no topic names it

--- a/eval/cases/L2-form-clone-basic.json
+++ b/eval/cases/L2-form-clone-basic.json
@@ -1,0 +1,13 @@
+{
+  "id": "L2-form-clone-basic",
+  "title": "Clone a two-datasource details-transaction form under a new name",
+  "tier": 2,
+  "instruction": "Clone the existing form eval/goldens/L1-form-details-transaction/ConFmVehicleServiceOrder.xml as ConFmVehicleServiceOrderInquiry. The clone keeps the original's pattern, both datasources and their join, and its whole control tree — only the form's own self-references (root name, class declaration, formStr) take the new name. Use only the d365fo CLI (search/get/generate/validate) — do not hand-write XML.",
+  "canonical_args": ["generate", "form-clone", "ConFmVehicleServiceOrderInquiry", "--from", "eval/goldens/L1-form-details-transaction/ConFmVehicleServiceOrder.xml"],
+  "target_artifact_types": ["AxForm"],
+  "golden_path": "L2-form-clone-basic",
+  "tags": ["form-clone", "form", "metadata"],
+  "ignore": [],
+  "requires_fixture_index": false,
+  "golden_pending": false
+}

--- a/eval/goldens/L2-form-clone-basic/ConFmVehicleServiceOrderInquiry.xml
+++ b/eval/goldens/L2-form-clone-basic/ConFmVehicleServiceOrderInquiry.xml
@@ -1,0 +1,411 @@
+<?xml version="1.0" encoding="utf-8"?>
+
+<AxForm xmlns:i="http://www.w3.org/2001/XMLSchema-instance" xmlns="Microsoft.Dynamics.AX.Metadata.V6">
+  <Name>ConFmVehicleServiceOrderInquiry</Name>
+  <SourceCode>
+    <Methods xmlns="">
+      <Method>
+        <Name>classDeclaration</Name>
+        <Source><![CDATA[
+[Form]
+public class ConFmVehicleServiceOrderInquiry extends FormRun
+{
+}
+
+]]></Source>
+      </Method>
+    </Methods>
+    <DataSources xmlns="" />
+    <DataControls xmlns="" />
+    <Members xmlns="" />
+  </SourceCode>
+  <DataSources>
+    <AxFormDataSource xmlns="">
+      <Name>FmVehicle</Name>
+      <Table>FmVehicle</Table>
+      <Fields />
+      <ReferencedDataSources />
+      <InsertIfEmpty>No</InsertIfEmpty>
+      <DataSourceLinks />
+      <DerivedDataSources />
+    </AxFormDataSource>
+    <AxFormDataSource xmlns="">
+      
+      
+      
+      
+      
+      
+      
+      
+      
+    <Name>FmVehicleLine</Name><Table>FmVehicleLine</Table><Fields /><ReferencedDataSources /><JoinSource>FmVehicle</JoinSource><LinkType>Active</LinkType><InsertIfEmpty>No</InsertIfEmpty><DataSourceLinks /><DerivedDataSources /></AxFormDataSource>
+  </DataSources>
+  <!--
+    Shaped after the AOT registry's DetailsTransaction 1.4. It is Details Master's
+    layout with the details panel split in two: a title group, then a HeaderLinePanels
+    tab holding a Lines panel and a Header panel. The previous shape declared version
+    1.1, which exists on no installation, and put an ActionPaneTab straight under a tab
+    page, which the reader forbids.
+  -->
+  <Design>
+    <ArrangeMethod xmlns="">Vertical</ArrangeMethod>
+    <Caption xmlns="">Vehicle service order</Caption>
+    <Columns xmlns="">1</Columns>
+    <ColumnsMode xmlns="">Fixed</ColumnsMode>
+    <DataSource xmlns="">FmVehicle</DataSource>
+    <Pattern xmlns="">DetailsTransaction</Pattern>
+    <PatternVersion xmlns="">1.4</PatternVersion>
+    <Style xmlns="">DetailsFormTransaction</Style>
+    <TitleDataSource xmlns="">FmVehicle</TitleDataSource>
+    <Controls xmlns="">
+      <AxFormControl xmlns="" i:type="AxFormActionPaneControl">
+        <Name>ActionPane</Name>
+        <ElementPosition>134217727</ElementPosition>
+        <FilterExpression>%1</FilterExpression>
+        <Type>ActionPane</Type>
+        <VerticalSpacing>-1</VerticalSpacing>
+        <FormControlExtension i:nil="true" />
+        <Controls>
+          <AxFormControl xmlns="" i:type="AxFormButtonGroupControl">
+            <Name>ButtonGroup</Name>
+            <Type>ButtonGroup</Type>
+            <FormControlExtension i:nil="true" />
+            <Controls />
+            <ArrangeMethod>Vertical</ArrangeMethod>
+          </AxFormControl>
+        </Controls>
+        <AlignChild>No</AlignChild>
+        <AlignChildren>No</AlignChildren>
+        <ArrangeMethod>Vertical</ArrangeMethod>
+        <Style>Standard</Style>
+      </AxFormControl>
+      <AxFormControl xmlns="" i:type="AxFormGroupControl">
+        <Name>NavigationList</Name>
+        <Height>-1</Height>
+        <HeightMode>SizeToAvailable</HeightMode>
+        <Type>Group</Type>
+        <Visible>No</Visible>
+        <Width>-1</Width>
+        <WidthMode>SizeToContent</WidthMode>
+        <FormControlExtension i:nil="true" />
+        <Controls>
+          <!-- Unique control name; the extension name is what identifies the type. -->
+          <AxFormControl>
+            <Name>NavigationListQuickFilter</Name>
+            <WidthMode>SizeToAvailable</WidthMode>
+            <FormControlExtension>
+              <Name>QuickFilterControl</Name>
+              <ExtensionComponents />
+              <ExtensionProperties>
+                <AxFormControlExtensionProperty>
+                  <Name>targetControlName</Name>
+                  <Type>String</Type>
+                  <Value>NavigationListGrid</Value>
+                </AxFormControlExtensionProperty>
+              </ExtensionProperties>
+            </FormControlExtension>
+          </AxFormControl>
+          <AxFormControl xmlns="" i:type="AxFormGridControl">
+            <Name>NavigationListGrid</Name>
+            <AllowEdit>No</AllowEdit>
+            <Height>-1</Height>
+            <HeightMode>SizeToAvailable</HeightMode>
+            <Type>Grid</Type>
+            <Width>-1</Width>
+            <WidthMode>SizeToContent</WidthMode>
+            <FormControlExtension i:nil="true" />
+            <Controls />
+            <DataSource>FmVehicle</DataSource>
+            <MultiSelect>No</MultiSelect>
+            <ShowRowLabels>No</ShowRowLabels>
+            <Style>List</Style>
+          </AxFormControl>
+        </Controls>
+        <ArrangeMethod>Vertical</ArrangeMethod>
+        <Columns>1</Columns>
+        <ColumnsMode>Fixed</ColumnsMode>
+        <FrameType>None</FrameType>
+        <Style>SidePanel</Style>
+      </AxFormControl>
+      <AxFormControl xmlns="" i:type="AxFormTabControl">
+        <Name>PanelTab</Name>
+        <Height>-1</Height>
+        <HeightMode>SizeToAvailable</HeightMode>
+        <Type>Tab</Type>
+        <Width>-1</Width>
+        <WidthMode>SizeToAvailable</WidthMode>
+        <FormControlExtension i:nil="true" />
+        <Controls>
+          <AxFormControl xmlns="" i:type="AxFormTabPageControl">
+            <Name>DetailsPanel</Name>
+            <Type>TabPage</Type>
+            <FormControlExtension i:nil="true" />
+            <Controls>
+              <AxFormControl xmlns="" i:type="AxFormGroupControl">
+                <Name>TitleGroup</Name>
+                <Height>-1</Height>
+                <HeightMode>SizeToContent</HeightMode>
+                <Type>Group</Type>
+                <Width>-1</Width>
+                <WidthMode>SizeToAvailable</WidthMode>
+                <FormControlExtension i:nil="true" />
+                <Controls>
+                <AxFormControl xmlns="" i:type="AxFormStringControl">
+                  <Name>HeaderTitle</Name>
+                  <Skip>Yes</Skip>
+                  <Type>String</Type>
+                  <WidthMode>SizeToAvailable</WidthMode>
+                  <FormControlExtension i:nil="true" />
+                  <DataField>VIN</DataField>
+                  <DataSource>FmVehicle</DataSource>
+                  <ShowLabel>No</ShowLabel>
+                  <Style>TitleField</Style>
+                </AxFormControl>
+                </Controls>
+                <ArrangeMethod>HorizontalLeft</ArrangeMethod>
+                <Columns>1</Columns>
+                <ColumnsMode>Fixed</ColumnsMode>
+                <DataSource>FmVehicle</DataSource>
+                <FrameType>None</FrameType>
+                <Style>DetailTitleContainer</Style>
+              </AxFormControl>
+              <AxFormControl xmlns="" i:type="AxFormTabControl">
+                <Name>HeaderLinePanels</Name>
+                <Height>-1</Height>
+                <HeightMode>SizeToAvailable</HeightMode>
+                <Type>Tab</Type>
+                <Width>-1</Width>
+                <WidthMode>SizeToAvailable</WidthMode>
+                <FormControlExtension i:nil="true" />
+                <Controls>
+                  <AxFormControl xmlns="" i:type="AxFormTabPageControl">
+                    <Name>LinesPanel</Name>
+                    <Type>TabPage</Type>
+                    <FormControlExtension i:nil="true" />
+                    <Controls>
+                      <AxFormControl xmlns="" i:type="AxFormTabControl">
+                        <Name>LineViewTab</Name>
+                        <Height>-1</Height>
+                        <HeightMode>SizeToAvailable</HeightMode>
+                        <Type>Tab</Type>
+                        <Width>-1</Width>
+                        <WidthMode>SizeToAvailable</WidthMode>
+                        <FormControlExtension i:nil="true" />
+                        <Controls>
+                          <AxFormControl xmlns="" i:type="AxFormTabPageControl">
+                            <Name>LineViewHeader</Name>
+                            <Type>TabPage</Type>
+                            <FormControlExtension i:nil="true" />
+                            <Controls />
+                            <HideIfEmpty>Yes</HideIfEmpty>
+                            <PanelStyle>Auto</PanelStyle>
+                          </AxFormControl>
+                          <AxFormControl xmlns="" i:type="AxFormTabPageControl">
+                            
+                            
+                            
+                            
+                            
+                            
+                            
+                            
+                            
+                          <Name>LineViewLines</Name><Height>-1</Height><HeightMode>SizeToAvailable</HeightMode><Type>TabPage</Type><FormControlExtension i:nil="true" /><Controls>
+                              <AxFormControl xmlns="" i:type="AxFormActionPaneControl">
+                                <Name>LineViewLinesToolbar</Name>
+                                <Height>-1</Height>
+                                <HeightMode>SizeToContent</HeightMode>
+                                <Type>ActionPane</Type>
+                                <Width>-1</Width>
+                                <WidthMode>SizeToAvailable</WidthMode>
+                                <FormControlExtension i:nil="true" />
+                                <Controls />
+                                <Style>Strip</Style>
+                              </AxFormControl>
+                              <AxFormControl xmlns="" i:type="AxFormGridControl">
+                                <Name>LineViewLinesGrid</Name>
+                                <Height>-1</Height>
+                                <HeightMode>SizeToAvailable</HeightMode>
+                                <Type>Grid</Type>
+                                <Width>-1</Width>
+                                <WidthMode>SizeToAvailable</WidthMode>
+                                <FormControlExtension i:nil="true" />
+                                <Controls />
+                                <DataGroup>Overview</DataGroup>
+                                <DataSource>FmVehicleLine</DataSource>
+                                <Style>Tabular</Style>
+                                <VisibleRows>5</VisibleRows>
+                                <VisibleRowsMode>Fixed</VisibleRowsMode>
+                              </AxFormControl>
+                            </Controls><HideIfEmpty>Yes</HideIfEmpty><FastTabExpanded>Always</FastTabExpanded><PanelStyle>Auto</PanelStyle></AxFormControl>
+                          <AxFormControl xmlns="" i:type="AxFormTabPageControl">
+                            <Name>LineViewLineDetails</Name>
+                            <Type>TabPage</Type>
+                            <FormControlExtension i:nil="true" />
+                            <Controls>
+                              <AxFormControl xmlns="" i:type="AxFormTabControl">
+                                <Name>LineDetailsTab</Name>
+                                <Height>-1</Height>
+                                <HeightMode>SizeToAvailable</HeightMode>
+                                <Type>Tab</Type>
+                                <Width>-1</Width>
+                                <WidthMode>SizeToAvailable</WidthMode>
+                                <FormControlExtension i:nil="true" />
+                                <Controls>
+                                  <AxFormControl xmlns="" i:type="AxFormTabPageControl">
+                                    
+                                    
+                                    
+                                    
+                                    
+                                    
+                                  <Name>LineDetailTabPage</Name><Type>TabPage</Type><FormControlExtension i:nil="true" /><Controls /><Caption>Line details</Caption><PanelStyle>Auto</PanelStyle></AxFormControl>
+                                </Controls>
+                                <ShowTabs>Yes</ShowTabs>
+                                <Style>Tabs</Style>
+                              </AxFormControl>
+                            </Controls>
+                            <HideIfEmpty>Yes</HideIfEmpty>
+                            <PanelStyle>Auto</PanelStyle>
+                          </AxFormControl>
+                        </Controls>
+                        <Style>FastTabs</Style>
+                      </AxFormControl>
+                    </Controls>
+                    <ArrangeMethod>Vertical</ArrangeMethod>
+                    <Columns>1</Columns>
+                    <ColumnsMode>Fixed</ColumnsMode>
+                    <HideIfEmpty>Yes</HideIfEmpty>
+                    <PanelStyle>DetailsLine</PanelStyle>
+                  </AxFormControl>
+                  <AxFormControl xmlns="" i:type="AxFormTabPageControl">
+                    <Name>HeaderPanel</Name>
+                    <Type>TabPage</Type>
+                    <FormControlExtension i:nil="true" />
+                    <Controls>
+                      <AxFormControl xmlns="" i:type="AxFormTabControl">
+                        <Name>HeaderDetailsTab</Name>
+                        <Height>-1</Height>
+                        <HeightMode>SizeToAvailable</HeightMode>
+                        <Type>Tab</Type>
+                        <Width>-1</Width>
+                        <WidthMode>SizeToAvailable</WidthMode>
+                        <FormControlExtension i:nil="true" />
+                        <Controls>
+                          <AxFormControl xmlns="" i:type="AxFormTabPageControl">
+                            
+                            
+                            
+                            
+                            
+                            
+                          <Name>HeaderGeneralPage</Name><Type>TabPage</Type><FormControlExtension i:nil="true" /><Controls>
+                              <AxFormControl xmlns="" i:type="AxFormGroupControl">
+                                <Name>HeaderGeneralGroup</Name>
+                                <Type>Group</Type>
+                                <FormControlExtension i:nil="true" />
+                                <Controls>
+                                  <AxFormControl xmlns="" i:type="AxFormStringControl">
+                                    <Name>Header_VIN</Name>
+                                    <Type>String</Type>
+                                    <FormControlExtension i:nil="true" />
+                                    <DataField>VIN</DataField>
+                                    <DataSource>FmVehicle</DataSource>
+                                  </AxFormControl>
+                                </Controls>
+                                <!-- DataGroup needs the sibling DataSource naming its table. -->
+                                <DataGroup>Overview</DataGroup>
+                                <DataSource>FmVehicle</DataSource>
+                              </AxFormControl>
+                            </Controls><Caption>General</Caption><PanelStyle>Auto</PanelStyle></AxFormControl>
+                        </Controls>
+                        <Style>FastTabs</Style>
+                      </AxFormControl>
+                    </Controls>
+                    <Columns>1</Columns>
+                    <ColumnsMode>Fixed</ColumnsMode>
+                    <HideIfEmpty>Yes</HideIfEmpty>
+                    <PanelStyle>DetailsHeader</PanelStyle>
+                  </AxFormControl>
+                </Controls>
+                <ShowTabs>No</ShowTabs>
+                <Style>Tabs</Style>
+              </AxFormControl>
+            </Controls>
+            <ArrangeMethod>Vertical</ArrangeMethod>
+            <Columns>1</Columns>
+            <ColumnsMode>Fixed</ColumnsMode>
+            <PanelStyle>Details</PanelStyle>
+            <Style>DetailsFormDetails</Style>
+          </AxFormControl>
+          <AxFormControl xmlns="" i:type="AxFormTabPageControl">
+            <Name>GridPanel</Name>
+            <Type>TabPage</Type>
+            <FormControlExtension i:nil="true" />
+            <Controls>
+              <AxFormControl xmlns="" i:type="AxFormGroupControl">
+                <Name>CustomAndQuickFilterGroup</Name>
+                <Pattern>CustomAndQuickFilters</Pattern>
+                <PatternVersion>1.1</PatternVersion>
+                <Type>Group</Type>
+                <WidthMode>SizeToAvailable</WidthMode>
+                <FormControlExtension i:nil="true" />
+                <Controls>
+                  <AxFormControl>
+                    <Name>QuickFilterControl</Name>
+                    <WidthMode>SizeToAvailable</WidthMode>
+                    <FormControlExtension>
+                      <Name>QuickFilterControl</Name>
+                      <ExtensionComponents />
+                      <ExtensionProperties>
+                        <AxFormControlExtensionProperty>
+                          <Name>targetControlName</Name>
+                          <Type>String</Type>
+                          <Value>MainGrid</Value>
+                        </AxFormControlExtensionProperty>
+                      </ExtensionProperties>
+                    </FormControlExtension>
+                  </AxFormControl>
+                </Controls>
+                <ArrangeMethod>HorizontalLeft</ArrangeMethod>
+                <FrameType>None</FrameType>
+                <Style>CustomFilter</Style>
+                <ViewEditMode>Edit</ViewEditMode>
+              </AxFormControl>
+              <AxFormControl xmlns="" i:type="AxFormGridControl">
+                <Name>MainGrid</Name>
+                <AllowEdit>Yes</AllowEdit>
+                <Height>-1</Height>
+                <HeightMode>SizeToAvailable</HeightMode>
+                <Type>Grid</Type>
+                <Width>-1</Width>
+                <WidthMode>SizeToAvailable</WidthMode>
+                <FormControlExtension i:nil="true" />
+                <Controls />
+                <DataSource>FmVehicle</DataSource>
+                <DefaultAction>MainGridDefaultAction</DefaultAction>
+                <Style>Tabular</Style>
+              </AxFormControl>
+              <AxFormControl xmlns="" i:type="AxFormCommandButtonControl">
+                <Name>MainGridDefaultAction</Name>
+                <Type>CommandButton</Type>
+                <Visible>No</Visible>
+                <FormControlExtension i:nil="true" />
+                <Command>DetailsView</Command>
+              </AxFormControl>
+            </Controls>
+            <ArrangeMethod>Vertical</ArrangeMethod>
+            <Columns>1</Columns>
+            <ColumnsMode>Fixed</ColumnsMode>
+            <PanelStyle>Grid</PanelStyle>
+            <Style>DetailsFormGrid</Style>
+          </AxFormControl>
+        </Controls>
+        <ShowTabs>No</ShowTabs>
+        <Style>Tabs</Style>
+      </AxFormControl>
+    </Controls>
+  </Design>
+  <Parts />
+</AxForm>

--- a/src/D365FO.Core/FormPatterns/FormCloner.cs
+++ b/src/D365FO.Core/FormPatterns/FormCloner.cs
@@ -141,12 +141,12 @@ public static class FormCloner
             xml = Regex.Replace(xml, tableTag, $"<Table>{newTable}</Table>");
             rebound.Add($"{oldTable} -> {newTable}");
 
-            // The datasource element that carried the table, and every control pointing at it.
+            // The datasource element that carried the table, and everything pointing at it.
             var dsName = $"<Name>{Regex.Escape(oldTable)}</Name>";
             if (Regex.IsMatch(xml, dsName))
             {
                 xml = Regex.Replace(xml, dsName, $"<Name>{newTable}</Name>");
-                xml = Regex.Replace(xml, $"<DataSource>{Regex.Escape(oldTable)}</DataSource>", $"<DataSource>{newTable}</DataSource>");
+                xml = RenameDataSourceReferences(xml, oldTable, newTable);
                 renamed.Add($"{oldTable} -> {newTable}");
             }
 
@@ -157,6 +157,48 @@ public static class FormCloner
         }
 
         return (rebound, renamed);
+    }
+
+    /// <summary>
+    /// Elements whose text is the name of a datasource, so a renamed datasource has to be
+    /// followed into all of them.
+    /// </summary>
+    /// <remarks>
+    /// Grounded on a live installation rather than guessed: across 300 shipped
+    /// <c>ApplicationSuite\Foundation\AxForm</c> forms these are the only elements carrying a
+    /// datasource name as their value. The rest of the <c>*DataSource*</c> family is either a
+    /// container (<c>DataSources</c>, <c>DataSourceLinks</c>, <c>ReferencedDataSources</c>) or
+    /// holds something else entirely (<c>DataSourceChangeGroupMode</c> is an enum,
+    /// <c>DataSourceRelation</c> names a relation). Datasource names reached through a nested
+    /// <c>&lt;Name&gt;</c> — root links, referenced and derived datasources — are already covered
+    /// by the <c>&lt;Name&gt;</c> rewrite above.
+    /// </remarks>
+    private static readonly string[] DataSourceRefElements =
+        ["DataSource", "TitleDataSource", "WorkflowDataSource", "PresenceDataSource", "JoinSource"];
+
+    /// <summary>
+    /// Repoint every reference to a renamed datasource, whatever attributes the tag carries.
+    /// </summary>
+    /// <remarks>
+    /// The attribute tolerance is the whole point. A <c>&lt;Design&gt;</c>'s own
+    /// <c>DataSource</c>/<c>TitleDataSource</c> are first-level children written in the empty
+    /// namespace, so they appear as <c>&lt;DataSource xmlns=""&gt;</c>, while the control-level
+    /// ones nested under <c>&lt;Controls xmlns=""&gt;</c> inherit it and appear bare. Matching only
+    /// the bare form rebinds the controls and leaves the design pointing at a datasource the
+    /// clone no longer has.
+    /// <para>
+    /// The alternation cannot bleed into a longer tag: the group must be followed immediately by
+    /// whitespace or <c>&gt;</c>, so <c>DataSource</c> never matches the start of
+    /// <c>DataSourceLinks</c>. The closing tag is a backreference, so the two always agree.
+    /// </para>
+    /// </remarks>
+    private static string RenameDataSourceReferences(string xml, string oldName, string newName)
+    {
+        var tags = string.Join('|', DataSourceRefElements);
+        return Regex.Replace(
+            xml,
+            $@"<({tags})((?:\s[^>]*)?)>{Regex.Escape(oldName)}</\1>",
+            m => $"<{m.Groups[1].Value}{m.Groups[2].Value}>{newName}</{m.Groups[1].Value}>");
     }
 
     /// <summary>

--- a/tests/D365FO.Cli.Tests/Eval/EvalListCommandTests.cs
+++ b/tests/D365FO.Cli.Tests/Eval/EvalListCommandTests.cs
@@ -33,9 +33,10 @@ public class EvalListCommandTests
 
         Assert.Equal(0, exit);
         Assert.Contains("\"ok\":true", stdout);
-        Assert.Contains("\"count\":51", stdout);
+        Assert.Contains("\"count\":52", stdout);
         Assert.Contains("L0-edt-basic", stdout);
         Assert.Contains("L2-coc-extension", stdout);
         Assert.Contains("L1-form-workspace", stdout);
+        Assert.Contains("L2-form-clone-basic", stdout);
     }
 }

--- a/tests/D365FO.Core.Tests/Eval/EvalCaseCatalogTests.cs
+++ b/tests/D365FO.Core.Tests/Eval/EvalCaseCatalogTests.cs
@@ -14,7 +14,7 @@ public class EvalCaseCatalogTests
         var (cases, errors) = EvalCaseCatalog.LoadAll(EvalPaths.CasesDir(RepoRoot));
 
         Assert.Empty(errors);
-        Assert.Equal(51, cases.Count);
+        Assert.Equal(52, cases.Count);
         Assert.Contains(cases, c => c.Id == "L0-edt-basic");
         Assert.Contains(cases, c => c.Id == "L0-enum-basic");
         Assert.Contains(cases, c => c.Id == "L1-table-basic");

--- a/tests/D365FO.Core.Tests/FormClonerTests.cs
+++ b/tests/D365FO.Core.Tests/FormClonerTests.cs
@@ -11,7 +11,10 @@ namespace D365FO.Core.Tests;
 /// <remarks>
 /// The fixture mirrors the shape of a real shipped form: the root name, the X++ class
 /// declaration, a datasource entry under <c>&lt;SourceCode&gt;</c> (where override methods live),
-/// the design datasource, and a control pointing at it by name. Verified against
+/// the design datasource, the design's own <c>DataSource</c>/<c>TitleDataSource</c> properties
+/// (first-level children of <c>&lt;Design&gt;</c>, so they carry an explicit <c>xmlns=""</c> where
+/// the control-level ones inherit it), and a control pointing at the datasource by name. Verified
+/// against
 /// <c>ApplicationSuite\Foundation\AxForm\CustGroup.xml</c> on a live installation — a 16 KB form
 /// where the clone differs from the source on exactly the intended lines and is byte-identical
 /// everywhere else.
@@ -41,8 +44,15 @@ public class FormClonerTests
         			<Name>CustGroup</Name>
         			<Table>CustGroup</Table>
         		</AxFormDataSource>
+        		<AxFormDataSource>
+        			<Name>CustTrans</Name>
+        			<Table>CustTrans</Table>
+        			<JoinSource>CustGroup</JoinSource>
+        		</AxFormDataSource>
         	</DataSources>
         	<Design>
+        		<DataSource xmlns="">CustGroup</DataSource>
+        		<TitleDataSource xmlns="">CustGroup</TitleDataSource>
         		<AxFormControl xmlns="" i:type="AxFormStringControl">
         			<Name>Grid_CustGroupId</Name>
         			<DataField>CustGroupId</DataField>
@@ -87,6 +97,61 @@ public class FormClonerTests
         Assert.Equal(2, Regex.Matches(result.Xml, "<Name>ConVehicleGroupTable</Name>").Count);
         Assert.Single(result.Rebound);
         Assert.Single(result.RenamedDataSources);
+    }
+
+    [Fact]
+    public void A_rebind_follows_the_datasource_into_the_design_properties_that_name_it()
+    {
+        // The design's own DataSource/TitleDataSource are first-level children of <Design>, so
+        // they are written as <DataSource xmlns="">. A pattern anchored on the bare "<DataSource>"
+        // misses them, and the clone then names a datasource it no longer has — a form that
+        // compiles and breaks at runtime. Grounded on a live installation: of 300 shipped
+        // ApplicationSuite forms, 128 <DataSource> and 78 <TitleDataSource> nodes carry attributes.
+        var result = FormCloner.Clone(Source, "ConVehicleGroup", Rebind("CustGroup", "ConVehicleGroupTable"));
+
+        Assert.Contains("<DataSource xmlns=\"\">ConVehicleGroupTable</DataSource>", result.Xml);
+        Assert.Contains("<TitleDataSource xmlns=\"\">ConVehicleGroupTable</TitleDataSource>", result.Xml);
+        Assert.DoesNotContain("CustGroup</DataSource>", result.Xml);
+        Assert.DoesNotContain("CustGroup</TitleDataSource>", result.Xml);
+    }
+
+    [Fact]
+    public void A_rebind_follows_the_datasource_into_the_join_that_names_it()
+    {
+        // A joined datasource names its parent by datasource name, so renaming the parent has to
+        // reach the join too — otherwise the child joins to something that no longer exists.
+        var result = FormCloner.Clone(Source, "ConVehicleGroup", Rebind("CustGroup", "ConVehicleGroupTable"));
+
+        Assert.Contains("<JoinSource>ConVehicleGroupTable</JoinSource>", result.Xml);
+    }
+
+    [Fact]
+    public void A_tag_that_merely_starts_with_a_matched_element_name_is_not_rewritten()
+    {
+        // The alternation must not let "DataSource" bleed into "DataSourceLinks" and friends.
+        var withLinks = Source.Replace(
+            "<JoinSource>CustGroup</JoinSource>",
+            "<JoinSource>CustGroup</JoinSource><DataSourceLinks>CustGroup</DataSourceLinks>");
+
+        var result = FormCloner.Clone(withLinks, "ConVehicleGroup", Rebind("CustGroup", "ConVehicleGroupTable"));
+
+        Assert.Contains("<DataSourceLinks>CustGroup</DataSourceLinks>", result.Xml);
+    }
+
+    [Fact]
+    public void A_rebind_leaves_no_control_or_design_node_naming_the_old_datasource()
+    {
+        // The whole-document guarantee behind the case above: after a rebind that renamed the
+        // datasource, nothing anywhere still refers to the old name.
+        var result = FormCloner.Clone(Source, "ConVehicleGroup", Rebind("CustGroup", "ConVehicleGroupTable"));
+
+        var stillNamingOld = XDocument.Parse(result.Xml)
+            .Descendants()
+            .Where(e => e.Value.Trim() == "CustGroup" && !e.HasElements)
+            .Select(e => e.Name.LocalName)
+            .ToList();
+
+        Assert.Empty(stillNamingOld);
     }
 
     [Fact]


### PR DESCRIPTION
## Why CI is red

`eval` has been failing on `main` since #167 merged. All 51 cases passed — the failure is the job's second step:

```
{"ok":false,"error":{"code":"COVERAGE_DRIFT",
 "message":"eval/COVERAGE.md is stale — a family, capability, case or topic changed since it was generated."}}
```

\#167 added the `form-clone` capability without regenerating `eval/COVERAGE.md`.

\#165's red `build-test (ubuntu)` and `knowledge-audit` were **not** code. Both died before checkout on an Actions outage (`Failed to resolve action download info. Error: Service Unavailable`); macOS and Windows passed in the same run and both jobs are already green on `main`. Nothing to fix there.

## The defect behind the stale row

Regenerating `COVERAGE.md` alone would have turned CI green while leaving `form-clone` at `--T` — shipped, untaught, unproven. Writing the missing eval case surfaced a real bug.

`--rebind` renamed the datasource and repointed the control-level `<DataSource>` nodes, but left the design's own `<DataSource>` and `<TitleDataSource>` naming a datasource the clone no longer has:

```xml
<DataSources>
  <AxFormDataSource xmlns="">
    <Name>FmVehicleLine</Name>          <!-- renamed -->
    <Table>FmVehicleLine</Table>        <!-- rebound -->
<Design>
  <DataSource xmlns="">FmVehicle</DataSource>        <!-- ← dangling -->
  <TitleDataSource xmlns="">FmVehicle</TitleDataSource>  <!-- ← dangling -->
```

A form that compiles and fails at runtime.

**Cause.** Those two are first-level children of `<Design>`, so they are written as `<DataSource xmlns="">`. The pattern was anchored on the bare `"<DataSource>"`. The control-level ones nest under `<Controls xmlns="">`, inherit the namespace, appear bare — so they matched and the design ones did not. `<JoinSource>` was not handled at all, leaving a joined datasource pointing at its parent's old name.

## The fix

The element list is grounded on the live installation rather than guessed. Across 300 shipped `ApplicationSuite` forms, these are the only elements whose *value* is a datasource name:

| Element | Occurrences | Carries attributes |
|---|---|---|
| `DataSource` | 6559 bare + 128 with | design-level ones do |
| `TitleDataSource` | 78 | yes |
| `WorkflowDataSource` | 4 | yes |
| `PresenceDataSource` | 1 | no |
| `JoinSource` | — | no |

The rest of the `*DataSource*` family is either a container (`DataSources`, `DataSourceLinks`, `ReferencedDataSources`) or holds something else — `DataSourceChangeGroupMode` is an enum, `DataSourceRelation` names a relation. Names reached through a nested `<Name>` (root links, referenced/derived datasources) were already covered by the existing `<Name>` rewrite.

Matching now tolerates attributes and backreferences the closing tag, so it cannot bleed from `DataSource` into `DataSourceLinks` — there is a negative test for exactly that.

## Why the tests missed it

The unit fixture's `<Design>` went straight to `<AxFormControl>`, so it never contained the nodes that break. It now carries the design properties and a joined datasource — which is what makes the four new tests fail before the fix and pass after.

## The eval case

`L2-form-clone-basic` clones the two-datasource details-transaction form: 19 KB in, and the clone differs on exactly the root `<Name>` and the class declaration, byte-identical everywhere else. That is the guarantee worth locking for string surgery over a document this code does not own.

It is a **plain clone rather than a rebind** deliberately. MiniAot has only `FmVehicle` and `FmVehicleLine`: rebinding the simple form onto `FmVehicleLine` binds a `<DataField>Make</DataField>` that table does not have, and the richer form already uses both, so either golden would enshrine a form nobody should ship. The rebind path is covered by unit tests, which assert it more precisely anyway. Adding a third fixture table would let it graduate to an eval case — left as follow-up, since `MiniAotEndToEndTests` asserts the fixture's table count.

`form-clone` now reads `-E T` in `COVERAGE.md`, matching its `control-method` / `datasource-method` siblings.

## Verification

All four CI jobs run locally:

| Job | Result |
|---|---|
| build-test | build clean, **1178 tests pass** (367 Cli + 811 Core) |
| knowledge-audit | clean — 35 topics, 269 symbols, 61 examples, 0 defects |
| eval | **52/52** cases, `coverage --check` green |
| skills | no drift |

🤖 Generated with [Claude Code](https://claude.com/claude-code)