### PR TITLE
fix(modify): resolve extension kinds from the registry, not a private table

### DIFF
--- a/src/D365FO.Core/Bridge/ObjectModifyEngine.cs
+++ b/src/D365FO.Core/Bridge/ObjectModifyEngine.cs
@@ -7,6 +7,7 @@ using System.Xml.Linq;
 using D365FO.Core.FormPatterns;
 using D365FO.Core.Index;
 using D365FO.Core.Journal;
+using D365FO.Core.ObjectTypes;
 using D365FO.Core.Scaffolding;
 
 namespace D365FO.Core.Bridge;
@@ -106,30 +107,21 @@ public static class ObjectModifyEngine
     private static readonly IReadOnlySet<string> SupportedKinds =
         new HashSet<string>(StringComparer.OrdinalIgnoreCase) { "class", "table", "edt", "enum", "form" };
 
-    /// <summary>Base kind → the bridge kind that extends it.</summary>
-    private static readonly IReadOnlyDictionary<string, string> ExtensionKindFor =
-        new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase)
-        {
-            ["table"] = "tableExtension",
-            ["form"] = "formExtension",
-            ["edt"] = "edtExtension",
-            ["enum"] = "enumExtension",
-            ["view"] = "viewExtension",
-            ["query"] = "queryExtension",
-            ["dataentityview"] = "dataEntityViewExtension",
-        };
-
-    /// <summary>Base kind → the root element name of its extension object.</summary>
-    private static readonly IReadOnlyDictionary<string, string> ExtensionRootFor =
-        new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase)
-        {
-            ["table"] = "AxTableExtension",
-            ["form"] = "AxFormExtension",
-            ["enum"] = "AxEnumExtension",
-            ["view"] = "AxViewExtension",
-            ["query"] = "AxQueryExtension",
-            ["dataentityview"] = "AxDataEntityViewExtension",
-        };
+    /// <summary>
+    /// The AOT type that extends <paramref name="kind"/>, or null when there is none.
+    /// </summary>
+    /// <remarks>
+    /// This used to be two hand-maintained dictionaries — one for the kind the bridge is
+    /// asked for, one for the root element to scaffold — and they drifted from the
+    /// registry the bridge itself resolves collections through, which is how a redirect
+    /// to a perfectly writable <c>AxTableExtension</c> came back as INVALID_KIND (#171).
+    /// One lookup, one source of truth. It also drops two wrong entries the tables
+    /// carried: <c>edt</c> had no root at all and fell through to a mis-cased
+    /// "AxedtExtension", and <c>query</c> named an <c>AxQueryExtension</c> type that no
+    /// MetaModel assembly declares.
+    /// </remarks>
+    private static ObjectTypeInfo? ExtensionTypeFor(string kind)
+        => ObjectTypeRegistry.ExtensionOf(kind);
 
     /// <summary>Entry point for the CLI and the MCP tool. Spawns the bridge and fails closed when it is absent.</summary>
     public static ToolResult<object> Modify(
@@ -214,9 +206,7 @@ public static class ObjectModifyEngine
             var msg = (string?)writeResult["message"] ?? "unknown error";
             return ToolResult<object>.Fail(code,
                 $"Bridge could not write {target.Kind} '{target.Name}': {msg}",
-                target.IsExtension
-                    ? $"The {target.Kind} collection may not be exposed by this platform build; check `d365fo doctor` and the bridge log."
-                    : null);
+                BridgeFailureHint(code, target));
         }
 
         warnings.Add($"Index not auto-refreshed — run `d365fo index refresh --model {target.Model}` so '{request.Member}' is searchable.");
@@ -232,6 +222,29 @@ public static class ObjectModifyEngine
             source = "bridge",
             applied,
         }, warnings);
