### PR TITLE
fix(generate): honour --verify on every subcommand

### DIFF
--- a/docs/EXAMPLES.md
+++ b/docs/EXAMPLES.md
@@ -206,6 +206,14 @@ In a real terminal, `init` is a wizard unless `--packages`, `--output`, `--dry-r
 
 Add `--verify` to read the artefact back through the D365FO Metadata API after writing it, the way Visual Studio would. It applies to `--install-to` (the provider resolves objects by name inside the packages paths, so an arbitrary `--out` path is not something it can look up) and is skipped with a note when the runtime is unavailable — generation keeps working offline either way. A write that the provider then refuses to load fails with `VERIFY_FAILED`; the file is left on disk so you can open it in Visual Studio.
 
+Every `generate` subcommand honours the flag, and the multi-file emitters (`business-event`, `custom-service`, `report`, `workflow`, `number-sequence`, …) verify each artefact they produce, not just the headline one. The payload always carries a `verify` object so a caller can tell the three outcomes apart rather than inferring them from silence:
+
+```jsonc
+"verify": { "status": "not-requested" }                       // --verify was not passed
+"verify": { "status": "skipped", "detail": "…" }              // runtime unavailable, or --out rather than --install-to
+"verify": { "status": "verified", "artefacts": [ … ] }        // every artefact read back, one entry each
+```
+
 ### Table
 
 ```sh

