### PR TITLE
feat(generate): add fields to a table extension offline

### DIFF
--- a/src/D365FO.Cli/Commands/Generate/GenerateMoreCommands.cs
+++ b/src/D365FO.Cli/Commands/Generate/GenerateMoreCommands.cs
@@ -323,6 +323,10 @@ public sealed class GenerateExtensionCommand : Command<GenerateExtensionCommand.
         [System.ComponentModel.Description("Extension suffix. Defaults to the InstallTo model name or 'Extension'.")]
         public string? Suffix { get; init; }
 
+        [CommandOption("--field <SPEC>")]
+        [System.ComponentModel.Description("Repeatable; Table only: <name>:<edt>[[:mandatory]]. Example: --field QuantityD:Qty:mandatory")]
+        public string[] Fields { get; init; } = Array.Empty<string>();
+
         [CommandOption("--privilege <NAME>")]
         [System.ComponentModel.Description("Repeatable; SecurityDuty/SecurityRole only: privilege reference to add to the base duty/role.")]
         public string[] Privileges { get; init; } = Array.Empty<string>();
@@ -334,6 +338,20 @@ public sealed class GenerateExtensionCommand : Command<GenerateExtensionCommand.
         [CommandOption("--set-property <SPEC>")]
         [System.ComponentModel.Description("Repeatable; SecurityDuty/SecurityRole only: <Member>=<Value>. Overrides a property of the base object (Enabled, Label, Description, ContextString…) without overlaying it.")]
         public string[] PropertyModifications { get; init; } = Array.Empty<string>();
+    }
+
+    /// <summary>
+    /// Parse <c>--field &lt;name&gt;:&lt;edt&gt;[:mandatory]</c>, the same spelling
+    /// <c>generate table --field</c> takes — a field added through an extension is the same
+    /// declaration, so it should not need a second syntax to remember.
+    /// </summary>
+    private static TableFieldSpec ParseField(string raw)
+    {
+        var parts = raw.Split(':', StringSplitOptions.TrimEntries);
+        var name = parts.Length > 0 ? parts[0] : "";
+        var edt = parts.Length > 1 ? parts[1] : null;
+        var mandatory = parts.Length > 2 && string.Equals(parts[2], "mandatory", StringComparison.OrdinalIgnoreCase);
+        return new TableFieldSpec(name, string.IsNullOrEmpty(edt) ? null : edt, null, mandatory);
     }
 
     /// <summary>Parse <c>--set-property &lt;Member&gt;=&lt;Value&gt;</c> pairs.</summary>
@@ -414,25 +432,45 @@ public sealed class GenerateExtensionCommand : Command<GenerateExtensionCommand.
                 $"--set-property applies to SecurityDuty and SecurityRole extensions only; {axFolder} has no PropertyModifications member, " +
                 "so the overrides would be dropped on read."));
 