+    }
+
+    /// <summary>
+    /// What to tell the caller when the bridge refuses a read or a write.
+    /// </summary>
+    /// <remarks>
+    /// INVALID_KIND used to be reported as "this platform build may not expose the
+    /// collection", which sent #171 chasing a platform capability that was there all
+    /// along. Both halves resolve kinds through the same <see cref="ObjectTypeRegistry"/>,
+    /// so if this process planned a write to a kind the bridge does not recognise, the
+    /// two binaries are from different builds — that is the thing to say.
+    /// </remarks>
+    private static string? BridgeFailureHint(string code, WriteTarget target)
+    {
+        if (string.Equals(code, "INVALID_KIND", StringComparison.Ordinal))
+        {
+            return $"The bridge does not recognise '{target.Kind}', but this build resolves it to the " +
+                   $"{ObjectTypeRegistry.Find(target.Kind)?.ProviderCollection ?? "?"} provider collection — " +
+                   "the bridge executable is from an older build. Rebuild it, or point D365FO_BRIDGE_PATH at a matching one.";
+        }
+        return target.IsExtension
+            ? $"Check `d365fo doctor` and the bridge log for why {target.Kind} '{target.Name}' was rejected."
+            : null;
     }
 
     // ---------------------------------------------------------------- validation
@@ -289,7 +302,8 @@ public static class ObjectModifyEngine
         if (baseWritable)
             return (new WriteTarget(kind, request.ObjectName, baseModel, IsExtension: false, Exists: true), null);
 
-        if (!ExtensionKindFor.TryGetValue(kind, out var extKind))
+        var extensionType = ExtensionTypeFor(kind);
+        if (extensionType is null)
         {
             if (request.RequireExtension || request.ExtensionSuffix is not null)
             {
@@ -301,6 +315,18 @@ public static class ObjectModifyEngine
                          "and this kind has no extension form — modifying it in place.");
             return (new WriteTarget(kind, request.ObjectName, baseModel, IsExtension: false, Exists: true), null);
         }
+
+        // Catch a type the AOT models but the provider exposes no channel for here,
+        // rather than letting the bridge answer INVALID_KIND from three layers down.
+        if (extensionType.ProviderCollection is null)
+        {
+            return (null, ToolResult<object>.Fail(D365FoErrorCodes.BadInput,
+                $"{extensionType.RootElement} cannot be written through the metadata provider, " +
+                $"so '{request.ObjectName}' cannot be extended.",
+                $"Scaffold the extension with `d365fo generate extension` and edit the {extensionType.RootElement} file instead."));
+        }
+
+        var extKind = extensionType.Kind;
 
         var suffix = request.ExtensionSuffix is { Length: > 0 } s ? s : DefaultSuffix(request, repo);
         var extName = $"{request.ObjectName}.{suffix}";
@@ -393,8 +419,11 @@ public static class ObjectModifyEngine
         {
             // A brand-new extension object: start from the minimal shape the scaffolder
             // emits, so the document the bridge deserializes is the same one
-            // `generate extension` would have produced.
-            var root = ExtensionRootFor.TryGetValue(kind, out var r) ? r : $"Ax{kind}Extension";
+            // `generate extension` would have produced. The registry owns the root
+            // element — PlanTarget already refused any kind it does not know.
+            var root = ExtensionTypeFor(kind)?.RootElement
+                       ?? ObjectTypeRegistry.Find(target.Kind)?.RootElement
+                       ?? throw new InvalidOperationException($"No registered AOT type for '{target.Kind}'.");
             var fresh = new XDocument(new XElement(root, new XElement("Name", target.Name)));
             return (fresh, null, null);
         }
@@ -421,7 +450,8 @@ public static class ObjectModifyEngine
             var code = (string?)readResult["error"] ?? "READ_FAILED";
             var msg = (string?)readResult["message"] ?? "unknown error";
             return (null, null, ToolResult<object>.Fail(code == "NOT_FOUND" ? NotFoundCodeFor(kind) : code,
-                $"Bridge could not read {target.Kind} '{target.Name}': {msg}"));
+                $"Bridge could not read {target.Kind} '{target.Name}': {msg}",
+                BridgeFailureHint(code, target)));
         }
 
         var xml = (string?)readResult["xml"];

--- a/src/D365FO.Core/ObjectTypes/ObjectTypeRegistry.cs
+++ b/src/D365FO.Core/ObjectTypes/ObjectTypeRegistry.cs
@@ -320,6 +320,28 @@ namespace D365FO.Core.ObjectTypes
             return null;
         }
 
