### PR TITLE
Preserve exact EDT suggestion candidates

### DIFF
--- a/src/D365FO.Core/EdtSuggester.cs
+++ b/src/D365FO.Core/EdtSuggester.cs
@@ -33,23 +33,31 @@ public static class EdtSuggester
         var target = fieldName.Trim();
         var stripped = Strip(target);
 
-        // Keep an exact EDT match outside the fuzzy-search budget. SearchEdts
-        // orders custom models first and applies its limit before scoring, so a
-        // standard EDT can otherwise be truncated before receiving a 1.0 score.
-        var exactCandidates = repo.FindEdtsExact(target);
-
         // Over-fetch then score. Single LIKE scan on Name — Edts table is small.
-        var candidates = repo.SearchEdts(stripped.Length >= 3 ? stripped : target, Math.Max(limit * 20, 100)).ToList();
+        var fetch = Math.Min(Math.Max(limit * 20, 100), MetadataRepository.MaxRowLimit);
+        var candidates = repo.SearchEdts(stripped.Length >= 3 ? stripped : target, fetch).ToList();
         if (candidates.Count == 0 && stripped.Length >= 3)
-            candidates.AddRange(repo.SearchEdts(stripped, Math.Max(limit * 20, 100)));
+            candidates.AddRange(repo.SearchEdts(stripped, fetch));
 
-        foreach (var exact in exactCandidates)
+        // SearchEdts orders custom models first and applies its limit before
+        // scoring, so a standard EDT can be truncated away before it ever earns
+        // its 1.0 exact-match score. Re-fetch exact names to put them back.
+        //
+        // Only when the sweep filled its whole budget can anything have been
+        // truncated — a short sweep already contains every name matching the
+        // root, exact ones included. Skipping the lookup in that case keeps
+        // the common path at a single query — prepare calls Suggest once per
+        // field, and each call opens its own connection.
+        if (candidates.Count >= fetch)
         {
-            if (!candidates.Any(candidate =>
-                    string.Equals(candidate.Name, exact.Name, StringComparison.OrdinalIgnoreCase) &&
-                    string.Equals(candidate.Model, exact.Model, StringComparison.OrdinalIgnoreCase)))
+            foreach (var exact in repo.FindEdtsExact(target))
             {
-                candidates.Add(exact);
+                if (!candidates.Any(candidate =>
+                        string.Equals(candidate.Name, exact.Name, StringComparison.OrdinalIgnoreCase) &&
+                        string.Equals(candidate.Model, exact.Model, StringComparison.OrdinalIgnoreCase)))
+                {
+                    candidates.Add(exact);
+                }
             }
         }
 

--- a/src/D365FO.Core/EdtSuggester.cs
+++ b/src/D365FO.Core/EdtSuggester.cs
@@ -33,10 +33,25 @@ public static class EdtSuggester
         var target = fieldName.Trim();
         var stripped = Strip(target);
 
+        // Keep an exact EDT match outside the fuzzy-search budget. SearchEdts
+        // orders custom models first and applies its limit before scoring, so a
+        // standard EDT can otherwise be truncated before receiving a 1.0 score.
+        var exactCandidates = repo.FindEdtsExact(target);
+
         // Over-fetch then score. Single LIKE scan on Name — Edts table is small.
-        var candidates = repo.SearchEdts(stripped.Length >= 3 ? stripped : target, Math.Max(limit * 20, 100));
+        var candidates = repo.SearchEdts(stripped.Length >= 3 ? stripped : target, Math.Max(limit * 20, 100)).ToList();
         if (candidates.Count == 0 && stripped.Length >= 3)
-            candidates = repo.SearchEdts(stripped, Math.Max(limit * 20, 100));
+            candidates.AddRange(repo.SearchEdts(stripped, Math.Max(limit * 20, 100)));
+
+        foreach (var exact in exactCandidates)
+        {
+            if (!candidates.Any(candidate =>
+                    string.Equals(candidate.Name, exact.Name, StringComparison.OrdinalIgnoreCase) &&
+                    string.Equals(candidate.Model, exact.Model, StringComparison.OrdinalIgnoreCase)))
+            {
+                candidates.Add(exact);
+            }
+        }
 
         var scored = new List<Suggestion>();
         foreach (var edt in candidates)

