### PR TITLE
fix(skills): quote frontmatter scalars and parse them in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -79,6 +79,10 @@ jobs:
       - uses: actions/setup-python@v5
         with:
           python-version: "3.x"
+      - name: Install PyYAML
+        run: pip install pyyaml
+      - name: Frontmatter quoting round-trip
+        run: python3 scripts/test-emit-skills.py
       - name: Emit skills (Copilot + Anthropic + d365fo-cli)
         run: python3 scripts/emit-skills.py
       - name: Fail on untracked drift
@@ -91,3 +95,7 @@ jobs:
             git status --porcelain skills/
             exit 1
           fi
+      - name: Fail on unparseable frontmatter
+        # Drift only proves the bytes match what the emitter produced — #172 shipped
+        # frontmatter no YAML parser could read and this job stayed green. Parse it.
+        run: python3 scripts/check-skill-frontmatter.py

--- a/.gitignore
+++ b/.gitignore
@@ -20,3 +20,7 @@ memory/
 
 # Agent workflow scratch worktrees
 .claude/worktrees/
+
+# Python bytecode from scripts/ (test-emit-skills.py imports emit-skills.py)
+__pycache__/
+*.pyc

--- a/scripts/check-skill-frontmatter.py
+++ b/scripts/check-skill-frontmatter.py
@@ -1,0 +1,117 @@
+#!/usr/bin/env python3
+"""Fail if any shipped skill file has frontmatter a YAML parser cannot read.
+
+The drift job next to this one compares generated output against skills/_source.
+It catches a stale file; it does not catch a *malformed* one — issue #172 shipped
+frontmatter that no YAML parser could load and CI stayed green, because the bytes
+matched what the emitter produced. Parsing is the missing half of that check.
+
+Covers the generated variants and the hand-written files alike: skills/d365fo-cli/
+SKILL.md keeps its own frontmatter (emit-skills.py only refreshes the marker-
+delimited regions below it), so an emitter fix alone would never protect it.
+
+Usage: python scripts/check-skill-frontmatter.py [root]
+"""
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+try:
+    import yaml
+except ImportError:  # pragma: no cover - environment problem, not a content problem
+    print("error: PyYAML is required (pip install pyyaml)", file=sys.stderr)
+    raise SystemExit(2)
+
+PATTERNS = (
+    "skills/**/SKILL.md",
+    "skills/copilot/*.instructions.md",
+    ".claude/skills/**/SKILL.md",
+    ".github/skills/**/SKILL.md",
+)
+
+# Keys every consumer reads. A file may carry more; it may not lose these.
+REQUIRED = {
+    "SKILL.md": ("name", "description"),
+    ".instructions.md": ("description",),
+}
+
+
+def required_keys(path: Path) -> tuple[str, ...]:
+    for suffix, keys in REQUIRED.items():
+        if path.name.endswith(suffix):
+            return keys
+    return ()
+
+
+def frontmatter(text: str) -> str | None:
+    """The block between the opening '---' fence and the next one, or None."""
+    if not text.startswith("---"):
+        return None
+    rest = text[3:].lstrip("\r\n")
+    end = rest.find("\n---")
+    if end == -1:
+        return None
+    return rest[:end]
+
+
+def check(path: Path) -> list[str]:
+    text = path.read_text(encoding="utf-8")
+    block = frontmatter(text)
+    if block is None:
+        return ["no '---' frontmatter fence at the top of the file"]
+
+    try:
+        data = yaml.safe_load(block)
+    except yaml.YAMLError as exc:
+        detail = str(exc).replace("\n", " ")
+        return [f"frontmatter is not valid YAML: {detail}"]
+
+    if not isinstance(data, dict):
+        return [f"frontmatter parsed as {type(data).__name__}, expected a mapping"]
+
+    problems = []
+    for key in required_keys(path):
+        value = data.get(key)
+        if value is None:
+            problems.append(f"missing required key '{key}'")
+        elif not isinstance(value, str):
+            # The #172 shape: 'description: a: b' parses as a nested mapping
+            # rather than failing outright, so a clean parse is not enough.
+            problems.append(
+                f"'{key}' parsed as {type(value).__name__}, expected a string "
+                "— quote the value if it contains a colon"
+            )
+        elif not value.strip():
+            problems.append(f"'{key}' is empty")
+    return problems
+
+
+def main(argv: list[str]) -> int:
+    root = Path(argv[1]).resolve() if len(argv) > 1 else Path(__file__).resolve().parent.parent
+
+    seen: set[Path] = set()
+    for pattern in PATTERNS:
+        seen.update(p for p in root.glob(pattern) if p.is_file())
+
+    if not seen:
+        print(f"error: no skill files found under {root}", file=sys.stderr)
+        return 2
+
+    failures = 0
+    for path in sorted(seen):
+        rel = path.relative_to(root).as_posix()
+        for problem in check(path):
+            print(f"::error file={rel}::{problem}")
+            failures += 1
+
+    if failures:
+        print(f"\n{failures} frontmatter problem(s) across {len(seen)} skill file(s).", file=sys.stderr)
+        return 1
+
+    print(f"OK — frontmatter parses in all {len(seen)} skill file(s).")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main(sys.argv))