+        var fieldSpecs = settings.Fields
+            .Where(f => !string.IsNullOrWhiteSpace(f))
+            .Select(ParseField)
+            .ToList();
+        if (fieldSpecs.Count > 0 && axFolder != "AxTableExtension")
+            return RenderHelpers.Render(kind, ToolResult<object>.Fail(
+                D365FoErrorCodes.BadInput,
+                $"--field applies to Table extensions only; {axFolder} has no Fields member, " +
+                "so the fields would be dropped on read."));
+        if (fieldSpecs.Any(f => string.IsNullOrWhiteSpace(f.Name)))
+            return RenderHelpers.Render(kind, ToolResult<object>.Fail(
+                D365FoErrorCodes.BadInput, "Every --field needs a name: <name>:<edt>[:mandatory]."));
+        if (fieldSpecs.FirstOrDefault(f => string.IsNullOrWhiteSpace(f.Edt)) is { } noEdt)
+            return RenderHelpers.Render(kind, ToolResult<object>.Fail(
+                D365FoErrorCodes.BadInput,
+                $"--field '{noEdt.Name}' has no EDT. Every field on a table extension needs one: <name>:<edt>[:mandatory].",
+                "Run `d365fo suggest edt <name>` to find one, or `d365fo generate edt` to create it."));
+
         var doc = axFolder switch
         {
             "AxSecurityDutyExtension" => XppScaffolder.SecurityDutyExtension(settings.Target, suffix, settings.Privileges, propertyMods),
             "AxSecurityRoleExtension" => XppScaffolder.SecurityRoleExtension(settings.Target, suffix, settings.Duties, settings.Privileges, propertyMods),
-            // The EDT case needs the index-backed base-type resolver to pin the concrete
-            // AxEdt*Extension subtype; the other kinds ignore it.
             // The scaffolder takes the base kind, not the type name — and the two differ for
             // queries, whose extension is AxQuerySimpleExtension.
             "AxQuerySimpleExtension" => XppScaffolder.Extension("query", settings.Target, suffix),
             // The EDT case needs the index-backed base-type resolver to pin the concrete
-            // AxEdt*Extension subtype; the other kinds ignore it.
+            // AxEdt*Extension subtype; for a table extension the same resolver picks the
+            // concrete AxTableField* subtype per field. The other kinds ignore it.
             _ => XppScaffolder.Extension(axFolder["Ax".Length..^"Extension".Length], settings.Target, suffix,
-                     GenerateInstaller.BuildEdtBaseTypeResolver()),
+                     GenerateInstaller.BuildEdtBaseTypeResolver(), fieldSpecs),
         };
 
         // Grounding gate: the target object must exist in the index; fail
-        // closed under D365FO_GROUNDING_ENFORCE=true.
+        // closed under D365FO_GROUNDING_ENFORCE=true. The EDTs a field names are
+        // required too — a hallucinated EDT is the failure this gate exists for.
         var gate = GenerateInstaller.Gate(settings, settings.Target, doc,
-            requiredSymbols: new[] { settings.Target });
+            requiredSymbols: new[] { settings.Target }
+                .Concat(fieldSpecs.Select(f => f.Edt!))
+                .ToArray());
         if (gate.Failure is not null) return RenderHelpers.Render(kind, gate.Failure);
 
         try
@@ -444,6 +482,9 @@ public sealed class GenerateExtensionCommand : Command<GenerateExtensionCommand.
                 name = fullName,
                 target = settings.Target,
                 suffix,
+                fields = fieldSpecs.Count == 0
+                    ? null
+                    : fieldSpecs.Select(f => new { name = f.Name, edt = f.Edt, mandatory = f.Mandatory }).ToArray(),
                 path = res.Path,
                 bytes = res.Bytes,
                 backup = res.BackupPath,

--- a/src/D365FO.Core/Scaffolding/XppScaffolder.cs
+++ b/src/D365FO.Core/Scaffolding/XppScaffolder.cs
@@ -81,18 +81,7 @@ public static class XppScaffolder
         // and a concrete i:type on every polymorphic AxTableField (abstract base).
         XNamespace xsi = "http://www.w3.org/2001/XMLSchema-instance";
 
-        var fieldEls = effectiveFields.Select(f =>
-        {
-            var edtName = f.Edt ?? "Name";
-            var suffix  = TableFieldConcreteSuffix(edtName, edtBaseTypeResolver);
-            var el = new XElement("AxTableField",
-                new XAttribute(XName.Get("type", xsi.NamespaceName), $"AxTableField{suffix}"),
-                new XElement("Name", f.Name),
-                new XElement("ExtendedDataType", edtName));
-            if (!string.IsNullOrEmpty(f.Label)) el.Add(new XElement("Label", f.Label));
-            if (f.Mandatory) el.Add(new XElement("Mandatory", "Yes"));
-            return el;
-        });
+        var fieldEls = effectiveFields.Select(f => TableFieldElement(f, edtBaseTypeResolver));
 
         // Pick the primary-key / alternate-key index. Order of preference:
         //   1. caller-supplied --primary-key list (must reference real fields).