--- a/src/D365FO.Core/Index/MetadataRepository.cs
+++ b/src/D365FO.Core/Index/MetadataRepository.cs
@@ -434,6 +434,19 @@ public sealed partial class MetadataRepository
             WHERE e.Name = @name LIMIT 1", new { name });
     }
 
+    internal IReadOnlyList<EdtInfo> FindEdtsExact(string name)
+    {
+        using var conn = OpenReadOnly();
+        return conn.Query<EdtInfo>(@"
+            SELECT e.Name, m.Name AS Model, e.ExtendsName AS Extends,
+                   e.BaseType, e.Label, e.StringSize,
+                   e.ReferenceTable, e.FormHelp, e.AnalysisUsage, e.EnumType
+            FROM Edts e JOIN Models m ON m.ModelId = e.ModelId
+            WHERE e.Name = @name COLLATE NOCASE
+            ORDER BY m.IsCustom DESC, m.Name COLLATE NOCASE, e.Name COLLATE NOCASE",
+            new { name }).ToList();
+    }
+
     /// <summary>
     /// Index rows store the <em>base</em> object an extension targets (e.g.
     /// <c>CustTable</c>), but callers and LLMs often pass the full extension

--- a/src/D365FO.Core/Index/MetadataRepository.cs
+++ b/src/D365FO.Core/Index/MetadataRepository.cs
@@ -14,7 +14,7 @@ namespace D365FO.Core.Index;
 public sealed partial class MetadataRepository
 {
     /// <summary>Current schema version tracked in PRAGMA user_version.</summary>
-    public const int CurrentSchemaVersion = 15;
+    public const int CurrentSchemaVersion = 16;
 
     private static readonly Lazy<string> SchemaSql = new(LoadEmbeddedSchema);
 
@@ -434,8 +434,14 @@ public sealed partial class MetadataRepository
             WHERE e.Name = @name LIMIT 1", new { name });
     }
 
-    internal IReadOnlyList<EdtInfo> FindEdtsExact(string name)
+    /// <summary>
+    /// Every EDT named exactly <paramref name="name"/> (case-insensitive),
+    /// across all models. Served by <c>IX_Edts_Name_NoCase</c> — the BINARY
+    /// <c>IX_Edts_Name</c> cannot answer a <c>COLLATE NOCASE</c> comparison.
+    /// </summary>
+    internal IReadOnlyList<EdtInfo> FindEdtsExact(string name, int limit = 50)
     {
+        limit = ClampLimit(limit, 50);
         using var conn = OpenReadOnly();
         return conn.Query<EdtInfo>(@"
             SELECT e.Name, m.Name AS Model, e.ExtendsName AS Extends,
@@ -443,8 +449,9 @@ public sealed partial class MetadataRepository
                    e.ReferenceTable, e.FormHelp, e.AnalysisUsage, e.EnumType
             FROM Edts e JOIN Models m ON m.ModelId = e.ModelId
             WHERE e.Name = @name COLLATE NOCASE
-            ORDER BY m.IsCustom DESC, m.Name COLLATE NOCASE, e.Name COLLATE NOCASE",
-            new { name }).ToList();
+            ORDER BY m.IsCustom DESC, m.Name COLLATE NOCASE, e.Name COLLATE NOCASE
+            LIMIT @limit",
+            new { name, limit }).ToList();
     }
 
     /// <summary>

--- a/src/D365FO.Core/Index/Schema.sql
+++ b/src/D365FO.Core/Index/Schema.sql
@@ -113,6 +113,10 @@ CREATE TABLE IF NOT EXISTS Edts (
     FOREIGN KEY (ModelId) REFERENCES Models(ModelId)
 );
 CREATE INDEX IF NOT EXISTS IX_Edts_Name ON Edts(Name);
