### PR TITLE
fix(edt): recover truncated whole-name matches, match GetEdt case-insensitively

### DIFF
--- a/src/D365FO.Core/EdtSuggester.cs
+++ b/src/D365FO.Core/EdtSuggester.cs
@@ -35,30 +35,29 @@ public static class EdtSuggester
 
         // Over-fetch then score. Single LIKE scan on Name — Edts table is small.
         var fetch = Math.Min(Math.Max(limit * 20, 100), MetadataRepository.MaxRowLimit);
-        var candidates = repo.SearchEdts(stripped.Length >= 3 ? stripped : target, fetch).ToList();
-        if (candidates.Count == 0 && stripped.Length >= 3)
-            candidates.AddRange(repo.SearchEdts(stripped, fetch));
+        var root = stripped.Length >= 3 ? stripped : target;
+        var candidates = repo.SearchEdts(root, fetch).ToList();
 
         // SearchEdts orders custom models first and applies its limit before
-        // scoring, so a standard EDT can be truncated away before it ever earns
-        // its 1.0 exact-match score. Re-fetch exact names to put them back.
-        //
-        // Only when the sweep filled its whole budget can anything have been
-        // truncated — a short sweep already contains every name matching the
-        // root, exact ones included. Skipping the lookup in that case keeps
-        // the common path at a single query — prepare calls Suggest once per
-        // field, and each call opens its own connection.
+        // scoring, so the sweep can drop a name that would have outscored
+        // everything it kept. That is only possible when the sweep filled its
+        // whole budget — a short one already holds every name matching the
+        // root. Checking first keeps the common path at a single query, which
+        // matters because prepare calls Suggest once per field and each call
+        // opens its own connection.
         if (candidates.Count >= fetch)
         {
-            foreach (var exact in repo.FindEdtsExact(target))
-            {
-                if (!candidates.Any(candidate =>
-                        string.Equals(candidate.Name, exact.Name, StringComparison.OrdinalIgnoreCase) &&
-                        string.Equals(candidate.Model, exact.Model, StringComparison.OrdinalIgnoreCase)))
-                {
-                    candidates.Add(exact);
-                }
-            }
+            // The root sweep is the broader of the two: stripping only ever
+            // shortens the term, so every name containing the whole field name
+            // also contains its root. Re-running on the full name therefore adds
+            // nothing unless the budget cut those longer, higher-scoring names
+            // off — which is exactly the case being repaired here.
+            if (!string.Equals(root, target, StringComparison.Ordinal))
+                Merge(candidates, repo.SearchEdts(target, fetch));
+
+            // Same reasoning for the exact name, which scores 1.0 and must never
+            // lose to a crowd of custom-model near-misses.
+            Merge(candidates, repo.FindEdtsExact(target));
         }
 
         var scored = new List<Suggestion>();
@@ -73,6 +72,20 @@ public static class EdtSuggester
             .ThenBy(s => s.Edt.Name, StringComparer.OrdinalIgnoreCase)
             .Take(limit)
             .ToList();
+    }
+
+    /// <summary>Appends the rows of <paramref name="extra"/> that <paramref name="into"/> does not already hold, keyed by qualified name.</summary>
+    private static void Merge(List<EdtInfo> into, IReadOnlyList<EdtInfo> extra)
+    {
+        foreach (var candidate in extra)
+        {
+            if (!into.Any(existing =>
+                    string.Equals(existing.Name, candidate.Name, StringComparison.OrdinalIgnoreCase) &&
+                    string.Equals(existing.Model, candidate.Model, StringComparison.OrdinalIgnoreCase)))
+            {
+                into.Add(candidate);
+            }
+        }
     }
 
     private static (double Score, string Reason) Score(string target, string stripped, string edtName)

--- a/src/D365FO.Core/Index/MetadataRepository.cs
+++ b/src/D365FO.Core/Index/MetadataRepository.cs
@@ -423,6 +423,13 @@ public sealed partial class MetadataRepository
         return new TableDetails(table, fields, relations, methods, indexes, deleteActions);
     }
 
+    /// <summary>
+    /// One EDT by name, case-insensitively — X++ identifiers are, and callers
+    /// pass names an LLM produced. Where the name exists in several models the
+    /// custom one wins, so the answer does not depend on insertion order.
+    /// Served by <c>IX_Edts_Name_NoCase</c>, the same index
+    /// <see cref="FindEdtsExact"/> uses.
+    /// </summary>
     public EdtInfo? GetEdt(string name)
     {
         using var conn = OpenReadOnly();
@@ -431,7 +438,9 @@ public sealed partial class MetadataRepository
                    e.BaseType, e.Label, e.StringSize,
                    e.ReferenceTable, e.FormHelp, e.AnalysisUsage, e.EnumType
             FROM Edts e JOIN Models m ON m.ModelId = e.ModelId
-            WHERE e.Name = @name LIMIT 1", new { name });
+            WHERE e.Name = @name COLLATE NOCASE
+            ORDER BY m.IsCustom DESC, m.Name COLLATE NOCASE
+            LIMIT 1", new { name });
     }
 
     /// <summary>

--- a/tests/D365FO.Core.Tests/EdtSuggesterTests.cs
+++ b/tests/D365FO.Core.Tests/EdtSuggesterTests.cs
@@ -115,6 +115,25 @@ public class EdtSuggesterTests : IDisposable
     }
 
     [Fact]