@@ -177,6 +166,29 @@ public static class XppScaffolder
                     BuildFieldGroup("Overview", effectiveFields),
                     BuildFieldGroup("General", effectiveFields)),
                 indexesEl));
+    }
+
+    /// <summary>
+    /// <summary>
+    /// One <c>&lt;AxTableField&gt;</c>, carrying the concrete <c>i:type</c> discriminator
+    /// the metadata reader requires on the abstract base.
+    /// </summary>
+    /// <remarks>
+    /// Shared by <see cref="Table"/> and <see cref="Extension"/>: a field added through a
+    /// table extension has exactly the shape it would have on the table itself, and two
+    /// copies of that rule is one copy too many.
+    /// </remarks>
+    private static XElement TableFieldElement(TableFieldSpec spec, Func<string, string?>? edtBaseTypeResolver)
+    {
+        var edtName = spec.Edt ?? "Name";
+        var suffix = TableFieldConcreteSuffix(edtName, edtBaseTypeResolver);
+        var el = new XElement("AxTableField",
+            new XAttribute(XName.Get("type", Xsi.NamespaceName), $"AxTableField{suffix}"),
+            new XElement("Name", spec.Name),
+            new XElement("ExtendedDataType", edtName));
+        if (!string.IsNullOrEmpty(spec.Label)) el.Add(new XElement("Label", spec.Label));
+        if (spec.Mandatory) el.Add(new XElement("Mandatory", "Yes"));
+        return el;
     }
 
     /// <summary>
@@ -573,8 +585,14 @@ public static class XppScaffolder
     /// changes as <c>PropertyModifications</c>, which is why an EDT extension can retype
     /// nothing and only override properties.</para>
     /// </summary>
+    /// <param name="tableFields">
+    /// Fields to add through a <c>table</c> extension. Any other kind rejects them rather
+    /// than dropping them silently — an <c>AxFormExtension</c> has no <c>Fields</c> member,
+    /// so anything written there vanishes on read. Omit for the bare skeleton.
+    /// </param>
     public static XDocument Extension(
-        string kind, string targetName, string suffix, Func<string, string?>? edtBaseTypeResolver = null)
+        string kind, string targetName, string suffix, Func<string, string?>? edtBaseTypeResolver = null,
+        IEnumerable<TableFieldSpec>? tableFields = null)
     {
         // The type name is not derivable from the kind: a query's extension is
         // AxQuerySimpleExtension, not AxQueryExtension — there is no type or AOT folder of the
@@ -598,12 +616,32 @@ public static class XppScaffolder
         XNamespace xsi = "http://www.w3.org/2001/XMLSchema-instance";
         root.SetAttributeValue(XNamespace.Xmlns + "i", xsi.NamespaceName);
 
+        var fields = (tableFields ?? Enumerable.Empty<TableFieldSpec>())
+            .Where(f => f is not null && !string.IsNullOrWhiteSpace(f.Name))
+            .ToList();
+        if (fields.Count > 0 && elementName != "AxTableExtension")
+        {
+            throw new ArgumentException(
+                $"Fields can only be added through a table extension; {elementName} has no Fields member.",
+                nameof(tableFields));
+        }
+
         // The empty collections a shipped extension of each kind carries. They are not
         // decoration: an extension is a list of modifications, and the collections are where a
         // caller's later edits go — emitting the container means the next tool has somewhere to
         // write instead of guessing at the order itself.
         foreach (var collection in ExtensionCollections(elementName))
             root.Add(new XElement(collection));
+
+        // AxTableExtension declares no collection up front — a shipped one carries only the
+        // members it actually modifies — so <Fields> appears exactly when there are fields
+        // to put in it. This is the same shape `modify add-field` builds when it creates the
+        // extension against a live AOT; the two paths differ only in reaching disk.
+        if (fields.Count > 0)
+        {
+            root.Add(new XElement("Fields",
+                fields.Select(f => TableFieldElement(f, edtBaseTypeResolver))));
+        }
 
         return new XDocument(root);
     }