+-- Case-insensitive twin for EdtSuggester's exact-name lookup. A COLLATE NOCASE
+-- comparison cannot use the BINARY index above, so without this every exact
+-- lookup scans Edts (~25k rows on a full AOT).
+CREATE INDEX IF NOT EXISTS IX_Edts_Name_NoCase ON Edts(Name COLLATE NOCASE);
 
 CREATE TABLE IF NOT EXISTS Enums (
     EnumId      INTEGER PRIMARY KEY AUTOINCREMENT,

--- a/tests/D365FO.Core.Tests/EdtSuggesterTests.cs
+++ b/tests/D365FO.Core.Tests/EdtSuggesterTests.cs
@@ -49,6 +49,36 @@ public class EdtSuggesterTests : IDisposable
             CocExtensions: Array.Empty<ExtractedCoc>(),
             Labels: Array.Empty<ExtractedLabel>());
         _repo.ApplyExtract(batch);
+
+        var crowdedBatch = new ExtractBatch(
+            Model: "CustomModel",
+            Publisher: "Test",
+            Layer: "cus",
+            IsCustom: true,
+            Tables: Array.Empty<ExtractedTable>(),
+            Classes: Array.Empty<ExtractedClass>(),
+            Edts: Enumerable.Range(0, 101)
+                .Select(i => new ExtractedEdt($"CustomItem{i:D3}", null, "String", null, 20))
+                .ToArray(),
+            Enums: Array.Empty<ExtractedEnum>(),
+            MenuItems: Array.Empty<ExtractedMenuItem>(),
+            CocExtensions: Array.Empty<ExtractedCoc>(),
+            Labels: Array.Empty<ExtractedLabel>());
+        _repo.ApplyExtract(crowdedBatch);
+
+        var standardBatch = new ExtractBatch(
+            Model: "Foundation",
+            Publisher: "Microsoft",
+            Layer: "sys",
+            IsCustom: false,
+            Tables: Array.Empty<ExtractedTable>(),
+            Classes: Array.Empty<ExtractedClass>(),
+            Edts: new[] { new ExtractedEdt("ItemId", "ItemIdBase", "String", null, 20) },
+            Enums: Array.Empty<ExtractedEnum>(),
+            MenuItems: Array.Empty<ExtractedMenuItem>(),
+            CocExtensions: Array.Empty<ExtractedCoc>(),
+            Labels: Array.Empty<ExtractedLabel>());
+        _repo.ApplyExtract(standardBatch);
     }
 
     [Fact]
@@ -58,6 +88,53 @@ public class EdtSuggesterTests : IDisposable
         Assert.NotEmpty(suggestions);
         Assert.Equal("CustAccount", suggestions[0].Edt.Name);
         Assert.Equal(1.0, suggestions[0].Confidence);
+    }
+
+    [Fact]
+    public void Exact_name_is_not_lost_when_fuzzy_candidates_are_truncated()
+    {
+        Assert.DoesNotContain(_repo.SearchEdts("Item", 100),
+            edt => string.Equals(edt.Name, "ItemId", StringComparison.OrdinalIgnoreCase));
+
+        var suggestions = EdtSuggester.Suggest(_repo, "itemid", limit: 5);
+
+        Assert.NotEmpty(suggestions);
+        Assert.Equal("ItemId", suggestions[0].Edt.Name);
+        Assert.Equal(1.0, suggestions[0].Confidence);
+        Assert.Equal("exact match", suggestions[0].Reason);
+    }
+
+    [Fact]
+    public void Exact_candidates_preserve_model_identity()
+    {
+        foreach (var (model, isCustom) in new[]
+                 {
+                     ("SyntheticBaseModel", false),
+                     ("SyntheticExtensionModel", true),
+                 })
+        {
+            _repo.ApplyExtract(new ExtractBatch(
+                Model: model,
+                Publisher: "Synthetic",
+                Layer: isCustom ? "cus" : "sys",
+                IsCustom: isCustom,
+                Tables: Array.Empty<ExtractedTable>(),
+                Classes: Array.Empty<ExtractedClass>(),
+                Edts: new[] { new ExtractedEdt("SharedReferenceId", null, "String", null, 20) },
+                Enums: Array.Empty<ExtractedEnum>(),
+                MenuItems: Array.Empty<ExtractedMenuItem>(),
+                CocExtensions: Array.Empty<ExtractedCoc>(),
+                Labels: Array.Empty<ExtractedLabel>()));
+        }
+
+        var exactSuggestions = EdtSuggester.Suggest(_repo, "sharedreferenceid", limit: 5)
+            .Where(suggestion => suggestion.Confidence == 1.0)
+            .ToList();
+
+        Assert.Equal(2, exactSuggestions.Count);
+        Assert.Equal(
+            new[] { "SyntheticExtensionModel", "SyntheticBaseModel" },
+            exactSuggestions.Select(suggestion => suggestion.Edt.Model));
     }
 
     [Fact]