--- a/scripts/emit-skills.ps1
+++ b/scripts/emit-skills.ps1
@@ -79,10 +79,39 @@ function Parse-Yaml {
     return $map
 }
 
+# Kept in lock-step with needs_quoting()/yaml_scalar() in scripts/emit-skills.py.
+$script:YamlLeaders = '-?:,[]{}#&*!|>''"%@`'.ToCharArray()
+$script:YamlReserved = @('true', 'false', 'yes', 'no', 'on', 'off', 'null', 'none', '~', '')
+
+<#
+.SYNOPSIS
+    Renders a value as a YAML scalar, quoting only when a bare one would misparse.
+.DESCRIPTION
+    The failure this guards against is a description containing ": " — YAML reads
+    that as a nested mapping key and the whole frontmatter block stops parsing
+    (issue #172). Deliberately conservative: quoting a value that would have been
+    fine costs nothing, missing one breaks every consumer of the generated file.
+#>
+function ConvertTo-YamlScalar {
+    param([string]$Value)
+
+    $text = [string]$Value
+    $needsQuoting =
+        $text -ne $text.Trim() -or
+        $script:YamlReserved -contains $text.ToLowerInvariant() -or
+        ($text.Length -gt 0 -and $script:YamlLeaders -contains $text[0]) -or
+        $text.Contains(': ') -or
+        $text.EndsWith(':') -or
+        $text.Contains(' #')
+
+    if (-not $needsQuoting) { return $text }
+    return '"' + ($text -replace '\\', '\\' -replace '"', '\"') + '"'
+}
+
 function Emit-Copilot {
     param($Meta, [string]$Body, [string]$OutDir)
     $id = $Meta.id
-    $desc = $Meta.description
+    $desc = ConvertTo-YamlScalar $Meta.description
     $applyTo = @($Meta.applyTo) | Where-Object { $_ }
     $glob = if ($applyTo.Count -gt 0) { $applyTo -join ',' } else { '**/*' }
 
@@ -101,8 +130,8 @@ applyTo: '$glob'
 function Emit-Anthropic {
     param($Meta, [string]$Body, [string]$OutDir)
     $id = $Meta.id
-    $desc = $Meta.description
-    $appliesWhen = $Meta.appliesWhen
+    $desc = ConvertTo-YamlScalar $Meta.description
+    $appliesWhen = if ($Meta.appliesWhen) { ConvertTo-YamlScalar $Meta.appliesWhen } else { $null }
 
     $fm = @"
 ---

--- a/scripts/emit-skills.py
+++ b/scripts/emit-skills.py
@@ -70,13 +70,44 @@ def parse_yaml(text: str) -> dict[str, object]:
     return data
 
 
+# YAML indicator characters: a plain scalar may not start with one of these.
+_YAML_LEADERS = set("-?:,[]{}#&*!|>'\"%@`")
+
+# Plain scalars YAML would read as something other than a string.
+_YAML_RESERVED = {"true", "false", "yes", "no", "on", "off", "null", "none", "~", ""}
+
+
+def needs_quoting(value: str) -> bool:
+    """
+    True when `value` cannot be written as a bare YAML scalar.
+
+    The failure this guards against is a description containing ": " — YAML
+    reads that as a nested mapping key and the whole frontmatter block stops
+    parsing (issue #172). Deliberately conservative: quoting a value that would
+    have been fine costs nothing, missing one breaks every consumer of the file.
+    """
+    if value != value.strip() or value.lower() in _YAML_RESERVED:
+        return True
+    if value[0] in _YAML_LEADERS:
+        return True
+    return ": " in value or value.endswith(":") or " #" in value
+
+
+def yaml_scalar(value: object) -> str:
+    """Render `value` as a YAML scalar, quoting only when a bare one would misparse."""
+    text = str(value)
+    if not needs_quoting(text):
+        return text
+    return '"' + text.replace("\\", "\\\\").replace('"', '\\"') + '"'
+
+
 def emit_copilot(meta: dict, body: str, out_dir: Path) -> Path:
     sid = meta["id"]
     apply_to = meta.get("applyTo") or []
     if isinstance(apply_to, str):
         apply_to = [apply_to]
     glob = ",".join(apply_to) if apply_to else "**/*"
-    fm = f"---\ndescription: {meta['description']}\napplyTo: '{glob}'\n---\n"
+    fm = f"---\ndescription: {yaml_scalar(meta['description'])}\napplyTo: '{glob}'\n---\n"
     out_dir.mkdir(parents=True, exist_ok=True)
     path = out_dir / f"{sid}.instructions.md"
     path.write_text(fm + body, encoding="utf-8")
@@ -85,9 +116,9 @@ def emit_copilot(meta: dict, body: str, out_dir: Path) -> Path:
 
 def emit_anthropic(meta: dict, body: str, out_dir: Path) -> Path:
     sid = meta["id"]
-    lines = ["---", f"name: {sid}", f"description: {meta['description']}"]
+    lines = ["---", f"name: {sid}", f"description: {yaml_scalar(meta['description'])}"]
     if "appliesWhen" in meta:
-        lines.append(f"applies_when: {meta['appliesWhen']}")
+        lines.append(f"applies_when: {yaml_scalar(meta['appliesWhen'])}")
     lines.append("---\n")
     fm = "\n".join(lines)
     dir_ = out_dir / sid

--- a/scripts/test-emit-skills.py
+++ b/scripts/test-emit-skills.py
@@ -1,0 +1,95 @@
+#!/usr/bin/env python3
+"""Round-trip tests for the frontmatter quoting in scripts/emit-skills.py.
+
+Run: python scripts/test-emit-skills.py
+
+Plain asserts rather than a test framework — the skills job installs PyYAML and
+nothing else, and this has to stay runnable on a bare `actions/setup-python`.
+Keep scripts/emit-skills.ps1's ConvertTo-YamlScalar in lock-step with anything
+changed here; the two emitters must produce byte-identical frontmatter.
+"""
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import yaml
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+
+from importlib import import_module
+
+emit = import_module("emit-skills")
+
+
+def roundtrip(key: str, value: str) -> object:
+    """Emit `key: value` the way the emitter would, then parse it back."""
+    return yaml.safe_load(f"{key}: {emit.yaml_scalar(value)}")[key]
+
+
+def check(value: str, why: str) -> None:
+    got = roundtrip("description", value)
+    assert got == value, f"{why}: {value!r} round-tripped to {got!r}"
+
+
+# The #172 shape: a colon-space makes YAML read a nested mapping key and the
+# whole frontmatter block stops parsing.
+check(
+    "D365 F&O X++ skill. Use when working in a D365 F&O X++ project: writing "
+    "classes, tables, forms, or any AOT artifact.",
+    "colon-space must survive",
+)
+
+# A space-hash starts a comment in a plain scalar and silently truncates the
+# value — no parse error, just a shorter string.
+check(
+    "User intent mentions macros and #define.",
+    "space-hash must survive",
+)
+
+# Values that are fine bare must stay bare, so the fix causes no regeneration
+# churn across the 70+ committed skill files.
+for bare in (
+    "Author a Chain-of-Command extension in D365FO without duplicating wrappers.",
+    'Use when the user asks to "wrap a method" or "add a CoC".',
+    "Scaffold an AxForm using one of the nine canonical patterns (SimpleList, Dialog).",
+    "Move data in and out of D365FO — DMF, dual-write, virtual entities.",
+):
+    assert emit.yaml_scalar(bare) == bare, f"unnecessarily quoted: {bare!r}"
+    check(bare, "bare value must survive")
+
+# Shapes YAML would read as a non-string, or lose entirely.
+for tricky in (
+    "yes",
+    "null",
+    "~",
+    "  leading and trailing  ",
+    "- looks like a sequence item",
+    "*anchor-ish",
+    "trailing colon:",
+    "{ looks like a flow mapping }",
+    "@reserved",
+    "%directive",
+    '"already quoted"',
+    "back\\slash and \"quotes\"",
+):
+    got = roundtrip("description", tricky)
+    assert got == tricky, f"tricky value {tricky!r} round-tripped to {got!r}"
+    assert isinstance(got, str), f"{tricky!r} parsed as {type(got).__name__}"
+
+# The emitted frontmatter block as a whole must parse, not just the one line.
+description = "Covers X++ interop: CLRInterop and #define."
+applies_when = "User mentions interop: .NET calls, or #macros."
+block = "\n".join(
+    [
+        "name: some-topic",
+        f"description: {emit.yaml_scalar(description)}",
+        f"applies_when: {emit.yaml_scalar(applies_when)}",
+    ]
+)
+parsed = yaml.safe_load(block)
+assert parsed["name"] == "some-topic"
+assert parsed["description"] == description
+assert parsed["applies_when"] == applies_when
+
+print("OK — emit-skills frontmatter quoting round-trips.")

--- a/skills/anthropic/xpp-runtime-types/SKILL.md
+++ b/skills/anthropic/xpp-runtime-types/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: xpp-runtime-types
 description: Use the X++ runtime type surface correctly — collections and containers, utcdatetime and time zones, .NET interop, the Dict* reflection API, and macros. Invoke when the user asks about List/Map/Set/Struct/container, date and time zone handling, calling .NET from X++, runtime metadata, or macro libraries.
-applies_when: User intent mentions List, Map, Set, Struct, container, conPeek/conIns, enumerator, utcdatetime, DateTimeUtil, time zone, date arithmetic, .NET interop, CLRInterop, CLRError, StringBuilder, reflection, DictTable/DictField/DictClass/DictEnum, or macros and #define.
+applies_when: "User intent mentions List, Map, Set, Struct, container, conPeek/conIns, enumerator, utcdatetime, DateTimeUtil, time zone, date arithmetic, .NET interop, CLRInterop, CLRError, StringBuilder, reflection, DictTable/DictField/DictClass/DictEnum, or macros and #define."
 ---
 > ⛔ **NEVER write X++ AOT XML files directly** via PowerShell, terminal file commands (`Set-Content`, `Out-File`, `New-Item`), editor write tools, or any raw text approach. The XML schema is proprietary. **ALWAYS use `d365fo generate …` commands** to produce correct AOT XML. If `d365fo` is unavailable in PATH, stop and ask the user to install it.
 


### PR DESCRIPTION
Closes #174. Follow-up to #172, which fixed one file by hand while the mechanism that produced it stayed in place.

## What was wrong

Both emitters interpolated `description` (and `appliesWhen`) into YAML frontmatter bare — `scripts/emit-skills.py:79,88` and `scripts/emit-skills.ps1:91,110` — so any value carrying YAML punctuation was at the parser's mercy.

## What it was already costing us

While wiring the fix I found a second live instance, this one silent. `xpp-runtime-types` ends its trigger with `... or macros and #define.`, and a space-hash opens a comment in a plain scalar:

```
>>> yaml.safe_load('applies_when: User intent mentions List, Map, or macros and #define.')
{'applies_when': 'User intent mentions List, Map, or macros and'}
```

No error, just a shorter string — every consumer had been reading that trigger truncated. The regenerated file in this PR is a content fix, not churn.

## The fix

A shared `yaml_scalar` in both emitters that quotes **only when a bare scalar would misparse** (colon-space, trailing colon, space-hash, a leading YAML indicator, reserved words like `yes`/`null`, leading or trailing whitespace). Quoting unconditionally would have rewritten the `description:` line of all 70+ committed skill files; this way the only file that changes is the one that was actually broken.

`scripts/emit-skills.ps1` carries the same predicate as `ConvertTo-YamlScalar` — the two emitters have to produce byte-identical frontmatter, so they are commented as a lock-step pair.

## The missing gate

The `skills` job compared bytes against what the emitter produced, which is exactly why #172 shipped green: the file was faithfully generated *and* unparseable. Two steps added:

- `scripts/test-emit-skills.py` — round-trips the #172 colon shape, the space-hash shape, and a set of tricky values through PyYAML, and asserts values that are fine bare stay bare.
- `scripts/check-skill-frontmatter.py` — parses the frontmatter of all 72 shipped skill files. Covers the hand-written ones too: `skills/d365fo-cli/SKILL.md` keeps its own frontmatter (`emit_skill_md` only refreshes the marker-delimited regions), so an emitter fix alone would never have protected it. It also rejects a `description` that parses as a *mapping* rather than a string, which is the #172 shape that can parse cleanly in some positions.

## Verification

- Both emitters run over all 35 topics produce identical frontmatter; only `xpp-runtime-types` changes.
- `test-emit-skills.py` fails with the quoting removed, passes with it.
- `check-skill-frontmatter.py` fails on a deliberately broken `SKILL.md`, passes on the tree.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