--- a/tests/D365FO.Cli.Tests/GenerateExtensionFieldTests.cs
+++ b/tests/D365FO.Cli.Tests/GenerateExtensionFieldTests.cs
@@ -1,0 +1,164 @@
+using System.Text.Json;
+using System.Xml.Linq;
+using D365FO.Cli.Commands.Generate;
+using Xunit;
+
+namespace D365FO.Cli.Tests;
+
+/// <summary>
+/// <c>generate extension Table --field</c> (#178). Adding a field to a table extension
+/// used to be reachable only through <c>modify add-field</c>, which requires the
+/// Windows-only metadata bridge — so on a machine without a D365FO install, or in CI,
+/// there was no way to produce one at all.
+/// </summary>
+// Captures Console.Out, which is process-global — see GenerateWorkflowCommandTests.
+[Collection("EnvIndexDb")]
+public class GenerateExtensionFieldTests
+{
+    private static (int Exit, JsonDocument Json) Run(GenerateExtensionCommand.Settings settings)
+    {
+        var saved = Console.Out;
+        var writer = new StringWriter();
+        try
+        {
+            Console.SetOut(writer);
+            var exit = new GenerateExtensionCommand().Execute(null!, settings);
+            return (exit, JsonDocument.Parse(writer.ToString()));
+        }
+        finally
+        {
+            Console.SetOut(saved);
+        }
+    }
+
+    private static string NewDir()
+    {
+        var dir = Path.Combine(Path.GetTempPath(), "d365fo-extfield-" + Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(dir);
+        return dir;
+    }
+
+    [Fact]
+    public void Fields_land_in_the_written_table_extension()
+    {
+        var dir = NewDir();
+        try
+        {
+            var path = Path.Combine(dir, "VendInvoiceInfoLine.DSV.xml");
+            var (exit, json) = Run(new GenerateExtensionCommand.Settings
+            {
+                Kind = "Table",
+                Target = "VendInvoiceInfoLine",
+                Suffix = "DSV",
+                Fields = new[] { "QuantityD:Qty:mandatory", "CommentD:Description" },
+                Out = path,
+                Output = "json",
+            });
+
+            Assert.Equal(0, exit);
+            Assert.True(json.RootElement.GetProperty("ok").GetBoolean());
+            Assert.Equal(2, json.RootElement.GetProperty("data").GetProperty("fields").GetArrayLength());
+
+            var root = XDocument.Load(path).Root!;
+            Assert.Equal("AxTableExtension", root.Name.LocalName);
+
+            var fields = root.Element("Fields")!.Elements("AxTableField").ToList();
+            Assert.Equal(new[] { "QuantityD", "CommentD" }, fields.Select(f => f.Element("Name")!.Value));
+            Assert.Equal("Yes", fields[0].Element("Mandatory")!.Value);
+            Assert.Null(fields[1].Element("Mandatory"));
+        }
+        finally
+        {
+            Directory.Delete(dir, true);
+        }
+    }
+
+    [Fact]
+    public void A_field_without_an_edt_is_refused_before_anything_is_written()
+    {
+        var dir = NewDir();
+        try
+        {
+            var path = Path.Combine(dir, "VendInvoiceInfoLine.DSV.xml");
+            var (exit, json) = Run(new GenerateExtensionCommand.Settings
+            {
+                Kind = "Table",
+                Target = "VendInvoiceInfoLine",
+                Suffix = "DSV",
+                Fields = new[] { "QuantityD" },
+                Out = path,
+                Output = "json",
+            });
+
+            Assert.NotEqual(0, exit);
+            Assert.False(json.RootElement.GetProperty("ok").GetBoolean());
+            Assert.Contains("has no EDT", json.RootElement.GetProperty("error").GetProperty("message").GetString());
+            // A field with no EDT would scaffold as AxTableFieldString against a
+            // <ExtendedDataType>Name</ExtendedDataType> nobody asked for.
+            Assert.False(File.Exists(path));
+        }
+        finally
+        {
+            Directory.Delete(dir, true);
+        }
+    }
+
+    [Theory]
+    [InlineData("Form")]
+    [InlineData("Enum")]
+    [InlineData("Edt")]
+    public void Fields_on_a_kind_that_cannot_hold_them_are_refused(string kind)
+    {
+        var dir = NewDir();
+        try
+        {
+            var path = Path.Combine(dir, "Something.DSV.xml");
+            var (exit, json) = Run(new GenerateExtensionCommand.Settings
+            {
+                Kind = kind,
+                Target = "SomeTarget",
+                Suffix = "DSV",
+                Fields = new[] { "QuantityD:Qty" },
+                Out = path,
+                Output = "json",
+            });
+
+            Assert.NotEqual(0, exit);
+            var message = json.RootElement.GetProperty("error").GetProperty("message").GetString()!;
+            Assert.Contains("--field applies to Table extensions only", message);
+            // Dropped-on-read is the failure mode worth naming: the provider accepts the
+            // document and simply loses the members it has no home for.
+            Assert.Contains("dropped on read", message);
+            Assert.False(File.Exists(path));
+        }
+        finally
+        {
+            Directory.Delete(dir, true);
+        }
+    }
+
+    [Fact]
+    public void The_bare_skeleton_is_unchanged_when_no_field_is_passed()
+    {
+        var dir = NewDir();
+        try
+        {
+            var path = Path.Combine(dir, "VendInvoiceInfoLine.DSV.xml");
+            var (exit, _) = Run(new GenerateExtensionCommand.Settings
+            {
+                Kind = "Table",
+                Target = "VendInvoiceInfoLine",
+                Suffix = "DSV",
+                Out = path,
+                Output = "json",
+            });
+
+            Assert.Equal(0, exit);
+            Assert.Null(XDocument.Load(path).Root!.Element("Fields"));
+        }
+        finally
+        {
+            Directory.Delete(dir, true);
+        }
+    }
+}

--- a/tests/D365FO.Cli.Tests/GenerateWorkflowCommandTests.cs
+++ b/tests/D365FO.Cli.Tests/GenerateWorkflowCommandTests.cs
@@ -13,6 +13,10 @@ namespace D365FO.Cli.Tests;
 /// <c>getQueryName()</c> named a query the command never created. The command used
 /// to warn about each and ship anyway — a warning, for metadata that could not build.
 /// </remarks>
+// Captures Console.Out, which is process-global: it has to be serialised against the
+// other console-capturing classes rather than left to xUnit's per-class parallelism.
+// Without this it reads another class's output and fails on empty JSON.
+[Collection("EnvIndexDb")]
 public class GenerateWorkflowCommandTests
 {
     private static (int Exit, JsonDocument Json) Run(GenerateWorkflowCommand.Settings settings)

--- a/tests/D365FO.Core.Tests/XppScaffolderTests.cs
+++ b/tests/D365FO.Core.Tests/XppScaffolderTests.cs
@@ -58,4 +58,84 @@ public class NumberSequenceScaffolderTests
         Assert.Equal("AxEdtString", root.Attribute(xsi + "type")?.Value);
         Assert.Equal(xsi.NamespaceName, root.Attribute(XNamespace.Xmlns + "i")?.Value);
     }
+
+}
+
+/// <summary>
+/// Fields carried by a table extension (#178). Before this, the only way to put a field
+/// on one was <c>modify add-field</c>, which is bridge-only — so the offline path stopped
+/// at an empty skeleton.
+/// </summary>
+public class XppScaffolderExtensionTests
+{
+    private static readonly XNamespace Xsi = "http://www.w3.org/2001/XMLSchema-instance";
+
+    [Fact]
+    public void Extension_without_fields_still_emits_the_bare_table_skeleton()
+    {
+        var root = XppScaffolder.Extension("table", "VendInvoiceInfoLine", "DSV").Root!;
+
+        Assert.Equal("AxTableExtension", root.Name.LocalName);
+        Assert.Equal("VendInvoiceInfoLine.DSV", root.Element("Name")!.Value);
+        // A shipped AxTableExtension declares only the members it modifies, so an empty
+        // <Fields> would be noise — and would churn every golden that pins the skeleton.
+        Assert.Null(root.Element("Fields"));
+    }
+
+    [Fact]
+    public void Extension_emits_table_fields_with_the_concrete_type_discriminator()
+    {
+        var doc = XppScaffolder.Extension(
+            "table", "VendInvoiceInfoLine", "DSV",
+            edtBaseTypeResolver: edt => edt switch { "Qty" => "Real", "Description" => "String", _ => null },
+            tableFields: new[]
+            {
+                new TableFieldSpec("QuantityD", "Qty", null, Mandatory: true),
+                new TableFieldSpec("CommentD", "Description", "@SYS1234", Mandatory: false),
+            });
+
+        var fields = doc.Root!.Element("Fields")!.Elements("AxTableField").ToList();
+        Assert.Equal(2, fields.Count);
+
+        // AxTableField is abstract: without the discriminator the metadata reader throws.
+        Assert.Equal("AxTableFieldReal", fields[0].Attribute(Xsi + "type")!.Value);
+        Assert.Equal("QuantityD", fields[0].Element("Name")!.Value);
+        Assert.Equal("Qty", fields[0].Element("ExtendedDataType")!.Value);
+        Assert.Equal("Yes", fields[0].Element("Mandatory")!.Value);
+
+        Assert.Equal("AxTableFieldString", fields[1].Attribute(Xsi + "type")!.Value);
+        Assert.Equal("@SYS1234", fields[1].Element("Label")!.Value);
+        Assert.Null(fields[1].Element("Mandatory"));
+    }
+
+    [Fact]
+    public void Extension_refuses_fields_on_kinds_that_have_no_Fields_member()
+    {
+        var fields = new[] { new TableFieldSpec("QuantityD", "Qty", null, Mandatory: false) };
+
+        foreach (var kind in new[] { "form", "edt", "enum" })
+        {
+            var ex = Assert.Throws<ArgumentException>(
+                () => XppScaffolder.Extension(kind, "SomeTarget", "DSV", null, fields));
+            Assert.Contains("no Fields member", ex.Message);
+        }
+    }
+
+    /// <summary>
+    /// The offline path must produce the same field element the live path does — otherwise
+    /// `generate extension --field` and `modify add-field` disagree about the same edit.
+    /// </summary>
+    [Fact]
+    public void Extension_fields_match_the_shape_a_table_carries_them_in()
+    {
+        Func<string, string?> resolver = edt => edt == "Qty" ? "Real" : null;
+        var spec = new TableFieldSpec("QuantityD", "Qty", null, Mandatory: true);
+
+        var onTable = XppScaffolder.Table("SomeTable", fields: new[] { spec }, edtBaseTypeResolver: resolver)
+            .Root!.Element("Fields")!.Elements("AxTableField").Single();
+        var onExtension = XppScaffolder.Extension("table", "SomeTable", "DSV", resolver, new[] { spec })
+            .Root!.Element("Fields")!.Elements("AxTableField").Single();
+
+        Assert.Equal(onTable.ToString(), onExtension.ToString());
+    }
 }