--- a/tests/D365FO.Core.Tests/EdtSuggesterTests.cs
+++ b/tests/D365FO.Core.Tests/EdtSuggesterTests.cs
@@ -49,37 +49,44 @@ public class EdtSuggesterTests : IDisposable
             CocExtensions: Array.Empty<ExtractedCoc>(),
             Labels: Array.Empty<ExtractedLabel>());
         _repo.ApplyExtract(batch);
+    }
 
-        var crowdedBatch = new ExtractBatch(
-            Model: "CustomModel",
+    /// <summary>
+    /// Fills the fuzzy-search window with 101 custom-model EDTs whose names all
+    /// contain <paramref name="root"/>, so that a standard EDT sharing that root
+    /// falls outside <c>SearchEdts</c>'s limit. Opt-in per test: seeding this
+    /// into the shared fixture would silently change what every other test
+    /// exercises.
+    /// </summary>
+    private void SeedCrowdedFuzzyWindow(string root) =>
+        _repo.ApplyExtract(new ExtractBatch(
+            Model: $"{root}CrowdingModel",
             Publisher: "Test",
             Layer: "cus",
             IsCustom: true,
             Tables: Array.Empty<ExtractedTable>(),
             Classes: Array.Empty<ExtractedClass>(),
             Edts: Enumerable.Range(0, 101)
-                .Select(i => new ExtractedEdt($"CustomItem{i:D3}", null, "String", null, 20))
+                .Select(i => new ExtractedEdt($"{root}Filler{i:D3}", null, "String", null, 20))
                 .ToArray(),
             Enums: Array.Empty<ExtractedEnum>(),
             MenuItems: Array.Empty<ExtractedMenuItem>(),
             CocExtensions: Array.Empty<ExtractedCoc>(),
-            Labels: Array.Empty<ExtractedLabel>());
-        _repo.ApplyExtract(crowdedBatch);
+            Labels: Array.Empty<ExtractedLabel>()));
 
-        var standardBatch = new ExtractBatch(
-            Model: "Foundation",
-            Publisher: "Microsoft",
-            Layer: "sys",
-            IsCustom: false,
+    private void SeedEdt(string model, bool isCustom, string edtName, string? extends = null) =>
+        _repo.ApplyExtract(new ExtractBatch(
+            Model: model,
+            Publisher: isCustom ? "Test" : "Microsoft",
+            Layer: isCustom ? "cus" : "sys",
+            IsCustom: isCustom,
             Tables: Array.Empty<ExtractedTable>(),
             Classes: Array.Empty<ExtractedClass>(),
-            Edts: new[] { new ExtractedEdt("ItemId", "ItemIdBase", "String", null, 20) },
+            Edts: new[] { new ExtractedEdt(edtName, extends, "String", null, 20) },
             Enums: Array.Empty<ExtractedEnum>(),
             MenuItems: Array.Empty<ExtractedMenuItem>(),
             CocExtensions: Array.Empty<ExtractedCoc>(),
-            Labels: Array.Empty<ExtractedLabel>());
-        _repo.ApplyExtract(standardBatch);
-    }
+            Labels: Array.Empty<ExtractedLabel>()));
 
     [Fact]
     public void Exact_name_gets_top_confidence()