+        /// <summary>
+        /// The type that extends <paramref name="baseKindOrRoot"/>, or null when the AOT
+        /// has no extension form for it. Every registered extension kind is its base kind
+        /// plus "extension", so the relation needs no second table to drift out of step:
+        /// the returned entry carries the real root element ("query" yields
+        /// <c>AxQuerySimpleExtension</c>, not the <c>AxQueryExtension</c> that no
+        /// assembly declares) and the provider collection the bridge writes through.
+        /// </summary>
+        public static ObjectTypeInfo ExtensionOf(string baseKindOrRoot)
+        {
+            var baseType = Find(baseKindOrRoot);
+            if (baseType == null) return null;
+            // Extensions do not nest: an extension has no extension of its own.
+            if (baseType.Kind.EndsWith("extension", StringComparison.Ordinal)) return null;
+
+            var wanted = baseType.Kind + "extension";
+            for (var i = 0; i < _all.Length; i++)
+                if (_all[i].Kind == wanted)
+                    return _all[i];
+            return null;
+        }
+
         /// <summary>AOT subfolder for a kind. Throws for an unknown kind — callers hard-code folders otherwise.</summary>
         public static string Subfolder(string kindOrRoot)
         {

--- a/tests/D365FO.Core.Tests/ObjectModifyEngineTests.cs
+++ b/tests/D365FO.Core.Tests/ObjectModifyEngineTests.cs
@@ -50,6 +50,7 @@ public sealed class ObjectModifyEngineTests : IDisposable
             IsCustom = false,
             Tables = new[] { new ExtractedTable("CustTable", null, "x", Array.Empty<ExtractedTableField>()) },
             Enums = new[] { new ExtractedEnum("CustAccountStatus", null, Array.Empty<ExtractedEnumValue>()) },
+            Edts = new[] { new ExtractedEdt("CustAccount", null, "String", null, 20) },
             Forms = new[] { new ExtractedForm("FmVehicleList", "x", Array.Empty<ExtractedFormDataSource>()) },
         });
 
@@ -249,7 +250,7 @@ public sealed class ObjectModifyEngineTests : IDisposable
         Assert.True(result.Ok, result.Error?.Message);
         // A new extension object is *created*, never an update of CustTable itself.
         Assert.Equal("createObject", capture.WriteVerb);
-        Assert.Equal("tableExtension", (string?)capture.WriteArgs!["kind"]);
+        Assert.Equal("tableextension", (string?)capture.WriteArgs!["kind"]);
         Assert.Equal("CustTable.Extension", (string?)capture.WriteArgs!["name"]);
         Assert.Equal("FleetCustom", (string?)capture.WriteArgs!["model"]);
 
@@ -278,7 +279,7 @@ public sealed class ObjectModifyEngineTests : IDisposable
         }, _repo, harness.Client, _journalDb);
 
         Assert.True(result.Ok, result.Error?.Message);
-        Assert.Equal("enumExtension", (string?)capture.WriteArgs!["kind"]);
+        Assert.Equal("enumextension", (string?)capture.WriteArgs!["kind"]);
 
         var written = XDocument.Parse((string)capture.WriteArgs!["xml"]!);
         var value = written.Descendants("AxEnumValue").Single();
@@ -286,6 +287,71 @@ public sealed class ObjectModifyEngineTests : IDisposable
         // An extensible enum is position-based; a written <Value> breaks when another
         // model inserts a member ahead of this one.
         Assert.Null(value.Element("Value"));
