### PR TITLE
fix: quote SKILL.md description to prevent YAML mapping parse error

### DIFF
--- a/skills/d365fo-cli/SKILL.md
+++ b/skills/d365fo-cli/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: d365fo-cli
-description: D365 Finance & Operations X++ AI development skill powered by the d365fo CLI. Use whenever the user is working in a D365 F&O X++ project: writing classes, tables, forms, CoC extensions, event handlers, entities, security, batch jobs, business events, labels, or any AOT artifact. Loads topic-specific guidance lazily from references/.
+description: "D365 Finance & Operations X++ AI development skill powered by the d365fo CLI. Use whenever the user is working in a D365 F&O X++ project: writing classes, tables, forms, CoC extensions, event handlers, entities, security, batch jobs, business events, labels, or any AOT artifact. Loads topic-specific guidance lazily from references/."
 compatibility: Requires GitHub Copilot agent mode (VS 2022/2026 or VS Code) and d365fo CLI in PATH.
 ---
 


### PR DESCRIPTION
The unquoted description value contained 'project: writing' which the YAML parser interpreted as a new mapping key at line 3, column 150, causing the error:

  Error in user YAML: mapping values are not allowed in this context
  at line 2 column 150

Wrapping the description in double quotes makes it a valid YAML scalar.