--- a/docs/EXAMPLES.md
+++ b/docs/EXAMPLES.md
@@ -214,6 +214,8 @@ Every `generate` subcommand honours the flag, and the multi-file emitters (`busi
 "verify": { "status": "verified", "artefacts": [ … ] }        // every artefact read back, one entry each
 ```
 
+Only one answer fails the command: `IMetadataProvider` was reachable and would not hand the object back — the document the reader refuses, which is what the flag is for. Everything else is a skip with its reason, because it is a limit of the tooling rather than a verdict on the artefact: a bridge that did not answer, a kind the bridge has no read channel for, or a MetaModel type its serializer cannot reflect (`AxMenuItemAction` and `AxSecurityPrivilege` load fine and still cannot be rendered back as XML — those verify, with the caveat in `detail`).
+
 ### Table
 
 ```sh

--- a/src/D365FO.Cli/Commands/Generate/GenerateBusinessEventCommand.cs
+++ b/src/D365FO.Cli/Commands/Generate/GenerateBusinessEventCommand.cs
@@ -104,7 +104,7 @@ public sealed class GenerateBusinessEventCommand : Command<GenerateBusinessEvent
             var eventResult    = GenerateInstaller.Write(gate, eventDoc, eventPath!, settings.Overwrite);
             var contractResult = GenerateInstaller.Write(gate, contractDoc, contractPath!, settings.Overwrite);
 
-            return RenderHelpers.Render(kind, ToolResult<object>.Success(new
+            return GenerateInstaller.Done(kind, gate, settings, new
             {
                 kind         = "BusinessEvent",
                 name         = settings.Name,
@@ -116,7 +116,7 @@ public sealed class GenerateBusinessEventCommand : Command<GenerateBusinessEvent
                 contract     = new { path = contractResult.Path, bytes = contractResult.Bytes, backup = contractResult.BackupPath },
                 model        = settings.InstallTo,
                 grounding    = gate.Grounding,
-            }, gate.Warnings));
+            });
         }
         catch (Exception ex)
         {

--- a/src/D365FO.Cli/Commands/Generate/GenerateCommands.cs
+++ b/src/D365FO.Cli/Commands/Generate/GenerateCommands.cs
@@ -26,7 +26,7 @@ public abstract class GenerateSettings : D365OutputSettings
     public string? GroundingToken { get; init; }
 
     [CommandOption("--verify")]
-    [System.ComponentModel.Description("After writing, read the artefact back through the D365FO Metadata API the way Visual Studio would. Skipped (never fails) when the runtime is unavailable. Requires D365FO_BRIDGE_ENABLED=1.")]
+    [System.ComponentModel.Description("After writing, read every artefact back through the D365FO Metadata API the way Visual Studio would. Applies to --install-to; skipped (never fails) when the runtime is unavailable. The payload's `verify` field reports which happened. Requires D365FO_BRIDGE_ENABLED=1.")]
     public bool Verify { get; init; }
 }
 
@@ -130,6 +130,8 @@ internal static class GenerateInstaller
         // Write finalises the document in place, so this is the form that reached disk — not the
         // scaffolder's pre-canonicalisation draft.
         gate.Observe(doc.ToString());
+        var (axKind, name) = IdentityOf(doc.Root);
+        gate.RecordArtefact(axKind, name, result.Path);
         return result;
     }
 
@@ -140,7 +142,30 @@ internal static class GenerateInstaller
         ArgumentNullException.ThrowIfNull(gate);
         var result = ScaffoldFileWriter.Write(xml, path, overwrite);
         gate.Observe(xml);
+        System.Xml.Linq.XElement? root = null;
+        try { root = System.Xml.Linq.XDocument.Parse(xml).Root; } catch { /* identity stays unknown */ }
+        var (axKind, name) = IdentityOf(root);
+        gate.RecordArtefact(axKind, name, result.Path);
         return result;
+    }
+
+    /// <summary>
+    /// The kind and name the metadata provider would use to look a written document up,
+    /// read off the document itself.
+    /// </summary>
+    /// <remarks>
+    /// Derived rather than declared, for the reason given on
+    /// <see cref="GroundingGate.GateResult.Artefacts"/>: the root element is already the
+    /// registry's key (<c>AxTable</c> → <c>table</c>), and every AOT document carries its
+    /// own <c>&lt;Name&gt;</c>, so a multi-file command gets each of its outputs identified
+    /// correctly without a table anyone has to remember to extend.
+    /// </remarks>
+    internal static (string? AxKind, string? Name) IdentityOf(System.Xml.Linq.XElement? root)
+    {
+        if (root is null) return (null, null);
+        var axKind = D365FO.Core.ObjectTypes.ObjectTypeRegistry.Find(root.Name.LocalName)?.Kind;
+        var name = root.Elements().FirstOrDefault(e => e.Name.LocalName == "Name")?.Value;
+        return (axKind, string.IsNullOrWhiteSpace(name) ? null : name);
     }
 
     /// <summary>
@@ -271,13 +296,18 @@ internal static class GenerateInstaller
     /// back to the scaffold. <paramref name="axKind"/> must be one of the bridge
     /// collection kinds: <c>class | table | edt | enum | form</c>.
     /// </summary>
+    /// <remarks>
+    /// Takes the whole <paramref name="settings"/> rather than the three or four fields it
+    /// reads off it, so that adding an option every emitter has to honour does not mean
+    /// revisiting each call site to thread it through — which is how <c>--verify</c> came to
+    /// be honoured by six subcommands and ignored by twenty-four (issue #180).
+    /// </remarks>
     internal static int Emit(
-        OutputMode.Kind kind, GroundingGate.GateResult gate, string axKind, string axSubfolder, string name,
-        string? installTo, string? outPath, bool overwrite,
+        OutputMode.Kind kind, GroundingGate.GateResult gate, GenerateSettings settings,
+        string axKind, string axSubfolder, string name,
         System.Xml.Linq.XDocument doc,
         Func<EmitResult, object> buildPayload,
-        List<string>? warnings = null,
-        bool verify = false)
+        List<string>? warnings = null)
     {
         // Canonicalise here, not only in ScaffoldFileWriter: the bridge path hands the XML
         // string straight to IMetadataProvider, so a document left in the wrong namespace or
@@ -286,60 +316,160 @@ internal static class GenerateInstaller
         ContractNamespaceApplier.Apply(doc);
         ContractOrderCanonicalizer.Apply(doc);
 
-        return EmitCore(kind, gate, axKind, axSubfolder, name, installTo, outPath, doc.ToString(),
-            path => Write(gate, doc, path, overwrite), buildPayload, warnings, verify);
+        return EmitCore(kind, gate, settings, axKind, axSubfolder, name, doc.ToString(),
+            path => Write(gate, doc, path, settings.Overwrite), buildPayload, warnings);
     }
 
     /// <summary>String-rendered counterpart of <see cref="Emit"/> (used for forms).</summary>
     internal static int EmitString(
-        OutputMode.Kind kind, GroundingGate.GateResult gate, string axKind, string axSubfolder, string name,
-        string? installTo, string? outPath, bool overwrite,
+        OutputMode.Kind kind, GroundingGate.GateResult gate, GenerateSettings settings,
+        string axKind, string axSubfolder, string name,
         string xml,
         Func<EmitResult, object> buildPayload,
-        List<string>? warnings = null,
-        bool verify = false)
-        => EmitCore(kind, gate, axKind, axSubfolder, name, installTo, outPath, xml,
-            path => Write(gate, xml, path, overwrite), buildPayload, warnings, verify);
+        List<string>? warnings = null)
+        => EmitCore(kind, gate, settings, axKind, axSubfolder, name, xml,
+            path => Write(gate, xml, path, settings.Overwrite), buildPayload, warnings);
 
     /// <summary>
-    /// Opt-in post-write check for <c>--verify</c>: read the artefact back through the
-    /// live metadata provider, the way Visual Studio would. Returns a rendered failure
-    /// only when the provider was reachable and still could not load the object —
-    /// an absent runtime is reported as a note and never blocks generation, which has
-    /// to keep working offline (CI, agent sessions, machines without the VS metadata
-    /// assemblies).
+    /// Opt-in post-write check for <c>--verify</c>: read every artefact the run emitted back
+    /// through the live metadata provider, the way Visual Studio would. Fails the command
+    /// only when the provider was reachable and still could not load an object — an absent
+    /// runtime is reported as a skip and never blocks generation, which has to keep working
+    /// offline (CI, agent sessions, machines without the VS metadata assemblies).
     /// </summary>
-    private static int? VerifyWritten(
-        OutputMode.Kind kind, string axKind, string name, string? installTo, string? writtenPath,
+    /// <remarks>
+    /// Issue #180. This used to live inside <see cref="EmitCore"/>, which only six of the
+    /// thirty subcommands reached: the other twenty-four accepted <c>--verify</c>, advertised
+    /// it in <c>--help</c>, and did nothing — output indistinguishable from a run that really
+    /// had verified. Running it from the shared terminal (<see cref="Finish"/>) puts it on the
+    /// path every generate command takes to render its success, and reporting the verdict in
+    /// the payload is what makes "not requested", "skipped" and "verified" tellable apart.
+    /// </remarks>
+    private static (object Report, int? Failure) RunVerify(
+        OutputMode.Kind kind, GroundingGate.GateResult? gate, bool verify, string? installTo,
         List<string> warnings)
     {
+        if (!verify) return (new { status = "not-requested" }, null);
+
         // The provider resolves objects by name inside the configured packages paths,
         // so an artefact parked at an arbitrary --out path is not something it can
         // look up — verifying would either miss it or match a different object of the
         // same name. Say so rather than emit a meaningless verdict.
         if (string.IsNullOrWhiteSpace(installTo))
+            return (Skip(warnings, "verification reads the object back by name from the configured " +
+                                   "packages paths, which only applies to --install-to."), null);
+
+        var artefacts = gate?.Artefacts ?? [];
+        if (artefacts.Count == 0)
+            return (Skip(warnings, "this command installed nothing through the shared writer, so there " +
+                                   "is no artefact to read back."), null);
+
+        var verdicts = new List<object>();
+        var skipped = false;
+
+        foreach (var artefact in artefacts)
         {
-            warnings.Add("--verify skipped: verification reads the object back by name from the " +
-                         "configured packages paths, which only applies to --install-to.");
-            return null;
+            if (artefact.AxKind is null || artefact.Name is null)
+            {
+                skipped = true;
+                const string unknown = "could not read the object's kind and name off the document root, " +
+                                       "so the provider has nothing to look up.";
+                warnings.Add($"--verify skipped for {artefact.Path ?? "an emitted document"}: {unknown}");
+                verdicts.Add(new { kind = artefact.AxKind, name = artefact.Name, path = artefact.Path, status = "skipped", detail = unknown });
+                continue;
+            }
+
+            var (outcome, detail) = BridgeGate.TryVerifyObject(artefact.AxKind, artefact.Name);
+            switch (outcome)
+            {
+                case BridgeGate.VerifyOutcome.Readable:
+                    warnings.Add($"--verify: the metadata provider read '{artefact.Name}' back successfully.");
+                    verdicts.Add(new { kind = artefact.AxKind, name = artefact.Name, path = artefact.Path, status = "verified", detail = (string?)null });
+                    break;
+
+                case BridgeGate.VerifyOutcome.Skipped:
+                    skipped = true;
+                    warnings.Add($"--verify skipped: {detail}");
+                    verdicts.Add(new { kind = artefact.AxKind, name = artefact.Name, path = artefact.Path, status = "skipped", detail });
+                    break;
+
+                default:
+                    return (new { status = "failed", artefacts = verdicts },
+                        RenderHelpers.Render(kind, ToolResult<object>.Fail(
+                            "VERIFY_FAILED",
+                            $"Wrote '{artefact.Name}' but {detail} " +
+                            (artefact.Path is null ? string.Empty : $"The file at {artefact.Path} was left in place. ") +
+                            "Open it in Visual Studio to see the metadata reader's own error.")));
+            }
         }
 
-        var (outcome, detail) = BridgeGate.TryVerifyObject(axKind, name);
-        switch (outcome)
+        return (new { status = skipped ? "skipped" : "verified", artefacts = verdicts }, null);
+
+        static object Skip(List<string> warnings, string detail)
         {
-            case BridgeGate.VerifyOutcome.Readable:
-                warnings.Add($"--verify: the metadata provider read '{name}' back successfully.");
-                return null;
-            case BridgeGate.VerifyOutcome.Skipped:
-                warnings.Add($"--verify skipped: {detail}");
-                return null;
-            default:
-                return RenderHelpers.Render(kind, ToolResult<object>.Fail(
-                    "VERIFY_FAILED",
-                    $"Wrote '{name}' but {detail} " +
-                    (writtenPath is null ? string.Empty : $"The file at {writtenPath} was left in place. ") +
-                    "Open it in Visual Studio to see the metadata reader's own error."));
+            warnings.Add("--verify skipped: " + detail);
+            return new { status = "skipped", detail };
         }
+    }
+
+    /// <summary>
+    /// Stamp the verification verdict onto a command's payload.
+    /// </summary>
+    /// <remarks>
+    /// The payloads are anonymous types built per command, so the field is grafted on as JSON
+    /// rather than by widening thirty declarations. Serialising with the same options the
+    /// renderer uses keeps naming and null-dropping identical to a payload that was never
+    /// touched.
+    /// </remarks>
+    private static object WithVerify(object payload, object verify)
+    {
+        try
+        {
+            if (System.Text.Json.JsonSerializer.SerializeToNode(payload, D365Json.Options)
+                is System.Text.Json.Nodes.JsonObject obj)
+            {
+                obj["verify"] = System.Text.Json.JsonSerializer.SerializeToNode(verify, D365Json.Options);
+                return obj;
+            }
+        }
+        catch { /* not an object-shaped payload — render it as it was */ }
+        return payload;
+    }
+
+    /// <summary>
+    /// The single success exit for every generate subcommand: run <c>--verify</c> over what was
+    /// emitted, fold in the property-honesty report, and render.
+    /// </summary>
+    /// <remarks>
+    /// <c>GenerateVerifySurfaceTests</c> fails the build if a command that writes renders its
+    /// own success envelope instead, which is the same guard <c>GenerateGateSurfaceTests</c>
+    /// puts on the grounding gate.
+    /// </remarks>
+    internal static int Done(
+        OutputMode.Kind kind, GroundingGate.GateResult? gate, GenerateSettings settings,
+        object payload, IEnumerable<string>? warnings = null)
+        => Finish(kind, gate, settings.Verify, settings.InstallTo, payload, Merge(gate, warnings));
+
+    private static int Finish(
+        OutputMode.Kind kind, GroundingGate.GateResult? gate, bool verify, string? installTo,
+        object payload, List<string> warnings)
+    {
+        var (report, failure) = RunVerify(kind, gate, verify, installTo, warnings);
+        if (failure.HasValue) return failure.Value;
+
+        if (gate is not null) WithHonesty(warnings, gate);
+
+        return RenderHelpers.Render(kind, ToolResult<object>.Success(
+            WithVerify(payload, report), warnings.Count > 0 ? warnings : null));
+    }
+
+    /// <summary>Gate warnings plus the caller's own, deduplicated and order-preserving.</summary>
+    private static List<string> Merge(GroundingGate.GateResult? gate, IEnumerable<string>? warnings)
+    {
+        var merged = new List<string>();
+        foreach (var w in (gate?.Warnings ?? Enumerable.Empty<string>()).Concat(warnings ?? []))
+            if (!merged.Contains(w)) merged.Add(w);
+        return merged;
     }
 
     /// <summary>
@@ -363,13 +493,15 @@ internal static class GenerateInstaller
     }
 
     private static int EmitCore(
-        OutputMode.Kind kind, GroundingGate.GateResult gate, string axKind, string axSubfolder, string name,
-        string? installTo, string? outPath, string xml,
+        OutputMode.Kind kind, GroundingGate.GateResult gate, GenerateSettings settings,
+        string axKind, string axSubfolder, string name, string xml,
         Func<string, ScaffoldFileWriter.WriteResult> write,
         Func<EmitResult, object> buildPayload,
-        List<string>? warnings,
-        bool verify)
+        List<string>? warnings)
     {
+        var installTo = settings.InstallTo;
+        var outPath   = settings.Out;
+        var verify    = settings.Verify;
         warnings ??= new List<string>();
         var hasInstall = !string.IsNullOrWhiteSpace(installTo);
         var hasOut     = !string.IsNullOrWhiteSpace(outPath);
@@ -385,23 +517,19 @@ internal static class GenerateInstaller
             if (plan.outcome == InstallOutcome.CreatedViaApi)
             {
                 // Nothing reached disk, but the provider was handed exactly this XML — which is
-                // the document the honesty report has to judge.
+                // the document the honesty report has to judge, and the object --verify reads
+                // back. Recorded explicitly because no Write ran to derive it.
                 gate.Observe(xml);
-                if (verify && VerifyWritten(kind, axKind, name, installTo, null, all) is int apiFailure)
-                    return apiFailure;
-                return RenderHelpers.Render(kind, ToolResult<object>.Success(
-                    buildPayload(new EmitResult("bridge", null, null, null)),
-                    WithHonesty(all, gate) is { Count: > 0 } w ? w : null));
+                gate.RecordArtefact(axKind, name, null);
+                return Finish(kind, gate, verify, installTo,
+                    buildPayload(new EmitResult("bridge", null, null, null)), all);
             }
 
             try
             {
                 var res = write(plan.writePath!);
-                if (verify && VerifyWritten(kind, axKind, name, installTo, res.Path, all) is int failure)
-                    return failure;
-                return RenderHelpers.Render(kind, ToolResult<object>.Success(
-                    buildPayload(new EmitResult("scaffold", res.Path, res.Bytes, res.BackupPath)),
-                    WithHonesty(all, gate) is { Count: > 0 } w ? w : null));
+                return Finish(kind, gate, verify, installTo,
+                    buildPayload(new EmitResult("scaffold", res.Path, res.Bytes, res.BackupPath)), all);
             }
             catch (Exception ex)
             {
@@ -412,11 +540,8 @@ internal static class GenerateInstaller
         try
         {
             var res = write(outPath!);
-            if (verify && VerifyWritten(kind, axKind, name, installTo, res.Path, warnings) is int outFailure)
-                return outFailure;
-            return RenderHelpers.Render(kind, ToolResult<object>.Success(
-                buildPayload(new EmitResult("scaffold", res.Path, res.Bytes, res.BackupPath)),
-                WithHonesty(warnings, gate) is { Count: > 0 } w ? w : null));
+            return Finish(kind, gate, verify, installTo,
+                buildPayload(new EmitResult("scaffold", res.Path, res.Bytes, res.BackupPath)), warnings);
         }
         catch (Exception ex)
         {
@@ -506,8 +631,8 @@ public sealed class GenerateTableCommand : Command<GenerateTableCommand.Settings
         // Prefer the live metadata provider for --install-to (canonical output,
         // consistent with VS / d365fo-mcp-server); fall back to the scaffold.
         return GenerateInstaller.Emit(
-            kind, gate, "table", Folders.Table, settings.Name,
-            settings.InstallTo, settings.Out, settings.Overwrite, doc,
+            kind, gate, settings, "table", Folders.Table, settings.Name,
+            doc,
             r => new
             {
                 kind = "AxTable",
@@ -525,8 +650,7 @@ public sealed class GenerateTableCommand : Command<GenerateTableCommand.Settings
                 model = settings.InstallTo,
                 grounding = gate.Grounding,
             },
-            warnings,
-            verify: settings.Verify);
+            warnings);
     }
 
     private static TableFieldSpec ParseField(string raw)
@@ -567,16 +691,15 @@ public sealed class GenerateClassCommand : Command<GenerateClassCommand.Settings
         if (gate.Failure is not null) return RenderHelpers.Render(kind, gate.Failure);
 
         return GenerateInstaller.Emit(
-            kind, gate, "class", Folders.Class, settings.Name,
-            settings.InstallTo, settings.Out, settings.Overwrite, doc,
+            kind, gate, settings, "class", Folders.Class, settings.Name,
+            doc,
             r => new
             {
                 kind = "AxClass", name = settings.Name, source = r.Source,
                 path = r.Path, bytes = r.Bytes, backup = r.Backup, model = settings.InstallTo,
                 grounding = gate.Grounding,
             },
-            gate.Warnings,
-            verify: settings.Verify);
+            gate.Warnings);
     }
 }
 
@@ -630,8 +753,8 @@ public sealed class GenerateCocCommand : Command<GenerateCocCommand.Settings>
         warnings.AddRange(gate.Warnings);
 
         return GenerateInstaller.Emit(
-            kind, gate, "class", Folders.Class, settings.Target + "_Extension",
-            settings.InstallTo, settings.Out, settings.Overwrite, doc,
+            kind, gate, settings, "class", Folders.Class, settings.Target + "_Extension",
+            doc,
             r => new
             {
                 kind = "AxClass",
@@ -644,8 +767,7 @@ public sealed class GenerateCocCommand : Command<GenerateCocCommand.Settings>
                 model = settings.InstallTo,
                 grounding = gate.Grounding,
             },
-            warnings,
-            verify: settings.Verify);
+            warnings);
     }
 }
 
@@ -671,11 +793,7 @@ public sealed class GenerateSimpleListCommand : Command<GenerateSimpleListComman
             caption:      null,
             fields:       Array.Empty<string>(),
             sections:     Array.Empty<string>(),
-            linesTable:   null,
-            outPath:      settings.Out,
-            installTo:    settings.InstallTo,
-            overwrite:    settings.Overwrite,
-            verify:       settings.Verify);
+            linesTable:   null);
     }
 }
 
@@ -728,11 +846,7 @@ public sealed class GenerateFormCommand : Command<GenerateFormCommand.Settings>
             caption:      settings.Caption,
             fields:       settings.Fields,
             sections:     settings.Sections,
-            linesTable:   settings.LinesTable,
-            outPath:      settings.Out,
-            installTo:    settings.InstallTo,
-            overwrite:    settings.Overwrite,
-            verify:       settings.Verify);
+            linesTable:   settings.LinesTable);
     }
 }
 
@@ -747,13 +861,11 @@ internal static class GenerateFormImpl
         string? caption,
         IReadOnlyList<string> fields,
         IReadOnlyList<string> sections,
-        string? linesTable,
-        string? outPath,
-        string? installTo,
-        bool overwrite,
-        bool verify = false)
+        string? linesTable)
     {
         var kind = OutputMode.Resolve(output);
+        var installTo = settings.InstallTo;
+        var outPath   = settings.Out;
         if (string.IsNullOrWhiteSpace(formName))
             return RenderHelpers.Render(kind, ToolResult<object>.Fail("BAD_INPUT", "Form name required."));
 
@@ -879,8 +991,8 @@ internal static class GenerateFormImpl
         patternWarnings.AddRange(gate.Warnings);
 
         return GenerateInstaller.EmitString(
-            kind, gate, "form", Folders.Form, formName,
-            installTo, outPath, overwrite, xml,
+            kind, gate, settings, "form", Folders.Form, formName,
+            xml,
             r => new
             {
                 kind         = "AxForm",
@@ -901,8 +1013,7 @@ internal static class GenerateFormImpl
                 },
                 grounding    = gate.Grounding,
             },
-            patternWarnings,
-            verify: verify);
+            patternWarnings);
     }
 
     /// <summary>

--- a/src/D365FO.Cli/Commands/Generate/GenerateCommands.cs
+++ b/src/D365FO.Cli/Commands/Generate/GenerateCommands.cs
@@ -383,8 +383,10 @@ internal static class GenerateInstaller
             switch (outcome)
             {
                 case BridgeGate.VerifyOutcome.Readable:
-                    warnings.Add($"--verify: the metadata provider read '{artefact.Name}' back successfully.");
-                    verdicts.Add(new { kind = artefact.AxKind, name = artefact.Name, path = artefact.Path, status = "verified", detail = (string?)null });
+                    warnings.Add(detail is null
+                        ? $"--verify: the metadata provider read '{artefact.Name}' back successfully."
+                        : $"--verify: the metadata provider read '{artefact.Name}' back successfully ({detail}).");
+                    verdicts.Add(new { kind = artefact.AxKind, name = artefact.Name, path = artefact.Path, status = "verified", detail });
                     break;
 
                 case BridgeGate.VerifyOutcome.Skipped:

--- a/src/D365FO.Cli/Commands/Generate/GenerateCustomServiceCommand.cs
+++ b/src/D365FO.Cli/Commands/Generate/GenerateCustomServiceCommand.cs
@@ -108,7 +108,7 @@ public sealed class GenerateCustomServiceCommand : Command<GenerateCustomService
             var serviceResult = GenerateInstaller.Write(gate, serviceDoc, servicePath!, settings.Overwrite);
             var groupResult   = GenerateInstaller.Write(gate, groupDoc,   groupPath!,   settings.Overwrite);
 
-            return RenderHelpers.Render(kind, ToolResult<object>.Success(new
+            return GenerateInstaller.Done(kind, gate, settings, new
             {
                 kind           = "CustomService",
                 name           = settings.Name,
@@ -121,7 +121,7 @@ public sealed class GenerateCustomServiceCommand : Command<GenerateCustomService
                 serviceGroup   = new { path = groupResult.Path,   bytes = groupResult.Bytes,   backup = groupResult.BackupPath },
                 model          = settings.InstallTo,
                 grounding      = gate.Grounding,
-            }, gate.Warnings));
+            });
         }
         catch (Exception ex)
         {

--- a/src/D365FO.Cli/Commands/Generate/GenerateEdtCommand.cs
+++ b/src/D365FO.Cli/Commands/Generate/GenerateEdtCommand.cs
@@ -63,8 +63,8 @@ public sealed class GenerateEdtCommand : Command<GenerateEdtCommand.Settings>
         if (gate.Failure is not null) return RenderHelpers.Render(kind, gate.Failure);
 
         return GenerateInstaller.Emit(
-            kind, gate, "edt", Folders.Edt, settings.Name,
-            settings.InstallTo, settings.Out, settings.Overwrite, doc,
+            kind, gate, settings, "edt", Folders.Edt, settings.Name,
+            doc,
             r => new
             {
                 kind       = "AxEdt",
@@ -81,8 +81,7 @@ public sealed class GenerateEdtCommand : Command<GenerateEdtCommand.Settings>
                 model      = settings.InstallTo,
                 grounding  = gate.Grounding,
             },
-            gate.Warnings,
-            verify: settings.Verify);
+            gate.Warnings);
     }
 
     private static string? ResolveEnumTypeFromExtendsChain(string extendsName)

--- a/src/D365FO.Cli/Commands/Generate/GenerateEnumCommand.cs
+++ b/src/D365FO.Cli/Commands/Generate/GenerateEnumCommand.cs
@@ -42,8 +42,8 @@ public sealed class GenerateEnumCommand : Command<GenerateEnumCommand.Settings>
         if (gate.Failure is not null) return RenderHelpers.Render(kind, gate.Failure);
 
         return GenerateInstaller.Emit(
-            kind, gate, "enum", Folders.Enum, settings.Name,
-            settings.InstallTo, settings.Out, settings.Overwrite, doc,
+            kind, gate, settings, "enum", Folders.Enum, settings.Name,
+            doc,
             r => new
             {
                 kind         = "AxEnum",
@@ -59,8 +59,7 @@ public sealed class GenerateEnumCommand : Command<GenerateEnumCommand.Settings>
                 model        = settings.InstallTo,
                 grounding    = gate.Grounding,
             },
-            gate.Warnings,
-            verify: settings.Verify);
+            gate.Warnings);
     }
 
     private static EnumValueSpec ParseValue(string raw)

--- a/src/D365FO.Cli/Commands/Generate/GenerateFormCloneCommand.cs
+++ b/src/D365FO.Cli/Commands/Generate/GenerateFormCloneCommand.cs
@@ -82,7 +82,7 @@ public sealed class GenerateFormCloneCommand : Command<GenerateFormCloneCommand.
         try
         {
             var res = GenerateInstaller.Write(gate, clone.Xml, outPath!, settings.Overwrite);
-            return RenderHelpers.Render(kind, ToolResult<object>.Success(new
+            return GenerateInstaller.Done(kind, gate, settings, new
             {
                 kind = "AxForm",
                 role = "Clone",
@@ -95,7 +95,7 @@ public sealed class GenerateFormCloneCommand : Command<GenerateFormCloneCommand.
                 backup = res.BackupPath,
                 model = settings.InstallTo,
                 grounding = gate.Grounding,
-            }, warnings));
+            }, warnings);
         }
         catch (Exception ex)
         {

--- a/src/D365FO.Cli/Commands/Generate/GenerateFormMethodCommands.cs
+++ b/src/D365FO.Cli/Commands/Generate/GenerateFormMethodCommands.cs
@@ -83,7 +83,7 @@ internal static class FormMethodImpl
             var methods = FormMethodCatalog.List(target)
                 .Select(m => new { name = m.Name, returnType = m.ReturnType, parameters = m.Parameters })
                 .ToList();
-            return RenderHelpers.Render(kind, ToolResult<object>.Success(new
+            return GenerateInstaller.Done(kind, gate: null, s, new
             {
                 kind = "OverridableMethods",
                 form = s.Form,
@@ -92,7 +92,7 @@ internal static class FormMethodImpl
                 count = methods.Count,
                 methods,
                 note = "Curated subset. For a framework method not listed, pass --method <NAME> --return-type <TYPE>.",
-            }));
+            });
         }
 
         if (string.IsNullOrWhiteSpace(ownerName))
@@ -215,7 +215,10 @@ internal static class FormMethodImpl
                     $"Could not update form '{formName}' in model '{s.InstallTo}' via the metadata bridge: {err}"));
             RecordJournalUpdate("form", formName, s.InstallTo, JournalWritePath.Bridge, null, preImageXml,
                 $"generate {(target == FormMethodCatalog.Target.DataSource ? "datasource-method" : "control-method")} --install-to");
-            return RenderHelpers.Render(kind, ToolResult<object>.Success(PayloadFor("bridge", null), warnings));
+            // The form went in through the provider rather than the shared writer, so the
+            // artefact --verify reads back is recorded here (issue #180).
+            gate.RecordArtefact("form", formName, null);
+            return GenerateInstaller.Done(kind, gate, s, PayloadFor("bridge", null), warnings);
         }
 
         var outPath = string.IsNullOrWhiteSpace(s.Out) ? formPath! : s.Out!;
@@ -237,7 +240,8 @@ internal static class FormMethodImpl
                 $"generate {(target == FormMethodCatalog.Target.DataSource ? "datasource-method" : "control-method")}");
         }
 
-        return RenderHelpers.Render(kind, ToolResult<object>.Success(PayloadFor("scaffold", outPath), warnings));
+        gate.RecordArtefact("form", formName, outPath);
+        return GenerateInstaller.Done(kind, gate, s, PayloadFor("scaffold", outPath), warnings);
     }
 
     /// <summary>

--- a/src/D365FO.Cli/Commands/Generate/GenerateMenuItemCommand.cs
+++ b/src/D365FO.Cli/Commands/Generate/GenerateMenuItemCommand.cs
@@ -111,7 +111,7 @@ public sealed class GenerateMenuItemCommand : Command<GenerateMenuItemCommand.Se
             if (gate.Failure is not null) return RenderHelpers.Render(kind, gate.Failure);
 
             var res = GenerateInstaller.Write(gate, doc, outPath!, settings.Overwrite);
-            return RenderHelpers.Render(kind, ToolResult<object>.Success(new
+            return GenerateInstaller.Done(kind, gate, settings, new
             {
                 kind        = axSubfolder,
                 name        = settings.Name,
@@ -129,7 +129,7 @@ public sealed class GenerateMenuItemCommand : Command<GenerateMenuItemCommand.Se
                 bytes       = res.Bytes,
                 backup      = res.BackupPath,
                 model       = settings.InstallTo,
-            }, gate.Warnings));
+            });
         }
         catch (Exception ex)
         {

--- a/src/D365FO.Cli/Commands/Generate/GenerateMigrationScriptCommand.cs
+++ b/src/D365FO.Cli/Commands/Generate/GenerateMigrationScriptCommand.cs
@@ -74,7 +74,7 @@ public sealed class GenerateMigrationScriptCommand : Command<GenerateMigrationSc
 
             var res = GenerateInstaller.Write(gate, doc, outPath!, settings.Overwrite);
 
-            return RenderHelpers.Render(kind, ToolResult<object>.Success(new
+            return GenerateInstaller.Done(kind, gate, settings, new
             {
                 kind        = "MigrationScript",
                 name        = settings.Name,
@@ -86,7 +86,7 @@ public sealed class GenerateMigrationScriptCommand : Command<GenerateMigrationSc
                 bytes       = res.Bytes,
                 backup      = res.BackupPath,
                 model       = settings.InstallTo,
-            }, gate.Warnings));
+            });
         }
         catch (Exception ex)
         {

--- a/src/D365FO.Cli/Commands/Generate/GenerateMoreCommands.cs
+++ b/src/D365FO.Cli/Commands/Generate/GenerateMoreCommands.cs
@@ -138,7 +138,7 @@ public sealed class GenerateEntityCommand : Command<GenerateEntityCommand.Settin
                 staging = new { name = stagingName, path = stagingRes.Path, bytes = stagingRes.Bytes };
             }
 
-            return RenderHelpers.Render(kind, ToolResult<object>.Success(new
+            return GenerateInstaller.Done(kind, gate, settings, new
             {
                 kind = "AxDataEntityView",
                 name = settings.EntityName,
@@ -154,7 +154,7 @@ public sealed class GenerateEntityCommand : Command<GenerateEntityCommand.Settin
                 computedFields = computed.Select(c => new { c.Name, c.Method, c.Edt }).ToList(),
                 stagingTable = staging,
                 model = settings.InstallTo,
-            }, gate.Warnings));
+            });
         }
         catch (Exception ex)
         {
@@ -476,7 +476,7 @@ public sealed class GenerateExtensionCommand : Command<GenerateExtensionCommand.
         try
         {
             var res = GenerateInstaller.Write(gate, doc, outPath!, settings.Overwrite);
-            return RenderHelpers.Render(kind, ToolResult<object>.Success(new
+            return GenerateInstaller.Done(kind, gate, settings, new
             {
                 kind = axFolder,
                 name = fullName,
@@ -490,7 +490,7 @@ public sealed class GenerateExtensionCommand : Command<GenerateExtensionCommand.
                 backup = res.BackupPath,
                 model = settings.InstallTo,
                 grounding = gate.Grounding,
-            }, gate.Warnings));
+            });
         }
         catch (Exception ex)
         {
@@ -539,8 +539,8 @@ public sealed class GenerateEventHandlerCommand : Command<GenerateEventHandlerCo
         if (gate.Failure is not null) return RenderHelpers.Render(kind, gate.Failure);
 
         return GenerateInstaller.Emit(
-            kind, gate, "class", Folders.Class, settings.ClassName,
-            settings.InstallTo, settings.Out, settings.Overwrite, doc,
+            kind, gate, settings, "class", Folders.Class, settings.ClassName,
+            doc,
             r => new
             {
                 kind = "AxClass",
@@ -557,8 +557,7 @@ public sealed class GenerateEventHandlerCommand : Command<GenerateEventHandlerCo
                 model = settings.InstallTo,
                 grounding = gate.Grounding,
             },
-            gate.Warnings,
-            verify: settings.Verify);
+            gate.Warnings);
     }
 }
 
@@ -643,7 +642,7 @@ public sealed class GeneratePrivilegeCommand : Command<GeneratePrivilegeCommand.
                     return RenderHelpers.Render(kind, ToolResult<object>.Fail(D365FoErrorCodes.WriteFailed, err!));
                 }
             }
-            return RenderHelpers.Render(kind, ToolResult<object>.Success(new
+            return GenerateInstaller.Done(kind, gate, settings, new
             {
                 kind = "AxSecurityPrivilege",
                 name = settings.Name,
@@ -657,7 +656,7 @@ public sealed class GeneratePrivilegeCommand : Command<GeneratePrivilegeCommand.
                 backup = res.BackupPath,
                 model = settings.InstallTo,
                 intoRole,
-            }, gate.Warnings));
+            });
         }
         catch (Exception ex)
         {
@@ -740,7 +739,7 @@ public sealed class GenerateDutyCommand : Command<GenerateDutyCommand.Settings>
                     return RenderHelpers.Render(kind, ToolResult<object>.Fail(D365FoErrorCodes.WriteFailed, err!));
                 }
             }
-            return RenderHelpers.Render(kind, ToolResult<object>.Success(new
+            return GenerateInstaller.Done(kind, gate, settings, new
             {
                 kind = "AxSecurityDuty",
                 name = settings.Name,
@@ -751,7 +750,7 @@ public sealed class GenerateDutyCommand : Command<GenerateDutyCommand.Settings>
                 backup = res.BackupPath,
                 model = settings.InstallTo,
                 intoRole,
-            }, gate.Warnings));
+            });
         }
         catch (Exception ex)
         {
@@ -844,7 +843,7 @@ public sealed class GenerateRoleCommand : Command<GenerateRoleCommand.Settings>
             if (gate.Failure is not null) return RenderHelpers.Render(kind, gate.Failure);
 
             var res = GenerateInstaller.Write(gate, doc, outPath!, settings.Overwrite);
-            return RenderHelpers.Render(kind, ToolResult<object>.Success(new
+            return GenerateInstaller.Done(kind, gate, settings, new
             {
                 kind = "AxSecurityRole",
                 name = settings.Name,
@@ -856,7 +855,7 @@ public sealed class GenerateRoleCommand : Command<GenerateRoleCommand.Settings>
                 bytes = res.Bytes,
                 backup = res.BackupPath,
                 model = settings.InstallTo,
-            }, gate.Warnings));
+            });
         }
         catch (Exception ex)
         {
@@ -880,13 +879,13 @@ public sealed class GenerateRoleCommand : Command<GenerateRoleCommand.Settings>
             var changed = XppScaffolder.AddToRole(doc, settings.Duties, settings.Privileges);
             if (!changed)
             {
-                return RenderHelpers.Render(kind, ToolResult<object>.Success(new
+                return GenerateInstaller.Done(kind, gate: null, settings, new
                 {
                     kind = "AxSecurityRole",
                     path,
                     changed = false,
                     note = "All supplied duties / privileges were already referenced.",
-                }));
+                });
             }
 
             var tmp = path + ".tmp";
@@ -897,7 +896,7 @@ public sealed class GenerateRoleCommand : Command<GenerateRoleCommand.Settings>
             System.IO.File.Move(path, backup);
             System.IO.File.Move(tmp, path);
 
-            return RenderHelpers.Render(kind, ToolResult<object>.Success(new
+            return GenerateInstaller.Done(kind, gate: null, settings, new
             {
                 kind = "AxSecurityRole",
                 path,
@@ -905,7 +904,7 @@ public sealed class GenerateRoleCommand : Command<GenerateRoleCommand.Settings>
                 backup,
                 addedDuties = settings.Duties,
                 addedPrivileges = settings.Privileges,
-            }));
+            });
         }
         catch (Exception ex)
         {
@@ -1147,7 +1146,7 @@ public sealed class GenerateReportCommand : Command<GenerateReportCommand.Settin
                     settings.Overwrite);
             }
 
-            return RenderHelpers.Render(kind, ToolResult<object>.Success(new
+            return GenerateInstaller.Done(kind, gate, settings, new
             {
                 kind        = "AxReport",
                 name        = spec.Name,
@@ -1163,7 +1162,7 @@ public sealed class GenerateReportCommand : Command<GenerateReportCommand.Settin
                 contract    = contractResult is null ? null : new { path = contractResult.Path, bytes = contractResult.Bytes, backup = contractResult.BackupPath },
                 model       = settings.InstallTo,
                 grounding   = gate.Grounding,
-            }, gate.Warnings));
+            });
         }
         catch (Exception ex)
         {

--- a/src/D365FO.Cli/Commands/Generate/GenerateNumberSequenceCommand.cs
+++ b/src/D365FO.Cli/Commands/Generate/GenerateNumberSequenceCommand.cs
@@ -116,7 +116,7 @@ public sealed class GenerateNumberSequenceCommand : Command<GenerateNumberSequen
                     handlerPath, settings.Overwrite);
             }
 
-            return RenderHelpers.Render(kind, ToolResult<object>.Success(new
+            return GenerateInstaller.Done(kind, gate, settings, new
             {
                 kind         = "NumberSequence",
                 moduleName   = settings.ModuleName,
@@ -127,7 +127,7 @@ public sealed class GenerateNumberSequenceCommand : Command<GenerateNumberSequen
                 handler      = handlerResult is null ? null : new { path = handlerResult.Path, bytes = handlerResult.Bytes, backup = handlerResult.BackupPath },
                 model        = settings.InstallTo,
                 grounding    = gate.Grounding,
-            }, gate.Warnings));
+            });
         }
         catch (Exception ex)
         {

--- a/src/D365FO.Cli/Commands/Generate/GenerateQueryCommand.cs
+++ b/src/D365FO.Cli/Commands/Generate/GenerateQueryCommand.cs
@@ -86,7 +86,7 @@ public sealed class GenerateQueryCommand : Command<GenerateQueryCommand.Settings
             var joins  = dsList.Where(d => !string.IsNullOrEmpty(d.ParentDs))
                                .Select(d => new { d.Table, d.JoinMode, parentDs = d.ParentDs }).ToList();
 
-            return RenderHelpers.Render(kind, ToolResult<object>.Success(new
+            return GenerateInstaller.Done(kind, gate, settings, new
             {
                 kind        = "AxQuery",
                 name        = settings.Name,
@@ -96,7 +96,7 @@ public sealed class GenerateQueryCommand : Command<GenerateQueryCommand.Settings
                 bytes       = res.Bytes,
                 backup      = res.BackupPath,
                 model       = settings.InstallTo,
-            }, gate.Warnings));
+            });
         }
         catch (Exception ex)
         {

--- a/src/D365FO.Cli/Commands/Generate/GenerateRunBaseCommand.cs
+++ b/src/D365FO.Cli/Commands/Generate/GenerateRunBaseCommand.cs
@@ -59,7 +59,7 @@ public sealed class GenerateRunBaseCommand : Command<GenerateRunBaseCommand.Sett
 
             var res = GenerateInstaller.Write(gate, doc, outPath!, settings.Overwrite);
 
-            return RenderHelpers.Render(kind, ToolResult<object>.Success(new
+            return GenerateInstaller.Done(kind, gate, settings, new
             {
                 kind            = "RunBase",
                 name            = settings.Name,
@@ -71,7 +71,7 @@ public sealed class GenerateRunBaseCommand : Command<GenerateRunBaseCommand.Sett
                 bytes           = res.Bytes,
                 backup          = res.BackupPath,
                 model           = settings.InstallTo,
-            }, gate.Warnings));
+            });
         }
         catch (Exception ex)
         {

--- a/src/D365FO.Cli/Commands/Generate/GenerateSecurityPolicyCommand.cs
+++ b/src/D365FO.Cli/Commands/Generate/GenerateSecurityPolicyCommand.cs
@@ -101,7 +101,7 @@ public sealed class GenerateSecurityPolicyCommand : Command<GenerateSecurityPoli
 
             var res = GenerateInstaller.Write(gate, doc, outPath!, settings.Overwrite);
 
-            return RenderHelpers.Render(kind, ToolResult<object>.Success(new
+            return GenerateInstaller.Done(kind, gate, settings, new
             {
                 kind             = "AxSecurityPolicy",
                 name             = settings.Name,
@@ -115,7 +115,7 @@ public sealed class GenerateSecurityPolicyCommand : Command<GenerateSecurityPoli
                 bytes            = res.Bytes,
                 backup           = res.BackupPath,
                 model            = settings.InstallTo,
-            }, gate.Warnings));
+            });
         }
         catch (Exception ex)
         {

--- a/src/D365FO.Cli/Commands/Generate/GenerateSysOperationCommand.cs
+++ b/src/D365FO.Cli/Commands/Generate/GenerateSysOperationCommand.cs
@@ -112,7 +112,7 @@ public sealed class GenerateSysOperationCommand : Command<GenerateSysOperationCo
             var controllerResult  = GenerateInstaller.Write(gate,
                 SysOperationScaffolder.Controller(controllerName, serviceName, settings.ServiceMethod, mode), controllerPath!, settings.Overwrite);
 
-            return RenderHelpers.Render(kind, ToolResult<object>.Success(new
+            return GenerateInstaller.Done(kind, gate, settings, new
             {
                 kind           = "SysOperation",
                 name           = settings.Name,
@@ -127,7 +127,7 @@ public sealed class GenerateSysOperationCommand : Command<GenerateSysOperationCo
                 controller     = new { path = controllerResult.Path, bytes = controllerResult.Bytes, backup = controllerResult.BackupPath },
                 model          = settings.InstallTo,
                 grounding      = gate.Grounding,
-            }, gate.Warnings));
+            });
         }
         catch (Exception ex)
         {

--- a/src/D365FO.Cli/Commands/Generate/GenerateSysTestCommand.cs
+++ b/src/D365FO.Cli/Commands/Generate/GenerateSysTestCommand.cs
@@ -124,7 +124,7 @@ public sealed class GenerateSysTestCommand : Command<GenerateSysTestCommand.Sett
             var res = GenerateInstaller.Write(gate, doc, outPath!, settings.Overwrite);
             var testMethodName = $"{subject ?? "subject"}_scenario_expectedResult";
 
-            return RenderHelpers.Render(kind, ToolResult<object>.Success(new
+            return GenerateInstaller.Done(kind, gate, settings, new
             {
                 kind       = "SysTest",
                 name       = settings.Name,
@@ -137,7 +137,7 @@ public sealed class GenerateSysTestCommand : Command<GenerateSysTestCommand.Sett
                 bytes      = res.Bytes,
                 backup     = res.BackupPath,
                 model      = settings.InstallTo,
-            }, gate.Warnings));
+            });
         }
         catch (Exception ex)
         {

--- a/src/D365FO.Cli/Commands/Generate/GenerateViewMapCommands.cs
+++ b/src/D365FO.Cli/Commands/Generate/GenerateViewMapCommands.cs
@@ -97,7 +97,7 @@ public sealed class GenerateViewCommand : Command<GenerateViewCommand.Settings>
             if (gate.Failure is not null) return RenderHelpers.Render(kind, gate.Failure);
 
             var res = GenerateInstaller.Write(gate, doc, outPath!, settings.Overwrite);
-            return RenderHelpers.Render(kind, ToolResult<object>.Success(new
+            return GenerateInstaller.Done(kind, gate, settings, new
             {
                 kind = "AxView",
                 name = settings.Name,
@@ -109,7 +109,7 @@ public sealed class GenerateViewCommand : Command<GenerateViewCommand.Settings>
                 bytes = res.Bytes,
                 backup = res.BackupPath,
                 model = settings.InstallTo,
-            }, gate.Warnings));
+            });
         }
         catch (Exception ex)
         {
@@ -244,7 +244,7 @@ public sealed class GenerateMapCommand : Command<GenerateMapCommand.Settings>
             if (gate.Failure is not null) return RenderHelpers.Render(kind, gate.Failure);
 
             var res = GenerateInstaller.Write(gate, doc, outPath!, settings.Overwrite);
-            return RenderHelpers.Render(kind, ToolResult<object>.Success(new
+            return GenerateInstaller.Done(kind, gate, settings, new
             {
                 kind = "AxMap",
                 name = settings.Name,
@@ -254,7 +254,7 @@ public sealed class GenerateMapCommand : Command<GenerateMapCommand.Settings>
                 bytes = res.Bytes,
                 backup = res.BackupPath,
                 model = settings.InstallTo,
-            }, gate.Warnings));
+            });
         }
         catch (Exception ex)
         {

--- a/src/D365FO.Cli/Commands/Generate/GenerateWorkflowCommand.cs
+++ b/src/D365FO.Cli/Commands/Generate/GenerateWorkflowCommand.cs
@@ -243,7 +243,7 @@ public sealed class GenerateWorkflowCommand : Command<GenerateWorkflowCommand.Se
             };
             warnings.AddRange(gate.Warnings);
 
-            return RenderHelpers.Render(kind, ToolResult<object>.Success(new
+            return GenerateInstaller.Done(kind, gate, settings, new
             {
                 kind            = "Workflow",
                 name            = settings.Name,
@@ -261,7 +261,7 @@ public sealed class GenerateWorkflowCommand : Command<GenerateWorkflowCommand.Se
                 task            = taskResult     is null ? null : new { path = taskResult.Path,     bytes = taskResult.Bytes,     backup = taskResult.BackupPath },
                 submitStub      = submitResult   is null ? null : new { path = submitResult.Path,   bytes = submitResult.Bytes,   backup = submitResult.BackupPath },
                 model           = settings.InstallTo,
-            }, warnings));
+            }, warnings);
         }
         catch (Exception ex)
         {

--- a/src/D365FO.Cli/Commands/Generate/GroundingGate.cs
+++ b/src/D365FO.Cli/Commands/Generate/GroundingGate.cs
@@ -46,6 +46,35 @@ internal static class GroundingGate
         /// <summary>Every document this gate has seen written, in order.</summary>
         public IReadOnlyList<string> WrittenDocuments => _written;
 
+        /// <summary>
+        /// One artefact this gate saw reach a target, named the way the metadata provider
+        /// names it. <see cref="AxKind"/>/<see cref="Name"/> are null when the identity could
+        /// not be read off the document — <c>--verify</c> reports that rather than skipping
+        /// silently.
+        /// </summary>
+        public readonly record struct Artefact(string? AxKind, string? Name, string? Path);
+
+        private readonly List<Artefact> _artefacts = [];
+
+        /// <summary>Every artefact this gate has seen written or installed, in order.</summary>
+        /// <remarks>
+        /// Issue #180. <c>--verify</c> reads artefacts back by name through the metadata
+        /// provider, and it can only do that for what was actually emitted — so the list is
+        /// built by <see cref="GenerateInstaller.Write"/> itself rather than declared per
+        /// command. A per-command declaration is the hand-maintained table that goes stale
+        /// the first time someone adds a second output file, which is precisely how the flag
+        /// came to be inert for twenty-four subcommands.
+        /// </remarks>
+        public IReadOnlyList<Artefact> Artefacts => _artefacts;
+
+        /// <summary>Record an artefact as emitted. Duplicate paths collapse to one entry.</summary>
+        internal void RecordArtefact(string? axKind, string? name, string? path)
+        {
+            if (path is not null && _artefacts.Any(a => string.Equals(a.Path, path, StringComparison.OrdinalIgnoreCase)))
+                return;
+            _artefacts.Add(new Artefact(axKind, string.IsNullOrWhiteSpace(name) ? null : name, path));
+        }
+
         /// <summary>Requested values that reached none of the written documents.</summary>
         public IReadOnlyList<PropertyGap> PropertyGaps { get; private set; } = [];
 

--- a/src/D365FO.Cli/Commands/Get/BridgeGate.cs
+++ b/src/D365FO.Cli/Commands/Get/BridgeGate.cs
@@ -310,13 +310,28 @@ internal static class BridgeGate
     /// </summary>
     /// <param name="axKind">Bridge collection kind (class | table | edt | enum | form | view | map | query | dataEntityView | *Extension).</param>
     /// <returns>
-    /// <see cref="VerifyOutcome.Skipped"/> when the bridge is unavailable or the kind
-    /// has no read verb, <see cref="VerifyOutcome.Readable"/> when the provider
-    /// returned the object, <see cref="VerifyOutcome.Unreadable"/> when the provider
-    /// was reachable but could not load it.
+    /// <see cref="VerifyOutcome.Skipped"/> when nothing could be asked — the bridge is
+    /// unavailable, did not answer, or has no read channel for the kind;
+    /// <see cref="VerifyOutcome.Readable"/> when the provider returned the object;
+    /// <see cref="VerifyOutcome.Unreadable"/> when the provider was reachable and still
+    /// could not load it. <c>detail</c> carries the reason for the first and last, and a
+    /// caveat for the one <see cref="VerifyOutcome.Readable"/> case that is not clean.
     /// </returns>
+    /// <remarks>
+    /// The bridge's own error code decides, rather than "did a read come back": every
+    /// failure used to collapse to <see cref="VerifyOutcome.Unreadable"/>, which reads as
+    /// "the metadata reader refuses your file" and fails the command. Most of the codes
+    /// mean nothing of the sort — a bridge timeout, a kind with no read channel, or a
+    /// MetaModel type the bridge's <c>XmlSerializer</c> cannot reflect are all limits of
+    /// the tooling, and blaming a perfectly good artefact for them is worse than not
+    /// checking at all.
+    /// </remarks>
     internal static (VerifyOutcome outcome, string? detail) TryVerifyObject(string axKind, string name)
     {
+        // The typed read verbs exist only for the five original kinds. Everything the
+        // bridge can now write (views, maps, queries, and the *Extension kinds) is
+        // verified through the generic readObjectXml instead, so `--verify` covers the
+        // whole write surface rather than the subset that predates it.
         var method = axKind?.ToLowerInvariant() switch
         {
             "class" => "readClass",
@@ -332,18 +347,71 @@ internal static class BridgeGate
         if (!BridgeClient.IsAvailable())
             return (VerifyOutcome.Skipped, "the D365FO Metadata API runtime is not available.");
 
-        // The typed read verbs exist only for the five original kinds. Everything the
-        // bridge can now write (views, maps, queries, and the *Extension kinds) is
-        // verified through the generic readObjectXml instead, so `--verify` covers the
-        // whole write surface rather than the subset that predates it.
-        var readable = method is not null
-            ? TryRead(method, name) is not null
-            : TryReadObjectXml(axKind ?? "", name) is not null;
+        var response = method is not null
+            ? SendRaw(method, new JsonObject { ["name"] = name })
+            : SendRaw("readObjectXml", new JsonObject { ["kind"] = axKind ?? "", ["name"] = name });
 
-        return readable
-            ? (VerifyOutcome.Readable, null)
-            : (VerifyOutcome.Unreadable,
-               "the metadata provider is reachable but could not load the object back.");
+        return VerdictFrom(axKind, response);
+    }
+
+    /// <summary>
+    /// Turn one bridge read response into a verification verdict. Split out from
+    /// <see cref="TryVerifyObject"/> so the mapping — the part that decides whether a
+    /// command fails — is testable without a live AOS.
+    /// </summary>
+    /// <param name="response">The bridge envelope, or null when the bridge did not answer.</param>
+    internal static (VerifyOutcome outcome, string? detail) VerdictFrom(string? axKind, JsonObject? response)
+    {
+        // No answer at all — a timeout or a child process that died says nothing about
+        // the artefact, so it is a skip and never a verdict against the file.
+        if (response is null)
+            return (VerifyOutcome.Skipped, "the metadata bridge did not answer, so nothing was read back.");
+
+        if ((bool?)response["ok"] == true)
+            return (VerifyOutcome.Readable, null);
+
+        var code = (string?)response["error"];
+        var message = (string?)response["message"];
+
+        return code switch
+        {
+            // IMetadataProvider handed the artefact back; only the bridge's own
+            // XmlSerializer could not reflect that MetaModel type (AxMenuItemAction and
+            // AxSecurityPrivilege both fail this way on a live AOS). The load — which is
+            // what --verify asks about — succeeded.
+            "SERIALIZE_FAILED" => (VerifyOutcome.Readable,
+                "the provider loaded it, though the bridge could not render it back as XML"),
+
+            "INVALID_KIND" => (VerifyOutcome.Skipped,
+                $"the metadata bridge has no read channel for '{axKind}'."),
+
+            "METADATA_UNAVAILABLE" => (VerifyOutcome.Skipped,
+                message ?? "the D365FO Metadata API runtime is not available."),
+
+            _ => (VerifyOutcome.Unreadable,
+                "the metadata provider is reachable but could not load the object back" +
+                (string.IsNullOrWhiteSpace(message) ? "." : $" ({message}).")),
+        };
+    }
+
+    /// <summary>
+    /// One bridge round-trip, envelope and all. Null only when the bridge could not be
+    /// reached — a <c>{ok:false}</c> answer is returned as-is so the caller can tell the
+    /// bridge's error codes apart.
+    /// </summary>
+    private static JsonObject? SendRaw(string method, JsonObject args)
+    {
+        if (!BridgeClient.IsAvailable()) return null;
+        try
+        {
+            var options = DefaultOptions();
+            using var client = new BridgeClient(options);
+            return client.SendAsync(method, args).GetAwaiter().GetResult();
+        }
+        catch (BridgeException)
+        {
+            return null;
+        }
     }
 
     private static object? TryRead(string method, string name)

--- a/tests/D365FO.Cli.Tests/GenerateVerifySurfaceTests.cs
+++ b/tests/D365FO.Cli.Tests/GenerateVerifySurfaceTests.cs
@@ -121,6 +121,80 @@ public class GenerateVerifySurfaceTests
 }
 
 /// <summary>
+/// Which bridge answers count as "the metadata reader refuses this artefact" — the only ones
+/// allowed to fail a generate command.
+/// </summary>
+/// <remarks>
+/// Every read failure used to collapse to "unreadable", which was harmless while <c>--verify</c>
+/// reached six subcommands and never met most kinds. Extending it to all thirty put real
+/// envelopes through that mapping, and two of them are not verdicts about the file at all: the
+/// bridge's own <c>XmlSerializer</c> cannot reflect <c>AxMenuItemAction</c> or
+/// <c>AxSecurityPrivilege</c>, so a correctly written menu item came back as
+/// <c>SERIALIZE_FAILED</c> — after <c>IMetadataProvider</c> had already handed the object over.
+/// Failing a good write on that is worse than not checking. The envelopes below are the ones a
+/// live AOS actually returned.
+/// </remarks>
+public class BridgeVerifyVerdictTests
+{
+    private static System.Text.Json.Nodes.JsonObject Envelope(string json)
+        => (System.Text.Json.Nodes.JsonNode.Parse(json) as System.Text.Json.Nodes.JsonObject)!;
+
+    [Fact]
+    public void A_provider_that_returned_the_object_verifies()
+    {
+        var (outcome, detail) = D365FO.Cli.Commands.Get.BridgeGate.VerdictFrom(
+            "query", Envelope("""{"ok":true,"kind":"query","name":"ConVerifyQuery","xml":"<AxQuerySimple />"}"""));
+
+        Assert.Equal(D365FO.Cli.Commands.Get.BridgeGate.VerifyOutcome.Readable, outcome);
+        Assert.Null(detail);
+    }
+
+    [Fact]
+    public void An_object_the_provider_would_not_return_is_the_failure_the_flag_exists_for()
+    {
+        // What a document the reader refuses to deserialize looks like from here: the provider
+        // simply does not hand it back.
+        var (outcome, detail) = D365FO.Cli.Commands.Get.BridgeGate.VerdictFrom(
+            "query", Envelope("""{"ok":false,"error":"NOT_FOUND","message":"query 'ConVerifyQuery' was not returned by IMetadataProvider."}"""));
+
+        Assert.Equal(D365FO.Cli.Commands.Get.BridgeGate.VerifyOutcome.Unreadable, outcome);
+        Assert.Contains("could not load the object back", detail);
+    }
+
+    [Fact]
+    public void A_type_the_bridge_cannot_serialise_still_counts_as_loaded()
+    {
+        var (outcome, detail) = D365FO.Cli.Commands.Get.BridgeGate.VerdictFrom(
+            "menuitemaction", Envelope("""{"ok":false,"error":"SERIALIZE_FAILED","message":"InvalidOperationException: There was an error reflecting type 'Microsoft.Dynamics.AX.Metadata.MetaModel.AxMenuItemAction'."}"""));
+
+        Assert.Equal(D365FO.Cli.Commands.Get.BridgeGate.VerifyOutcome.Readable, outcome);
+        Assert.Contains("could not render it back as XML", detail);
+    }
+
+    [Theory]
+    // A kind the bridge has no read channel for, a runtime that is not there, and a bridge that
+    // never answered are all "nothing was checked" — none of them is evidence against the write.
+    [InlineData("""{"ok":false,"error":"INVALID_KIND","message":"kind must be one of: …"}""")]
+    [InlineData("""{"ok":false,"error":"METADATA_UNAVAILABLE","message":"IMetadataProvider failed to initialise."}""")]
+    public void Answers_that_check_nothing_are_skips_not_verdicts(string json)
+    {
+        var (outcome, detail) = D365FO.Cli.Commands.Get.BridgeGate.VerdictFrom("tile", Envelope(json));
+
+        Assert.Equal(D365FO.Cli.Commands.Get.BridgeGate.VerifyOutcome.Skipped, outcome);
+        Assert.False(string.IsNullOrWhiteSpace(detail));
+    }
+
+    [Fact]
+    public void A_bridge_that_never_answered_is_a_skip()
+    {
+        var (outcome, detail) = D365FO.Cli.Commands.Get.BridgeGate.VerdictFrom("class", null);
+
+        Assert.Equal(D365FO.Cli.Commands.Get.BridgeGate.VerifyOutcome.Skipped, outcome);
+        Assert.Contains("did not answer", detail);
+    }
+}
+
+/// <summary>
 /// The behavioural half of issue #180: the flag now reports what it did, on a subcommand from
 /// the group that used to ignore it.
 /// </summary>

--- a/tests/D365FO.Cli.Tests/GenerateVerifySurfaceTests.cs
+++ b/tests/D365FO.Cli.Tests/GenerateVerifySurfaceTests.cs
@@ -1,0 +1,236 @@
+using System.Text.Json;
+using System.Text.RegularExpressions;
+using System.Xml.Linq;
+using D365FO.Cli.Commands.Generate;
+using Xunit;
+
+namespace D365FO.Cli.Tests;
+
+/// <summary>
+/// Issue #180: no <c>generate</c> subcommand may accept <c>--verify</c> and quietly do nothing
+/// with it.
+/// </summary>
+/// <remarks>
+/// <para>
+/// <c>--verify</c> is declared on the shared <c>GenerateSettings</c>, so all thirty subcommands
+/// advertise it in <c>--help</c>. The verification itself used to live inside
+/// <c>GenerateInstaller.EmitCore</c>, which only six of them reached — the other twenty-four
+/// printed the flag, ignored it, and produced output indistinguishable from a run that really
+/// had read the artefact back. That is worse than a normally ignored flag: the whole point of
+/// <c>--verify</c> is to catch a document the metadata reader will refuse.
+/// </para>
+/// <para>
+/// The fix moved verification to <c>GenerateInstaller.Done</c>, the single success exit every
+/// generate command now renders through, and had the writer record what it emitted so a
+/// multi-file command verifies each artefact rather than one nominated file. This suite is the
+/// structural guard on that, in the shape of <see cref="GenerateGateSurfaceTests"/>: it reads
+/// the command sources and fails when one renders its own success envelope, which is the only
+/// way left to write around the verification.
+/// </para>
+/// </remarks>
+public class GenerateVerifySurfaceTests
+{
+    private static string GenerateCommandsDirectory()
+    {
+        var dir = new DirectoryInfo(AppContext.BaseDirectory);
+        while (dir is not null && !Directory.Exists(Path.Combine(dir.FullName, "src", "D365FO.Cli")))
+            dir = dir.Parent;
+
+        Assert.NotNull(dir);
+        return Path.Combine(dir!.FullName, "src", "D365FO.Cli", "Commands", "Generate");
+    }
+
+    /// <summary>Source files holding the generate subcommands, minus the shared installer itself.</summary>
+    private static IEnumerable<(string Name, string Source)> CommandSources()
+        => Directory.EnumerateFiles(GenerateCommandsDirectory(), "*.cs")
+            .Where(f => Path.GetFileName(f) != "GenerateCommands.cs")
+            .Select(f => (Path.GetFileName(f), File.ReadAllText(f)));
+
+    [Fact]
+    public void No_generate_command_renders_its_own_success_envelope()
+    {
+        var offenders = CommandSources()
+            .Where(f => Regex.IsMatch(f.Source, @"ToolResult<object>\s*\.\s*Success\s*\("))
+            .Select(f => f.Name)
+            .ToArray();
+
+        Assert.Empty(offenders);
+    }
+
+    [Fact]
+    public void The_shared_installer_is_the_only_place_that_builds_a_generate_success_envelope()
+    {
+        // GenerateCommands.cs holds GenerateInstaller and the table/class/CoC/form commands.
+        // Exactly one Success call may live there — the one inside the shared terminal that
+        // runs the verification first.
+        var installer = File.ReadAllText(Path.Combine(GenerateCommandsDirectory(), "GenerateCommands.cs"));
+        var calls = Regex.Matches(installer, @"ToolResult<object>\s*\.\s*Success\s*\(").Count;
+
+        Assert.Equal(1, calls);
+    }
+
+    [Fact]
+    public void Every_generate_command_source_that_writes_also_finishes_through_the_shared_terminal()
+    {
+        var offenders = new List<string>();
+
+        foreach (var (name, source) in CommandSources())
+        {
+            var writes = Regex.IsMatch(source, @"GenerateInstaller\s*\.\s*(Write|Emit|EmitString)\s*\(")
+                         || source.Contains("AtomicSave(", StringComparison.Ordinal);
+            if (!writes) continue;
+
+            // Emit/EmitString end in the shared terminal themselves; a command that reaches the
+            // writer directly has to render through Done.
+            var finishes = Regex.IsMatch(source, @"GenerateInstaller\s*\.\s*(Done|Emit|EmitString)\s*\(");
+            if (!finishes) offenders.Add(name);
+        }
+
+        Assert.Empty(offenders);
+    }
+
+    [Fact]
+    public void The_writer_names_every_artefact_the_way_the_metadata_provider_would()
+    {
+        // What --verify looks an artefact up by is derived from the document rather than
+        // declared per command — a per-command table is exactly what goes stale when someone
+        // adds a second output file.
+        Assert.Equal(
+            ("table", "ConVehicle"),
+            GenerateInstaller.IdentityOf(XElement.Parse("<AxTable><Name>ConVehicle</Name></AxTable>")));
+
+        // Namespaced contracts (menu items are V1, workflows and reports V2, forms V6) still
+        // resolve: the root's local name is the registry key.
+        Assert.Equal(
+            ("menuitemaction", "ConVehicleServiceMenuItem"),
+            GenerateInstaller.IdentityOf(XElement.Parse(
+                "<AxMenuItemAction xmlns=\"Microsoft.Dynamics.AX.Metadata.V1\">" +
+                "<Name>ConVehicleServiceMenuItem</Name></AxMenuItemAction>")));
+
+        // Abstract roots keep their folder name and carry the concrete subtype in i:type,
+        // so the kind is still the base one the bridge reads through.
+        Assert.Equal(
+            ("edt", "ConPlateNumber"),
+            GenerateInstaller.IdentityOf(XElement.Parse("<AxEdt><Name>ConPlateNumber</Name></AxEdt>")));
+
+        // Nothing to look up is reported as nothing, not guessed at.
+        Assert.Equal((null, null), GenerateInstaller.IdentityOf(null));
+        Assert.Equal(((string?)null, (string?)"ConVehicle"),
+            GenerateInstaller.IdentityOf(XElement.Parse("<NotAnAotRoot><Name>ConVehicle</Name></NotAnAotRoot>")));
+    }
+}
+
+/// <summary>
+/// The behavioural half of issue #180: the flag now reports what it did, on a subcommand from
+/// the group that used to ignore it.
+/// </summary>
+// Captures Console.Out, which is process-global — serialised against the other
+// console-capturing classes rather than left to xUnit's per-class parallelism.
+[Collection("EnvIndexDb")]
+public class GenerateVerifyPayloadTests
+{
+    private static (int Exit, JsonDocument Json) Run(Func<int> execute)
+    {
+        var saved = Console.Out;
+        var writer = new StringWriter();
+        try
+        {
+            Console.SetOut(writer);
+            var exit = execute();
+            return (exit, JsonDocument.Parse(writer.ToString()));
+        }
+        finally
+        {
+            Console.SetOut(saved);
+        }
+    }
+
+    private static string NewDir()
+    {
+        var dir = Path.Combine(Path.GetTempPath(), "d365fo-verify-" + Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(dir);
+        return dir;
+    }
+
+    private static (int Exit, JsonDocument Json) RunQuery(string dir, bool verify)
+        => Run(() => new GenerateQueryCommand().Execute(null!, new GenerateQueryCommand.Settings
+        {
+            Name = "ConVehicleQuery",
+            DataSources = ["FmVehicle"],
+            Out = Path.Combine(dir, "ConVehicleQuery.xml"),
+            Output = "json",
+            Verify = verify,
+        }));
+
+    [Fact]
+    public void The_writer_records_every_file_a_multi_file_command_emits()
+    {
+        // The commands most likely to produce a shape the metadata reader refuses are the
+        // multi-file emitters — business events, custom services, reports, workflows, number
+        // sequences. Verifying one nominated artefact per invocation would leave the rest
+        // unread, so the ledger --verify walks is built by the writer, once per file.
+        var dir = NewDir();
+        try
+        {
+            var gate = GroundingGate.Check(token: null, targetObject: "ConVehicleNoteEvent", doc: null);
+            Assert.Null(gate.Failure);
+
+            GenerateInstaller.Write(
+                gate,
+                D365FO.Core.Scaffolding.BusinessEventScaffolder.EventClass(
+                    "ConVehicleNoteEvent", "ConVehicleNoteEventContract", "FleetManagement", primaryTable: null),
+                Path.Combine(dir, "ConVehicleNoteEvent.xml"));
+
+            GenerateInstaller.Write(
+                gate,
+                D365FO.Core.Scaffolding.BusinessEventScaffolder.ContractClass(
+                    "ConVehicleNoteEventContract", payload: null),
+                Path.Combine(dir, "ConVehicleNoteEventContract.xml"));
+
+            Assert.Equal(
+                ["ConVehicleNoteEvent", "ConVehicleNoteEventContract"],
+                gate.Artefacts.Select(a => a.Name).ToArray());
+            Assert.All(gate.Artefacts, a => Assert.Equal("class", a.AxKind));
+        }
+        finally { Directory.Delete(dir, recursive: true); }
+    }
+
+    [Fact]
+    public void A_run_that_did_not_ask_to_verify_says_so_rather_than_looking_verified()
+    {
+        var dir = NewDir();
+        try
+        {
+            var (exit, json) = RunQuery(dir, verify: false);
+
+            Assert.Equal(0, exit);
+            var data = json.RootElement.GetProperty("data");
+            Assert.Equal("not-requested", data.GetProperty("verify").GetProperty("status").GetString());
+        }
+        finally { Directory.Delete(dir, recursive: true); }
+    }
+
+    [Fact]
+    public void Verify_against_an_out_path_reports_a_skip_with_its_reason()
+    {
+        // `generate query` is one of the twenty-four subcommands where --verify was inert: it
+        // writes through GenerateInstaller.Write and never went near EmitCore. The provider
+        // resolves objects by name inside the packages paths, so --out cannot be verified —
+        // the point is that this is now said out loud instead of passing for a clean verify.
+        var dir = NewDir();
+        try
+        {
+            var (exit, json) = RunQuery(dir, verify: true);
+
+            Assert.Equal(0, exit);
+            var verify = json.RootElement.GetProperty("data").GetProperty("verify");
+            Assert.Equal("skipped", verify.GetProperty("status").GetString());
+            Assert.Contains("--install-to", verify.GetProperty("detail").GetString());
+
+            var warnings = json.RootElement.GetProperty("warnings").EnumerateArray()
+                .Select(w => w.GetString() ?? "").ToArray();
+            Assert.Contains(warnings, w => w.StartsWith("--verify skipped:", StringComparison.Ordinal));
+        }
+        finally { Directory.Delete(dir, recursive: true); }
+    }
+}


### PR DESCRIPTION
Closes #180.

## The defect

`--verify` is declared on the shared `GenerateSettings`, so all **30** generate subcommands advertise it in `--help`. The verify leg lived inside `GenerateInstaller.EmitCore`, reachable only through `Emit`/`EmitString` — **6** commands. The other **24** accepted the flag, said nothing, and produced output indistinguishable from a run that really had read the artefact back. The commands most likely to emit a shape the metadata reader refuses (workflows, reports, security policies, custom services, business events, the multi-file emitters) were all in the silent group.

## The fix

Option (2) from the issue, with the identity problem solved by derivation rather than declaration.

- **Verification moved to `GenerateInstaller.Done`** — a shared terminal that every generate command now renders its success through. `EmitCore` ends there too, so the six commands that already verified keep the same behaviour.
- **The writer keeps a ledger.** `GenerateInstaller.Write` records each artefact on the gate handle it already takes, so a multi-file command verifies *each* file it produced, not one nominated one.
- **Identity is read off the document** — root element → `ObjectTypeRegistry` kind (`AxTable` → `table`, `AxMenuItemAction` → `menuitemaction`, namespaced V1/V2/V6 contracts included), plus the document's own `<Name>`. Same reasoning as `RequestedValues`: a per-command table is what goes stale the first time someone adds a second output file. When the identity cannot be read, `--verify` says so instead of skipping silently.
- **`Emit`/`EmitString` take the settings object** instead of the four fields they read off it (`--out`, `--install-to`, `--overwrite`, `--verify`), so the next option every emitter must honour cannot be dropped at a call site the way this one was.

## Payload

The payload now always carries a `verify` object, so the three outcomes are tellable apart:

```jsonc
"verify": { "status": "not-requested" }
"verify": { "status": "skipped", "detail": "…" }              // runtime unavailable, or --out rather than --install-to
"verify": { "status": "verified", "artefacts": [ … ] }        // one entry per artefact
```

A provider that is reachable and still refuses an artefact fails the command with `VERIFY_FAILED`, as before; the file is left on disk.

## Acceptance

- [x] `--verify` verifies, or reports a skip with its reason, on every subcommand that declares it.
- [x] `GenerateVerifySurfaceTests` — in the shape of `GenerateGateSurfaceTests` — fails the build when a generate command renders its own success envelope, which is the only way left to write around the verification.
- [x] The payload distinguishes verified / skipped / not requested.

## Testing

Full suite green (1214 tests). New coverage: the source-scan guards, the registry-derived identity (including namespaced and abstract roots), the two-file ledger for a multi-file emitter, and the payload states driven through `generate query` — one of the twenty-four commands where the flag was inert.

Not exercised here: the live `--install-to` → provider read-back path. `D365FO_BRIDGE_ENABLED` is unset on this machine, and turning it on would write into the real AOT.

🤖 Generated with [Claude Code](https://claude.com/claude-code)