+    }
+
+    [Fact]
+    public void An_edt_extension_is_scaffolded_with_the_root_element_the_metamodel_declares()
+    {
+        var capture = new BridgeCapture(readXml: null);
+        using var harness = FakeBridge.Create(capture.Respond);
+
+        var result = ObjectModifyEngine.ModifyCore(new ObjectModifyEngine.ModifyRequest
+        {
+            Operation = ObjectModifyEngine.Operation.SetProperty,
+            Kind = "edt",
+            ObjectName = "CustAccount",
+            Member = "StringSize",
+            Value = "30",
+        }, _repo, harness.Client, _journalDb);
+
+        Assert.True(result.Ok, result.Error?.Message);
+        Assert.Equal("edtextension", (string?)capture.WriteArgs!["kind"]);
+
+        // The table this replaced had no "edt" row, so the root fell through to
+        // $"Ax{kind}Extension" and emitted a mis-cased <AxedtExtension>.
+        var written = XDocument.Parse((string)capture.WriteArgs!["xml"]!);
+        Assert.Equal("AxEdtExtension", written.Root!.Name.LocalName);
+    }
+
+    [Fact]
+    public void An_invalid_kind_from_the_bridge_points_at_the_bridge_build_not_the_platform()
+    {
+        using var harness = FakeBridge.Create(request =>
+        {
+            // An older bridge: its kind table predates the extension entries, so it
+            // rejects the redirect target on whichever leg reaches it first.
+            var result = new JsonObject
+            {
+                ["ok"] = false,
+                ["error"] = "INVALID_KIND",
+                ["message"] = "kind must be one of: class, table, edt, enum, form",
+            };
+            return new JsonObject
+            {
+                ["jsonrpc"] = "2.0",
+                ["id"] = request["id"]?.DeepClone(),
+                ["result"] = result,
+            };
+        });
+
+        var result = ObjectModifyEngine.ModifyCore(new ObjectModifyEngine.ModifyRequest
+        {
+            Operation = ObjectModifyEngine.Operation.AddField,
+            Kind = "table",
+            ObjectName = "CustTable",
+            Member = "FleetRating",
+            Type = "Name",
+            ExtensionSuffix = "Fleet",
+        }, _repo, harness.Client, _journalDb);
+
+        Assert.False(result.Ok);
+        Assert.Equal("INVALID_KIND", result.Error!.Code);
+        // #171 blamed the platform for a collection it does in fact expose. The
+        // registry both halves read says this kind is writable, so the two
+        // binaries disagreeing is the only thing left.
+        Assert.Contains("older build", result.Error.Hint);
+        Assert.Contains("TableExtensions", result.Error.Hint);
+        Assert.DoesNotContain("platform build", result.Error.Hint);
     }
 
     [Fact]

--- a/tests/D365FO.Core.Tests/ObjectTypeRegistryTests.cs
+++ b/tests/D365FO.Core.Tests/ObjectTypeRegistryTests.cs
@@ -217,4 +217,60 @@ public class ObjectTypeRegistryTests
                  })
             Assert.Contains(expected, commands);
     }
+
+    // ---- extension relation (#171) -------------------------------------------
+
+    [Theory]
+    [InlineData("table", "AxTableExtension", "TableExtensions")]
+    [InlineData("form", "AxFormExtension", "FormExtensions")]
+    [InlineData("enum", "AxEnumExtension", "EnumExtensions")]
+    [InlineData("edt", "AxEdtExtension", "EdtExtensions")]
+    [InlineData("view", "AxViewExtension", "ViewExtensions")]
+    [InlineData("dataentityview", "AxDataEntityViewExtension", "DataEntityViewExtensions")]
+    public void ExtensionOf_resolves_the_root_and_collection(string baseKind, string root, string collection)
+    {
+        var extension = ObjectTypeRegistry.ExtensionOf(baseKind);
+
+        Assert.NotNull(extension);
+        Assert.Equal(root, extension!.RootElement);
+        Assert.Equal(collection, extension.ProviderCollection);
+    }
+
+    [Fact]
+    public void ExtensionOf_query_names_the_type_that_actually_exists()
+    {
+        // The hand-maintained table this replaced said "AxQueryExtension". No MetaModel
+        // assembly declares one — the real type is AxQuerySimpleExtension.
+        Assert.Equal("AxQuerySimpleExtension", ObjectTypeRegistry.ExtensionOf("query")!.RootElement);
+    }
+
+    [Fact]
+    public void ExtensionOf_returns_null_for_types_with_no_extension_form_and_does_not_nest()
+    {
+        Assert.Null(ObjectTypeRegistry.ExtensionOf("class"));
+        Assert.Null(ObjectTypeRegistry.ExtensionOf("tableextension"));
+        Assert.Null(ObjectTypeRegistry.ExtensionOf("nosuchkind"));
+        Assert.Null(ObjectTypeRegistry.ExtensionOf(""));
+    }
+
+    /// <summary>
+    /// The failure in #171 was a redirect the CLI planned to a kind the bridge would not
+    /// accept. Both halves read this registry, so an extension the CLI can target must
+    /// carry the provider collection the bridge resolves it through.
+    /// </summary>
+    [Fact]
+    public void Every_extension_the_modify_path_can_target_is_bridge_writable()
+    {
+        var bridgeKinds = ObjectTypeRegistry.BridgeCollections();
+
+        foreach (var baseKind in new[] { "table", "form", "edt", "enum" })
+        {
+            var extension = ObjectTypeRegistry.ExtensionOf(baseKind);
+            Assert.NotNull(extension);
+            Assert.True(
+                bridgeKinds.ContainsKey(extension!.Kind),
+                $"'{extension.Kind}' is reachable by redirecting a {baseKind} write, " +
+                "but the bridge would answer INVALID_KIND for it.");
+        }
+    }
 }