### PR DESCRIPTION
Closes #178.

## The gap

`generate extension Table <target>` scaffolded `<AxTableExtension><Name>…</Name></AxTableExtension>` and stopped. The only way to put a field on a table extension was `modify add-field`, which is bridge-only by design:

> `d365fo modify` requires D365FO.Bridge (.NET Framework 4.8, Windows-only, IMetadataProvider-backed) … This command intentionally has no raw-XML fallback.

That is the right call for editing a live AOT, but it meant the edit was not expressible at all on a dev box without a D365FO install, in CI, in a container, or in any flow that reviews AOT XML before it reaches an AOS. Every other new-object path (`generate table --field`, `generate entity --field`) works offline; extensions were the hole.

## The change

```
d365fo generate extension Table VendInvoiceInfoLine \
  --suffix DSV --field QuantityD:Qty:mandatory --field CommentD:Description
```

```xml
<AxTableExtension xmlns:i="http://www.w3.org/2001/XMLSchema-instance">
  <Name>VendInvoiceInfoLine.DSV</Name>
  <Fields>
    <AxTableField i:type="AxTableFieldReal">
      <Name>QuantityD</Name>
      <ExtendedDataType>Qty</ExtendedDataType>
      <Mandatory>Yes</Mandatory>
    </AxTableField>
    <AxTableField i:type="AxTableFieldString">
      <Name>CommentD</Name>
      <ExtendedDataType>Description</ExtendedDataType>
    </AxTableField>
  </Fields>
</AxTableExtension>
```