+    public void Whole_name_match_is_recovered_when_the_root_sweep_is_truncated()
+    {
+        // "LineNum" strips to the root "Line", and the root sweep is the broader
+        // of the two — so the only way a name carrying the whole field name gets
+        // lost is the budget cutting it off behind a crowd of custom names.
+        SeedCrowdedFuzzyWindow("Line");
+        SeedEdt("Foundation", isCustom: false, "InventLineNum");
+
+        Assert.DoesNotContain(_repo.SearchEdts("Line", 100),
+            edt => string.Equals(edt.Name, "InventLineNum", StringComparison.OrdinalIgnoreCase));
+
+        var suggestions = EdtSuggester.Suggest(_repo, "LineNum", limit: 5);
+
+        Assert.NotEmpty(suggestions);
+        Assert.Equal("InventLineNum", suggestions[0].Edt.Name);
+        Assert.Equal("whole-name token match", suggestions[0].Reason);
+    }
+
+    [Fact]
     public void Exact_candidates_preserve_model_identity()
     {
         // Crowd the window too, otherwise the fuzzy sweep returns both rows on

--- a/tests/D365FO.Core.Tests/MetadataRepositoryTests.cs
+++ b/tests/D365FO.Core.Tests/MetadataRepositoryTests.cs
@@ -345,4 +345,45 @@ public class MetadataRepositoryTests : IDisposable
         Assert.Equal("RunBaseBatch", detail!.Class.Extends);
         Assert.Empty(detail.InheritedMethods);
     }
+
+    [Theory]
+    [InlineData("CustAccount")]
+    [InlineData("custaccount")]
+    [InlineData("CUSTACCOUNT")]
+    [InlineData("cUsTaCcOuNt")]
+    public void GetEdt_matches_regardless_of_case(string queried)
+    {
+        var repo = new MetadataRepository(_dbPath);
+        repo.EnsureSchema();
+        repo.ApplyExtract(ExtractBatch.Empty("ApplicationSuite") with
+        {
+            Edts = new[] { new ExtractedEdt("CustAccount", null, "String", null, 20) },
+        });
+
+        var edt = repo.GetEdt(queried);
+
+        Assert.NotNull(edt);
+        Assert.Equal("CustAccount", edt!.Name);
+    }
+
+    [Fact]
+    public void GetEdt_prefers_the_custom_model_when_the_name_exists_in_several()
+    {
+        var repo = new MetadataRepository(_dbPath);
+        repo.EnsureSchema();
+        repo.ApplyExtract(ExtractBatch.Empty("ApplicationSuite") with
+        {
+            IsCustom = false,
+            Edts = new[] { new ExtractedEdt("SharedId", null, "String", null, 10) },
+        });
+        repo.ApplyExtract(ExtractBatch.Empty("Contoso") with
+        {
+            IsCustom = true,
+            Edts = new[] { new ExtractedEdt("SharedId", null, "String", null, 20) },
+        });
+
+        // Without an ORDER BY the LIMIT 1 took whichever row SQLite reached
+        // first, so the answer depended on insertion order.
+        Assert.Equal("Contoso", repo.GetEdt("sharedid")!.Model);
+    }
 }


### PR DESCRIPTION
Closes #173.

## 1. The dead fallback

```csharp
if (candidates.Count == 0 && stripped.Length >= 3)
    candidates.AddRange(repo.SearchEdts(stripped, fetch));
```

The issue called for repointing this at the unstripped `target`. Working through it, that would not have helped either: `Strip` only ever shortens the term, so `stripped` is a prefix of `target` and every name matching `%target%` also matches `%stripped%`. A root sweep that returned nothing guarantees the narrower sweep returns nothing too — the branch is unreachable in one direction and useless in the other.

What it was reaching for is real, but it fires under a different condition. `SearchEdts` orders custom models first and cuts at its limit, so a crowd of custom names sharing the root can push out a longer name carrying the **whole** field name — worth 0.70 (`whole-name token match`) against the 0.60 the crowd earns. That loss is only possible when the sweep filled its budget, which is the same trigger the exact-name lookup from #170 already uses. Both now run behind one `candidates.Count >= fetch` check and share a `Merge` helper for the qualified-name dedup.

New regression test: field `LineNum` (root `Line`) against 101 custom `LineFiller*` names plus a standard `InventLineNum`. Without the fix `InventLineNum` never reaches the scorer.

## 2. `GetEdt` case-sensitivity

`GetEdt` matched `WHERE e.Name = @name` with no collation override while `FindEdtsExact` sat right below it using `COLLATE NOCASE`. X++ identifiers are case-insensitive and these names arrive from an LLM, so the strict one was the odd path. It now reuses `IX_Edts_Name_NoCase` — the index #170 added, so no new scan.

Matching case-insensitively can hit several models at once, so the query also takes a deterministic `ORDER BY m.IsCustom DESC, m.Name` — the bare `LIMIT 1` previously returned whichever row SQLite reached first. Covered by a `[Theory]` over four casings plus a multi-model ordering test; all four fail with the collation removed.

## Deliberately not changed

- **`NameSuggester`** takes the same 50-row truncation, but it only runs *after* an exact lookup already missed, so there is no exact match for it to lose — truncation costs hint quality, not correctness.
- **The rest of the `Get*` family** (`GetClass`, `GetTable`, `GetEnum`, `GetMenuItem`, `GetMap`, `GetBusinessEvent`, `GetSecurityPolicy`, `GetModel`) is uniformly case-sensitive. Widening that means moving the name-joined detail queries with it (`GetClassDetails` would otherwise find the class and none of its methods) and adding NOCASE indexes for tables that have none. That is a bigger, riskier change than this issue covers and is left alone rather than half-done.

## Verification

1180+6 tests pass; `knowledge audit --verify`, `eval run --all` (52/52) and `eval coverage --check` all clean. Both fixes fail their tests when reverted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