@@ -93,6 +100,9 @@ public class EdtSuggesterTests : IDisposable
     [Fact]
     public void Exact_name_is_not_lost_when_fuzzy_candidates_are_truncated()
     {
+        SeedCrowdedFuzzyWindow("Item");
+        SeedEdt("Foundation", isCustom: false, "ItemId", extends: "ItemIdBase");
+
         Assert.DoesNotContain(_repo.SearchEdts("Item", 100),
             edt => string.Equals(edt.Name, "ItemId", StringComparison.OrdinalIgnoreCase));
 
@@ -107,34 +117,25 @@ public class EdtSuggesterTests : IDisposable
     [Fact]
     public void Exact_candidates_preserve_model_identity()
     {
-        foreach (var (model, isCustom) in new[]
-                 {
-                     ("SyntheticBaseModel", false),
-                     ("SyntheticExtensionModel", true),
-                 })
-        {
-            _repo.ApplyExtract(new ExtractBatch(
-                Model: model,
-                Publisher: "Synthetic",
-                Layer: isCustom ? "cus" : "sys",
-                IsCustom: isCustom,
-                Tables: Array.Empty<ExtractedTable>(),
-                Classes: Array.Empty<ExtractedClass>(),
-                Edts: new[] { new ExtractedEdt("SharedReferenceId", null, "String", null, 20) },
-                Enums: Array.Empty<ExtractedEnum>(),
-                MenuItems: Array.Empty<ExtractedMenuItem>(),
-                CocExtensions: Array.Empty<ExtractedCoc>(),
-                Labels: Array.Empty<ExtractedLabel>()));
-        }
+        // Crowd the window too, otherwise the fuzzy sweep returns both rows on
+        // its own and the test passes without exercising the exact-name lookup.
+        SeedCrowdedFuzzyWindow("SharedReference");
+        SeedEdt("SyntheticBaseModel", isCustom: false, "SharedReferenceId");
+        SeedEdt("SyntheticExtensionModel", isCustom: true, "SharedReferenceId");
 
-        var exactSuggestions = EdtSuggester.Suggest(_repo, "sharedreferenceid", limit: 5)
+        Assert.DoesNotContain(_repo.SearchEdts("SharedReference", 100),
+            edt => string.Equals(edt.Name, "SharedReferenceId", StringComparison.OrdinalIgnoreCase));
+
+        var exactModels = EdtSuggester.Suggest(_repo, "sharedreferenceid", limit: 5)
             .Where(suggestion => suggestion.Confidence == 1.0)
+            .Select(suggestion => suggestion.Edt.Model)
             .ToList();
 
-        Assert.Equal(2, exactSuggestions.Count);
-        Assert.Equal(
-            new[] { "SyntheticExtensionModel", "SyntheticBaseModel" },
-            exactSuggestions.Select(suggestion => suggestion.Edt.Model));
+        // Order between same-name ties is not a documented contract, so assert
+        // the set: both qualified candidates survive for downstream disambiguation.
+        Assert.Equal(2, exactModels.Count);
+        Assert.Contains("SyntheticBaseModel", exactModels);
+        Assert.Contains("SyntheticExtensionModel", exactModels);
     }
 
     [Fact]


### PR DESCRIPTION
Fixes #169.

## Summary

- Retrieve case-insensitive exact-name EDT candidates independently of the fuzzy-search budget.
- Merge exact and fuzzy candidates by qualified `{ Name, Model }` identity.
- Add regression coverage for fuzzy candidate truncation and same-named EDTs across models.
- Keep the existing public repository lookup behavior unchanged outside the suggestion path.

## Root cause

`SearchEdts` applies ordering and a candidate limit before `EdtSuggester` scores results. A valid exact-name EDT outside that initial fuzzy result window was therefore never considered for the existing `1.0` exact-match score.

## Impact

Exact EDT suggestions are no longer silently lost when the fuzzy candidate set is crowded. When the same EDT name exists in multiple models, each qualified candidate remains available for downstream disambiguation.

## Validation

- `dotnet restore d365fo-cli.slnx` — passed; NuGet audit reachability and existing package advisory warnings were reported.
- `dotnet build d365fo-cli.slnx --no-restore -c Release -nologo` — passed with 0 errors.
- `dotnet test d365fo-cli.slnx --no-build -c Release --logger console;verbosity=minimal` — 1,180/1,180 passed outside the restricted sandbox.
- `dotnet run --project src/D365FO.Cli -c Release --no-build -- knowledge audit --verify --output json` — passed.
- `dotnet run --project src/D365FO.Cli -c Release --no-build -- eval run --all --output json` — 52/52 passed.
- `dotnet run --project src/D365FO.Cli -c Release --no-build -- eval coverage --check --output json` — passed.
- `python scripts/emit-skills.py` — not run locally because Python is unavailable; the upstream CI skill-drift job remains the verification gate.