That is real output from this branch against the live install in my environment — `Qty` → `AxTableFieldReal` and `Description` → `AxTableFieldString` came off the index-backed resolver, with `referenceErrors: 0`.

Decisions worth flagging, from the issue's open questions:

- **Syntax** is `<name>:<edt>[:mandatory]`, identical to `generate table --field`. A field declared through an extension is the same declaration; a second syntax to remember would be a tax for nothing.
- **EDT validation** goes through the existing grounding gate alongside the target object, so an unknown EDT warns by default and fails only under `D365FO_GROUNDING_ENFORCE` — which is what the issue wanted, since an extension of a standard table is exactly where the EDT may live in a model the index has not seen. A field with *no* EDT at all is refused outright: it would otherwise scaffold as `AxTableFieldString` over `<ExtendedDataType>Name</ExtendedDataType>` that nobody asked for.
- **Scope is single-shot emit**, not read-modify-write of an existing file. `generate` writes a complete artifact and already has `--overwrite`; declaring the extension with all its fields fits that model. Appending to a file on disk can follow if this turns out not to cover it.
- **Table fields only.** `--field` on a Form/Edt/Enum extension is refused at both the command and the scaffolder, because those types have no `Fields` member and the provider would accept the document and silently drop them on read.

## Shared element builder

