### PR TITLE
fix(publish): make the trimmed single-file build behave like an ordinary one (#182)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,6 +41,30 @@ jobs:
           name: test-results-${{ matrix.os }}
           path: "**/TestResults/**"
 
+  # What `dotnet test` builds is not what anybody installs. install.ps1/install.sh publish
+  # self-contained, single-file and TRIMMED, and issue #182 showed that shape failing on
+  # every SQLite query, on the native SQLite load, and - worst - returning an empty journal
+  # instead of an error, all while the suite above stayed green. So publish the installed
+  # shape here and diff it against an ordinary build: see scripts/smoke-published-cli.ps1.
+  published-cli:
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - os: windows-latest
+            rid: win-x64
+          - os: ubuntu-latest
+            rid: linux-x64
+    runs-on: ${{ matrix.os }}
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-dotnet@v4
+        with:
+          dotnet-version: 10.0.x
+      - name: Published build must match an ordinary build
+        shell: pwsh
+        run: ./scripts/smoke-published-cli.ps1 -Rid ${{ matrix.rid }}
+
   # The knowledge corpus is gated the same fail-closed way generated code is: every named
   # AOT type/API must be covered by the snapshot captured against a real standard index, and
   # every X++/XML example must pass the offline BP validator. CI has no index, so this is the

--- a/docs/TROUBLESHOOTING.md
+++ b/docs/TROUBLESHOOTING.md
@@ -18,6 +18,23 @@ D365FO VMs are Windows Server, where `winget` is often missing. The installer fa
 
 The installer probes `$env:D365FO_CLI_DIR` / `$D365FO_CLI_DIR`, then `K:\d365fo-cli` (Windows) or `~/d365fo-cli`, and updates in place (`git pull --ff-only`) whichever it finds first. If you have a checkout elsewhere, set that env var before running the installer so it targets the right directory instead of cloning a second copy.
 
+### `The type initializer for 'Microsoft.Data.Sqlite.SqliteConnection' threw an exception`
+
+Also seen as `A parameterless default constructor ... is required for ... materialization`,
+`Must add values for the following parameters: @v, @t`, or a `journal list` that reports zero
+entries on a journal that plainly has some. All four are the same thing: a binary published
+before the fix for [#182](https://github.com/dynamics365ninja/d365fo-cli/issues/182), where
+trimming removed the reflection the SQLite provider, Dapper and `System.Text.Json` need, and
+`PublishSingleFile` left the native `e_sqlite3` library outside the executable.
+
+**Fix:** re-run the installer, or re-publish from a checkout that includes the fix. Nothing
+about the publish command changes — the settings live in `src/D365FO.Cli/D365FO.Cli.csproj`
+and `src/D365FO.Cli/TrimmerRootDescriptor.xml`, and CI now diffs a published build against an
+ordinary one on every push (`scripts/smoke-published-cli.ps1`).
+
+To confirm which one you are running, `d365fo models list --output json` on the fixed build
+returns models rather than an error.
+
 ### `git pull --ff-only` failed
 
 Local commits or a detached `HEAD` in the install directory diverge from `origin/main`. The installer won't merge or discard anything for you — resolve it yourself (`git status` in that directory), then re-run the installer.

--- a/scripts/smoke-published-cli.ps1
+++ b/scripts/smoke-published-cli.ps1
@@ -1,0 +1,289 @@
+<#
+.SYNOPSIS
+    Proves a PUBLISHED d365fo binary behaves like an ordinary build.
+
+.DESCRIPTION
+    Issue #182: `dotnet publish -p:PublishSingleFile=true -p:PublishTrimmed=true` - the exact
+    command install.ps1 and install.sh run - shipped a CLI that threw "The type initializer
+    for 'Microsoft.Data.Sqlite.SqliteConnection' threw an exception", failed every Dapper
+    query, and returned an EMPTY journal instead of erroring. The unit suite cannot see any
+    of it: it runs against an untrimmed, non-single-file build, where all the reflection
+    those paths depend on is still present.
+
+    So this script publishes the CLI both ways and diffs them:
+
+      baseline  - framework-dependent, untrimmed: reflection fully intact
+      published - self-contained, single-file, trimmed: what users actually install
+
+    Both get their own throwaway SQLite index seeded from tests/Samples/MiniAot, then run the
+    same commands. Any difference in output that is not genuinely volatile (temp paths, ids,
+    timings) fails the run. Three defect classes are additionally asserted head-on, because
+    each of them once failed SILENTLY rather than loudly:
+
+      * the journal must read back what a write put there (System.Text.Json reflection)
+      * a grounding token must validate                   (provenance store round-trip)
+      * the single binary must run with NO sibling files  (bundled native e_sqlite3)
+
+.PARAMETER Rid
+    Runtime identifier for the published build. Defaults to the host RID.
+
+.PARAMETER WorkDir
+    Scratch directory. Defaults to a new temp directory, removed on success.
+
+.PARAMETER KeepWorkDir
+    Keep the scratch directory (both publishes, both indexes) for debugging.
+#>
+[CmdletBinding()]
+param(
+    [string]$Rid,
+    [string]$WorkDir,
+    [switch]$KeepWorkDir
+)
+
+Set-StrictMode -Version Latest
+$ErrorActionPreference = 'Stop'
+
+# $IsWindows/$IsMacOS are PowerShell 7 automatic variables. Windows PowerShell 5.1 - still the
+# default shell on a D365FO VM - does not define them, and StrictMode turns reading one into an
+# error rather than a silent $null, so seed them before anything reads them.
+if (-not (Test-Path 'variable:IsWindows')) {
+    $IsWindows = $true
+    $IsMacOS = $false
+}
+
+$repoRoot = Split-Path -Parent $PSScriptRoot
+$fixture = Join-Path $repoRoot 'tests/Samples/MiniAot'
+$project = Join-Path $repoRoot 'src/D365FO.Cli'
+
+if (-not $Rid) {
+    $Rid = if ($IsWindows) { 'win-x64' } elseif ($IsMacOS) { 'osx-x64' } else { 'linux-x64' }
+}
+if (-not $WorkDir) {
+    $WorkDir = Join-Path ([IO.Path]::GetTempPath()) ('d365fo-smoke-' + [Guid]::NewGuid().ToString('N'))
+}
+New-Item -ItemType Directory -Force -Path $WorkDir | Out-Null
+
+$exeName = if ($IsWindows) { 'd365fo.exe' } else { 'd365fo' }
+$baselineDir = Join-Path $WorkDir 'baseline'
+$publishedDir = Join-Path $WorkDir 'published'
+$publishedExe = Join-Path $publishedDir $exeName
+$failures = New-Object 'System.Collections.Generic.List[string]'
+
+function Write-Step([string]$Text) { Write-Host "==> $Text" -ForegroundColor Cyan }
+function Add-Failure([string]$Text) { $failures.Add($Text); Write-Host "FAIL  $Text" -ForegroundColor Red }
+function Write-Ok([string]$Text) { Write-Host "ok    $Text" }
+
+function Get-Excerpt([string]$Text, [int]$Max = 220) {
+    $flat = ($Text -replace '\s+', ' ').Trim()
+    if ($flat.Length -le $Max) { return $flat }
+    return $flat.Substring(0, $Max) + ' ...'
+}
+
+# --- publish both shapes -----------------------------------------------------
+
+# A publish of this solution emits hundreds of doc-comment and trim-analysis warnings that
+# would bury the diff below, so it is logged to a file and only replayed when it fails.
+function Invoke-Publish {
+    param([Parameter(Mandatory)][string]$What, [Parameter(Mandatory)][string[]]$PublishArgs)
+
+    $log = Join-Path $WorkDir "publish-$What.log"
+    & dotnet publish $project -c Release --nologo -v quiet @PublishArgs *>&1 | Out-File -FilePath $log -Encoding utf8
+    if ($LASTEXITCODE -ne 0) {
+        Get-Content $log | Select-Object -Last 40 | ForEach-Object { Write-Host $_ }
+        throw "$What publish failed (full log: $log)"
+    }
+}
+
+Write-Step 'Publishing the baseline (framework-dependent, untrimmed)'
+Invoke-Publish 'baseline' @('-o', $baselineDir)
+
+Write-Step "Publishing as installed (self-contained, single-file, trimmed, $Rid)"
+Invoke-Publish 'published' @('-r', $Rid, '--self-contained',
+    '-p:PublishSingleFile=true', '-p:PublishTrimmed=true', '-o', $publishedDir)
+if (-not (Test-Path $publishedExe)) { throw "published build produced no $exeName" }
+
+# --- running one command against one build -----------------------------------
+
+function Invoke-Native {
+    param([Parameter(Mandatory)][string]$Exe, [Parameter(Mandatory)][string[]]$ExeArgs)
+
+    # The CLI reports failures as JSON on stderr. Windows PowerShell turns a native command's
+    # stderr into an error record, which $ErrorActionPreference='Stop' would promote to a
+    # terminating error - and a reported failure is exactly what this script is here to
+    # compare, so it must come back as ordinary text instead of killing the run.
+    $previous = $ErrorActionPreference
+    $ErrorActionPreference = 'Continue'
+    try {
+        $output = & $Exe @ExeArgs 2>&1
+    } finally {
+        $ErrorActionPreference = $previous
+    }
+
+    # Those error records render with the script's own file and line number bolted on. Keep
+    # only the message the CLI actually wrote.
+    $lines = $output | ForEach-Object {
+        if ($_ -is [System.Management.Automation.ErrorRecord]) { $_.ToString() } else { $_ }
+    }
+    # ANSI escapes: written as [char]27 because Windows PowerShell 5.1 has no `e escape.
+    return ((($lines | Out-String) -replace "$([char]27)\[[0-9;]*m", '')).Trim()
+}
+
+function Invoke-Cli {
+    param([Parameter(Mandatory)][string]$Build, [Parameter(Mandatory)][string[]]$CliArgs)
+
+    $env:D365FO_INDEX_DB = Join-Path (Join-Path $WorkDir $Build) 'index/index.sqlite'
+    $env:D365FO_PACKAGES_PATH = $fixture
+    $env:NO_COLOR = '1'
+
+    if ($Build -eq 'baseline') {
+        return Invoke-Native 'dotnet' (@((Join-Path $baselineDir 'd365fo.dll')) + $CliArgs)
+    }
+    return Invoke-Native $publishedExe $CliArgs
+}
+
+# Volatile by construction: the two builds live in different directories, mint fresh ids and
+# measure their own wall-clock. Everything else must match, character for character.
+$masks = @(
+    @{ Pattern = '"(groundingToken|token|id|runId)":"[^"]*"'; Replacement = '"$1":"<id>"' }
+    # Surrogate keys: SQLite hands out rowids in insert order, and the two indexes are
+    # extracted by their own process, so FmVehicle can be table 1 in one and 2 in the other.
+    @{ Pattern = '"([A-Za-z]+Id)":\s*\d+'; Replacement = '"$1":<id>' }
+    @{ Pattern = '"(elapsedMs|bytes|durationMs|sizeBytes)":\s*-?\d+'; Replacement = '"$1":<num>' }
+    @{ Pattern = '\d{4}-\d{2}-\d{2}[T ][0-9:.]+([+-][0-9:]+|Z)?'; Replacement = '<ts>' }
+)
+
+function Get-Normalized([string]$Text) {
+    $normalized = $Text
+    foreach ($form in @($WorkDir, $WorkDir.Replace('\', '\\'), $WorkDir.Replace('\', '/'))) {
+        $normalized = $normalized -replace [Regex]::Escape($form), '<work>'
+    }
+    # ... and each build's own directory under it, so paths the CLI echoes back compare equal.
+    $normalized = $normalized -replace '<work>[\\/]+(baseline|published)', '<work>/<build>'
+    foreach ($mask in $masks) { $normalized = $normalized -replace $mask.Pattern, $mask.Replacement }
+    return $normalized
+}
+
+# --- seed one throwaway index per build --------------------------------------
+
+foreach ($build in @('baseline', 'published')) {
+    Write-Step "Seeding the $build index from tests/Samples/MiniAot"
+    New-Item -ItemType Directory -Force -Path (Join-Path (Join-Path $WorkDir $build) 'index') | Out-Null
+
+    $built = Invoke-Cli $build @('index', 'build', '--output', 'json')
+    if ($built -notmatch '"ok":\s*true') { Add-Failure "[$build] index build: $(Get-Excerpt $built)" }
+
+    $extracted = Invoke-Cli $build @('index', 'extract', '--packages', $fixture, '--output', 'json')
+    if ($extracted -notmatch '"ok":\s*true') { Add-Failure "[$build] index extract: $(Get-Excerpt $extracted)" }
+    elseif ($extracted -notmatch '"tables":\s*[1-9]') { Add-Failure "[$build] index extract ingested no tables: $(Get-Excerpt $extracted)" }
+}
+
+# --- the diffed surface ------------------------------------------------------
+
+# Every command here reads through Dapper (record materialization + anonymous-type
+# parameters) or serializes an anonymous payload - the two things trimming broke.
+$cases = @(
+    @('models', 'list', '--output', 'json'),
+    @('index', 'status', '--output', 'json'),
+    @('search', 'table', 'Fm', '--output', 'json'),
+    @('search', 'class', 'Fm', '--output', 'json'),
+    @('search', 'any', 'Fm', '--output', 'json'),
+    @('get', 'table', 'FmVehicle', '--output', 'json'),
+    @('get', 'class', 'FmVehicleService', '--output', 'json'),
+    @('get', 'edt', 'VinEdt', '--output', 'json'),
+    @('get', 'enum', 'FmVehicleStatus', '--output', 'json'),
+    @('get', 'query', 'FmVehicleQuery', '--output', 'json'),
+    @('suggest', 'edt', 'Vin', '--output', 'json'),
+    @('prepare', 'create', 'ConFmVehicleProbe', '--type', 'table', '--output', 'json'),
+    @('prepare', 'change', 'FmVehicle', '--output', 'json'),
+    @('report-integrations', '--output', 'json'),
+    @('knowledge', 'list', '--output', 'json'),
+    @('form-pattern', 'spec', '--output', 'json'),
+    @('validate', 'name', 'table', 'ConFmVehicle', '--output', 'json')
+)
+
+Write-Step "Diffing $($cases.Count) commands, published vs baseline"
+foreach ($case in $cases) {
+    $label = 'd365fo ' + ($case -join ' ')
+    $expected = Get-Normalized (Invoke-Cli 'baseline' $case)
+    $actual = Get-Normalized (Invoke-Cli 'published' $case)
+
+    if ($expected -ceq $actual) {
+        Write-Ok $label
+    } else {
+        Add-Failure $label
+        Write-Host "      baseline : $(Get-Excerpt $expected)"
+        Write-Host "      published: $(Get-Excerpt $actual)"
+    }
+}
+
+# --- the three that failed silently ------------------------------------------
+
+Write-Step 'Grounding token round-trip (provenance store, System.Text.Json)'
+foreach ($build in @('baseline', 'published')) {
+    $prepared = Invoke-Cli $build @('prepare', 'create', 'ConFmVehicleProbe', '--type', 'class', '--output', 'json')
+    $token = [Regex]::Match($prepared, '"groundingToken":"([^"]+)"').Groups[1].Value
+    if (-not $token) {
+        Add-Failure "[$build] prepare create minted no grounding token: $(Get-Excerpt $prepared)"
+        continue
+    }
+
+    $outFile = Join-Path (Join-Path $WorkDir $build) 'ConFmVehicleProbe.xml'
+    $generated = Invoke-Cli $build @('generate', 'class', 'ConFmVehicleProbe',
+        '--grounding-token', $token, '--out', $outFile, '--overwrite', '--output', 'json')
+    if ($generated -notmatch '"tokenValid":\s*true') {
+        Add-Failure "[$build] the token prepare minted did not validate in generate: $(Get-Excerpt $generated)"
+    } else {
+        Write-Ok "[$build] token round-trip"
+    }
+}
+
+Write-Step 'Journal reads back what the generate above wrote (System.Text.Json)'
+foreach ($build in @('baseline', 'published')) {
+    $journal = Invoke-Cli $build @('journal', 'list', '--output', 'json')
+    $count = [Regex]::Match($journal, '"count":\s*(\d+)').Groups[1].Value
+    if (-not $count -or [int]$count -lt 1) {
+        Add-Failure "[$build] journal list came back empty after a write: $(Get-Excerpt $journal)"
+    } else {
+        Write-Ok "[$build] journal list -> $count entries"
+    }
+}
+
+Write-Step 'The single-file binary runs with no sibling files (bundled native SQLite)'
+$aloneDir = Join-Path $WorkDir 'alone'
+New-Item -ItemType Directory -Force -Path $aloneDir | Out-Null
+$aloneExe = Join-Path $aloneDir $exeName
+Copy-Item $publishedExe $aloneExe
+if (-not $IsWindows) { & chmod +x $aloneExe }
+
+$env:D365FO_INDEX_DB = Join-Path (Join-Path $WorkDir 'published') 'index/index.sqlite'
+$env:D365FO_PACKAGES_PATH = $fixture
+$alone = Invoke-Native $aloneExe @('models', 'list', '--output', 'json')
+if ($alone -notmatch '"ok":\s*true') {
+    Add-Failure "the published binary copied on its own could not open SQLite: $(Get-Excerpt $alone)"
+} else {
+    Write-Ok 'single binary, empty directory'
+}
+
+# --- verdict -----------------------------------------------------------------
+
+if ($KeepWorkDir -or $failures.Count -gt 0) {
+    Write-Host ''
+    Write-Host "work directory kept: $WorkDir"
+} else {
+    Remove-Item -Recurse -Force $WorkDir -ErrorAction SilentlyContinue
+}
+
+Write-Host ''
+if ($failures.Count -gt 0) {
+    Write-Host "$($failures.Count) check(s) failed:" -ForegroundColor Red
+    foreach ($failure in $failures) { Write-Host "  - $failure" -ForegroundColor Red }
+    Write-Host ''
+    Write-Host 'A published build that differs from the baseline is a trimming/single-file defect,'
+    Write-Host 'not a test bug. The knobs that keep the two in step are the roots in'
+    Write-Host 'src/D365FO.Cli/TrimmerRootDescriptor.xml and the JsonSerializerIsReflectionEnabledByDefault'
+    Write-Host '/ IncludeNativeLibrariesForSelfExtract properties in src/D365FO.Cli/D365FO.Cli.csproj.'
+    exit 1
+}
+
+Write-Host 'published build matches the baseline on every checked command.' -ForegroundColor Green
+exit 0

--- a/src/D365FO.Cli/D365FO.Cli.csproj
+++ b/src/D365FO.Cli/D365FO.Cli.csproj
@@ -26,6 +26,19 @@
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
     <InvariantGlobalization>true</InvariantGlobalization>
+    <!-- The SQLite provider ships a native e_sqlite3.dll. PublishSingleFile leaves native
+         assets loose next to the .exe unless they are bundled, so a d365fo.exe that travels
+         without its folder dies with "The type initializer for
+         'Microsoft.Data.Sqlite.SqliteConnection' threw an exception" (issue #182). Bundle it. -->
+    <IncludeNativeLibrariesForSelfExtract>true</IncludeNativeLibrariesForSelfExtract>
+    <!-- PublishTrimmed defaults this feature switch to false, which makes every
+         reflection-based System.Text.Json call throw ("Reflection-based serialization has
+         been disabled for this application"). The journal, the provenance store behind
+         `prepare`, the eval catalog and the metadata contracts all use reflection-based
+         (de)serialization, and the journal/provenance paths swallow the exception, so the
+         damage is silent: `journal list` returned an empty list on a 500-entry journal.
+         Reflection still works in a trimmed (non-AOT) app, so switch it back on. -->
+    <JsonSerializerIsReflectionEnabledByDefault>true</JsonSerializerIsReflectionEnabledByDefault>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/D365FO.Cli/TrimmerRootDescriptor.xml
+++ b/src/D365FO.Cli/TrimmerRootDescriptor.xml
@@ -4,19 +4,44 @@
     type arguments at runtime.  The .NET trimmer cannot see these reflection-based
     lookups statically, so it silently removes the Settings inner classes, which
     causes CommandRuntimeException: "could not get settings type for command of
-    type …" when the trimmed binary starts.
+    type ..." when the trimmed binary starts.
 
     Preserving the whole CLI assembly ensures every Command<TSettings> and its
     nested Settings class survives trimming regardless of which /p:PublishTrimmed
-    flag the caller passes.  Core and Bridge are untouched — they are plain data
-    libraries whose referenced members the trimmer can track statically.
+    flag the caller passes.
 
     Spectre.Console.Cli also registers internal built-in commands (ExplainCommand,
     VersionCommand) whose Settings constructors are resolved by the framework at
     startup.  The trimmer strips those constructors because it cannot trace the
     reflection path inside the library.  Preserving the entire Spectre.Console.Cli
     assembly keeps all framework-internal types intact.
+
+    Issue #182: the same class of failure hits the data layer, which is not
+    statically trackable either.  Dapper materializes rows by reflecting over the
+    target type's constructor and binds parameters by reflecting over anonymous
+    types declared in D365FO.Core; System.Text.Json reflects over the same records.
+    Trimming those away produced, in a published build, "A parameterless default
+    constructor or one matching signature ... is required for ModelInfo
+    materialization" and "Must add values for the following parameters: @name" on
+    `models list`, `search`, `get` and `prepare`.  Microsoft.Data.Sqlite in turn
+    reaches SQLitePCLRaw through Type.GetType, so those three assemblies have no
+    static reference to keep them alive either, so when the trimmer drops them the
+    symptom is "The type initializer for 'Microsoft.Data.Sqlite.SqliteConnection'
+    threw an exception".
+
+    d365fo-mcp is rooted for the same reason: the CLI's `prepare`, `find` and
+    friends return the MCP tool handlers' anonymous-type payloads, and a trimmed
+    build that drops those properties serialized them as an empty {} object.
+
+    Root all of them.
   -->
   <assembly fullname="d365fo" preserve="all" />
   <assembly fullname="Spectre.Console.Cli" preserve="all" />
+  <assembly fullname="D365FO.Core" preserve="all" />
+  <assembly fullname="d365fo-mcp" preserve="all" />
+  <assembly fullname="Dapper" preserve="all" />
+  <assembly fullname="Microsoft.Data.Sqlite" preserve="all" />
+  <assembly fullname="SQLitePCLRaw.core" preserve="all" />
+  <assembly fullname="SQLitePCLRaw.batteries_v2" preserve="all" />
+  <assembly fullname="SQLitePCLRaw.provider.e_sqlite3" preserve="all" />
 </linker>


### PR DESCRIPTION
Closes #182.

## What was wrong

The reporter published exactly what `install.ps1` publishes — self-contained, single-file, `PublishTrimmed=true` — and got `The type initializer for 'Microsoft.Data.Sqlite.SqliteConnection' threw an exception`. Reproducing it on a live D365FO VM turned up **three** independent defects in that build shape, none of which `dotnet test` can see: the suite runs against an untrimmed, non-single-file build, where all the reflection these paths depend on is still there.

| # | Defect | Symptom |
|---|---|---|
| 1 | `PublishSingleFile` leaves native assets loose, so `e_sqlite3.dll` sat *next to* the exe | the reported `TypeInitializationException`, whenever the exe travels without its folder |
| 2 | Trimmer dropped the reflection targets of the data layer (Dapper record ctors + anonymous types in `D365FO.Core`/`d365fo-mcp`, SQLitePCLRaw reached via `Type.GetType`) | `models list`, `search`, `get`, `prepare`, `report-integrations` fail with `... is required for ModelInfo materialization` / `Must add values for the following parameters: @name`, or serialize `{}` |
| 3 | `PublishTrimmed` defaults `JsonSerializerIsReflectionEnabledByDefault` to **false** | **silent**: `journal list` returned 0 entries on a 500-entry journal; the grounding token `prepare` mints never validated in `generate` |

Defect 3 is the one worth pausing on — `ModificationJournal.TryRead` and `ProvenanceStore.TryGet` both catch and return null, so a published CLI reported success while losing data. `--output json` kept working only by accident: `D365Json` sets `TypeInfoResolver` explicitly, which bypasses the disabled default.

## The fix

- `D365FO.Cli.csproj`: `IncludeNativeLibrariesForSelfExtract=true`, `JsonSerializerIsReflectionEnabledByDefault=true`
- `TrimmerRootDescriptor.xml`: root `D365FO.Core`, `d365fo-mcp`, `Dapper`, `Microsoft.Data.Sqlite`, `SQLitePCLRaw.*`

Trimming stays on: the published binary is 36 MB, against 114 MB untrimmed. (`PublishTrimmed=false`, the workaround in the issue, also works — it just costs 78 MB.)

## Regression guard

`scripts/smoke-published-cli.ps1`, wired into CI as the `published-cli` job (windows-latest + ubuntu-latest). It publishes both shapes, seeds each with its own throwaway index from `tests/Samples/MiniAot`, diffs 17 commands after masking genuinely volatile fields (temp paths, surrogate rowids, timings), and then asserts head-on the three things that failed *silently*: the journal reads back a write, a grounding token round-trips, and the single binary runs from an otherwise empty directory.

Run against the code before this commit, it fails all three classes — including the reported type-initializer error. Run against this branch, it is green on both.

## Verification

On a live D365FO VM (`K:\AosService\PackagesLocalDirectory`, real xppc install):

- 26 commands byte-identical between published and untrimmed builds (only difference: the freshly minted `groundingToken`)
- `index build` and `index extract --model AccountsPayableMobile` against the real packages directory
- `prepare` → `generate --grounding-token` returns `tokenValid: true`
- `d365fo.exe` copied alone into an empty directory opens SQLite
- `dotnet test`: 1369 passed, 0 failed

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011s9tz54pNN1JmR9qgiZC91