### PR DESCRIPTION
Closes #171.

## What the report was actually hitting

The issue offered two explanations — the Bridge lacks `tableExtension`, or the platform build does not expose the collection. Neither holds. I reflected over `Microsoft.Dynamics.AX.Metadata.dll` on the live install in this environment:

```
IMetadataProvider properties matching *Extension*:
  TableExtensions, FormExtensions, EdtExtensions, EnumExtensions, ViewExtensions,
  QuerySimpleExtensions, DataEntityViewExtensions, MapExtensions, MenuExtensions,
  MenuItem{Display,Action,Output}Extensions, Security{Role,Duty}Extensions,
  Workflow{Template,Approval,Task}Extensions
```

`TableExtensions` is there. The error's hint pointed at the platform, and the platform was innocent.

## The real cause

`ObjectModifyEngine` carried its own `ExtensionKindFor` and `ExtensionRootFor` dictionaries — two of the hand-maintained kind tables that "single object-type registry, replacing four drifting kind tables" set out to retire. This pair was missed, so it drifted from the registry the bridge resolves provider collections through, and the CLI planned a redirect to a kind its own bridge would not accept.

Both are replaced by one `ObjectTypeRegistry.ExtensionOf(baseKind)` lookup. Every registered extension kind is its base kind plus `"extension"`, so the relation needs no second table to fall out of step, and the entry it returns already carries both the root element and the provider collection.

## Two wrong rows those tables were carrying

| base kind | old root | correct root |
|---|---|---|
| `edt` | *(absent — fell through to `$"Ax{kind}Extension"` → `AxedtExtension`)* | `AxEdtExtension` |
| `query` | `AxQueryExtension` | `AxQuerySimpleExtension` |

The registry has carried a comment since the type census saying `AxQueryExtension` does not exist in any MetaModel assembly — "the bridge used to name one". The private table still did.

## Error paths

- An extension type the AOT models but the provider exposes no channel for is now refused **before** the bridge round-trip, naming the file to edit instead of surfacing a generic `INVALID_KIND` from three layers down. That is the issue's second acceptance option.
- `INVALID_KIND` no longer blames the platform. Both halves read the same registry, so a kind this build resolves to a collection while the bridge does not recognise it means the two binaries are from different builds — which is exactly the reporter's situation, on a `0.1.0-dev` build predating the registry. The read leg now carries a hint too; it had none, though that is the leg the report hit.

## Compatibility

The wire kind becomes the registry spelling (`tableextension` rather than `tableExtension`). The bridge matches kinds with `StringComparer.OrdinalIgnoreCase` on both sides, so old and new bridges accept either; two test assertions move with it.

## Regression guard

`Every_extension_the_modify_path_can_target_is_bridge_writable` asserts that every extension reachable by redirecting a supported write appears in `BridgeCollections()`. This class of drift now fails a test rather than a customer's AOS.

## Out of scope

The issue's closing note — that no `generate`-based command can append a field to an *existing* `AxTableExtension` — is a feature gap, not this defect. `modify add-field` is the supported path and it works once the kind resolves.

## Verification

1191 tests pass (5 new); `knowledge audit --verify`, `eval run --all` 52/52, `eval coverage --check` clean; `D365FO.Bridge` (net48) builds.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