The `<AxTableField>` element now comes from one helper used by both `XppScaffolder.Table` and `XppScaffolder.Extension`, with a test asserting the two produce byte-identical elements for the same spec. The offline and live paths have to agree about what "add this field" means, and the concrete `AxTableField*` discriminator — mandatory on an abstract base — is the part that is easy to get subtly wrong in a second copy.

`<Fields>` is emitted only when there are fields for it. A shipped `AxTableExtension` declares only the members it modifies, and an unconditional empty collection would churn every golden that pins the bare skeleton; a test pins that too.

## Unrelated fix that this made necessary

`GenerateWorkflowCommandTests` captures `Console.Out`, which is process-global, and was not in the `EnvIndexDb` (`DisableParallelization`) collection that every other console-capturing class uses. Adding a second such class to this assembly made it read the other's output and fail on empty JSON. Both are now in the collection. Latent flake, exposed rather than introduced.

## Noted, not fixed

`--verify` is accepted by `generate extension` and silently does nothing: the command calls `GenerateInstaller.Write` directly instead of going through `Emit`/`EmitCore`, which is where the verify leg lives. Pre-existing, and rerouting the command through `Emit` would also move its `--install-to` path handling — too much to bundle into a feature PR, especially on the extension install path #171 just touched. Happy to file it.

## Verification

1207 tests pass (10 new); `knowledge audit --verify`, `eval run --all` 52/52, `eval coverage --check` clean; `generate extension --help` renders (the `[:mandatory]` in the option description needed Spectre's `[[…]]` escaping, same as `generate table`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
