### PR TITLE
Waves 01-02: stabilise the repo's claims, and take the write surface from 5 operations to 22

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,8 +31,13 @@ jobs:
       - name: Build
         run: dotnet build d365fo-cli.slnx --no-restore -c Release -nologo
 
+      # No LogFileName: both test assemblies run concurrently and a fixed name makes the
+      # second one overwrite the first. That is not cosmetic — when the run went red the
+      # surviving .trx was the assembly that PASSED, so the failing test was unnamed in the
+      # artifact and only visible in the console scrollback. The default name carries the
+      # assembly and a timestamp, so each writes its own.
       - name: Test
-        run: dotnet test d365fo-cli.slnx --no-build -c Release --logger "trx;LogFileName=test-results.trx" --collect "XPlat Code Coverage"
+        run: dotnet test d365fo-cli.slnx --no-build -c Release --logger "trx" --collect "XPlat Code Coverage"
 
       - name: Upload test results
         if: always()
@@ -40,6 +45,21 @@ jobs:
         with:
           name: test-results-${{ matrix.os }}
           path: "**/TestResults/**"
+
+  # A hundred-odd warnings hide the one that matters — NU1903 (a known-vulnerable transitive
+  # SQLite package) sat in the build output unnoticed. This ratchets the count: it may fall
+  # freely, and any rise fails with the new warnings named. Ubuntu only; the count is the same
+  # on every OS and there is no reason to pay for it three times.
+  warning-baseline:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-dotnet@v4
+        with:
+          dotnet-version: 10.0.x
+      - name: Warning count must not rise
+        shell: pwsh
+        run: ./scripts/check-build-warnings.ps1 -Baseline 117
 
   # What `dotnet test` builds is not what anybody installs. install.ps1/install.sh publish
   # self-contained, single-file and TRIMMED, and issue #182 showed that shape failing on

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,256 @@
+# Changelog
+
+All notable changes to `d365fo-cli` are recorded here. The format follows
+[Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
+
+## Versioning
+
+This repository has no release tags yet, and the assembly carries no explicit version, so
+entries below are grouped by the date the work landed on `main` rather than by a version
+number that does not exist. `d365fo version` reports the assembly version. Once the first
+tag is cut, this file switches to [Semantic Versioning](https://semver.org/spec/v2.0.0.html)
+and the dated sections become the pre-1.0 history.
+
+Upstream references of the form "upstream 1.15.0" point at the sibling
+[`d365fo-mcp-server`](https://github.com/dynamics365ninja/d365fo-mcp-server) release the work
+was ported from.
+
+---
+
+## [Unreleased]
+
+### Added — the structural half of `modify`
+- **Seventeen new `modify` sub-commands**, taking the write surface from 5 operations to 22:
+  `add-index`, `add-relation`, `add-field-group`, `add-delete-action`, `rename-field`,
+  and the removals `remove-field`, `remove-index`, `remove-relation`, `remove-field-group`,
+  `remove-delete-action`, `remove-enum-value`, `remove-control`. Before these, an agent that
+  wanted to add an index to an existing table had no path through the CLI at all and fell back
+  to editing AOT XML by hand — which walks straight past the grounding, form-pattern and
+  reference gates the tool exists to enforce. Each goes through `ObjectModifyEngine`, so each
+  inherits the extension fallback (never overwrite a model this installation does not own),
+  the journalled pre-image (`d365fo undo` reverts it), and contract-order canonicalisation.
+- Guards that cost nothing and save a build cycle: `add-index` refuses a field the table does
+  not declare (kernel fields excepted), is unique unless `--allow-duplicates`, and rejects
+  `--allow-duplicates` alongside `--alternate-key`; `add-delete-action` accepts only the four
+  actions the platform defines; `add-relation` pins the concrete
+  `AxTableRelationConstraintField` discriminator, without which the metadata reader throws on
+  the abstract base; `rename-field` rewrites the indexes, field groups and relation constraints
+  that name the field, and says plainly that X++ `fieldStr()`/`fieldNum()` references are not
+  rewritten.
+- `D365FoErrorCodes.MemberNotFound` for the collection members the removals address.
+- **`modify` reaches every kind the bridge can write, not five.** `SupportedKinds` was a
+  hand-written set of `class, table, edt, enum, form` while the bridge resolves its collections
+  from `ObjectTypeRegistry.BridgeCollections()`, which names **41** — so `modify property`
+  refused a query, a privilege, a menu item, a service group, a view, a report and a tile the
+  layer underneath was perfectly able to write, and the refusal named the five as if they were
+  the platform's limit. Same drift as the extension-type lookup in #171, same fix: derive it.
+  An unknown kind now names the near misses rather than printing all 41.
+- **`modify add-query-range` / `remove-query-range`** for AOT queries. The datasource is optional
+  when the query has exactly one; with two or more the command refuses and lists them, because a
+  range on the wrong datasource returns the wrong rows silently instead of failing.
+- **`modify add-entry-point` / `remove-entry-point`** for security privileges, writing the six
+  independent permissions the security model actually has — there is no `AccessLevel` member, and
+  writing one produces a privilege that grants nothing while reading as deliberate.
+- **`modify batch`** — several changes to one object in a single read-edit-write, from
+  `--operations` JSON or `--operations-file`. Adding a field, an index over it and a field group
+  showing it was three bridge round trips, three journal entries, and two intermediate states
+  published to disk (one of them a table carrying a field no index covers). Batched, the object
+  moves from one valid state to the next in one write, and a refused step discards the batch with
+  **nothing written** — the answer says so, because "step 3 of 5 failed" otherwise reads like a
+  half-applied change.
+- **`get table --merged`** and `extension_info(mode="table-merge")` now return the effective
+  schema: base fields, indexes, relations and field groups with every TableExtension folded in,
+  each member labelled with the object contributing it. An extension whose file cannot be read is
+  **reported**, not skipped — a merge missing a contributor answers "that field does not exist"
+  with the same confidence as a complete one. Verified against the shipped `VendInvoiceInfoTable`:
+  126 fields, 11 of them from 4 extensions.
+
+### Added
+- **`prepare test` resolves a TABLE, not only a class.** A table method is named the way a
+  developer says it — `d365fo prepare test CustTable.validateWrite` — and the dotted form is
+  split before resolution. The symbol index stores *declared* members only, so a table that has
+  never overridden `validateWrite` has no row for it, which is exactly the method the caller
+  came for; the inherited kernel data methods are now listed from `TableDataMethods` beside the
+  table's own overrides, each labelled with where it comes from. The answer carries the scaffold
+  call already spelled `--table`, and the shape a table test needs that a class test does not:
+  arrange a buffer with `initValue()` rather than selecting a row, assert the verdict **and** the
+  infolog line the rule writes, and keep the accepting case beside the rejecting one — without it
+  a rule that refuses every row passes its own test. Write-path methods (`insert`/`update`/
+  `delete`) get a transaction and an assertion against a re-read instead of the buffer.
+- `TableDataMethods.All`, `.IsWritePath()` and `.IsVerdictMethod()` — the kernel data-method
+  catalog is now enumerable, not only addressable by name.
+
+### Fixed — found by running against the live installation
+These five were invisible to a green suite: every one needed a real `IMetadataProvider`, and
+three of them were wrong about what Microsoft's own AOT actually writes.
+
+- **The bridge could not read a table at all.** `readObjectXml` serialised with
+  `XmlSerializer`, which reflects a type eagerly and refuses anything implementing
+  `IEnumerable` without `Add(object)` — Microsoft's `AccessGrant` does exactly that, so every
+  artifact transitively holding one (`AxTable`, `AxSecurityPrivilege`, `AxMenuItem*`) failed
+  with *"There was an error reflecting type 'AxTable'"*. The write path had the identical
+  fault. `modify` therefore never worked against a real installation for the kinds people use
+  most. Both now use `DataContractSerializer`, which is what the `validateArtifact` path
+  already used and already explained: the MetaModel types are DataContract-annotated and that
+  contract is what the on-disk format encodes.
+- The read path reported only the outer exception, so *"error reflecting type 'AxTable'"* was
+  undiagnosable. It chains the inner exceptions now, as the validate path already did.
+- **Every `modify remove-*` command failed on invocation.** `ModifyRemoveSettings` was
+  `abstract`, and Spectre.Console.Cli constructs a command's settings by reflection — so all
+  seven compiled, registered, and appeared in `--help`, then died with *"Could not resolve type
+  'ModifyRemoveSettings'"*. Engine tests could not see it because they call the engine, not the
+  command. `CommandSurfaceTests` now walks all 175 registered settings types.
+- **A delete action was written naming nothing.** `AxTableDeleteAction` declares
+  `Name, DeleteAction, Relation, Table, Tags` — the related table is `<Table>`. The tool wrote
+  `<RelatedTable>`, which the contract does not have, so the serializer dropped it and a
+  `Cascade` rule with no target reached disk while the write reported `ok`. The extractor read
+  the same wrong element, which is worse: measured on this repo's own host, the index held
+  **0 delete actions across 214 packages** and `get table` answered `deleteActions: []` for
+  every table in the installation.
+- **The index held 4,896 queries and zero datasources.** Shipped queries use
+  `AxQuerySimpleRootDataSource` and `AxQuerySimpleEmbeddedDataSource`; the extractor matched
+  `AxQuerySimpleDataSource` / `AxQueryDataSource`, which occur in no shipped query at all. Only
+  the sample fixtures use the shorter name, which is exactly why the suite stayed green. Matching
+  now keys on the `DataSource` suffix, which also keeps `…DataSourceField`, `…Range` and
+  `…Relation` out — a prefix match would have swept those in.
+
+### Fixed
+- **`modify` never canonicalised member order before writing back.** The disk write path has
+  always done it (`ScaffoldFileWriter.Finalize`) but the bridge path serialised the edited
+  document as-is. `DataContractSerializer` — which is what reads AOT XML — matches children in
+  contract order and *skips* anything arriving out of turn: it is not rejected, it is dropped.
+  So an edit that had to create a missing collection (`<Fields>` on a table that had none,
+  `<EnumValues>`, `<Controls>`) appended it after a later-ordered sibling, the write came back
+  `ok`, and the change was silently absent. `modify property` had the mirror problem, inserting
+  every property directly after `<Name>` — far too early for most of the AxTable contract. Both
+  are covered by tests that assert the written element order.
+- **A doc comment was reported as a method's signature.** `ExtractSignatureLine` skipped blank
+  lines and attribute blocks but not comments, so any method opening with `/// <summary>` — or a
+  `//` note, or a `/* … */` banner — stored that line as its exact declaration. Measured on the
+  shipped `SalesTable`: **362 of its 621 methods** had an unusable signature; after the fix, zero.
+  This is worse than an empty signature, because `prepare change`, `get table` and `get class`
+  present it as the declaration a CoC wrapper has to match exactly, and a green build cannot
+  correct it. `IsStatic` and the inferred return type were derived from the same line and were
+  wrong with it. Block comments that close on the declaration line are handled.
+  **An index built before this fix keeps the bad signatures — re-run `d365fo index extract`.**
+- `extension_info(mode="table-merge")` promised an "effective merged schema" and returned the
+  extension roster. Returning a list under a contract that says "merged" is worse than returning
+  a list, because a caller that trusts it reads a missing field as a field that does not exist.
+  The merge is now computed — see `TableMergeAnalyzer` under Added.
+- README claimed 310+ tests (1 373), 19 skills (38), 29 `generate` commands (33), 27 adapter
+  tools (28), and enumerated 19 of the 38 topic files. The skill listing is now generated from
+  `skills/_source`, so it cannot drift again silently.
+
+### Security
+- **`Microsoft.Data.Sqlite` 8.0.10 → 10.0.11**, which moves the transitive `SQLitePCLRaw`
+  stack from 2.1.6 to 2.1.12 and clears **GHSA-2m69-gcr7-jv3q** (high severity). NuGet had
+  been printing `NU1903` on every build and nothing was watching. The bump also aligns the
+  package with the `net10.0` target. Verified against the shape people actually install:
+  `scripts/smoke-published-cli.ps1 -Rid win-x64` passes, including the bundled native SQLite
+  in the trimmed single-file binary that issue #182 was about.
+
+### Changed — CI
+- **Warning-count ratchet** (`scripts/check-build-warnings.ps1`, baseline 117). The count may
+  fall freely; any rise fails the run with the new warnings grouped by code. A hundred-odd
+  standing warnings are exactly how `NU1903` stayed invisible.
+- **The test logger no longer collides.** Both assemblies wrote `test-results.trx` into one
+  directory, so the second overwrote the first — and when a run went red, the surviving file
+  was usually the assembly that PASSED, leaving the failing test unnamed in the CI artifact.
+  Now each writes its own default-named file.
+- **The test suite wrote into the developer's real index — and pruned their undo history.**
+  `ModificationJournal.ForIndex` resolves the journal to `<dirname(D365FO_INDEX_DB)>/journal`,
+  and every scaffold-writing test journals. On a machine where `d365fo init` has configured
+  `D365FO_INDEX_DB` — the normal state — a full run appended into the real journal, and the
+  500-entry cap then evicted the developer's genuine entries oldest-first. Measured on this
+  repo's host: exactly 500 entries, the newest a `scaffold-write` naming a test temp directory.
+  Both assemblies also ran as concurrent processes appending to and pruning that one directory.
+  A `[ModuleInitializer]` now points each test process at its own index; `D365FO_PACKAGES_PATH`
+  is deliberately left alone so the AOT-gated tests still run against a real installation.
+- **The suite's intermittent failure had a name after all.** Twenty test classes called the
+  process-wide `SqliteConnection.ClearAllPools()` in `Dispose` to unlock their temp database.
+  That disposes every pooled connection in the process, including one another test is mid-query
+  on, so the loser failed with `ObjectDisposedException: 'SQLitePCL.sqlite3'` from somewhere
+  unrelated — about one full-suite run in ten, and never reproducible when an assembly ran
+  alone. Replaced with `SqlitePool.ReleaseFor(path)`, which clears only that database's pools
+  (all three connection-string spellings this codebase opens). **0 failures in 14 consecutive
+  full-suite runs**, against 2–3 per 10 before.
+- A flaky assertion in `WorkflowScaffolderTests` and `ScaffoldFileWriterAtomicityTests` read
+  "which files were written" off a `Directory.GetFiles` listing taken immediately after the
+  writes. Under load that listing can miss an entry the rename just created, which surfaced
+  as "Expected 3, Actual 2" with no exception anywhere — the writer had already proven the
+  file was there by taking `FileInfo.Length` on it. Existence is now queried per path
+  (`WrittenFilesAssert`). A real but secondary cause — the `ClearAllPools` entry above is what
+  the remaining failures turned out to be.
+
+### Added — documentation
+- This file, and `SECURITY.md`.
+
+---
+
+## 2026-09-01 — trimmed publish
+
+### Fixed
+- The trimmed, single-file, self-contained build — the shape `install.ps1` / `install.sh`
+  actually produce — failed on every SQLite query and on the native SQLite load, and returned an
+  empty journal instead of an error, all while the test suite stayed green (#182). CI now
+  publishes that shape and diffs it against an ordinary build
+  (`scripts/smoke-published-cli.ps1`).
+
+## 2026-08-31 — the upstream 1.15.0 wave
+
+### Added
+- **Compiler-oracle validator**: the validator wave ported from upstream, with the compiler as
+  the oracle rather than hand-held expectations.
+- **`prepare test`** (`mode=test`): everything needed to write a SysTest, before writing it.
+- **Kernel table-method catalog** for `prepare`, EDT `StringSize` inheritance, CoC target
+  normalization.
+- **`generate report-extension`** — the three compiler-checked ways to extend a shipped report.
+- **Report scaffold depth**: `--pre-process`, `--controller-type print-mgmt`, `--ui-builder`.
+- **`generate table --field-group` / `--index`**, with valid-time-state index properties.
+- `generate table-relation` and `generate find-methods` augmenters, and the catalog-driven form
+  expander.
+- Three knowledge topics — warehouse-app, barcode-scanning, runtime-functions — plus
+  language-core additions, taking the corpus from 35 to 38.
+- Labels: search/resolve hits are confirmed against the `.label.txt` before being recommended.
+
+### Fixed
+- Every pattern `generate form` emits now compiles; the expanded forms are something the AOS
+  accepts.
+- The `#184` report DP and contract scaffolds now compile.
+- Every scaffolder wraps `Source`/`Declaration` in CDATA (#183).
+- Labels resolve the `@File:Id` token shape the AOT actually writes.
+- Knowledge corrections carried over from the upstream 1.15.0 wave.
+- Kernel enums, red-first SysTest, `NumberSeqFormHandler`, form `DataGroup` honesty.
+
+## 2026-08-21 / 2026-08-23 — generate and modify correctness
+
+### Added
+- Fields can be added to a table extension offline.
+
+### Fixed
+- `--verify` is honoured on every `generate` subcommand, and only a refused artefact fails it.
+- `modify` resolves extension kinds from the registry rather than a private table.
+- EDT lookup recovers truncated whole-name matches and matches `GetEdt` case-insensitively.
+- Skills frontmatter is quoted and parsed in CI (#172 shipped frontmatter no YAML parser
+  could read while CI stayed green).
+
+## 2026-08-06 / 2026-08-07 — forms, eval and validation depth
+
+### Added
+- Clone a reference form under a new name (#164).
+- Cross-check the shipped catalogs against the installation (#164).
+- `test run` invokes the real SysTest runner, and its result document is parsed (#160).
+- The grounding gate applies uniformly across `generate`, with property honesty (#161).
+- Security and data-entity scaffolding depth (#162).
+- Per-family root-shape validation rules XML009–XML013 (#163).
+
+### Fixed
+- A renamed datasource is followed into the design and the join (#164).
+- A bound field's control type is derived from the field (#164).
+- The atomic write is actually atomic (#158).
+
+## 2026-04-23 — bootstrap
+
+### Added
+- The `d365fo` CLI, the dual Agent Skills layer (Anthropic + Copilot), the extract pipeline and
+  the first parity commands.

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
 [![.NET](https://img.shields.io/badge/.NET-10-purple.svg)](https://dotnet.microsoft.com/)
 [![Platform](https://img.shields.io/badge/platform-Windows%20%7C%20macOS%20%7C%20Linux-lightgrey.svg)]()
-[![Tests](https://img.shields.io/badge/tests-310%2B-brightgreen.svg)]()
+[![Tests](https://img.shields.io/badge/tests-1580-brightgreen.svg)]()
 [![Successor to d365fo-mcp-server](https://img.shields.io/badge/successor%20to-d365fo--mcp--server-orange.svg)](https://github.com/dynamics365ninja/d365fo-mcp-server)
 
 *Grounded AI development for Dynamics 365 Finance & Operations — works with GitHub Copilot, Claude Code, Codex, Gemini CLI, and any agent with a shell*
@@ -32,7 +32,7 @@ This CLI pre-indexes your entire D365FO installation (hundreds of thousands of s
 | Labels | Hardcoded strings | Right `@SYS`/`@MODULE` key found instantly |
 | Security chains | Hours of manual tracing | Role → Duty → Privilege → Entry Point in one call |
 | Generated code | Hallucinated fields and types | Every reference proven against the index, gated before write |
-| Agent context cost | 26–27 MCP tool schemas every turn | 1 shell tool + lazy-loaded Skills (~85 % fewer tokens) |
+| Agent context cost | 26–28 MCP tool schemas every turn | 1 shell tool + lazy-loaded Skills (~85 % fewer tokens) |
 
 ---
 
@@ -43,9 +43,9 @@ This CLI pre-indexes your entire D365FO installation (hundreds of thousands of s
 | 🔍 **Full-codebase intelligence** | Tables, classes, EDTs, enums, forms, queries, views, entities, reports, services, workflows, security artifacts, labels (FTS5) — results in milliseconds, no VM round-trip |
 | 🛡️ **Grounded generation** | Fail-closed gates: `prepare change`/`prepare create` issue grounding tokens, `validate references` proves every identifier, `validate xpp` enforces BP rules — hallucinated code never reaches disk |
 | 🧩 **Form pattern engine** | Catalog of Microsoft form patterns and container sub-patterns: `get form-pattern` serves the required structure, `generate form` self-tests against it (FP001–FP010), `validate form-pattern` re-checks any hand edit |
-| ✍️ **Pattern-correct scaffolding** | 29 `generate` commands — tables, classes, CoC, forms (9 patterns), form datasource/control override methods, entities, security, SysOperation, workflows, business events, number sequences, XDS policies |
+| ✍️ **Pattern-correct scaffolding** | 33 `generate` commands — tables, classes, CoC, forms (9 patterns), form datasource/control override methods, entities, security, SysOperation, workflows, business events, number sequences, XDS policies |
 | 🏗️ **SDLC integration** | MSBuild compilation with structured `xppcDiagnostics`, DB sync, xppbp best practices, SysTestRunner — on Windows D365FO VMs |
-| 📐 **X++ knowledge base** | 19 lazy-loaded Skills: select grammar, CoC authoring, FormRun lifecycle, BP rule canon — loaded only when relevant, for Copilot and Claude alike |
+| 📐 **X++ knowledge base** | 38 lazy-loaded Skills: select grammar, CoC authoring, FormRun lifecycle, BP rule canon — loaded only when relevant, for Copilot and Claude alike |
 | ⚡ **Agent-first ergonomics** | Stable `{ ok, data, warnings }` JSON envelope, `search batch` / `get batch` / `prepare` single-round aggregators, `agent-prompt` + `schema` manifests |
 | 🔌 **Daemon & MCP adapter** | Warm-cache named-pipe daemon with file-system watcher; `d365fo-mcp` speaks JSON-RPC 2.0 over the same index for MCP-only hosts, over stdio or `--http` for a shared team deployment (`API_KEY`, `MCP_SERVER_MODE`) |
 
@@ -145,7 +145,7 @@ Ready to scaffold your first table, form, and CoC extension? Full walkthrough wi
 
 ### GitHub Copilot (VS Code / Visual Studio)
 
-The preferred method is the **one-command skill installer** — it deploys the bundled `d365fo-cli` Copilot skill (SKILL.md + 19 lazily-loaded topic references) into your X++ project's `.github/skills/d365fo-cli/` folder. Copilot auto-discovers skills in `.github/skills/` with no extra configuration.
+The preferred method is the **one-command skill installer** — it deploys the bundled `d365fo-cli` Copilot skill (SKILL.md + 38 lazily-loaded topic references) into your X++ project's `.github/skills/d365fo-cli/` folder. Copilot auto-discovers skills in `.github/skills/` with no extra configuration.
 
 ```powershell
 # From the d365fo-cli repo's scripts folder:
@@ -165,26 +165,45 @@ The installer:
 └── skills/
     └── d365fo-cli/
         ├── SKILL.md              # core rule canon + tool mapping (loaded when the skill activates)
-        └── references/            # 19 X++ topic files, loaded per topic on demand
+        └── references/            # 38 X++ topic files, loaded per topic on demand
+            ├── analytics-and-er.md
+            ├── barcode-scanning.md
+            ├── build-error-triage.md
+            ├── business-events-authoring.md
             ├── coc-extension-authoring.md
-            ├── xpp-database-queries.md
-            ├── x++-class-authoring.md
-            ├── xpp-class-and-method-rules.md
-            ├── xpp-statement-and-type-rules.md
-            ├── xpp-best-practice-rules.md
-            ├── form-pattern-scaffolding.md
-            ├── table-scaffolding.md
+            ├── custom-service-authoring.md
             ├── data-entity-scaffolding.md
             ├── event-handler-authoring.md
-            ├── object-extension-authoring.md
-            ├── security-hierarchy-trace.md
-            ├── sysoperation-batch-patterns.md
-            ├── business-events-authoring.md
-            ├── custom-service-authoring.md
+            ├── form-pattern-scaffolding.md
+            ├── forms-and-navigation.md
+            ├── integration-dmf-dualwrite.md
             ├── integration-patterns.md
+            ├── inventory-and-warehouse.md
             ├── label-translation.md
             ├── model-dependency-and-coupling.md
-            └── review-and-checkpoint-workflow.md
+            ├── number-sequence-patterns.md
+            ├── object-extension-authoring.md
+            ├── performance-and-caching.md
+            ├── posting-and-financials.md
+            ├── review-and-checkpoint-workflow.md
+            ├── runtime-frameworks.md
+            ├── security-hierarchy-trace.md
+            ├── security-modeling.md
+            ├── ssrs-report-authoring.md
+            ├── sysoperation-batch-patterns.md
+            ├── table-scaffolding.md
+            ├── testing-and-quality.md
+            ├── transactions-and-concurrency.md
+            ├── warehouse-mobile-app.md
+            ├── workflow-authoring.md
+            ├── x++-class-authoring.md
+            ├── xpp-best-practice-rules.md
+            ├── xpp-class-and-method-rules.md
+            ├── xpp-data-access-apis.md
+            ├── xpp-database-queries.md
+            ├── xpp-runtime-functions.md
+            ├── xpp-runtime-types.md
+            └── xpp-statement-and-type-rules.md
 ```
 
 **Legacy path (pre-skill format):** If you previously used `copilot-instructions.md` + `instructions/*.instructions.md`, you can migrate by running the installer and then removing the old files:
@@ -212,7 +231,7 @@ Reference the `SKILL.md` files from `skills/anthropic/` in your session prompt o
 
 ### MCP (Claude Desktop, Continue, VS Code MCP)
 
-The bundled `d365fo-mcp` adapter speaks JSON-RPC 2.0 over the same index. Its tool surface is **consolidated** into 27 discriminator-based tools (e.g. `search`, `get_object_info`, `get_method`, `labels`, `security_info`, `extension_info`, `object_patterns`, `generate_object`, `modify_method`, `analyze`, `models`) — see [docs/MIGRATION_FROM_MCP.md](docs/MIGRATION_FROM_MCP.md):
+The bundled `d365fo-mcp` adapter speaks JSON-RPC 2.0 over the same index. Its tool surface is **consolidated** into 28 discriminator-based tools (e.g. `search`, `get_object_info`, `get_method`, `labels`, `security_info`, `extension_info`, `object_patterns`, `generate_object`, `modify_method`, `analyze`, `models`) — see [docs/MIGRATION_FROM_MCP.md](docs/MIGRATION_FROM_MCP.md):
 
 ```json
 {
@@ -246,7 +265,7 @@ MCP servers inject every tool definition into the model's context on every singl
 
 | | MCP server | CLI + Skills |
 |---|---|---|
-| Tool definitions per turn | 26–27 tools (~1,800 tokens) | 1 shell tool (~100 tokens) |
+| Tool definitions per turn | 26–28 tools (~1,800 tokens) | 1 shell tool (~100 tokens) |
 | Discovery round-trips | 2–3 per task | often 1 (`d365fo prepare change`) |
 | Scriptable (shell, CI/CD) | No | Yes |
 | Works in any AI harness | No — MCP hosts only | Yes — Copilot, Claude, Codex, Gemini, … |
@@ -272,6 +291,7 @@ See [docs/TOKEN_ECONOMICS.md](docs/TOKEN_ECONOMICS.md) for the full analysis and
 | **Generate** | `generate table\|class\|coc\|form\|datasource-method\|control-method\|simple-list\|entity\|extension\|event-handler\|privilege\|duty\|role\|report\|sysoperation\|number-sequence\|workflow\|menu-item\|edt\|enum\|query\|view\|map\|business-event\|custom-service\|migration-script\|runbase\|security-policy\|systest` |
 | **Labels** | `labels search\|resolve\|info\|create\|rename\|delete` — search/resolve plus in-place `*.label.txt` edits, multi-language via `--lang` (mirrors the MCP `labels` tool) |
 | **Journal / undo** | `undo [--steps N] [--dry-run]`, `journal list`, `delete` (kind/name, bridge or on-disk) — deterministic single-command rollback for every write path (mirrors the MCP `undo_last_modification` tool) |
+| **Modify** | `modify property\|method`, `modify add-field\|add-enum-value\|add-control`, `modify add-index\|add-relation\|add-field-group\|add-delete-action`, `modify rename-field`, `modify add-query-range\|remove-query-range`, `modify add-entry-point\|remove-entry-point`, seven `modify remove-*` forms, and `modify batch` (several changes in one read-edit-write) — 22 operations over all 41 bridge-writable kinds, extension-aware and journalled for `undo` |
 | **Analyze** | `analyze completeness`, `analyze integration`, `analyze impact`, `lint`, `suggest edt`, `suggest extension`, `report-integrations` |
 | **Review** | `review diff` |
 | **Models** | `models list`, `models deps`, `models coupling` |

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,93 @@
+# Security Policy
+
+## Supported versions
+
+This repository has no release tags yet. Security fixes land on `main`, and installations made
+with `install.ps1` / `install.sh` are updated in place by re-running the installer. Once the
+first tag is cut, this table will name the supported minor versions.
+
+| Version | Supported |
+|---------|-----------|
+| `main`  | ✅ |
+
+## Reporting a vulnerability
+
+**Please do not open a public issue.**
+
+Use GitHub's private vulnerability reporting:
+**[Report a vulnerability](https://github.com/dynamics365ninja/d365fo-cli/security/advisories/new)**
+(Security → Advisories → Report a vulnerability)
+
+This opens a private thread visible only to maintainers, and lets us credit you in the published
+advisory.
+
+Helpful to include:
+
+- Affected commit, and whether you are running the plain `d365fo` binary, the `d365fo daemon`,
+  or the `d365fo-mcp` adapter (stdio or `--http`)
+- The file and line, or a command that demonstrates the behaviour
+- What an attacker gains — reading indexed source, writing into `PackagesLocalDirectory`,
+  or executing on the build VM
+
+### What to expect
+
+| Stage | Target |
+|-------|--------|
+| Acknowledgement | 3 working days |
+| Initial assessment | 10 working days |
+| Fix released | 90 days, sooner for actively exploitable issues |
+
+We request a CVE from the GitHub CNA for anything we assess as valid, and publish the advisory
+once the fix ships. You will be credited under the name or handle you choose unless you ask
+otherwise.
+
+## Threat model
+
+Some context on what this project treats as a vulnerability, so reports land accurately.
+
+**The index is sensitive.** The SQLite index is built from your `PackagesLocalDirectory`. It
+contains X++ source snippets, extension and event-handler wiring, security roles, privileges and
+duties, and label text — including your own custom and ISV models, not just the standard
+Microsoft ones. Treat any unauthenticated read path into it as a disclosure of proprietary
+source. The same applies to an index moved between machines with `index export` / `index import`.
+
+**The CLI writes to the AOT.** `generate --install-to`, `modify`, `labels create|rename|delete`
+and `delete` write into `PackagesLocalDirectory` and register objects in `.rnrproj` files.
+`build`, `sync`, `test run` and `bp check` execute Microsoft's own tooling on the VM. Anything
+that lets those escape their configured root, or run against a model the caller did not name, is
+in scope.
+
+**In scope**
+
+- Reaching `d365fo-mcp --http` tools without valid authentication (`API_KEY`)
+- Reaching the `d365fo daemon` named pipe from a security context that should not have it
+- Reading indexed metadata across a boundary that should have separated it
+- Write paths escaping the configured metadata root, or a path traversal through an object name,
+  model name or `--out` value
+- Command injection through any argument that reaches MSBuild, `xppc`, `xppbp`, `SyncEngine`
+  or `SysTestConsole`
+- Credential leakage into logs, command output, or error envelopes
+
+**Out of scope**
+
+- `MCP_SERVER_MODE` — a tool-surface partition for the hybrid deployment, not a privilege
+  boundary. It limits which tools are reachable, not who may reach them.
+- The grounding gate (`D365FO_GROUNDING_ENFORCE`) and the form-pattern gate
+  (`D365FO_FORM_PATTERN_ENFORCE`) — correctness gates against hallucinated code, not security
+  controls. Bypassing one is a bug, not a vulnerability.
+- Findings that require an attacker who already has filesystem access to the VM, the API key, or
+  write access to `PackagesLocalDirectory`
+- Vulnerabilities in D365 F&O, Visual Studio, or the Microsoft-supplied metadata assemblies
+  themselves
+
+## Hardening
+
+- **Do not publish the index.** It is proprietary source in a single file. `index export`
+  produces a portable copy — treat it like the codebase it came from.
+- **`d365fo-mcp --http` requires `API_KEY`.** Put it behind a private endpoint or IP
+  restrictions where the team's addresses are known, and rotate the key when someone leaves the
+  project — it is a single shared secret.
+- **Run the read-only surface where you can.** A shared instance serving search/get/prepare
+  needs none of the write or SDLC commands.
+- **The daemon is a local named pipe.** It is reachable by anything running as that user; do not
+  run it on a shared interactive host.

--- a/scripts/check-build-warnings.ps1
+++ b/scripts/check-build-warnings.ps1
@@ -1,0 +1,81 @@
+<#
+.SYNOPSIS
+    Fail the build when the compiler-warning count rises above the agreed baseline.
+
+.DESCRIPTION
+    The solution carries a backlog of warnings (mostly CS1573 missing <param> tags and
+    CS8625 nullability). Turning on /warnaserror today would fail every build, and leaving
+    the count unwatched is how a backlog grows quietly - a genuinely new warning is
+    invisible among a hundred old ones.
+
+    This is the middle path: the count may go DOWN freely, and any rise fails the run with
+    the new warnings named. When you fix a batch, lower -Baseline in the same commit so the
+    ratchet cannot slip back.
+
+    NU* warnings are counted too, deliberately: NU1903 (a known-vulnerable transitive
+    package) sat in the build output for weeks and nothing was watching.
+
+.PARAMETER Baseline
+    The highest warning count that passes. Lower it as warnings are fixed; never raise it
+    to make a run go green.
+#>
+[CmdletBinding()]
+param(
+    [int]$Baseline = 117,
+    [string]$Solution = "d365fo-cli.slnx",
+    [string]$Configuration = "Release"
+)
+
+$ErrorActionPreference = "Stop"
+
+Write-Host "Building $Solution ($Configuration) to count warnings..."
+# Windows PowerShell 5.1 wraps a native command's stderr in ErrorRecords, which
+# $ErrorActionPreference='Stop' then turns into a terminating error even on exit 0.
+# Relax it just for the build call and judge the result by $LASTEXITCODE.
+$previousPreference = $ErrorActionPreference
+$ErrorActionPreference = "Continue"
+$output = & dotnet build $Solution -c $Configuration --no-incremental -v q --nologo 2>&1
+$buildExit = $LASTEXITCODE
+$ErrorActionPreference = $previousPreference
+
+$text = $output -join "`n"
+
+if ($buildExit -ne 0) {
+    Write-Host $text
+    Write-Error "Build failed (exit $buildExit) - warning count not meaningful."
+    exit 1
+}
+
+# MSBuild prints its own deduplicated total; trust that over counting lines, which
+# double-counts a warning reported once per referencing project.
+$match = [regex]::Match($text, '(?m)^\s*(\d+)\s+Warning\(s\)\s*$')
+if (-not $match.Success) {
+    Write-Error "Could not find the 'N Warning(s)' summary in the build output."
+    exit 1
+}
+
+$count = [int]$match.Groups[1].Value
+Write-Host "Warnings: $count (baseline $Baseline)"
+
+if ($count -gt $Baseline) {
+    Write-Host ""
+    Write-Host "Warnings by code:"
+    [regex]::Matches($text, 'warning ([A-Z]+\d+)') |
+        ForEach-Object { $_.Groups[1].Value } |
+        Group-Object |
+        Sort-Object Count -Descending |
+        ForEach-Object { "  {0,4}  {1}" -f $_.Count, $_.Name } |
+        Write-Host
+
+    Write-Error ("Warning count rose from the baseline of $Baseline to $count. " +
+        "Fix the new warnings, or - if they are genuinely acceptable - say so in the PR " +
+        "and raise -Baseline deliberately rather than as a reflex.")
+    exit 1
+}
+
+if ($count -lt $Baseline) {
+    Write-Host ""
+    Write-Host "Warning count is BELOW the baseline. Lower -Baseline to $count in scripts/check-build-warnings.ps1 and in .github/workflows/ci.yml so the ratchet holds."
+}
+
+exit 0

--- a/src/D365FO.Bridge/Handlers.cs
+++ b/src/D365FO.Bridge/Handlers.cs
@@ -1,4 +1,4 @@
-// <copyright file="Handlers.cs" company="d365fo-cli contributors">
+﻿// <copyright file="Handlers.cs" company="d365fo-cli contributors">
 // MIT
 // </copyright>
 
@@ -67,6 +67,16 @@ namespace D365FO.Bridge
         /// it never reaches disk itself; <see cref="MetadataBootstrap.SaveArtifact"/>
         /// re-serialises through the provider on write, same as every other write path here.
         /// </summary>
+
+        /// <summary>Exception type and message, with the whole inner chain appended.</summary>
+        private static string Detail(Exception ex)
+        {
+            var sb = new System.Text.StringBuilder(ex.GetType().Name + ": " + ex.Message);
+            for (var inner = ex.InnerException; inner != null; inner = inner.InnerException)
+                sb.Append(" / ").Append(inner.GetType().Name).Append(": ").Append(inner.Message);
+            return sb.ToString();
+        }
+
         internal JsonObject ReadObjectXml(JsonObject args)
         {
             string kind = args != null ? (string)args["kind"] : null;
@@ -103,16 +113,32 @@ namespace D365FO.Bridge
             string xml;
             try
             {
-                var serializer = new XmlSerializer(artifact.GetType());
+                // DataContractSerializer, not XmlSerializer — the same reason validateArtifact
+                // gives below, and the reason this path was BROKEN for the most-used kinds.
+                // XmlSerializer reflects a type eagerly and refuses anything implementing
+                // IEnumerable without Add(object); Microsoft's own AccessGrant does exactly
+                // that, so reading ANY artifact transitively referencing it — AxTable,
+                // AxSecurityPrivilege, AxMenuItem* — failed with "There was an error reflecting
+                // type 'AxTable'". `modify` reads through here, so on a real installation it
+                // could not touch a table at all. The MetaModel types are DataContract-annotated
+                // and that contract is what the on-disk format encodes, so this is also the
+                // shape the caller expects to edit and hand back.
+                var serializer = new System.Runtime.Serialization.DataContractSerializer(artifact.GetType());
                 using (var sw = new StringWriter())
+                using (var xw = System.Xml.XmlWriter.Create(sw, new System.Xml.XmlWriterSettings { Indent = true, OmitXmlDeclaration = false }))
                 {
-                    serializer.Serialize(sw, artifact);
+                    serializer.WriteObject(xw, artifact);
+                    xw.Flush();
                     xml = sw.ToString();
                 }
             }
             catch (Exception ex)
             {
-                return Fail("SERIALIZE_FAILED", ex.GetType().Name + ": " + ex.Message);
+                // "There was an error reflecting type 'AxTable'" says nothing on its own; the
+                // reason is always in the inner chain, and the validate path already chains it.
+                // Without this, a serializer limitation and a genuinely unreadable artifact
+                // produce the same undiagnosable message.
+                return Fail("SERIALIZE_FAILED", Detail(ex));
             }
 
             return new JsonObject
@@ -573,16 +599,24 @@ namespace D365FO.Bridge
 
                 try
                 {
-                    var serializer = new XmlSerializer(serializerType);
+                    // DataContractSerializer for the same reason the read and validate paths use
+                    // it: XmlSerializer refuses to reflect any type transitively holding an
+                    // AccessGrant (IEnumerable with no Add(object)), which is every AxTable,
+                    // AxSecurityPrivilege and AxMenuItem*. With XmlSerializer here, a write to a
+                    // table failed before it reached IMetadataProvider — and the read path had
+                    // the identical fault, so `modify` never worked against a real installation
+                    // for the kinds people use most. It is also the serializer whose contract the
+                    // on-disk format encodes, so what is parsed here matches what was handed out.
+                    var serializer = new System.Runtime.Serialization.DataContractSerializer(serializerType);
                     using (var reader = new StringReader(xml))
+                    using (var xr = System.Xml.XmlReader.Create(reader, new System.Xml.XmlReaderSettings { DtdProcessing = System.Xml.DtdProcessing.Prohibit }))
                     {
-                        ax = serializer.Deserialize(reader);
+                        ax = serializer.ReadObject(xr, true);
                     }
                 }
                 catch (Exception ex)
                 {
-                    var inner = ex.InnerException?.Message;
-                    return Fail("XML_DESERIALIZE_FAILED", ex.Message + (inner != null ? " / " + inner : string.Empty));
+                    return Fail("XML_DESERIALIZE_FAILED", Detail(ex));
                 }
 
                 // Use the deserialized instance's runtime (concrete) type from here on —
@@ -675,7 +709,11 @@ namespace D365FO.Bridge
             }
             catch (Exception ex)
             {
-                return Fail("SERIALIZE_FAILED", ex.GetType().Name + ": " + ex.Message);
+                // "There was an error reflecting type 'AxTable'" says nothing on its own; the
+                // reason is always in the inner chain, and the validate path already chains it.
+                // Without this, a serializer limitation and a genuinely unreadable artifact
+                // produce the same undiagnosable message.
+                return Fail("SERIALIZE_FAILED", Detail(ex));
             }
 
             return new JsonObject

--- a/src/D365FO.Cli/CliApp.cs
+++ b/src/D365FO.Cli/CliApp.cs
@@ -1,4 +1,4 @@
-using D365FO.Cli.Commands;
+﻿using D365FO.Cli.Commands;
 using D365FO.Cli.Commands.Agent;
 using D365FO.Cli.Commands.Analyze;
 using D365FO.Cli.Commands.Daemon;
@@ -277,6 +277,23 @@ public static class CliApp
                 b.AddCommand<ModifyAddFieldCommand>("add-field").WithDescription("Add a field to a live table — concrete AxTableField subtype resolved from the EDT.");
                 b.AddCommand<ModifyAddEnumValueCommand>("add-enum-value").WithDescription("Add a value to a live base enum (positional, never a hard-coded ordinal).");
                 b.AddCommand<ModifyAddControlCommand>("add-control").WithDescription("Add a control to a live form's design, optionally bound to a datasource field.");
+                b.AddCommand<ModifyAddIndexCommand>("add-index").WithDescription("Add an index to a live table; unique unless --allow-duplicates.");
+                b.AddCommand<ModifyAddRelationCommand>("add-relation").WithDescription("Add a foreign-key relation to a live table.");
+                b.AddCommand<ModifyAddFieldGroupCommand>("add-field-group").WithDescription("Add a field group to a live table.");
+                b.AddCommand<ModifyAddDeleteActionCommand>("add-delete-action").WithDescription("Add a delete action to a live table (Cascade | Restricted | CascadeRestricted | None).");
+                b.AddCommand<ModifyRenameFieldCommand>("rename-field").WithDescription("Rename a table field, rewriting the indexes, field groups and relations that name it.");
+                b.AddCommand<ModifyRemoveFieldCommand>("remove-field").WithDescription("Remove a field from a live table.");
+                b.AddCommand<ModifyRemoveIndexCommand>("remove-index").WithDescription("Remove an index from a live table.");
+                b.AddCommand<ModifyRemoveRelationCommand>("remove-relation").WithDescription("Remove a relation from a live table.");
+                b.AddCommand<ModifyRemoveFieldGroupCommand>("remove-field-group").WithDescription("Remove a field group from a live table.");
+                b.AddCommand<ModifyRemoveDeleteActionCommand>("remove-delete-action").WithDescription("Remove a delete action, named by its related table.");
+                b.AddCommand<ModifyRemoveEnumValueCommand>("remove-enum-value").WithDescription("Remove a value from a live base enum.");
+                b.AddCommand<ModifyRemoveControlCommand>("remove-control").WithDescription("Remove a control, and everything nested under it, from a live form.");
+                b.AddCommand<ModifyAddQueryRangeCommand>("add-query-range").WithDescription("Add a range to an AOT query's datasource.");
+                b.AddCommand<ModifyRemoveQueryRangeCommand>("remove-query-range").WithDescription("Remove a range from an AOT query's datasource.");
+                b.AddCommand<ModifyAddEntryPointCommand>("add-entry-point").WithDescription("Grant an entry point on a security privilege.");
+                b.AddCommand<ModifyRemoveEntryPointCommand>("remove-entry-point").WithDescription("Revoke an entry point from a security privilege.");
+                b.AddCommand<ModifyBatchCommand>("batch").WithDescription("Apply several changes to one object in a single read-edit-write; a refused step discards the batch.");
             });
 
             cfg.AddBranch("analyze", b =>

--- a/src/D365FO.Cli/Commands/Get/GetCommands.cs
+++ b/src/D365FO.Cli/Commands/Get/GetCommands.cs
@@ -1,4 +1,4 @@
-using D365FO.Core;
+﻿using D365FO.Core;
 using D365FO.Core.Index;
 using Spectre.Console;
 using Spectre.Console.Cli;
@@ -15,11 +15,31 @@ public sealed class GetTableCommand : Command<GetTableCommand.Settings>
         [CommandOption("--include <PARTS>")]
         [System.ComponentModel.Description("Comma list: fields,indexes,relations (default: all)")]
         public string? Include { get; init; }
+
+        [CommandOption("--merged")]
+        [System.ComponentModel.Description("Return the EFFECTIVE shape: the base table with every TableExtension folded in, each member labelled with the object that contributes it. This is what the AOS sees; the plain output is the base table alone.")]
+        public bool Merged { get; init; }
     }
 
     public override int Execute(CommandContext ctx, Settings settings)
     {
         var kind = OutputMode.Resolve(settings.Output);
+
+        // The merged view is assembled from the index plus each extension's own XML, so it
+        // cannot come from the bridge's single-object read — resolve it before that gate.
+        if (settings.Merged)
+        {
+            var mergeRepo = RepoFactory.Create();
+            var merged = D365FO.Core.Index.TableMergeAnalyzer.Merge(mergeRepo, settings.Name);
+            var mergeWarnings = merged.Unreadable.Count > 0
+                ? new List<string>
+                {
+                    $"{merged.Unreadable.Count} extension(s) could not be read, so this schema is INCOMPLETE: "
+                    + string.Join("; ", merged.Unreadable),
+                }
+                : null;
+            return RenderHelpers.Render(kind, ToolResult<object>.Success(merged, mergeWarnings));
+        }
 
         if (BridgeGate.ShouldTry())
         {

--- a/src/D365FO.Cli/Commands/Modify/ModifyQuerySecurityCommands.cs
+++ b/src/D365FO.Cli/Commands/Modify/ModifyQuerySecurityCommands.cs
@@ -1,0 +1,315 @@
+using System.Text.Json;
+using D365FO.Core;
+using D365FO.Core.Bridge;
+using Spectre.Console.Cli;
+
+namespace D365FO.Cli.Commands.Modify;
+
+/// <summary><c>d365fo modify add-query-range</c> — add a range to an AOT query's datasource.</summary>
+public sealed class ModifyAddQueryRangeCommand : Command<ModifyAddQueryRangeCommand.Settings>
+{
+    public sealed class Settings : ModifyObjectSettings
+    {
+        [CommandArgument(0, "<QUERY>")]
+        [System.ComponentModel.Description("AOT query to add the range to.")]
+        public string Query { get; init; } = "";
+
+        [CommandArgument(1, "<FIELD>")]
+        [System.ComponentModel.Description("Field the range filters on. Also names the range, as every shipped query does.")]
+        public string Field { get; init; } = "";
+
+        [CommandOption("--data-source <NAME>")]
+        [System.ComponentModel.Description("Datasource the range belongs to. Optional when the query has exactly one.")]
+        public string? DataSource { get; init; }
+
+        [CommandOption("--value <EXPRESSION>")]
+        [System.ComponentModel.Description("Range expression, e.g. \"1\" or \"!Closed\". Omit for a range whose value is set at run time via QueryBuildRange.value().")]
+        public string? Value { get; init; }
+    }
+
+    public override int Execute(CommandContext ctx, Settings settings) =>
+        ModifyRunner.Run(settings, new ObjectModifyEngine.ModifyRequest
+        {
+            Operation = ObjectModifyEngine.Operation.AddQueryRange,
+            Kind = "query",
+            ObjectName = settings.Query,
+            Member = settings.Field,
+            DataSourceName = settings.DataSource,
+            RangeValue = settings.Value,
+            Model = settings.Model,
+            ExtensionSuffix = settings.ResolvedExtensionSuffix,
+            ExtensionModel = settings.ExtensionModel,
+            RequireExtension = settings.RequireExtension,
+        });
+}
+
+/// <summary><c>d365fo modify remove-query-range</c> — remove a range from an AOT query's datasource.</summary>
+public sealed class ModifyRemoveQueryRangeCommand : Command<ModifyRemoveQueryRangeCommand.Settings>
+{
+    public sealed class Settings : ModifyObjectSettings
+    {
+        [CommandArgument(0, "<QUERY>")]
+        [System.ComponentModel.Description("AOT query holding the range.")]
+        public string Query { get; init; } = "";
+
+        [CommandArgument(1, "<FIELD>")]
+        [System.ComponentModel.Description("Field the range filters on.")]
+        public string Field { get; init; } = "";
+
+        [CommandOption("--data-source <NAME>")]
+        [System.ComponentModel.Description("Datasource the range belongs to. Optional when the query has exactly one.")]
+        public string? DataSource { get; init; }
+    }
+
+    public override int Execute(CommandContext ctx, Settings settings) =>
+        ModifyRunner.Run(settings, new ObjectModifyEngine.ModifyRequest
+        {
+            Operation = ObjectModifyEngine.Operation.RemoveQueryRange,
+            Kind = "query",
+            ObjectName = settings.Query,
+            Member = settings.Field,
+            DataSourceName = settings.DataSource,
+            Model = settings.Model,
+            ExtensionSuffix = settings.ResolvedExtensionSuffix,
+            ExtensionModel = settings.ExtensionModel,
+            RequireExtension = settings.RequireExtension,
+        });
+}
+
+/// <summary><c>d365fo modify add-entry-point</c> — grant an entry point on a security privilege.</summary>
+public sealed class ModifyAddEntryPointCommand : Command<ModifyAddEntryPointCommand.Settings>
+{
+    public sealed class Settings : ModifyObjectSettings
+    {
+        [CommandArgument(0, "<PRIVILEGE>")]
+        [System.ComponentModel.Description("Security privilege to grant on.")]
+        public string Privilege { get; init; } = "";
+
+        [CommandArgument(1, "<OBJECT>")]
+        [System.ComponentModel.Description("Object granted, e.g. the menu item name.")]
+        public string ObjectName { get; init; } = "";
+
+        [CommandOption("--type <TYPE>")]
+        [System.ComponentModel.Description("AOT type of the entry point: MenuItemDisplay, MenuItemAction, MenuItemOutput, Form, … Required.")]
+        public string? Type { get; init; }
+
+        [CommandOption("--access <LEVEL>")]
+        [System.ComponentModel.Description("Read (default) | Update | Create | Correct | Delete | Invoke. Levels are cumulative, and are written as the six independent permissions the security model actually has.")]
+        public string? Access { get; init; }
+    }
+
+    public override int Execute(CommandContext ctx, Settings settings) =>
+        ModifyRunner.Run(settings, new ObjectModifyEngine.ModifyRequest
+        {
+            Operation = ObjectModifyEngine.Operation.AddEntryPoint,
+            Kind = "securityprivilege",
+            ObjectName = settings.Privilege,
+            Member = settings.ObjectName,
+            EntryPointType = settings.Type,
+            Access = settings.Access,
+            Model = settings.Model,
+            ExtensionSuffix = settings.ResolvedExtensionSuffix,
+            ExtensionModel = settings.ExtensionModel,
+            RequireExtension = settings.RequireExtension,
+        });
+}
+
+/// <summary><c>d365fo modify remove-entry-point</c> — revoke an entry point from a security privilege.</summary>
+public sealed class ModifyRemoveEntryPointCommand : Command<ModifyRemoveEntryPointCommand.Settings>
+{
+    public sealed class Settings : ModifyObjectSettings
+    {
+        [CommandArgument(0, "<PRIVILEGE>")]
+        [System.ComponentModel.Description("Security privilege to revoke on.")]
+        public string Privilege { get; init; } = "";
+
+        [CommandArgument(1, "<OBJECT>")]
+        [System.ComponentModel.Description("Entry point to revoke, by name or object name.")]
+        public string ObjectName { get; init; } = "";
+    }
+
+    public override int Execute(CommandContext ctx, Settings settings) =>
+        ModifyRunner.Run(settings, new ObjectModifyEngine.ModifyRequest
+        {
+            Operation = ObjectModifyEngine.Operation.RemoveEntryPoint,
+            Kind = "securityprivilege",
+            ObjectName = settings.Privilege,
+            Member = settings.ObjectName,
+            Model = settings.Model,
+            ExtensionSuffix = settings.ResolvedExtensionSuffix,
+            ExtensionModel = settings.ExtensionModel,
+            RequireExtension = settings.RequireExtension,
+        });
+}
+
+/// <summary>
+/// <c>d365fo modify batch</c> — several changes to one object in a single read-edit-write.
+/// </summary>
+/// <remarks>
+/// Adding a field, an index over it and a field group showing it is three commands, three bridge
+/// round trips, three journal entries — and two intermediate states published to disk, one of
+/// them a table carrying a field no index covers. Batched, the object moves from one valid state
+/// to the next in a single write. A step that refuses discards the whole batch with nothing
+/// written, so a half-applied change cannot reach the AOT.
+/// </remarks>
+public sealed class ModifyBatchCommand : Command<ModifyBatchCommand.Settings>
+{
+    public sealed class Settings : ModifyObjectSettings
+    {
+        [CommandArgument(0, "<KIND>")]
+        [System.ComponentModel.Description("Object kind: table, form, enum, query, securityprivilege, …")]
+        public string Kind { get; init; } = "";
+
+        [CommandArgument(1, "<OBJECT>")]
+        [System.ComponentModel.Description("Object every step applies to.")]
+        public string ObjectName { get; init; } = "";
+
+        [CommandOption("--operations <JSON>")]
+        [System.ComponentModel.Description("JSON array of steps, e.g. [{\"operation\":\"add-field\",\"member\":\"Note\",\"type\":\"Notes\"},{\"operation\":\"add-index\",\"member\":\"NoteIdx\",\"fields\":[\"Note\"]}]. Use --operations-file for anything long.")]
+        public string? Operations { get; init; }
+
+        [CommandOption("--operations-file <PATH>")]
+        [System.ComponentModel.Description("File holding the same JSON array. Shell quoting makes a long inline array painful; this avoids it.")]
+        public string? OperationsFile { get; init; }
+    }
+
+    public override int Execute(CommandContext ctx, Settings settings)
+    {
+        var outputKind = OutputMode.Resolve(settings.Output);
+
+        var json = settings.Operations;
+        if (!string.IsNullOrWhiteSpace(settings.OperationsFile))
+        {
+            if (!File.Exists(settings.OperationsFile))
+            {
+                return RenderHelpers.Render(outputKind, ToolResult<object>.Fail(
+                    D365FoErrorCodes.BadInput, $"No such file: {settings.OperationsFile}"));
+            }
+            json = File.ReadAllText(settings.OperationsFile);
+        }
+
+        if (string.IsNullOrWhiteSpace(json))
+        {
+            return RenderHelpers.Render(outputKind, ToolResult<object>.Fail(
+                D365FoErrorCodes.BadInput, "--operations or --operations-file is required.",
+                "Each step is {\"operation\":\"<name>\", \"member\":\"<name>\", …} — the operation names are the "
+                + "`modify` sub-commands: add-field, add-index, add-relation, add-field-group, add-delete-action, "
+                + "rename-field, property, add-enum-value, add-control, add-query-range, add-entry-point, and the remove-* forms."));
+        }
+
+        List<ObjectModifyEngine.ModifyRequest> steps;
+        try
+        {
+            steps = BatchStepParser.Parse(json!, settings.Kind, settings.ObjectName, settings.Model);
+        }
+        catch (Exception ex)
+        {
+            return RenderHelpers.Render(outputKind, ToolResult<object>.Fail(
+                D365FoErrorCodes.BadInput, $"--operations is not a usable step array: {ex.Message}"));
+        }
+
+        if (steps.Count == 0)
+        {
+            return RenderHelpers.Render(outputKind, ToolResult<object>.Fail(
+                D365FoErrorCodes.BadInput, "The step array is empty."));
+        }
+
+        return ModifyRunner.Run(settings, new ObjectModifyEngine.ModifyRequest
+        {
+            // Placeholders: the header names the object, the steps carry the operations.
+            Operation = ObjectModifyEngine.Operation.SetProperty,
+            Kind = settings.Kind,
+            ObjectName = settings.ObjectName,
+            Member = "batch",
+            Batch = steps,
+            Model = settings.Model,
+            ExtensionSuffix = settings.ResolvedExtensionSuffix,
+            ExtensionModel = settings.ExtensionModel,
+            RequireExtension = settings.RequireExtension,
+        });
+    }
+}
+
+/// <summary>Turns the JSON step array into engine requests.</summary>
+/// <remarks>
+/// Steps are named by their <c>modify</c> sub-command — <c>add-index</c>, not <c>AddIndex</c> —
+/// because that is the name the caller already knows from `--help` and from every error message
+/// this engine produces. Accepting the enum spelling too costs nothing and stops a plausible
+/// guess from being an error.
+/// </remarks>
+internal static class BatchStepParser
+{
+    internal static List<ObjectModifyEngine.ModifyRequest> Parse(
+        string json, string kind, string objectName, string? model)
+    {
+        using var doc = JsonDocument.Parse(json);
+        if (doc.RootElement.ValueKind != JsonValueKind.Array)
+            throw new InvalidOperationException("expected a JSON array of steps");
+
+        var steps = new List<ObjectModifyEngine.ModifyRequest>();
+        var index = 0;
+        foreach (var element in doc.RootElement.EnumerateArray())
+        {
+            index++;
+            var name = Str(element, "operation")
+                       ?? throw new InvalidOperationException($"step {index} has no \"operation\"");
+            if (!TryParseOperation(name, out var operation))
+                throw new InvalidOperationException($"step {index}: unknown operation \"{name}\"");
+
+            steps.Add(new ObjectModifyEngine.ModifyRequest
+            {
+                Operation = operation,
+                Kind = kind,
+                ObjectName = objectName,
+                Model = model,
+                Member = Str(element, "member") ?? Str(element, "name") ?? "",
+                Value = Str(element, "value"),
+                Type = Str(element, "type") ?? Str(element, "edt"),
+                Label = Str(element, "label"),
+                Mandatory = Bool(element, "mandatory"),
+                Parent = Str(element, "parent"),
+                DataSource = Str(element, "dataSource"),
+                DataField = Str(element, "dataField"),
+                Fields = Strings(element, "fields"),
+                RelatedTable = Str(element, "relatedTable"),
+                RelatedField = Str(element, "relatedField"),
+                DeleteAction = Str(element, "action") ?? Str(element, "deleteAction"),
+                AllowDuplicates = Bool(element, "allowDuplicates"),
+                AlternateKey = Bool(element, "alternateKey"),
+                NewName = Str(element, "newName"),
+                DataSourceName = Str(element, "dataSourceName") ?? Str(element, "dataSource"),
+                RangeValue = Str(element, "rangeValue") ?? Str(element, "value"),
+                EntryPointType = Str(element, "entryPointType") ?? Str(element, "type"),
+                Access = Str(element, "access"),
+            });
+        }
+        return steps;
+    }
+
+    private static bool TryParseOperation(string name, out ObjectModifyEngine.Operation operation)
+    {
+        // "add-field" -> "AddField"; the enum spelling is accepted as-is by Enum.TryParse.
+        var pascal = string.Concat(name.Split('-', StringSplitOptions.RemoveEmptyEntries)
+            .Select(part => char.ToUpperInvariant(part[0]) + part[1..]));
+        return Enum.TryParse(pascal, ignoreCase: true, out operation)
+               || Enum.TryParse(name, ignoreCase: true, out operation);
+    }
+
+    private static string? Str(JsonElement element, string name) =>
+        element.TryGetProperty(name, out var value) && value.ValueKind == JsonValueKind.String
+            ? value.GetString()
+            : null;
+
+    private static bool Bool(JsonElement element, string name) =>
+        element.TryGetProperty(name, out var value) && value.ValueKind == JsonValueKind.True;
+
+    private static IReadOnlyList<string>? Strings(JsonElement element, string name)
+    {
+        if (!element.TryGetProperty(name, out var value) || value.ValueKind != JsonValueKind.Array)
+            return null;
+        return value.EnumerateArray()
+            .Where(v => v.ValueKind == JsonValueKind.String)
+            .Select(v => v.GetString()!)
+            .ToList();
+    }
+}

--- a/src/D365FO.Cli/Commands/Modify/ModifyTableStructureCommands.cs
+++ b/src/D365FO.Cli/Commands/Modify/ModifyTableStructureCommands.cs
@@ -1,0 +1,296 @@
+using D365FO.Core.Bridge;
+using Spectre.Console.Cli;
+
+namespace D365FO.Cli.Commands.Modify;
+
+// The structural half of `d365fo modify`: the collections a table owns (indexes, relations,
+// field groups, delete actions) plus the removals every kind needs. Before these, an agent that
+// wanted to add an index to an existing table had no path through the CLI at all and fell back
+// to editing AOT XML by hand — which walks straight past the grounding, form-pattern and
+// reference gates the tool exists to enforce.
+//
+// Every one of them goes through ObjectModifyEngine, so they inherit the same three guarantees
+// as `modify add-field`: the base object is extended rather than overwritten when it belongs to
+// a model this installation does not own, the pre-image is journalled so `d365fo undo` reverts
+// it, and the document is canonicalised into contract order before the write.
+
+/// <summary><c>d365fo modify add-index</c> — add an index to a live table.</summary>
+public sealed class ModifyAddIndexCommand : Command<ModifyAddIndexCommand.Settings>
+{
+    public sealed class Settings : ModifyObjectSettings
+    {
+        [CommandArgument(0, "<TABLE>")]
+        [System.ComponentModel.Description("Table to add the index to.")]
+        public string Table { get; init; } = "";
+
+        [CommandArgument(1, "<INDEX>")]
+        [System.ComponentModel.Description("New index name, e.g. VehicleIdx.")]
+        public string Index { get; init; } = "";
+
+        [CommandOption("--field <FIELD>")]
+        [System.ComponentModel.Description("Field in the index key (repeatable). Order matters — it decides which queries the index can serve.")]
+        public string[]? Field { get; init; }
+
+        [CommandOption("--allow-duplicates")]
+        [System.ComponentModel.Description("Permit duplicate keys. Omitted, the index is unique (AllowDuplicates=No).")]
+        public bool AllowDuplicates { get; init; }
+
+        [CommandOption("--alternate-key")]
+        [System.ComponentModel.Description("Mark the index an alternate key. Implies a unique index.")]
+        public bool AlternateKey { get; init; }
+    }
+
+    public override int Execute(CommandContext ctx, Settings settings) =>
+        ModifyRunner.Run(settings, new ObjectModifyEngine.ModifyRequest
+        {
+            Operation = ObjectModifyEngine.Operation.AddIndex,
+            Kind = "table",
+            ObjectName = settings.Table,
+            Member = settings.Index,
+            Fields = settings.Field,
+            // An alternate key is unique by definition; accepting --allow-duplicates beside it
+            // would let the caller ask for something the AOS refuses after a build cycle.
+            AllowDuplicates = settings.AllowDuplicates && !settings.AlternateKey,
+            AlternateKey = settings.AlternateKey,
+            Model = settings.Model,
+            ExtensionSuffix = settings.ResolvedExtensionSuffix,
+            ExtensionModel = settings.ExtensionModel,
+            RequireExtension = settings.RequireExtension,
+        });
+}
+
+/// <summary><c>d365fo modify add-relation</c> — add a foreign-key relation to a live table.</summary>
+public sealed class ModifyAddRelationCommand : Command<ModifyAddRelationCommand.Settings>
+{
+    public sealed class Settings : ModifyObjectSettings
+    {
+        [CommandArgument(0, "<TABLE>")]
+        [System.ComponentModel.Description("Table the relation is declared on.")]
+        public string Table { get; init; } = "";
+
+        [CommandArgument(1, "<FIELD>")]
+        [System.ComponentModel.Description("Field on this table that holds the foreign key. Also names the relation.")]
+        public string Field { get; init; } = "";
+
+        [CommandOption("--related-table <TABLE>")]
+        [System.ComponentModel.Description("Table the relation points at. Required.")]
+        public string? RelatedTable { get; init; }
+
+        [CommandOption("--related-field <FIELD>")]
+        [System.ComponentModel.Description("Field on the related table. Defaults to the same name as <FIELD>.")]
+        public string? RelatedField { get; init; }
+    }
+
+    public override int Execute(CommandContext ctx, Settings settings) =>
+        ModifyRunner.Run(settings, new ObjectModifyEngine.ModifyRequest
+        {
+            Operation = ObjectModifyEngine.Operation.AddRelation,
+            Kind = "table",
+            ObjectName = settings.Table,
+            Member = settings.Field,
+            RelatedTable = settings.RelatedTable,
+            RelatedField = settings.RelatedField,
+            Model = settings.Model,
+            ExtensionSuffix = settings.ResolvedExtensionSuffix,
+            ExtensionModel = settings.ExtensionModel,
+            RequireExtension = settings.RequireExtension,
+        });
+}
+
+/// <summary><c>d365fo modify add-field-group</c> — add a field group to a live table.</summary>
+public sealed class ModifyAddFieldGroupCommand : Command<ModifyAddFieldGroupCommand.Settings>
+{
+    public sealed class Settings : ModifyObjectSettings
+    {
+        [CommandArgument(0, "<TABLE>")]
+        [System.ComponentModel.Description("Table to add the field group to.")]
+        public string Table { get; init; } = "";
+
+        [CommandArgument(1, "<GROUP>")]
+        [System.ComponentModel.Description("New field group name. Overview, General and the five Auto* groups already exist on every table.")]
+        public string Group { get; init; } = "";
+
+        [CommandOption("--field <FIELD>")]
+        [System.ComponentModel.Description("Field in the group (repeatable). Order is the order the form renders them in.")]
+        public string[]? Field { get; init; }
+
+        [CommandOption("--label <LABEL>")]
+        [System.ComponentModel.Description("Label token (@File:Id) for the group.")]
+        public string? Label { get; init; }
+    }
+
+    public override int Execute(CommandContext ctx, Settings settings) =>
+        ModifyRunner.Run(settings, new ObjectModifyEngine.ModifyRequest
+        {
+            Operation = ObjectModifyEngine.Operation.AddFieldGroup,
+            Kind = "table",
+            ObjectName = settings.Table,
+            Member = settings.Group,
+            Fields = settings.Field,
+            Label = settings.Label,
+            Model = settings.Model,
+            ExtensionSuffix = settings.ResolvedExtensionSuffix,
+            ExtensionModel = settings.ExtensionModel,
+            RequireExtension = settings.RequireExtension,
+        });
+}
+
+/// <summary><c>d365fo modify add-delete-action</c> — add a delete action to a live table.</summary>
+public sealed class ModifyAddDeleteActionCommand : Command<ModifyAddDeleteActionCommand.Settings>
+{
+    public sealed class Settings : ModifyObjectSettings
+    {
+        [CommandArgument(0, "<TABLE>")]
+        [System.ComponentModel.Description("Table the delete action is declared on.")]
+        public string Table { get; init; } = "";
+
+        [CommandOption("--related-table <TABLE>")]
+        [System.ComponentModel.Description("Table whose rows the action governs. Required — it also identifies the action.")]
+        public string? RelatedTable { get; init; }
+
+        [CommandOption("--action <ACTION>")]
+        [System.ComponentModel.Description("Cascade | Restricted | CascadeRestricted | None. Required.")]
+        public string? Action { get; init; }
+    }
+
+    public override int Execute(CommandContext ctx, Settings settings) =>
+        ModifyRunner.Run(settings, new ObjectModifyEngine.ModifyRequest
+        {
+            Operation = ObjectModifyEngine.Operation.AddDeleteAction,
+            Kind = "table",
+            ObjectName = settings.Table,
+            // A delete action carries no name of its own; the related table is the identity,
+            // and Member has to be non-empty for the shared validation.
+            Member = settings.RelatedTable ?? "",
+            RelatedTable = settings.RelatedTable,
+            DeleteAction = settings.Action,
+            Model = settings.Model,
+            ExtensionSuffix = settings.ResolvedExtensionSuffix,
+            ExtensionModel = settings.ExtensionModel,
+            RequireExtension = settings.RequireExtension,
+        });
+}
+
+/// <summary><c>d365fo modify rename-field</c> — rename a field and the members that reference it.</summary>
+public sealed class ModifyRenameFieldCommand : Command<ModifyRenameFieldCommand.Settings>
+{
+    public sealed class Settings : ModifyObjectSettings
+    {
+        [CommandArgument(0, "<TABLE>")]
+        [System.ComponentModel.Description("Table holding the field.")]
+        public string Table { get; init; } = "";
+
+        [CommandArgument(1, "<FIELD>")]
+        [System.ComponentModel.Description("Current field name.")]
+        public string Field { get; init; } = "";
+
+        [CommandOption("--new-name <NAME>")]
+        [System.ComponentModel.Description("New field name. Required. Indexes, field groups and relation constraints naming the field are rewritten with it; X++ is not.")]
+        public string? NewName { get; init; }
+    }
+
+    public override int Execute(CommandContext ctx, Settings settings) =>
+        ModifyRunner.Run(settings, new ObjectModifyEngine.ModifyRequest
+        {
+            Operation = ObjectModifyEngine.Operation.RenameField,
+            Kind = "table",
+            ObjectName = settings.Table,
+            Member = settings.Field,
+            NewName = settings.NewName,
+            Model = settings.Model,
+            ExtensionSuffix = settings.ResolvedExtensionSuffix,
+            ExtensionModel = settings.ExtensionModel,
+            RequireExtension = settings.RequireExtension,
+        });
+}
+
+/// <summary>
+/// Shared settings for the removals: kind and object come from the sub-command, the member
+/// name is the one argument they all take.
+/// </summary>
+/// <remarks>
+/// Deliberately NOT abstract. Every remove sub-command uses this type directly as its
+/// <c>TSettings</c>, and Spectre.Console.Cli constructs the settings type by reflection — an
+/// abstract one fails at RUN time with "Could not resolve type
+/// 'ModifyRemoveSettings'", not at compile time. Engine tests cannot see it either, since they
+/// call the engine rather than the command. Caught on a live run; pinned by
+/// <c>CommandSurfaceTests</c>.
+/// </remarks>
+public class ModifyRemoveSettings : ModifyObjectSettings
+{
+    [CommandArgument(0, "<OBJECT>")]
+    [System.ComponentModel.Description("Object to remove the member from.")]
+    public string ObjectName { get; init; } = "";
+
+    [CommandArgument(1, "<MEMBER>")]
+    [System.ComponentModel.Description("Name of the member to remove.")]
+    public string Member { get; init; } = "";
+}
+
+/// <summary>Builds the removal request every remove sub-command shares.</summary>
+internal static class RemoveRunner
+{
+    internal static int Run(ModifyRemoveSettings settings, ObjectModifyEngine.Operation operation, string kind) =>
+        ModifyRunner.Run(settings, new ObjectModifyEngine.ModifyRequest
+        {
+            Operation = operation,
+            Kind = kind,
+            ObjectName = settings.ObjectName,
+            Member = settings.Member,
+            // A delete action is addressed by its related table, which arrives in the same slot.
+            RelatedTable = operation == ObjectModifyEngine.Operation.RemoveDeleteAction ? settings.Member : null,
+            Model = settings.Model,
+            ExtensionSuffix = settings.ResolvedExtensionSuffix,
+            ExtensionModel = settings.ExtensionModel,
+            RequireExtension = settings.RequireExtension,
+        });
+}
+
+/// <summary><c>d365fo modify remove-field</c> — remove a field from a live table.</summary>
+public sealed class ModifyRemoveFieldCommand : Command<ModifyRemoveSettings>
+{
+    public override int Execute(CommandContext ctx, ModifyRemoveSettings settings) =>
+        RemoveRunner.Run(settings, ObjectModifyEngine.Operation.RemoveField, "table");
+}
+
+/// <summary><c>d365fo modify remove-index</c> — remove an index from a live table.</summary>
+public sealed class ModifyRemoveIndexCommand : Command<ModifyRemoveSettings>
+{
+    public override int Execute(CommandContext ctx, ModifyRemoveSettings settings) =>
+        RemoveRunner.Run(settings, ObjectModifyEngine.Operation.RemoveIndex, "table");
+}
+
+/// <summary><c>d365fo modify remove-relation</c> — remove a relation from a live table.</summary>
+public sealed class ModifyRemoveRelationCommand : Command<ModifyRemoveSettings>
+{
+    public override int Execute(CommandContext ctx, ModifyRemoveSettings settings) =>
+        RemoveRunner.Run(settings, ObjectModifyEngine.Operation.RemoveRelation, "table");
+}
+
+/// <summary><c>d365fo modify remove-field-group</c> — remove a field group from a live table.</summary>
+public sealed class ModifyRemoveFieldGroupCommand : Command<ModifyRemoveSettings>
+{
+    public override int Execute(CommandContext ctx, ModifyRemoveSettings settings) =>
+        RemoveRunner.Run(settings, ObjectModifyEngine.Operation.RemoveFieldGroup, "table");
+}
+
+/// <summary><c>d365fo modify remove-delete-action</c> — remove a delete action, named by its related table.</summary>
+public sealed class ModifyRemoveDeleteActionCommand : Command<ModifyRemoveSettings>
+{
+    public override int Execute(CommandContext ctx, ModifyRemoveSettings settings) =>
+        RemoveRunner.Run(settings, ObjectModifyEngine.Operation.RemoveDeleteAction, "table");
+}
+
+/// <summary><c>d365fo modify remove-enum-value</c> — remove a value from a live base enum.</summary>
+public sealed class ModifyRemoveEnumValueCommand : Command<ModifyRemoveSettings>
+{
+    public override int Execute(CommandContext ctx, ModifyRemoveSettings settings) =>
+        RemoveRunner.Run(settings, ObjectModifyEngine.Operation.RemoveEnumValue, "enum");
+}
+
+/// <summary><c>d365fo modify remove-control</c> — remove a control, and its children, from a live form.</summary>
+public sealed class ModifyRemoveControlCommand : Command<ModifyRemoveSettings>
+{
+    public override int Execute(CommandContext ctx, ModifyRemoveSettings settings) =>
+        RemoveRunner.Run(settings, ObjectModifyEngine.Operation.RemoveControl, "form");
+}

--- a/src/D365FO.Cli/Commands/Prepare/PrepareCommands.cs
+++ b/src/D365FO.Cli/Commands/Prepare/PrepareCommands.cs
@@ -125,13 +125,20 @@ public sealed class PrepareCreateCommand : Command<PrepareCreateCommand.Settings
 /// cover the target, whether the model references TestEssentials, the scaffold
 /// call, the red-first order and a grounding token. The aggregation lives in
 /// <see cref="D365FO.Mcp.ToolHandlers.PrepareTest"/>.
+///
+/// Resolves a TABLE as well as a class. The index stores declared members only, so a
+/// table that has never overridden <c>validateWrite</c> has no row for it — which is
+/// exactly the method a caller naming <c>CustTable.validateWrite</c> came for. The
+/// inherited data methods are listed from <see cref="D365FO.Core.Knowledge.TableDataMethods"/>
+/// alongside the declared overrides, and the answer carries the shape a table test needs
+/// (arrange a buffer, assert the verdict AND the infolog line, keep the accepting case).
 /// </summary>
 public sealed class PrepareTestCommand : Command<PrepareTestCommand.Settings>
 {
     public sealed class Settings : D365OutputSettings
     {
-        [CommandArgument(0, "<CLASS>")]
-        [System.ComponentModel.Description("The class under test. Example: FmVehicleService.")]
+        [CommandArgument(0, "<TARGET>")]
+        [System.ComponentModel.Description("The class or table under test. A table method may be named in one go: FmVehicleService, CustTable, or CustTable.validateWrite.")]
         public string ObjectName { get; init; } = "";
 
         [CommandOption("--goal <TEXT>")]
@@ -151,7 +158,7 @@ public sealed class PrepareTestCommand : Command<PrepareTestCommand.Settings>
     {
         var kind = OutputMode.Resolve(settings.Output);
         if (string.IsNullOrWhiteSpace(settings.ObjectName))
-            return RenderHelpers.Render(kind, ToolResult<object>.Fail("BAD_INPUT", "Class name required."));
+            return RenderHelpers.Render(kind, ToolResult<object>.Fail("BAD_INPUT", "Class or table name required."));
 
         MetadataRepository repo;
         try { repo = RepoFactory.Create(); }

--- a/src/D365FO.Core/Bridge/ObjectModifyEngine.cs
+++ b/src/D365FO.Core/Bridge/ObjectModifyEngine.cs
@@ -1,9 +1,10 @@
-// <copyright file="ObjectModifyEngine.cs" company="d365fo-cli contributors">
+﻿// <copyright file="ObjectModifyEngine.cs" company="d365fo-cli contributors">
 // MIT
 // </copyright>
 
 using System.Text.Json.Nodes;
 using System.Xml.Linq;
+using D365FO.Core.Extract;
 using D365FO.Core.FormPatterns;
 using D365FO.Core.Index;
 using D365FO.Core.Journal;
@@ -53,7 +54,80 @@ public static class ObjectModifyEngine
 
         /// <summary>Add a control to a form's Design tree.</summary>
         AddControl,
+
+        /// <summary>Add an index to a table.</summary>
+        AddIndex,
+
+        /// <summary>Add a foreign-key relation to a table.</summary>
+        AddRelation,
+
+        /// <summary>Add a field group to a table.</summary>
+        AddFieldGroup,
+
+        /// <summary>Add a delete action to a table.</summary>
+        AddDeleteAction,
+
+        /// <summary>Remove a field from a table.</summary>
+        RemoveField,
+
+        /// <summary>Remove an index from a table.</summary>
+        RemoveIndex,
+
+        /// <summary>Remove a relation from a table.</summary>
+        RemoveRelation,
+
+        /// <summary>Remove a field group from a table.</summary>
+        RemoveFieldGroup,
+
+        /// <summary>Remove a delete action from a table.</summary>
+        RemoveDeleteAction,
+
+        /// <summary>Rename a field on a table.</summary>
+        RenameField,
+
+        /// <summary>Remove a value from a base enum.</summary>
+        RemoveEnumValue,
+
+        /// <summary>Remove a control from a form's Design tree.</summary>
+        RemoveControl,
+
+        /// <summary>Add a range to a datasource of an AOT query.</summary>
+        AddQueryRange,
+
+        /// <summary>Remove a range from a datasource of an AOT query.</summary>
+        RemoveQueryRange,
+
+        /// <summary>Add an entry point to a security privilege.</summary>
+        AddEntryPoint,
+
+        /// <summary>Remove an entry point from a security privilege.</summary>
+        RemoveEntryPoint,
     }
+
+    /// <summary>
+    /// Operations that only ever remove something. They share one shape — find the member by
+    /// name inside its collection, refuse when it is not there, remove it — so they are
+    /// described once rather than repeated thirteen times.
+    /// </summary>
+    /// <remarks>
+    /// <c>Collection</c> is the container element under the object root, <c>Item</c> the element
+    /// name of one entry, and <c>Key</c> the child element carrying the name to match on. The
+    /// table collections key on <c>Name</c>; a delete action is addressed by the table it
+    /// governs, which the contract calls <c>Table</c> (there is no <c>RelatedTable</c> member -
+    /// writing one produced a rule naming nothing, and keying on one found nothing).
+    /// </remarks>
+    private sealed record RemovalShape(string Collection, string Item, string Key, string Noun);
+
+    private static readonly IReadOnlyDictionary<Operation, RemovalShape> Removals =
+        new Dictionary<Operation, RemovalShape>
+        {
+            [Operation.RemoveField]       = new("Fields", "AxTableField", "Name", "Field"),
+            [Operation.RemoveIndex]       = new("Indexes", "AxTableIndex", "Name", "Index"),
+            [Operation.RemoveRelation]    = new("Relations", "AxTableRelation", "Name", "Relation"),
+            [Operation.RemoveFieldGroup]  = new("FieldGroups", "AxTableFieldGroup", "Name", "Field group"),
+            [Operation.RemoveDeleteAction] = new("DeleteActions", "AxTableDeleteAction", "Table", "Delete action"),
+            [Operation.RemoveEnumValue]   = new("EnumValues", "AxEnumValue", "Name", "Enum value"),
+        };
 
     /// <summary>Inputs for one structured modification.</summary>
     public sealed record ModifyRequest
@@ -102,10 +176,82 @@ public static class ObjectModifyEngine
 
         /// <summary>Never modify the base object in place; fail instead of falling back.</summary>
         public bool RequireExtension { get; init; }
+
+        /// <summary>
+        /// Member fields, in order, for <see cref="Operation.AddIndex"/> and
+        /// <see cref="Operation.AddFieldGroup"/>. Order is data, not decoration — an index's
+        /// field order decides which queries it can serve.
+        /// </summary>
+        public IReadOnlyList<string>? Fields { get; init; }
+
+        /// <summary>Target table for <see cref="Operation.AddRelation"/> / <see cref="Operation.AddDeleteAction"/>.</summary>
+        public string? RelatedTable { get; init; }
+
+        /// <summary>Field on <see cref="RelatedTable"/> the relation constrains to. Defaults to <see cref="Member"/>.</summary>
+        public string? RelatedField { get; init; }
+
+        /// <summary>Cascade | Restricted | CascadeRestricted | None, for <see cref="Operation.AddDeleteAction"/>.</summary>
+        public string? DeleteAction { get; init; }
+
+        /// <summary><see cref="Operation.AddIndex"/>: allow duplicate keys. A unique index is the default.</summary>
+        public bool AllowDuplicates { get; init; }
+
+        /// <summary><see cref="Operation.AddIndex"/>: mark the index an alternate key.</summary>
+        public bool AlternateKey { get; init; }
+
+        /// <summary>New member name for <see cref="Operation.RenameField"/>.</summary>
+        public string? NewName { get; init; }
+
+        /// <summary>Query datasource the range belongs to. Defaults to the query's only datasource.</summary>
+        public string? DataSourceName { get; init; }
+
+        /// <summary>
+        /// Range value for <see cref="Operation.AddQueryRange"/> — the range EXPRESSION, not a
+        /// literal to be quoted. Empty is legal and common: a range with no value is one the
+        /// caller sets at run time through <c>QueryBuildRange.value()</c>.
+        /// </summary>
+        public string? RangeValue { get; init; }
+
+        /// <summary>AOT type of an entry point: MenuItemDisplay, MenuItemAction, MenuItemOutput, Form, …</summary>
+        public string? EntryPointType { get; init; }
+
+        /// <summary>Access level granted to an entry point: Read | Update | Create | Correct | Delete | Invoke.</summary>
+        public string? Access { get; init; }
+
+        /// <summary>
+        /// Several operations against the SAME object, applied in order to one in-memory
+        /// document. Null or empty means this request is the single operation.
+        /// </summary>
+        /// <remarks>
+        /// The saving is not cosmetic. Each entry would otherwise be its own bridge read, write
+        /// and journal entry, and the intermediate states get published — a table is briefly on
+        /// disk with a field and no index covering it. Batched, the object goes from one valid
+        /// state to the next in a single write, and a step that refuses discards the whole batch
+        /// with nothing written.
+        ///
+        /// Steps inherit <see cref="Kind"/>, <see cref="ObjectName"/> and <see cref="Model"/>
+        /// from the request carrying them; anything they set for those is ignored, because a
+        /// batch that could retarget mid-flight is not a batch.
+        /// </remarks>
+        public IReadOnlyList<ModifyRequest>? Batch { get; init; }
     }
 
+    /// <summary>
+    /// Every kind the bridge can read and write, taken from the registry rather than listed here.
+    /// </summary>
+    /// <remarks>
+    /// This was a hand-written set of five — class, table, edt, enum, form — while the bridge
+    /// resolves its collections from <see cref="ObjectTypeRegistry.BridgeCollections"/>, which
+    /// names 41. So <c>modify property</c> refused a query, a privilege, a menu item, a service
+    /// group, a view, a report and a tile that the layer underneath was perfectly able to write,
+    /// and the refusal named the five as if they were the platform's limit. It is the same drift
+    /// the extension-type lookup had (#171), with the same fix: one source of truth.
+    ///
+    /// Operations narrower than a property set still gate themselves — <c>add-field</c> on
+    /// anything but a table, <c>add-index</c> on anything but a table, and so on.
+    /// </remarks>
     private static readonly IReadOnlySet<string> SupportedKinds =
-        new HashSet<string>(StringComparer.OrdinalIgnoreCase) { "class", "table", "edt", "enum", "form" };
+        ObjectTypeRegistry.BridgeCollections().Keys.ToHashSet(StringComparer.OrdinalIgnoreCase);
 
     /// <summary>
     /// The AOT type that extends <paramref name="kind"/>, or null when there is none.
@@ -152,8 +298,22 @@ public static class ObjectModifyEngine
         ModifyRequest request, MetadataRepository? repo, BridgeClient client, string? journalDbOverride = null)
     {
         var kind = (request.Kind ?? string.Empty).Trim().ToLowerInvariant();
-        var validation = ValidateRequest(request, kind);
-        if (validation is not null) return validation;
+
+        // A batch header names the object, not an operation — its Operation and Member are
+        // placeholders, so validating it as if it were a step would refuse every batch for a
+        // missing member name. The steps are each validated in the loop below.
+        if (request.Batch is { Count: > 0 })
+        {
+            if (!SupportedKinds.Contains(kind))
+                return ValidateRequest(request with { Batch = null, Member = "batch" }, kind)!;
+            if (string.IsNullOrWhiteSpace(request.ObjectName))
+                return ToolResult<object>.Fail(D365FoErrorCodes.BadInput, "Object name is required.");
+        }
+        else
+        {
+            var validation = ValidateRequest(request, kind);
+            if (validation is not null) return validation;
+        }
 
         var warnings = new List<string>();
 
@@ -173,11 +333,45 @@ public static class ObjectModifyEngine
         var (doc, preImage, readFailure) = ReadOrCreate(client, target!, request, kind);
         if (readFailure is not null) return readFailure;
 
-        // ---- 3. Structured edit ----
-        var (applied, editFailure) = ApplyOperation(doc!, request, kind, target!, repo);
-        if (editFailure is not null) return editFailure;
+        // ---- 3. Structured edit(s) ----
+        // A batch applies every operation to the SAME in-memory document, so N changes cost one
+        // bridge read, one write and one journal entry. Stopped at the first failure, and since
+        // nothing has been written at that point the object is untouched — a half-applied batch
+        // is never published.
+        var operations = request.Batch is { Count: > 0 } ? request.Batch : new[] { request };
+        var applied = new List<object?>(operations.Count);
+        for (var i = 0; i < operations.Count; i++)
+        {
+            var step = operations[i] with
+            {
+                // The batch header owns where the write lands; a step only says what to change.
+                // `Kind` is `required` but callers can still pass null through it, which is why
+                // the top of this method normalises it the same defensive way.
+                Kind = request.Kind ?? string.Empty,
+                ObjectName = request.ObjectName,
+                Model = request.Model,
+            };
+
+            var stepValidation = ValidateRequest(step, kind);
+            if (stepValidation is not null)
+                return BatchFailure(stepValidation, i, operations.Count, applied);
+
+            var (stepApplied, editFailure) = ApplyOperation(doc!, step, kind, target!, repo);
+            if (editFailure is not null)
+                return BatchFailure(editFailure, i, operations.Count, applied);
+
+            applied.Add(stepApplied);
+        }
 
         // ---- 4. Write back, journaling the pre-image first ----
+        // An element that arrives out of contract order is not rejected by the AOT reader, it is
+        // DROPPED: DataContractSerializer matches children in order and skips anything early or
+        // late. The disk write path has always canonicalised (ScaffoldFileWriter.Finalize) but
+        // this one did not, so an edit that created a missing collection — `<Fields>` on a table
+        // that had none, `<EnumValues>`, `<Controls>` — appended it at the end of the root and
+        // the write came back "ok" with the change silently absent. Canonicalise the same way
+        // before serialising; it is idempotent and leaves collection item order alone.
+        ContractOrderCanonicalizer.Apply(doc!);
         var newXml = doc!.ToString(SaveOptions.DisableFormatting);
         var verb = target!.Exists ? "updateObject" : "createObject";
 
@@ -209,19 +403,43 @@ public static class ObjectModifyEngine
                 BridgeFailureHint(code, target));
         }
 
-        warnings.Add($"Index not auto-refreshed — run `d365fo index refresh --model {target.Model}` so '{request.Member}' is searchable.");
+        warnings.Add($"Index not auto-refreshed — run `d365fo index refresh --model {target.Model}` so the change is searchable.");
 
+        var isBatch = request.Batch is { Count: > 0 };
         return ToolResult<object>.Success(new
         {
-            operation = request.Operation.ToString(),
+            operation = isBatch ? "Batch" : request.Operation.ToString(),
+            operations = isBatch ? operations.Select(o => o.Operation.ToString()).ToArray() : null,
             kind,
             name = request.ObjectName,
-            member = request.Member,
+            member = isBatch ? null : request.Member,
             wroteTo = new { kind = target.Kind, name = target.Name, model = target.Model, extension = target.IsExtension },
             created = !target.Exists,
             source = "bridge",
-            applied,
+            applied = isBatch ? applied : applied.FirstOrDefault(),
         }, warnings);
+    }
+
+    /// <summary>
+    /// Report a batch step that refused, naming which one and what had already been applied.
+    /// </summary>
+    /// <remarks>
+    /// Nothing has been written when this runs — the failure happens against the in-memory
+    /// document, before the single write — so the object on disk is untouched. Saying so
+    /// matters: "step 3 of 5 failed" reads like a half-applied change unless the answer also
+    /// says the other four were discarded rather than published.
+    /// </remarks>
+    private static ToolResult<object> BatchFailure(
+        ToolResult<object> failure, int index, int total, IReadOnlyList<object?> appliedSoFar)
+    {
+        if (total <= 1) return failure;
+
+        var error = failure.Error!;
+        var hint = $"Step {index + 1} of {total} refused; NOTHING was written — the {appliedSoFar.Count} " +
+                   "earlier step(s) were applied to an in-memory copy and discarded, so the object is unchanged. " +
+                   "Fix this step and re-run the whole batch.";
+        return ToolResult<object>.Fail(error.Code, error.Message,
+            string.IsNullOrWhiteSpace(error.Hint) ? hint : error.Hint + " " + hint);
     }
 
     /// <summary>
@@ -253,8 +471,19 @@ public static class ObjectModifyEngine
     {
         if (!SupportedKinds.Contains(kind))
         {
+            // 41 kinds is too many to print at a caller who mistyped one of them, so name the
+            // near misses and point at the full list rather than filling the terminal.
+            var close = SupportedKinds
+                .Where(k => k.Contains(kind, StringComparison.OrdinalIgnoreCase)
+                            || kind.Contains(k, StringComparison.OrdinalIgnoreCase))
+                .OrderBy(k => k.Length)
+                .Take(5)
+                .ToList();
             return ToolResult<object>.Fail(D365FoErrorCodes.BadInput,
-                $"Unsupported object kind '{request.Kind}'. Supported: {string.Join(", ", SupportedKinds)}.");
+                $"Unsupported object kind '{request.Kind}'.",
+                close.Count > 0
+                    ? $"Did you mean: {string.Join(", ", close)}? Full list: `d365fo schema --output json`."
+                    : $"{SupportedKinds.Count} kinds are writable; see `d365fo schema --output json`.");
         }
         if (string.IsNullOrWhiteSpace(request.ObjectName))
             return ToolResult<object>.Fail(D365FoErrorCodes.BadInput, "Object name is required.");
@@ -278,9 +507,103 @@ public static class ObjectModifyEngine
             Operation.AddControl when string.IsNullOrWhiteSpace(request.Type) =>
                 ToolResult<object>.Fail(D365FoErrorCodes.BadInput,
                     "--type is required for `modify add-control` (Grid, Group, TabPage, String, …)."),
+
+            // ---- table-shaped operations ----
+            _ when TableOnly.Contains(request.Operation) && kind != "table" =>
+                ToolResult<object>.Fail(D365FoErrorCodes.BadInput,
+                    $"`modify {CommandNameFor(request.Operation)}` applies to tables, not {kind}."),
+            Operation.AddIndex when (request.Fields?.Count ?? 0) == 0 =>
+                ToolResult<object>.Fail(D365FoErrorCodes.BadInput,
+                    "--field is required for `modify add-index` (repeat it; the order is the index's key order)."),
+            Operation.AddFieldGroup when (request.Fields?.Count ?? 0) == 0 =>
+                ToolResult<object>.Fail(D365FoErrorCodes.BadInput,
+                    "--field is required for `modify add-field-group` (repeat it for each member)."),
+            Operation.AddRelation when string.IsNullOrWhiteSpace(request.RelatedTable) =>
+                ToolResult<object>.Fail(D365FoErrorCodes.BadInput,
+                    "--related-table is required for `modify add-relation`."),
+            Operation.AddDeleteAction when string.IsNullOrWhiteSpace(request.RelatedTable) =>
+                ToolResult<object>.Fail(D365FoErrorCodes.BadInput,
+                    "--related-table is required for `modify add-delete-action`."),
+            Operation.AddDeleteAction when !ValidDeleteActions.Contains(request.DeleteAction ?? "") =>
+                ToolResult<object>.Fail(D365FoErrorCodes.BadInput,
+                    $"--action must be one of: {string.Join(", ", ValidDeleteActions)}."),
+            Operation.RenameField when string.IsNullOrWhiteSpace(request.NewName) =>
+                ToolResult<object>.Fail(D365FoErrorCodes.BadInput,
+                    "--new-name is required for `modify rename-field`."),
+
+            Operation.RemoveEnumValue when kind != "enum" =>
+                ToolResult<object>.Fail(D365FoErrorCodes.BadInput,
+                    $"`modify remove-enum-value` applies to enums, not {kind}."),
+            Operation.RemoveControl when kind != "form" =>
+                ToolResult<object>.Fail(D365FoErrorCodes.BadInput,
+                    $"`modify remove-control` applies to forms, not {kind}."),
+
+            _ when QueryOnly.Contains(request.Operation) && kind != "query" =>
+                ToolResult<object>.Fail(D365FoErrorCodes.BadInput,
+                    $"`modify {CommandNameFor(request.Operation)}` applies to AOT queries, not {kind}."),
+            Operation.AddQueryRange when string.IsNullOrWhiteSpace(request.Member) =>
+                ToolResult<object>.Fail(D365FoErrorCodes.BadInput,
+                    "The range's field name is required for `modify add-query-range`."),
+
+            _ when PrivilegeOnly.Contains(request.Operation) && kind != "securityprivilege" =>
+                ToolResult<object>.Fail(D365FoErrorCodes.BadInput,
+                    $"`modify {CommandNameFor(request.Operation)}` applies to security privileges, not {kind}."),
+            Operation.AddEntryPoint when string.IsNullOrWhiteSpace(request.EntryPointType) =>
+                ToolResult<object>.Fail(D365FoErrorCodes.BadInput,
+                    "--type is required for `modify add-entry-point` (MenuItemDisplay, MenuItemAction, MenuItemOutput, Form, …)."),
             _ => null,
         };
     }
+
+    /// <summary>Operations that only make sense on an <c>AxQuery</c>.</summary>
+    private static readonly IReadOnlySet<Operation> QueryOnly = new HashSet<Operation>
+    {
+        Operation.AddQueryRange, Operation.RemoveQueryRange,
+    };
+
+    /// <summary>Operations that only make sense on an <c>AxSecurityPrivilege</c>.</summary>
+    private static readonly IReadOnlySet<Operation> PrivilegeOnly = new HashSet<Operation>
+    {
+        Operation.AddEntryPoint, Operation.RemoveEntryPoint,
+    };
+
+    /// <summary>Operations that only make sense on an <c>AxTable</c>.</summary>
+    private static readonly IReadOnlySet<Operation> TableOnly = new HashSet<Operation>
+    {
+        Operation.AddIndex, Operation.AddRelation, Operation.AddFieldGroup, Operation.AddDeleteAction,
+        Operation.RemoveField, Operation.RemoveIndex, Operation.RemoveRelation,
+        Operation.RemoveFieldGroup, Operation.RemoveDeleteAction, Operation.RenameField,
+    };
+
+    /// <summary>The four delete actions the platform defines. Anything else is a typo.</summary>
+    private static readonly IReadOnlySet<string> ValidDeleteActions =
+        new HashSet<string>(StringComparer.OrdinalIgnoreCase) { "Cascade", "Restricted", "CascadeRestricted", "None" };
+
+    /// <summary>The <c>modify</c> subcommand an operation is reached through, for error text.</summary>
+    private static string CommandNameFor(Operation op) => op switch
+    {
+        Operation.SetProperty => "property",
+        Operation.AddField => "add-field",
+        Operation.AddEnumValue => "add-enum-value",
+        Operation.AddControl => "add-control",
+        Operation.AddIndex => "add-index",
+        Operation.AddRelation => "add-relation",
+        Operation.AddFieldGroup => "add-field-group",
+        Operation.AddDeleteAction => "add-delete-action",
+        Operation.RemoveField => "remove-field",
+        Operation.RemoveIndex => "remove-index",
+        Operation.RemoveRelation => "remove-relation",
+        Operation.RemoveFieldGroup => "remove-field-group",
+        Operation.RemoveDeleteAction => "remove-delete-action",
+        Operation.RenameField => "rename-field",
+        Operation.RemoveEnumValue => "remove-enum-value",
+        Operation.RemoveControl => "remove-control",
+        Operation.AddQueryRange => "add-query-range",
+        Operation.RemoveQueryRange => "remove-query-range",
+        Operation.AddEntryPoint => "add-entry-point",
+        Operation.RemoveEntryPoint => "remove-entry-point",
+        _ => op.ToString(),
+    };
 
     // ------------------------------------------------------------ target planning
 
@@ -478,8 +801,473 @@ public static class ObjectModifyEngine
             Operation.AddField => AddField(doc, request, repo),
             Operation.AddEnumValue => AddEnumValue(doc, request),
             Operation.AddControl => AddControl(doc, request),
+            Operation.AddIndex => AddIndex(doc, request),
+            Operation.AddRelation => AddRelation(doc, request),
+            Operation.AddFieldGroup => AddFieldGroup(doc, request),
+            Operation.AddDeleteAction => AddDeleteAction(doc, request),
+            Operation.RenameField => RenameField(doc, request),
+            Operation.RemoveControl => RemoveControl(doc, request),
+            Operation.AddQueryRange => AddQueryRange(doc, request),
+            Operation.RemoveQueryRange => RemoveQueryRange(doc, request),
+            Operation.AddEntryPoint => AddEntryPoint(doc, request),
+            Operation.RemoveEntryPoint => RemoveEntryPoint(doc, request),
+            _ when Removals.TryGetValue(request.Operation, out var shape) => RemoveMember(doc, request, shape),
             _ => (null, ToolResult<object>.Fail(D365FoErrorCodes.BadInput, $"Unhandled operation {request.Operation}.")),
         };
+
+    /// <summary>
+    /// The container element under the root, created in place if the object does not have one yet.
+    /// </summary>
+    /// <remarks>
+    /// Creating it by appending to the root is only safe because the write path canonicalises
+    /// member order before serialising — see the comment at the write-back step. Without that,
+    /// a collection appended after a later-ordered sibling is dropped on read.
+    /// </remarks>
+    private static XElement EnsureCollection(XElement root, string name)
+    {
+        var existing = root.Elements().FirstOrDefault(e => e.Name.LocalName == name);
+        if (existing is not null) return existing;
+
+        var created = new XElement(root.Name.Namespace + name);
+        root.Add(created);
+        return created;
+    }
+
+    private static bool HasNamed(XElement collection, string key, string value) =>
+        collection.Elements().Any(e => string.Equals(LocalValue(e, key), value, StringComparison.OrdinalIgnoreCase));
+
+    private static (object?, ToolResult<object>?) AddIndex(XDocument doc, ModifyRequest request)
+    {
+        var root = doc.Root!;
+        var ns = root.Name.Namespace;
+        var indexes = EnsureCollection(root, "Indexes");
+
+        if (HasNamed(indexes, "Name", request.Member))
+        {
+            return (null, ToolResult<object>.Fail(D365FoErrorCodes.AlreadyExists,
+                $"Index '{request.Member}' already exists on {request.ObjectName}.",
+                $"Drop it first with `d365fo modify remove-index {request.ObjectName} {request.Member}`."));
+        }
+
+        // Every named field must exist on the table, or the index is one the AOS will refuse
+        // after a build cycle has already been paid for.
+        var declared = root.Elements().FirstOrDefault(e => e.Name.LocalName == "Fields");
+        var known = declared?.Elements()
+            .Select(e => LocalValue(e, "Name"))
+            .Where(n => !string.IsNullOrEmpty(n))
+            .ToHashSet(StringComparer.OrdinalIgnoreCase);
+        if (known is not null && known.Count > 0)
+        {
+            var missing = request.Fields!.Where(f => !known.Contains(f) && !SystemFieldNames.Contains(f)).ToList();
+            if (missing.Count > 0)
+            {
+                return (null, ToolResult<object>.Fail(D365FoErrorCodes.FieldNotFound,
+                    $"{request.ObjectName} has no field named {string.Join(", ", missing.Select(m => $"'{m}'"))}.",
+                    $"See the real field list with `d365fo get table {request.ObjectName}`."));
+            }
+        }
+
+        var index = new XElement(ns + "AxTableIndex",
+            new XElement(ns + "Name", request.Member),
+            request.AlternateKey ? new XElement(ns + "AlternateKey", "Yes") : null,
+            // The serializer's default is AllowDuplicates=Yes, so a unique index has to say so.
+            request.AllowDuplicates ? null : new XElement(ns + "AllowDuplicates", "No"),
+            new XElement(ns + "Fields",
+                request.Fields!.Select(f => new XElement(ns + "AxTableIndexField",
+                    new XElement(ns + "DataField", f)))));
+
+        indexes.Add(index);
+        return (new
+        {
+            index = request.Member,
+            fields = request.Fields,
+            unique = !request.AllowDuplicates,
+            alternateKey = request.AlternateKey,
+        }, null);
+    }
+
+    /// <summary>Fields the kernel puts on every table; they are indexable but never declared.</summary>
+    private static readonly IReadOnlySet<string> SystemFieldNames = new HashSet<string>(StringComparer.OrdinalIgnoreCase)
+    {
+        "RecId", "RecVersion", "DataAreaId", "Partition", "createdBy", "createdDateTime",
+        "modifiedBy", "modifiedDateTime", "createdTransactionId", "modifiedTransactionId",
+    };
+
+    private static (object?, ToolResult<object>?) AddRelation(XDocument doc, ModifyRequest request)
+    {
+        var root = doc.Root!;
+        var ns = root.Name.Namespace;
+        XNamespace xsi = "http://www.w3.org/2001/XMLSchema-instance";
+        var relations = EnsureCollection(root, "Relations");
+
+        if (HasNamed(relations, "Name", request.Member))
+        {
+            return (null, ToolResult<object>.Fail(D365FoErrorCodes.AlreadyExists,
+                $"Relation '{request.Member}' already exists on {request.ObjectName}."));
+        }
+
+        // The constraint's concrete i:type is mandatory: AxTableRelationConstraint is abstract
+        // and the metadata reader throws on it, the same way an untyped AxTableField does.
+        var relatedField = string.IsNullOrWhiteSpace(request.RelatedField) ? request.Member : request.RelatedField!;
+        var relation = new XElement(ns + "AxTableRelation",
+            new XElement(ns + "Name", request.Member),
+            new XElement(ns + "Cardinality", "ZeroMore"),
+            new XElement(ns + "RelatedTable", request.RelatedTable!),
+            new XElement(ns + "RelatedTableCardinality", "ExactlyOne"),
+            new XElement(ns + "RelationshipType", "Association"),
+            new XElement(ns + "Constraints",
+                new XElement(ns + "AxTableRelationConstraint",
+                    new XAttribute(xsi + "type", "AxTableRelationConstraintField"),
+                    new XElement(ns + "Name", request.Member),
+                    new XElement(ns + "Field", request.Member),
+                    new XElement(ns + "RelatedField", relatedField))));
+
+        if (root.Attributes().All(a => a.Value != xsi.NamespaceName))
+            root.SetAttributeValue(XNamespace.Xmlns + "i", xsi.NamespaceName);
+
+        relations.Add(relation);
+        return (new
+        {
+            relation = request.Member,
+            relatedTable = request.RelatedTable,
+            field = request.Member,
+            relatedField,
+        }, null);
+    }
+
+    private static (object?, ToolResult<object>?) AddFieldGroup(XDocument doc, ModifyRequest request)
+    {
+        var root = doc.Root!;
+        var ns = root.Name.Namespace;
+        var groups = EnsureCollection(root, "FieldGroups");
+
+        if (HasNamed(groups, "Name", request.Member))
+        {
+            return (null, ToolResult<object>.Fail(D365FoErrorCodes.AlreadyExists,
+                $"Field group '{request.Member}' already exists on {request.ObjectName}.",
+                "The five Auto* groups and Overview/General are created with every table."));
+        }
+
+        var group = new XElement(ns + "AxTableFieldGroup",
+            new XElement(ns + "Name", request.Member),
+            string.IsNullOrWhiteSpace(request.Label) ? null : new XElement(ns + "Label", request.Label),
+            new XElement(ns + "Fields",
+                request.Fields!.Select(f => new XElement(ns + "AxTableFieldGroupField",
+                    new XElement(ns + "DataField", f)))));
+
+        groups.Add(group);
+        return (new { fieldGroup = request.Member, fields = request.Fields, label = request.Label }, null);
+    }
+
+    private static (object?, ToolResult<object>?) AddDeleteAction(XDocument doc, ModifyRequest request)
+    {
+        var root = doc.Root!;
+        var ns = root.Name.Namespace;
+        var actions = EnsureCollection(root, "DeleteActions");
+
+        // A delete action is identified by the table it points at — two actions for the same
+        // related table is not a richer rule, it is a conflict.
+        if (HasNamed(actions, "RelatedTable", request.RelatedTable!))
+        {
+            return (null, ToolResult<object>.Fail(D365FoErrorCodes.AlreadyExists,
+                $"{request.ObjectName} already has a delete action for '{request.RelatedTable}'.",
+                $"Remove it first with `d365fo modify remove-delete-action {request.ObjectName} {request.RelatedTable}`."));
+        }
+
+        // The contract is `Name, DeleteAction, Relation, Table, Tags` — the related table is
+        // <Table>. Writing <RelatedTable> produced a delete action naming NOTHING: the member
+        // does not exist, so the serializer dropped it while the write reported ok, and what
+        // landed on disk was a Cascade rule with no target. Shipped tables emit an empty
+        // <Relation> alongside, and this matches them.
+        actions.Add(new XElement(ns + "AxTableDeleteAction",
+            new XElement(ns + "Name", request.RelatedTable!),
+            new XElement(ns + "DeleteAction", request.DeleteAction!),
+            new XElement(ns + "Relation", string.Empty),
+            new XElement(ns + "Table", request.RelatedTable!)));
+
+        return (new { deleteAction = request.DeleteAction, relatedTable = request.RelatedTable }, null);
+    }
+
+    private static (object?, ToolResult<object>?) RenameField(XDocument doc, ModifyRequest request)
+    {
+        var root = doc.Root!;
+        var fields = root.Elements().FirstOrDefault(e => e.Name.LocalName == "Fields");
+        var field = fields?.Elements().FirstOrDefault(e =>
+            string.Equals(LocalValue(e, "Name"), request.Member, StringComparison.OrdinalIgnoreCase));
+
+        if (field is null)
+        {
+            return (null, ToolResult<object>.Fail(D365FoErrorCodes.FieldNotFound,
+                $"{request.ObjectName} has no field named '{request.Member}'.",
+                $"See the real field list with `d365fo get table {request.ObjectName}`."));
+        }
+
+        if (fields!.Elements().Any(e =>
+                string.Equals(LocalValue(e, "Name"), request.NewName, StringComparison.OrdinalIgnoreCase)))
+        {
+            return (null, ToolResult<object>.Fail(D365FoErrorCodes.AlreadyExists,
+                $"{request.ObjectName} already has a field named '{request.NewName}'."));
+        }
+
+        field.Elements().First(e => e.Name.LocalName == "Name").SetValue(request.NewName!);
+
+        // Indexes, field groups and relations reference a field BY NAME. Renaming the field and
+        // leaving those behind produces a table that no longer resolves its own index — the AOS
+        // reports it as a missing field, pointing at the index rather than at this edit.
+        var rewritten = new List<string>();
+        foreach (var (collection, item, member) in new[]
+                 {
+                     ("Indexes", "AxTableIndexField", "DataField"),
+                     ("FieldGroups", "AxTableFieldGroupField", "DataField"),
+                 })
+        {
+            var container = root.Elements().FirstOrDefault(e => e.Name.LocalName == collection);
+            if (container is null) continue;
+            foreach (var reference in container.Descendants()
+                         .Where(e => e.Name.LocalName == member)
+                         .Where(e => string.Equals(e.Value, request.Member, StringComparison.OrdinalIgnoreCase)))
+            {
+                reference.SetValue(request.NewName!);
+                rewritten.Add($"{collection}/{item}");
+            }
+        }
+
+        var relations = root.Elements().FirstOrDefault(e => e.Name.LocalName == "Relations");
+        if (relations is not null)
+        {
+            foreach (var reference in relations.Descendants()
+                         .Where(e => e.Name.LocalName == "Field")
+                         .Where(e => string.Equals(e.Value, request.Member, StringComparison.OrdinalIgnoreCase)))
+            {
+                reference.SetValue(request.NewName!);
+                rewritten.Add("Relations/AxTableRelationConstraintField");
+            }
+        }
+
+        return (new
+        {
+            renamedField = request.Member,
+            to = request.NewName,
+            referencesRewritten = rewritten.Distinct().ToArray(),
+            warning = "X++ that names this field by fieldStr()/fieldNum() is NOT rewritten — " +
+                      $"check with `d365fo find refs {request.ObjectName}.{request.Member}` before you build.",
+        }, null);
+    }
+
+    private static (object?, ToolResult<object>?) RemoveControl(XDocument doc, ModifyRequest request)
+    {
+        var root = doc.Root!;
+        var design = root.Elements().FirstOrDefault(e => e.Name.LocalName == "Design") ?? root;
+
+        var control = design.Descendants()
+            .FirstOrDefault(e => e.Name.LocalName.StartsWith("AxFormControl", StringComparison.Ordinal)
+                                 && string.Equals(LocalValue(e, "Name"), request.Member, StringComparison.OrdinalIgnoreCase));
+
+        if (control is null)
+        {
+            return (null, ToolResult<object>.Fail(D365FoErrorCodes.ControlNotFound,
+                $"Control '{request.Member}' was not found on {request.ObjectName}.",
+                $"See the control tree with `d365fo get form {request.ObjectName}`."));
+        }
+
+        // Removing a container takes its children with it — say so, rather than reporting "1".
+        var descendants = control.Descendants()
+            .Count(e => e.Name.LocalName.StartsWith("AxFormControl", StringComparison.Ordinal));
+        control.Remove();
+
+        return (new { removedControl = request.Member, nestedControlsRemoved = descendants }, null);
+    }
+
+    /// <summary>
+    /// The query datasource a range operation targets: the one named, or the only one there is.
+    /// </summary>
+    /// <remarks>
+    /// Most queries have exactly one datasource, and making the caller name it would be asking
+    /// for something the document already determines. With two or more it is genuinely ambiguous,
+    /// so the refusal lists them rather than picking the first — picking would put the range on a
+    /// join the caller never mentioned, and a range on the wrong datasource silently returns the
+    /// wrong rows instead of failing.
+    /// </remarks>
+    private static (XElement? DataSource, ToolResult<object>? Failure) ResolveQueryDataSource(
+        XElement root, ModifyRequest request)
+    {
+        var container = root.Elements().FirstOrDefault(e => e.Name.LocalName == "DataSources");
+        // Shared with the extractor: the AOT writes AxQuerySimpleRootDataSource and
+        // AxQuerySimpleEmbeddedDataSource, not the shorter names the fixtures use.
+        var sources = container?.Elements()
+            .Where(e => MetadataExtractor.IsQueryDataSourceElement(e.Name.LocalName))
+            .ToList() ?? new List<XElement>();
+
+        if (sources.Count == 0)
+        {
+            return (null, ToolResult<object>.Fail(D365FoErrorCodes.MemberNotFound,
+                $"Query '{request.ObjectName}' declares no datasources.",
+                $"Check it with `d365fo get query {request.ObjectName}`."));
+        }
+
+        if (!string.IsNullOrWhiteSpace(request.DataSourceName))
+        {
+            var named = sources.FirstOrDefault(e =>
+                string.Equals(LocalValue(e, "Name"), request.DataSourceName, StringComparison.OrdinalIgnoreCase));
+            if (named is null)
+            {
+                return (null, ToolResult<object>.Fail(D365FoErrorCodes.MemberNotFound,
+                    $"Query '{request.ObjectName}' has no datasource named '{request.DataSourceName}'.",
+                    $"It has: {string.Join(", ", sources.Select(e => LocalValue(e, "Name")))}."));
+            }
+            return (named, null);
+        }
+
+        if (sources.Count > 1)
+        {
+            return (null, ToolResult<object>.Fail(D365FoErrorCodes.BadInput,
+                $"Query '{request.ObjectName}' has {sources.Count} datasources — name the one you mean with --data-source.",
+                $"It has: {string.Join(", ", sources.Select(e => LocalValue(e, "Name")))}."));
+        }
+
+        return (sources[0], null);
+    }
+
+    private static (object?, ToolResult<object>?) AddQueryRange(XDocument doc, ModifyRequest request)
+    {
+        var (dataSource, failure) = ResolveQueryDataSource(doc.Root!, request);
+        if (failure is not null) return (null, failure);
+
+        var ns = doc.Root!.Name.Namespace;
+        var ranges = dataSource!.Elements().FirstOrDefault(e => e.Name.LocalName == "Ranges");
+        if (ranges is null)
+        {
+            ranges = new XElement(ns + "Ranges");
+            dataSource.Add(ranges);
+        }
+
+        if (HasNamed(ranges, "Field", request.Member))
+        {
+            return (null, ToolResult<object>.Fail(D365FoErrorCodes.AlreadyExists,
+                $"Datasource '{LocalValue(dataSource, "Name")}' already ranges on '{request.Member}'.",
+                "A second range on the same field ANDs with the first, which is almost never what is wanted — " +
+                "remove it first, or widen the existing value."));
+        }
+
+        // Name and Field carry the same value in every shipped query: the name is the field.
+        ranges.Add(new XElement(ns + "AxQuerySimpleDataSourceRange",
+            new XElement(ns + "Name", request.Member),
+            new XElement(ns + "Field", request.Member),
+            // An empty <Value> is legal and idiomatic — it is the shape a range gets when the
+            // value is supplied at run time via QueryBuildRange.value().
+            new XElement(ns + "Value", request.RangeValue ?? "")));
+
+        return (new
+        {
+            range = request.Member,
+            dataSource = LocalValue(dataSource, "Name"),
+            value = request.RangeValue ?? "",
+            note = string.IsNullOrWhiteSpace(request.RangeValue)
+                ? "Empty value — set it at run time with QueryBuildRange.value()."
+                : null,
+        }, null);
+    }
+
+    private static (object?, ToolResult<object>?) RemoveQueryRange(XDocument doc, ModifyRequest request)
+    {
+        var (dataSource, failure) = ResolveQueryDataSource(doc.Root!, request);
+        if (failure is not null) return (null, failure);
+
+        var ranges = dataSource!.Elements().FirstOrDefault(e => e.Name.LocalName == "Ranges");
+        var range = ranges?.Elements().FirstOrDefault(e =>
+            string.Equals(LocalValue(e, "Field"), request.Member, StringComparison.OrdinalIgnoreCase));
+
+        if (range is null)
+        {
+            return (null, ToolResult<object>.Fail(D365FoErrorCodes.MemberNotFound,
+                $"Datasource '{LocalValue(dataSource, "Name")}' has no range on '{request.Member}'.",
+                "Nothing was changed."));
+        }
+
+        var wasValue = LocalValue(range, "Value");
+        range.Remove();
+        return (new { removedRange = request.Member, dataSource = LocalValue(dataSource, "Name"), wasValue }, null);
+    }
+
+    private static (object?, ToolResult<object>?) AddEntryPoint(XDocument doc, ModifyRequest request)
+    {
+        var root = doc.Root!;
+        var ns = root.Name.Namespace;
+        var entryPoints = EnsureCollection(root, "EntryPoints");
+
+        if (HasNamed(entryPoints, "Name", request.Member))
+        {
+            return (null, ToolResult<object>.Fail(D365FoErrorCodes.AlreadyExists,
+                $"Privilege '{request.ObjectName}' already grants '{request.Member}'.",
+                "Remove it and add it back to change the access level."));
+        }
+
+        // Contract order for AxSecurityEntryPointReference is Name, Grant, …, ObjectName,
+        // ObjectType. Access is six independent permissions, never an <AccessLevel> element —
+        // writing one produces a privilege that grants nothing and reads as deliberate.
+        entryPoints.Add(new XElement(ns + "AxSecurityEntryPointReference",
+            new XElement(ns + "Name", request.Member),
+            XppScaffolder.SecurityGrant(request.Access),
+            new XElement(ns + "ObjectName", request.Member),
+            new XElement(ns + "ObjectType", request.EntryPointType!)));
+
+        return (new
+        {
+            entryPoint = request.Member,
+            objectType = request.EntryPointType,
+            access = request.Access ?? "Read",
+        }, null);
+    }
+
+    private static (object?, ToolResult<object>?) RemoveEntryPoint(XDocument doc, ModifyRequest request)
+    {
+        var entryPoints = doc.Root!.Elements().FirstOrDefault(e => e.Name.LocalName == "EntryPoints");
+        var entryPoint = entryPoints?.Elements().FirstOrDefault(e =>
+            string.Equals(LocalValue(e, "Name"), request.Member, StringComparison.OrdinalIgnoreCase)
+            || string.Equals(LocalValue(e, "ObjectName"), request.Member, StringComparison.OrdinalIgnoreCase));
+
+        if (entryPoint is null)
+        {
+            return (null, ToolResult<object>.Fail(D365FoErrorCodes.MemberNotFound,
+                $"Privilege '{request.ObjectName}' does not grant '{request.Member}'.",
+                $"See what it grants with `d365fo get privilege {request.ObjectName}`."));
+        }
+
+        var objectType = LocalValue(entryPoint, "ObjectType");
+        entryPoint.Remove();
+        return (new { removedEntryPoint = request.Member, objectType }, null);
+    }
+
+    private static (object?, ToolResult<object>?) RemoveMember(XDocument doc, ModifyRequest request, RemovalShape shape)
+    {
+        var root = doc.Root!;
+        var collection = root.Elements().FirstOrDefault(e => e.Name.LocalName == shape.Collection);
+
+        // A delete action is addressed by the table it governs, everything else by its own name.
+        var wanted = shape.Key == "Table" ? request.RelatedTable ?? request.Member : request.Member;
+
+        var member = collection?.Elements()
+            .FirstOrDefault(e => string.Equals(LocalValue(e, shape.Key), wanted, StringComparison.OrdinalIgnoreCase));
+
+        if (member is null)
+        {
+            return (null, ToolResult<object>.Fail(D365FoErrorCodes.MemberNotFound,
+                $"{shape.Noun} '{wanted}' was not found on {request.ObjectName}.",
+                $"Nothing was changed. Check the current members with `d365fo get {request.Kind} {request.ObjectName}`."));
+        }
+
+        var removed = member.ToString(SaveOptions.DisableFormatting);
+        member.Remove();
+
+        return (new
+        {
+            removed = wanted,
+            of = shape.Noun,
+            // The pre-image is in the journal, but printing it here is what lets a caller see
+            // what it just gave up without going and reading the journal back.
+            wasXml = removed.Length <= 2000 ? removed : removed[..2000] + "…",
+        }, null);
+    }
 
     private static (object?, ToolResult<object>?) SetProperty(XDocument doc, ModifyRequest request)
     {

--- a/src/D365FO.Core/D365FO.Core.csproj
+++ b/src/D365FO.Core/D365FO.Core.csproj
@@ -42,7 +42,7 @@
 
   <ItemGroup>
     <PackageReference Include="Dapper" Version="2.1.35" />
-    <PackageReference Include="Microsoft.Data.Sqlite" Version="8.0.10" />
+    <PackageReference Include="Microsoft.Data.Sqlite" Version="10.0.11" />
     <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="8.0.2" />
   </ItemGroup>
 

--- a/src/D365FO.Core/D365FoErrorCodes.cs
+++ b/src/D365FO.Core/D365FoErrorCodes.cs
@@ -80,5 +80,12 @@ public static class D365FoErrorCodes
     public const string FieldNotFound = "FIELD_NOT_FOUND";
     public const string ControlNotFound = "CONTROL_NOT_FOUND";
     public const string PropertyNotFound = "PROPERTY_NOT_FOUND";
+
+    /// <summary>
+    /// A named member of a collection an object owns — index, relation, field group, delete
+    /// action, enum value — is not there. Distinct from the per-kind codes above because the
+    /// removal operations share one implementation and the collection is a parameter to it.
+    /// </summary>
+    public const string MemberNotFound = "MEMBER_NOT_FOUND";
     public const string AlreadyExists = "ALREADY_EXISTS";
 }

--- a/src/D365FO.Core/Extract/MetadataExtractor.cs
+++ b/src/D365FO.Core/Extract/MetadataExtractor.cs
@@ -454,7 +454,14 @@ public sealed class MetadataExtractor
         {
             foreach (var de in daContainer.Elements().Where(x => x.Name.LocalName.StartsWith("AxTableDeleteAction", StringComparison.Ordinal)))
             {
-                var related = Local(de, "RelatedTable");
+                // The member is <Table>. AxTableDeleteAction declares
+                // `Name, DeleteAction, Relation, Table, Tags` — there is no RelatedTable, so
+                // looking for one skipped EVERY delete action: measured against this repo's own
+                // installation, the index held 0 rows across 214 packages while shipped tables
+                // plainly declare them, and `get table` answered `deleteActions: []` for all of
+                // them. `RelatedTable` is still accepted, for documents written by the tool
+                // before this was understood.
+                var related = Local(de, "Table") ?? Local(de, "RelatedTable");
                 if (string.IsNullOrEmpty(related)) continue;
                 deleteActions.Add(new ExtractedTableDeleteAction(
                     Local(de, "Name"),
@@ -932,18 +939,54 @@ public sealed class MetadataExtractor
         }
     }
 
+    /// <summary>
+    /// The declaration line of a method body, skipping everything that can legally precede it.
+    /// </summary>
+    /// <remarks>
+    /// Three kinds of thing sit between the start of a method's source and its declaration:
+    /// blank lines, attribute blocks, and COMMENTS. Only the first two were skipped, so any
+    /// method carrying an XML doc comment reported <c>/// &lt;summary&gt;</c> as its signature —
+    /// 362 of the 621 methods on <c>SalesTable</c>, and the same for a plain <c>//</c> or a
+    /// <c>/* … */</c> banner. That is worse than an empty signature: <c>prepare change</c> and
+    /// <c>get table</c> present it as the exact declaration a CoC wrapper has to match, which is
+    /// the one thing a green build cannot correct.
+    /// </remarks>
     private static string ExtractSignatureLine(string source)
     {
-        // Find the first non-empty, non-attribute line — that's the actual
-        // method signature. Attribute lines start with '[' and may span
+        // Find the first non-empty, non-attribute, non-comment line — that's the
+        // actual method signature. Attribute lines start with '[' and may span
         // multiple lines (e.g. [FormEventHandler(\n    formStr(X),\n ...)]).
         using var reader = new StringReader(source);
         int attrDepth = 0;
+        bool inBlockComment = false;
         string? line;
         while ((line = reader.ReadLine()) is not null)
         {
             var t = line.TrimStart();
+
+            // A /* … */ banner opened on an earlier line runs until it closes; the
+            // declaration may follow on the very line that closes it.
+            if (inBlockComment)
+            {
+                var close = t.IndexOf("*/", StringComparison.Ordinal);
+                if (close < 0) continue;
+                inBlockComment = false;
+                t = t[(close + 2)..].TrimStart();
+            }
+
             if (t.Length == 0) continue;
+
+            // `///` doc comments and `//` line comments precede a declaration, they are never it.
+            if (t.StartsWith("//", StringComparison.Ordinal)) continue;
+
+            if (t.StartsWith("/*", StringComparison.Ordinal))
+            {
+                var close = t.IndexOf("*/", StringComparison.Ordinal);
+                if (close < 0) { inBlockComment = true; continue; }
+                t = t[(close + 2)..].TrimStart();
+                if (t.Length == 0) continue;
+            }
+
             if (attrDepth > 0)
             {
                 foreach (var ch in t) { if (ch == '[') attrDepth++; else if (ch == ']') attrDepth--; }
@@ -1293,12 +1336,27 @@ public sealed class MetadataExtractor
         return new ExtractedQuery(name, file, ds);
     }
 
+    /// <summary>Is this element, directly under a <c>&lt;DataSources&gt;</c>, a datasource?</summary>
+    /// <remarks>
+    /// The names the AOT actually writes are <c>AxQuerySimpleRootDataSource</c> and
+    /// <c>AxQuerySimpleEmbeddedDataSource</c>. The code looked for <c>AxQuerySimpleDataSource</c>
+    /// and <c>AxQueryDataSource</c>, neither of which occurs in a shipped query — so the index
+    /// held <b>4 896 queries and zero datasources</b>, and `get query` answered "no datasources"
+    /// for every query in the installation. The sample fixtures use the shorter name, which is
+    /// why nothing in the suite noticed; it is still accepted here.
+    ///
+    /// Matching on the suffix rather than a prefix also keeps <c>AxQuerySimpleDataSourceField</c>,
+    /// <c>…Range</c> and <c>…Relation</c> out, which a prefix match would have swept in.
+    /// </remarks>
+    internal static bool IsQueryDataSourceElement(string localName) =>
+        localName.StartsWith("AxQuery", StringComparison.Ordinal)
+        && localName.EndsWith("DataSource", StringComparison.Ordinal);
+
     private static void CollectQueryDataSources(XElement parentEl, string? parent, List<ExtractedQueryDataSource> acc)
     {
         var container = parentEl.Elements().FirstOrDefault(x => x.Name.LocalName == "DataSources");
         if (container is null) return;
-        foreach (var ds in container.Elements().Where(x => x.Name.LocalName.StartsWith("AxQuerySimpleDataSource", StringComparison.Ordinal)
-                                                        || x.Name.LocalName.StartsWith("AxQueryDataSource", StringComparison.Ordinal)))
+        foreach (var ds in container.Elements().Where(x => IsQueryDataSourceElement(x.Name.LocalName)))
         {
             var dsName = Local(ds, "Name");
             if (string.IsNullOrEmpty(dsName)) continue;

--- a/src/D365FO.Core/Index/TableMergeAnalyzer.cs
+++ b/src/D365FO.Core/Index/TableMergeAnalyzer.cs
@@ -1,0 +1,150 @@
+// <copyright file="TableMergeAnalyzer.cs" company="d365fo-cli contributors">
+// MIT
+// </copyright>
+
+using System.Xml.Linq;
+
+namespace D365FO.Core.Index;
+
+/// <summary>One member of a merged table, and where it came from.</summary>
+/// <param name="Name">Member name as the AOT spells it.</param>
+/// <param name="Origin">The base table, or the extension that contributes it.</param>
+/// <param name="Model">Model the contributor belongs to.</param>
+/// <param name="Detail">Type, key fields, or related table — whatever identifies the member.</param>
+public sealed record MergedMember(string Name, string Origin, string? Model, string? Detail);
+
+/// <summary>The effective shape of a table once every extension of it is folded in.</summary>
+public sealed record MergedTableSchema(
+    string Table,
+    string? BaseModel,
+    IReadOnlyList<string> Extensions,
+    IReadOnlyList<MergedMember> Fields,
+    IReadOnlyList<MergedMember> Indexes,
+    IReadOnlyList<MergedMember> Relations,
+    IReadOnlyList<MergedMember> FieldGroups,
+    IReadOnlyList<string> Unreadable);
+
+/// <summary>
+/// Folds a table's extensions onto the base table to produce the shape the AOS actually sees.
+/// </summary>
+/// <remarks>
+/// <para>
+/// The index answers "what extends CustTable" — a roster of extension names. It does not answer
+/// the question a developer is really asking, which is "what fields does CustTable HAVE here",
+/// and the two differ by exactly the customisations that matter. Before this, the roster was
+/// returned under a contract that promised a merged schema; a caller who trusted it read the
+/// absence of a field as the field not existing.
+/// </para>
+/// <para>
+/// Extensions are read from their own XML rather than from the index, because the index stores
+/// an extension as a row about the relationship, not as a member list. An extension whose file
+/// cannot be read is REPORTED in <see cref="MergedTableSchema.Unreadable"/> rather than skipped:
+/// a merged schema missing a contributor is worse than no merged schema at all, and the caller
+/// has to be able to tell the two apart.
+/// </para>
+/// </remarks>
+public static class TableMergeAnalyzer
+{
+    public static MergedTableSchema Merge(MetadataRepository repo, string tableName)
+    {
+        ArgumentNullException.ThrowIfNull(repo);
+        ArgumentException.ThrowIfNullOrWhiteSpace(tableName);
+
+        var details = repo.GetTableDetails(tableName);
+        var baseModel = details?.Table.Model;
+        var table = details?.Table.Name ?? tableName;
+
+        var fields = new List<MergedMember>();
+        var indexes = new List<MergedMember>();
+        var relations = new List<MergedMember>();
+        var fieldGroups = new List<MergedMember>();
+        var unreadable = new List<string>();
+
+        if (details is not null)
+        {
+            foreach (var f in details.Fields)
+                fields.Add(new MergedMember(f.Name, table, baseModel, f.EdtName ?? f.Type));
+            foreach (var i in details.Indexes)
+                indexes.Add(new MergedMember(i.Name, table, baseModel, i.FieldsCsv));
+            foreach (var r in details.Relations)
+                relations.Add(new MergedMember(r.RelationName ?? r.ToTable, table, baseModel, r.ToTable));
+        }
+
+        var extensions = repo.FindExtensions(table, "Table");
+        foreach (var extension in extensions)
+        {
+            if (string.IsNullOrWhiteSpace(extension.SourcePath) || !File.Exists(extension.SourcePath))
+            {
+                unreadable.Add($"{extension.ExtensionName} ({extension.Model}): source file not on disk");
+                continue;
+            }
+
+            XDocument doc;
+            try
+            {
+                doc = XDocument.Load(extension.SourcePath!);
+            }
+            catch (Exception ex)
+            {
+                unreadable.Add($"{extension.ExtensionName} ({extension.Model}): {ex.GetType().Name}");
+                continue;
+            }
+
+            var root = doc.Root;
+            if (root is null)
+            {
+                unreadable.Add($"{extension.ExtensionName} ({extension.Model}): empty document");
+                continue;
+            }
+
+            Collect(root, "Fields", "AxTableField", "ExtendedDataType", extension, fields, "EnumType");
+            Collect(root, "Indexes", "AxTableIndex", null, extension, indexes);
+            Collect(root, "Relations", "AxTableRelation", "RelatedTable", extension, relations);
+            Collect(root, "FieldGroups", "AxTableFieldGroup", null, extension, fieldGroups);
+        }
+
+        return new MergedTableSchema(
+            table,
+            baseModel,
+            extensions.Select(e => e.ExtensionName).ToList(),
+            fields, indexes, relations, fieldGroups,
+            unreadable);
+    }
+
+    /// <summary>
+    /// Append one collection's members from an extension document.
+    /// </summary>
+    /// <remarks>
+    /// A member an extension redeclares is recorded a SECOND time rather than replacing the
+    /// first. Two contributors naming the same field is a real conflict the AOS resolves by
+    /// layer, and collapsing it here would hide the thing most worth seeing.
+    /// </remarks>
+    private static void Collect(
+        XElement root,
+        string collection,
+        string itemPrefix,
+        string? detailElement,
+        ObjectExtensionInfo extension,
+        List<MergedMember> into,
+        string? fallbackDetailElement = null)
+    {
+        var container = root.Elements().FirstOrDefault(e => e.Name.LocalName == collection);
+        if (container is null) return;
+
+        foreach (var item in container.Elements()
+                     .Where(e => e.Name.LocalName.StartsWith(itemPrefix, StringComparison.Ordinal)))
+        {
+            var name = Value(item, "Name");
+            if (string.IsNullOrEmpty(name)) continue;
+
+            var detail = detailElement is null ? null : Value(item, detailElement);
+            if (string.IsNullOrEmpty(detail) && fallbackDetailElement is not null)
+                detail = Value(item, fallbackDetailElement);
+
+            into.Add(new MergedMember(name!, extension.ExtensionName, extension.Model, detail));
+        }
+    }
+
+    private static string? Value(XElement parent, string localName) =>
+        parent.Elements().FirstOrDefault(e => e.Name.LocalName == localName)?.Value;
+}

--- a/src/D365FO.Core/Knowledge/TableDataMethods.cs
+++ b/src/D365FO.Core/Knowledge/TableDataMethods.cs
@@ -104,6 +104,35 @@ public static class TableDataMethods
         => Catalog.TryGetValue(methodName.Trim(), out var m) ? m : null;
 
     /// <summary>
+    /// Every inherited data method, in the order a test author meets them: the three validation
+    /// gates first (the ones a rule is written into), then the write path, then the seeding and
+    /// field-level hooks. <c>prepare test</c> lists these for a table because the index cannot —
+    /// it stores declared members only, so a table that has never overridden <c>validateWrite</c>
+    /// has no row for it, and that is exactly the method the caller wants to pin down.
+    /// </summary>
+    public static IReadOnlyList<TableDataMethod> All { get; } =
+    [
+        Catalog["validateWrite"], Catalog["validateField"], Catalog["validateDelete"],
+        Catalog["insert"], Catalog["update"], Catalog["delete"],
+        Catalog["initValue"], Catalog["modifiedField"],
+    ];
+
+    /// <summary>
+    /// Does this method write to the database? A test for one needs a transaction and a re-read;
+    /// a test for a validation gate only needs the buffer and the verdict.
+    /// </summary>
+    public static bool IsWritePath(string methodName)
+        => methodName.Trim().ToLowerInvariant() is "insert" or "update" or "delete";
+
+    /// <summary>
+    /// Does this method report its verdict as a boolean the caller must assert on? Those are the
+    /// gates — and a test that asserts only the rejecting case passes even when the rule refuses
+    /// every row, which is why <c>prepare test</c> insists on the accepting case beside it.
+    /// </summary>
+    public static bool IsVerdictMethod(string methodName)
+        => methodName.Trim().ToLowerInvariant() is "validatewrite" or "validatefield" or "validatedelete";
+
+    /// <summary>
     /// True for the object types this fallback speaks for. Tables only, deliberately — a
     /// fallback that guessed for views/maps/entities would be inventing a signature, which is
     /// the failure it exists to prevent.

--- a/src/D365FO.Mcp/ToolCatalog.cs
+++ b/src/D365FO.Mcp/ToolCatalog.cs
@@ -232,7 +232,9 @@ public static class ToolCatalog
             "D365FO extensibility analyzer. Pick a `mode`: " +
             "coc (Chain-of-Command extensions for `target` class, optionally scoped to `method`) · " +
             "events (DataEventHandler / SubscribesTo handlers bound to `target`; set `objectType` to its kind) · " +
-            "table-merge (all TableExtensions targeting `target` table + effective merged schema) · " +
+            "table-merge (all TableExtensions targeting `target` table + the effective merged schema: base fields, " +
+            "indexes, relations and field groups with every extension folded in, each member labelled with the " +
+            "object that contributes it; reports any extension whose file could not be read rather than dropping it) · " +
             "points (Table/Form/Enum/EDT _Extension objects targeting `target`; filter with `kind`) · " +
             "strategy (enumerate existing extensions/handlers/CoC on `target` and recommend the least-invasive change). " +
             "Use before writing any extension to check for conflicts and pick the right mechanism. " +

--- a/src/D365FO.Mcp/ToolHandlers.cs
+++ b/src/D365FO.Mcp/ToolHandlers.cs
@@ -2,6 +2,7 @@ using D365FO.Core;
 using D365FO.Core.Extract;
 using D365FO.Core.Guardrails;
 using D365FO.Core.Index;
+using D365FO.Core.Knowledge;
 using System.IO;
 
 namespace D365FO.Mcp;
@@ -417,15 +418,44 @@ public sealed class ToolHandlers
         });
     }
 
+    /// <summary>
+    /// Every TableExtension targeting <paramref name="table"/>, plus the effective merged schema.
+    /// </summary>
+    /// <remarks>
+    /// The roster alone was returned under a contract promising a merge, which is worse than
+    /// returning a roster honestly: a caller that trusts it reads the absence of a field as the
+    /// field not existing. <see cref="TableMergeAnalyzer"/> now folds each extension's own XML
+    /// onto the base table, and an extension whose file cannot be read is reported rather than
+    /// silently dropped.
+    /// </remarks>
     public ToolResult<object> GetTableExtensionInfo(string table)
     {
         var items = _repo.FindExtensions(table, "Table");
+        var merged = TableMergeAnalyzer.Merge(_repo, table);
+
+        var warnings = merged.Unreadable.Count > 0
+            ? new List<string>
+            {
+                $"{merged.Unreadable.Count} extension(s) could not be read, so the merged schema is INCOMPLETE: "
+                + string.Join("; ", merged.Unreadable),
+            }
+            : null;
+
         return ToolResult<object>.Success(new
         {
-            target = table,
+            target = merged.Table,
+            baseModel = merged.BaseModel,
             count = items.Count,
             extensions = items,
-        });
+            merged = new
+            {
+                fields = merged.Fields,
+                indexes = merged.Indexes,
+                relations = merged.Relations,
+                fieldGroups = merged.FieldGroups,
+                complete = merged.Unreadable.Count == 0,
+            },
+        }, warnings);
     }
 
     public ToolResult<object> AnalyzeExtensionPoints(string target)
@@ -2042,23 +2072,70 @@ public sealed class ToolHandlers
     public ToolResult<object> PrepareTest(string objectName, string? goal, string? methodName, string? modelName)
     {
         if (string.IsNullOrWhiteSpace(objectName))
-            return ToolResult<object>.Fail("BAD_INPUT", "Object name (the class under test) required.");
+            return ToolResult<object>.Fail("BAD_INPUT", "Object name (the class or table under test) required.");
 
-        var target = objectName.Trim();
+        // `CustTable.validateWrite` is how a developer names a table CoC target, and it was the
+        // single most-asked shape across real runs. Split it before resolution, and let an
+        // explicit --method win over the dotted half so the two spellings cannot disagree.
+        var raw = objectName.Trim();
+        var focus = methodName?.Trim();
+        var target = raw;
+        if (raw.Contains('.'))
+        {
+            var cut = raw.LastIndexOf('.');
+            var head = raw[..cut].Trim();
+            var tail = raw[(cut + 1)..].Trim();
+            if (head.Length > 0 && tail.Length > 0)
+            {
+                target = head;
+                focus ??= tail;
+            }
+        }
+
         var testClass = $"{target}Test";
         var details = _repo.GetClassDetails(target);
+
+        // Resolve the kind. Class first (the original contract), table second — a table only wins
+        // when nothing of that name is a class, so an installation holding both keeps the old answer.
+        TableDetails? tableDetails = details is null ? _repo.GetTableDetails(target) : null;
+        var isTable = details is null && tableDetails is not null;
+        var targetKind = isTable ? "table" : "class";
 
         // Lifecycle and serialisation members are not what a unit test pins down.
         var skip = new HashSet<string>(StringComparer.OrdinalIgnoreCase)
             { "new", "finalize", "typenew", "pack", "unpack", "classdeclaration" };
-        var focus = methodName?.Trim();
-        var methods = details?.Methods ?? Array.Empty<MethodInfo>();
-        var suggested = methods
-            .Where(m => !skip.Contains(m.Name))
-            .Where(m => focus is null || string.Equals(m.Name, focus, StringComparison.OrdinalIgnoreCase))
-            .Take(8)
-            .Select(m => new { m.Name, m.Signature })
-            .ToList();
+
+        List<SuggestedTestMethod> suggested;
+        if (isTable)
+        {
+            // The index stores DECLARED members only, so a table that has never overridden
+            // validateWrite has no row for it — and that is the method the caller came for.
+            // Declared overrides first (they carry the table's own signature), then the kernel
+            // data methods it inherits and could still wrap.
+            var declared = (tableDetails!.Methods ?? Array.Empty<TableMethodInfo>())
+                .Where(m => !skip.Contains(m.Name))
+                .Select(m => new SuggestedTestMethod(m.Name, m.Signature, "declared on the table"))
+                .ToList();
+            var declaredNames = new HashSet<string>(declared.Select(m => m.Name), StringComparer.OrdinalIgnoreCase);
+            var inherited = TableDataMethods.All
+                .Where(m => !declaredNames.Contains(m.Name))
+                .Select(m => new SuggestedTestMethod(m.Name, m.Signature, $"inherited from {m.DeclaredOn} — no AOT row, wrap with CoC"))
+                .ToList();
+
+            suggested = declared.Concat(inherited)
+                .Where(m => focus is null || string.Equals(m.Name, focus, StringComparison.OrdinalIgnoreCase))
+                .Take(8)
+                .ToList();
+        }
+        else
+        {
+            suggested = (details?.Methods ?? Array.Empty<MethodInfo>())
+                .Where(m => !skip.Contains(m.Name))
+                .Where(m => focus is null || string.Equals(m.Name, focus, StringComparison.OrdinalIgnoreCase))
+                .Take(8)
+                .Select(m => new SuggestedTestMethod(m.Name, m.Signature, null))
+                .ToList();
+        }
 
         // Classes that look like tests and mention the target — the coverage that exists.
         var existingTests = new List<string>();
@@ -2077,22 +2154,26 @@ public sealed class ToolHandlers
 
         var testEssentials = TestEssentialsReferenced(modelName);
 
-        var scaffold = $"d365fo generate systest {testClass} --class {target}"
+        var scaffold = $"d365fo generate systest {testClass} --{targetKind} {target}"
             + string.Join("", suggested.Select(m => $" --method {m.Name}"))
             + " --install-to <Model>";
 
         var token = ProvenanceStore.CreateToken(new ProvenanceContext(
-            goal ?? $"unit tests for {target}", target, focus, "class", testClass));
+            goal ?? $"unit tests for {target}", target, focus, targetKind, testClass));
+
+        var resolved = details is not null || tableDetails is not null;
 
         return ToolResult<object>.Success(new
         {
             target,
+            targetKind,
             testClass = $"{testClass} extends SysTestCase (the platform's own convention: <Target>Test)",
-            targetIndexed = details is not null,
-            targetHint = details is null
-                ? $"\"{target}\" is not in the index as a class — check the name (`d365fo search any {target}`), or re-extract if it was written outside this session. The rest of this answer is generic."
-                : null,
+            targetIndexed = resolved,
+            targetHint = resolved
+                ? null
+                : $"\"{target}\" is in the index as neither a class nor a table — check the name (`d365fo search any {target}`), or re-extract if it was written outside this session. The rest of this answer is generic.",
             methodsWorthTesting = suggested,
+            tableTestShape = isTable ? TableTestShape(target, focus) : null,
             scaffoldCall = scaffold,
             existingTests = existingTests.Count > 0 ? existingTests : null,
             existingTestsVerdict = existingTests.Count > 0
@@ -2123,6 +2204,62 @@ public sealed class ToolHandlers
                 "cleanup and there is no rollback attribute to add.",
             groundingToken = token,
         });
+    }
+
+    /// <summary>One method <c>prepare test</c> puts forward, with why it is on the list.</summary>
+    /// <param name="Name">Method name as the scaffold call spells it.</param>
+    /// <param name="Signature">The declaration, when one is known.</param>
+    /// <param name="Origin">Declared on the object, or inherited from a kernel type. Null for classes.</param>
+    private sealed record SuggestedTestMethod(string Name, string? Signature, string? Origin);
+
+    /// <summary>
+    /// What a test for a TABLE method has to do that a test for a class method does not. A table
+    /// rule is exercised through a record buffer, and the two mistakes it invites are structural:
+    /// asserting only the rejecting case (a rule that refuses every row then passes its own test),
+    /// and asserting only the boolean while the message the rule writes goes unchecked.
+    /// </summary>
+    private static object TableTestShape(string table, string? focus)
+    {
+        var method = focus ?? "validateWrite";
+        var isVerdict = TableDataMethods.IsVerdictMethod(method);
+        var isWrite = TableDataMethods.IsWritePath(method);
+
+        var steps = new List<string>
+        {
+            $"Arrange a buffer, do not select one: `{table} rec; rec.initValue();` then set exactly the fields the rule reads. " +
+            "A row fetched from the database drags in whatever demo data the box happens to hold.",
+        };
+
+        if (isVerdict)
+        {
+            steps.Add($"Act on the buffer and keep the verdict: `boolean verdict = rec.{method}();`");
+            steps.Add("Assert the verdict AND the message: SysTestAssert::assertFalse(verdict) alone passes even when the " +
+                      "rule refuses every row. Pin the infolog line the rule writes with " +
+                      "`this.assertExpectedInfoLogMessage(\"@MyModel:MyLabel\")` after the act.");
+            steps.Add("Add the ACCEPTING case beside the rejecting one — same arrangement, a value the rule must let through, " +
+                      "assertTrue. Without it the test cannot tell a working rule from one that refuses everything.");
+        }
+        else if (isWrite)
+        {
+            steps.Add($"Act inside a transaction: `ttsbegin; rec.{method}(); ttscommit;` — the write path is what is under test, " +
+                      "so it has to actually run.");
+            steps.Add($"Assert against a RE-READ, not against the buffer you wrote: `{table} stored = {table}::find(rec.RecId);` " +
+                      "then assert on `stored`. The in-memory buffer still holds what you set, so asserting on it proves nothing.");
+        }
+        else
+        {
+            steps.Add($"Act on the buffer: `rec.{method}(…);` then assert on the fields the method is supposed to have derived.");
+        }
+
+        return new
+        {
+            method,
+            steps,
+            rollback = "Every SysTest method runs in its own transaction and is rolled back, so records created here need no " +
+                       "cleanup and there is no rollback attribute to add.",
+            company = "A table with SaveDataPerCompany needs a company: pass one with [SysTestCaseDataDependency('<Company>')] " +
+                      "(`d365fo generate systest … --data-area-id <Company>`) rather than switching company inside the method.",
+        };
     }
 
     /// <summary>Does the model that will hold the test reference TestEssentials? Null when unknowable here.</summary>

--- a/tests/D365FO.Cli.Tests/CommandSurfaceTests.cs
+++ b/tests/D365FO.Cli.Tests/CommandSurfaceTests.cs
@@ -1,0 +1,64 @@
+using System.Reflection;
+using D365FO.Cli;
+using Spectre.Console.Cli;
+using Xunit;
+
+namespace D365FO.Cli.Tests;
+
+/// <summary>
+/// Every command the app registers must be one Spectre can actually construct.
+/// </summary>
+/// <remarks>
+/// Spectre.Console.Cli resolves a command's <c>TSettings</c> by reflection at RUN time, so an
+/// abstract settings type compiles, registers, and shows up in <c>--help</c> — then fails on
+/// invocation with "Could not resolve type '…Settings'". That is exactly what shipped for all
+/// seven <c>modify remove-*</c> commands: the engine tests passed, because they call the engine
+/// rather than the command, and the defect only appeared when the commands were run for real.
+///
+/// This walks the registered command types instead of waiting for a live run.
+/// </remarks>
+public class CommandSurfaceTests
+{
+    /// <summary>The <c>TSettings</c> of every <c>Command&lt;T&gt;</c> in the CLI assembly.</summary>
+    public static TheoryData<Type, Type> CommandsWithSettings()
+    {
+        var data = new TheoryData<Type, Type>();
+        foreach (var type in typeof(CliApp).Assembly.GetTypes())
+        {
+            if (type.IsAbstract || !type.IsClass) continue;
+
+            for (var baseType = type.BaseType; baseType is not null; baseType = baseType.BaseType)
+            {
+                if (!baseType.IsGenericType) continue;
+                var definition = baseType.GetGenericTypeDefinition();
+                if (definition != typeof(Command<>) && definition != typeof(AsyncCommand<>)) continue;
+
+                data.Add(type, baseType.GetGenericArguments()[0]);
+                break;
+            }
+        }
+        return data;
+    }
+
+    [Theory]
+    [MemberData(nameof(CommandsWithSettings))]
+    public void Every_commands_settings_type_can_be_constructed(Type command, Type settings)
+    {
+        Assert.False(settings.IsAbstract,
+            $"{command.Name} uses {settings.Name} as its settings type, but it is abstract — " +
+            "Spectre constructs settings by reflection, so this fails at run time with " +
+            "\"Could not resolve type\" while compiling and appearing in --help perfectly happily.");
+
+        Assert.NotNull(settings.GetConstructor(Type.EmptyTypes));
+        Assert.NotNull(Activator.CreateInstance(settings));
+    }
+
+    [Fact]
+    public void The_app_builds_without_a_duplicate_or_unresolvable_registration()
+    {
+        // Configure() runs the whole registration tree, which is where a duplicate command name
+        // or an unconstructable branch would throw.
+        var app = CliApp.Build();
+        Assert.NotNull(app);
+    }
+}

--- a/tests/D365FO.Cli.Tests/D365FO.Cli.Tests.csproj
+++ b/tests/D365FO.Cli.Tests/D365FO.Cli.Tests.csproj
@@ -18,6 +18,12 @@
     <Using Include="Xunit" />
   </ItemGroup>
 
+  <!-- Redirects D365FO_INDEX_DB (and the journal beside it) into a per-run temp directory so
+       the suite cannot write into the real index of the machine it runs on. See the file. -->
+  <ItemGroup>
+    <Compile Include="..\Shared\TestIndexIsolation.cs" Link="TestIndexIsolation.cs" />
+  </ItemGroup>
+
   <ItemGroup>
     <ProjectReference Include="..\..\src\D365FO.Cli\D365FO.Cli.csproj" />
     <ProjectReference Include="..\..\src\D365FO.Core\D365FO.Core.csproj" />

--- a/tests/D365FO.Core.Tests/CatalogCrossCheckTests.cs
+++ b/tests/D365FO.Core.Tests/CatalogCrossCheckTests.cs
@@ -24,7 +24,7 @@ public sealed class CatalogCrossCheckTests : IDisposable
 
     public void Dispose()
     {
-        Microsoft.Data.Sqlite.SqliteConnection.ClearAllPools();
+        SqlitePool.ReleaseFor(_dbPath);
         foreach (var ext in new[] { "", "-wal", "-shm" })
         {
             var p = _dbPath + ext;

--- a/tests/D365FO.Core.Tests/D365FO.Core.Tests.csproj
+++ b/tests/D365FO.Core.Tests/D365FO.Core.Tests.csproj
@@ -9,7 +9,7 @@
 
   <ItemGroup>
     <PackageReference Include="coverlet.collector" Version="6.0.4" />
-    <PackageReference Include="Microsoft.Data.Sqlite" Version="8.0.10" />
+    <PackageReference Include="Microsoft.Data.Sqlite" Version="10.0.11" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.14.1" />
     <PackageReference Include="xunit" Version="2.9.3" />
     <PackageReference Include="xunit.runner.visualstudio" Version="3.1.4" />
@@ -17,6 +17,12 @@
 
   <ItemGroup>
     <Using Include="Xunit" />
+  </ItemGroup>
+
+  <!-- Redirects D365FO_INDEX_DB (and the journal beside it) into a per-run temp directory so
+       the suite cannot write into the real index of the machine it runs on. See the file. -->
+  <ItemGroup>
+    <Compile Include="..\Shared\TestIndexIsolation.cs" Link="TestIndexIsolation.cs" />
   </ItemGroup>
 
   <ItemGroup>

--- a/tests/D365FO.Core.Tests/EdtSuggesterTests.cs
+++ b/tests/D365FO.Core.Tests/EdtSuggesterTests.cs
@@ -19,7 +19,7 @@ public class EdtSuggesterTests : IDisposable
 
     public void Dispose()
     {
-        Microsoft.Data.Sqlite.SqliteConnection.ClearAllPools();
+        SqlitePool.ReleaseFor(_dbPath);
         foreach (var ext in new[] { "", "-wal", "-shm" })
         {
             var p = _dbPath + ext;
@@ -193,7 +193,7 @@ public class EnsureSchemaReturnsAppliedTests : IDisposable
 
     public void Dispose()
     {
-        Microsoft.Data.Sqlite.SqliteConnection.ClearAllPools();
+        SqlitePool.ReleaseFor(_dbPath);
         foreach (var ext in new[] { "", "-wal", "-shm" })
         {
             var p = _dbPath + ext;

--- a/tests/D365FO.Core.Tests/Eval/EvalScorerTests.cs
+++ b/tests/D365FO.Core.Tests/Eval/EvalScorerTests.cs
@@ -19,7 +19,7 @@ public class EvalScorerTests : IDisposable
 
     public void Dispose()
     {
-        Microsoft.Data.Sqlite.SqliteConnection.ClearAllPools();
+        SqlitePool.ReleaseFor(_dbPath);
         foreach (var ext in new[] { "", "-wal", "-shm" })
         {
             var p = _dbPath + ext;

--- a/tests/D365FO.Core.Tests/ExtractPipelineTests.cs
+++ b/tests/D365FO.Core.Tests/ExtractPipelineTests.cs
@@ -1,4 +1,4 @@
-using D365FO.Core.Extract;
+﻿using D365FO.Core.Extract;
 using D365FO.Core.Index;
 using D365FO.Core.Scaffolding;
 using System.Xml.Linq;
@@ -20,7 +20,7 @@ public class ExtractPipelineTests : IDisposable
 
     public void Dispose()
     {
-        Microsoft.Data.Sqlite.SqliteConnection.ClearAllPools();
+        SqlitePool.ReleaseFor(_dbPath);
         foreach (var ext in new[] { "", "-wal", "-shm" })
         {
             var p = _dbPath + ext;
@@ -772,4 +772,241 @@ public void run()
         repo.ApplyExtract(batch);
         Assert.Single(repo.SearchMaps("DirParty"));
     }
+
+    [Fact]
+    public void MetadataExtractor_doc_comment_is_not_the_signature()
+    {
+        // A doc comment is one of the three things that can legally precede a declaration
+        // (blank line, attribute block, comment) and it was the only one not skipped —
+        // so every documented method reported "/// <summary>" as its exact signature.
+        var model = Path.Combine(_workRoot, "PkgSig1", "PkgSig1");
+        Directory.CreateDirectory(Path.Combine(model, "AxClass"));
+        File.WriteAllText(Path.Combine(model, "AxClass", "Documented.xml"), """
+            <AxClass>
+              <Name>Documented</Name>
+              <SourceCode>
+                <Methods>
+                  <Method>
+                    <Name>agreementIsLinked</Name>
+                    <Source>
+            /// &lt;summary&gt;
+            /// Tells whether the agreement is linked.
+            /// &lt;/summary&gt;
+            /// &lt;returns&gt;true when linked.&lt;/returns&gt;
+            display public SalesAgreementIsLinked agreementIsLinked()
+            {
+                return true;
+            }
+                    </Source>
+                  </Method>
+                </Methods>
+              </SourceCode>
+            </AxClass>
+            """);
+
+        var batch = new MetadataExtractor().ExtractAll(_workRoot).ToList().Single(b => b.Model == "PkgSig1");
+        var method = Assert.Single(Assert.Single(batch.Classes).Methods);
+        Assert.Equal("display public SalesAgreementIsLinked agreementIsLinked()", method.Signature);
+        Assert.True(method.HasDocComment, "the doc comment is still recorded, just not as the signature");
+    }
+
+    [Fact]
+    public void MetadataExtractor_line_and_block_comments_are_not_the_signature()
+    {
+        var model = Path.Combine(_workRoot, "PkgSig2", "PkgSig2");
+        Directory.CreateDirectory(Path.Combine(model, "AxClass"));
+        File.WriteAllText(Path.Combine(model, "AxClass", "Commented.xml"), """
+            <AxClass>
+              <Name>Commented</Name>
+              <SourceCode>
+                <Methods>
+                  <Method>
+                    <Name>lineComment</Name>
+                    <Source>
+            // legacy, kept for the batch job
+            public void lineComment()
+            {
+            }
+                    </Source>
+                  </Method>
+                  <Method>
+                    <Name>blockComment</Name>
+                    <Source>
+            /* ----------------------------
+               banner spanning lines
+               ---------------------------- */
+            protected int blockComment(int _n)
+            {
+                return _n;
+            }
+                    </Source>
+                  </Method>
+                  <Method>
+                    <Name>closesOnDeclarationLine</Name>
+                    <Source>
+            /* opened here
+               and closed */ public void closesOnDeclarationLine()
+            {
+            }
+                    </Source>
+                  </Method>
+                </Methods>
+              </SourceCode>
+            </AxClass>
+            """);
+
+        var batch = new MetadataExtractor().ExtractAll(_workRoot).ToList().Single(b => b.Model == "PkgSig2");
+        var methods = Assert.Single(batch.Classes).Methods.ToDictionary(m => m.Name, m => m.Signature);
+        Assert.Equal("public void lineComment()", methods["lineComment"]);
+        Assert.Equal("protected int blockComment(int _n)", methods["blockComment"]);
+        Assert.Equal("public void closesOnDeclarationLine()", methods["closesOnDeclarationLine"]);
+    }
+
+    [Fact]
+    public void MetadataExtractor_comment_before_attribute_still_finds_the_declaration()
+    {
+        // Comments and attributes interleave: the skip for one must not consume the other.
+        var model = Path.Combine(_workRoot, "PkgSig3", "PkgSig3");
+        Directory.CreateDirectory(Path.Combine(model, "AxClass"));
+        File.WriteAllText(Path.Combine(model, "AxClass", "Mixed.xml"), """
+            <AxClass>
+              <Name>Mixed</Name>
+              <SourceCode>
+                <Methods>
+                  <Method>
+                    <Name>handler</Name>
+                    <Source>
+            /// &lt;summary&gt;Handles the event.&lt;/summary&gt;
+            [FormEventHandler(
+                formStr(CustTable),
+                FormEventType::Initialized)]
+            public static void handler(FormRun _sender, FormEventArgs _e)
+            {
+            }
+                    </Source>
+                  </Method>
+                </Methods>
+              </SourceCode>
+            </AxClass>
+            """);
+
+        var batch = new MetadataExtractor().ExtractAll(_workRoot).ToList().Single(b => b.Model == "PkgSig3");
+        var method = Assert.Single(Assert.Single(batch.Classes).Methods);
+        Assert.Equal("public static void handler(FormRun _sender, FormEventArgs _e)", method.Signature);
+        Assert.True(method.IsStatic, "IsStatic is derived from the signature, so it was wrong too");
+    }
+
+    [Fact]
+    public void MetadataExtractor_comment_only_source_yields_no_signature()
+    {
+        var model = Path.Combine(_workRoot, "PkgSig4", "PkgSig4");
+        Directory.CreateDirectory(Path.Combine(model, "AxClass"));
+        File.WriteAllText(Path.Combine(model, "AxClass", "Empty.xml"), """
+            <AxClass>
+              <Name>Empty</Name>
+              <SourceCode>
+                <Methods>
+                  <Method>
+                    <Name>nothing</Name>
+                    <Source>
+            // everything here is commented out
+            // public void nothing() {}
+                    </Source>
+                  </Method>
+                </Methods>
+              </SourceCode>
+            </AxClass>
+            """);
+
+        var batch = new MetadataExtractor().ExtractAll(_workRoot).ToList().Single(b => b.Model == "PkgSig4");
+        var method = Assert.Single(Assert.Single(batch.Classes).Methods);
+        Assert.Equal(string.Empty, method.Signature);
+    }
+
+
+    [Fact]
+    public void MetadataExtractor_reads_a_delete_action_from_the_element_the_AOT_writes()
+    {
+        // AxTableDeleteAction declares `Name, DeleteAction, Relation, Table, Tags` - the related
+        // table is <Table>. The extractor looked for <RelatedTable>, which the contract does not
+        // have, so it skipped EVERY delete action: measured against a real installation, the
+        // index held 0 rows across 214 packages while shipped tables plainly declare them.
+        var model = Path.Combine(_workRoot, "PkgDelAct", "PkgDelAct");
+        Directory.CreateDirectory(Path.Combine(model, "AxTable"));
+        File.WriteAllText(Path.Combine(model, "AxTable", "ParentTable.xml"), """
+            <AxTable>
+              <Name>ParentTable</Name>
+              <DeleteActions>
+                <AxTableDeleteAction>
+                  <Name>JournalError</Name>
+                  <DeleteAction>Cascade</DeleteAction>
+                  <Relation></Relation>
+                  <Table>JournalError</Table>
+                </AxTableDeleteAction>
+              </DeleteActions>
+            </AxTable>
+            """);
+
+        var batch = new MetadataExtractor().ExtractAll(_workRoot).ToList().Single(b => b.Model == "PkgDelAct");
+        var action = Assert.Single(Assert.Single(batch.Tables).DeleteActions);
+        Assert.Equal("JournalError", action.RelatedTable);
+        Assert.Equal("Cascade", action.DeleteAction);
+    }
+
+    [Fact]
+    public void MetadataExtractor_reads_the_datasource_element_names_the_AOT_writes()
+    {
+        // Shipped queries use AxQuerySimpleRootDataSource and AxQuerySimpleEmbeddedDataSource.
+        // The extractor matched AxQuerySimpleDataSource / AxQueryDataSource, which occur in no
+        // shipped query at all - so the index held 4,896 queries and zero datasources, and
+        // `get query` answered "no datasources" for every one of them. Only the sample fixtures
+        // used the shorter name, which is why the suite stayed green.
+        var model = Path.Combine(_workRoot, "PkgQds", "PkgQds");
+        Directory.CreateDirectory(Path.Combine(model, "AxQuery"));
+        File.WriteAllText(Path.Combine(model, "AxQuery", "RealShapeQuery.xml"), """
+            <AxQuery>
+              <Name>RealShapeQuery</Name>
+              <DataSources>
+                <AxQuerySimpleRootDataSource>
+                  <Name>CustTable</Name>
+                  <Table>CustTable</Table>
+                  <DataSources>
+                    <AxQuerySimpleEmbeddedDataSource>
+                      <Name>CustTrans</Name>
+                      <Table>CustTrans</Table>
+                      <JoinMode>InnerJoin</JoinMode>
+                    </AxQuerySimpleEmbeddedDataSource>
+                  </DataSources>
+                </AxQuerySimpleRootDataSource>
+              </DataSources>
+            </AxQuery>
+            """);
+
+        var batch = new MetadataExtractor().ExtractAll(_workRoot).ToList().Single(b => b.Model == "PkgQds");
+        var query = Assert.Single(batch.Queries);
+        Assert.Equal(2, query.DataSources.Count);
+
+        var root = Assert.Single(query.DataSources, d => d.Name == "CustTable");
+        Assert.Equal("CustTable", root.Table);
+        Assert.Null(root.ParentDs);
+
+        var nested = Assert.Single(query.DataSources, d => d.Name == "CustTrans");
+        Assert.Equal("CustTable", nested.ParentDs);
+        Assert.Equal("InnerJoin", nested.JoinMode);
+    }
+
+    [Theory]
+    // The real names.
+    [InlineData("AxQuerySimpleRootDataSource", true)]
+    [InlineData("AxQuerySimpleEmbeddedDataSource", true)]
+    // The fixture spelling, still accepted.
+    [InlineData("AxQuerySimpleDataSource", true)]
+    // Members of a datasource, which a prefix match would have swept in as datasources.
+    [InlineData("AxQuerySimpleDataSourceField", false)]
+    [InlineData("AxQuerySimpleDataSourceRange", false)]
+    [InlineData("AxQuerySimpleDataSourceRelation", false)]
+    [InlineData("AxTableField", false)]
+    public void MetadataExtractor_datasource_predicate_matches_only_datasources(string localName, bool expected)
+        => Assert.Equal(expected, MetadataExtractor.IsQueryDataSourceElement(localName));
+
 }

--- a/tests/D365FO.Core.Tests/FormPatternAnalyzerTests.cs
+++ b/tests/D365FO.Core.Tests/FormPatternAnalyzerTests.cs
@@ -18,7 +18,7 @@ public class FormPatternAnalyzerTests : IDisposable
 
     public void Dispose()
     {
-        Microsoft.Data.Sqlite.SqliteConnection.ClearAllPools();
+        SqlitePool.ReleaseFor(_dbPath);
         foreach (var ext in new[] { "", "-wal", "-shm" })
         {
             var p = _dbPath + ext;

--- a/tests/D365FO.Core.Tests/GoldenQualityGateTests.cs
+++ b/tests/D365FO.Core.Tests/GoldenQualityGateTests.cs
@@ -33,7 +33,7 @@ public class GoldenQualityGateTests : IDisposable
 
     public void Dispose()
     {
-        Microsoft.Data.Sqlite.SqliteConnection.ClearAllPools();
+        SqlitePool.ReleaseFor(_dbPath);
         foreach (var ext in new[] { "", "-wal", "-shm" })
         {
             var p = _dbPath + ext;

--- a/tests/D365FO.Core.Tests/HttpServerHostTests.cs
+++ b/tests/D365FO.Core.Tests/HttpServerHostTests.cs
@@ -29,7 +29,7 @@ public class HttpServerHostTests : IAsyncLifetime
     public async Task DisposeAsync()
     {
         if (_app is not null) await _app.StopAsync();
-        Microsoft.Data.Sqlite.SqliteConnection.ClearAllPools();
+        SqlitePool.ReleaseFor(_dbPath);
         foreach (var ext in new[] { "", "-wal", "-shm" })
         {
             var p = _dbPath + ext;

--- a/tests/D365FO.Core.Tests/IndexStalenessTests.cs
+++ b/tests/D365FO.Core.Tests/IndexStalenessTests.cs
@@ -19,7 +19,7 @@ public class IndexStalenessTests : IDisposable
 
     public void Dispose()
     {
-        Microsoft.Data.Sqlite.SqliteConnection.ClearAllPools();
+        SqlitePool.ReleaseFor(_dbPath);
         try { Directory.Delete(_root, recursive: true); } catch { }
     }
 

--- a/tests/D365FO.Core.Tests/LabelDiskCheckTests.cs
+++ b/tests/D365FO.Core.Tests/LabelDiskCheckTests.cs
@@ -21,7 +21,7 @@ public class LabelDiskCheckTests : IDisposable
 
     public void Dispose()
     {
-        Microsoft.Data.Sqlite.SqliteConnection.ClearAllPools();
+        SqlitePool.ReleaseFor(_dbPath);
         try { Directory.Delete(_dir, recursive: true); } catch { /* best-effort */ }
     }
 

--- a/tests/D365FO.Core.Tests/LintRuleTests.cs
+++ b/tests/D365FO.Core.Tests/LintRuleTests.cs
@@ -21,7 +21,7 @@ public class LintRuleTests : IDisposable
 
     public void Dispose()
     {
-        Microsoft.Data.Sqlite.SqliteConnection.ClearAllPools();
+        SqlitePool.ReleaseFor(_dbPath);
         foreach (var ext in new[] { "", "-wal", "-shm" })
         {
             var p = _dbPath + ext;

--- a/tests/D365FO.Core.Tests/McpDispatcherTests.cs
+++ b/tests/D365FO.Core.Tests/McpDispatcherTests.cs
@@ -11,7 +11,7 @@ public class McpDispatcherTests : IDisposable
 
     public void Dispose()
     {
-        Microsoft.Data.Sqlite.SqliteConnection.ClearAllPools();
+        SqlitePool.ReleaseFor(_dbPath);
         foreach (var ext in new[] { "", "-wal", "-shm" })
         {
             var p = _dbPath + ext;

--- a/tests/D365FO.Core.Tests/McpModeGateTests.cs
+++ b/tests/D365FO.Core.Tests/McpModeGateTests.cs
@@ -20,7 +20,7 @@ public class McpModeGateTests : IDisposable
 
     public void Dispose()
     {
-        Microsoft.Data.Sqlite.SqliteConnection.ClearAllPools();
+        SqlitePool.ReleaseFor(_dbPath);
         foreach (var ext in new[] { "", "-wal", "-shm" })
         {
             var p = _dbPath + ext;

--- a/tests/D365FO.Core.Tests/McpServerHostTests.cs
+++ b/tests/D365FO.Core.Tests/McpServerHostTests.cs
@@ -18,7 +18,7 @@ public class McpServerHostTests : IDisposable
 
     public void Dispose()
     {
-        Microsoft.Data.Sqlite.SqliteConnection.ClearAllPools();
+        SqlitePool.ReleaseFor(_dbPath);
         foreach (var ext in new[] { "", "-wal", "-shm" })
         {
             var p = _dbPath + ext;

--- a/tests/D365FO.Core.Tests/MetadataRepositoryTests.cs
+++ b/tests/D365FO.Core.Tests/MetadataRepositoryTests.cs
@@ -16,7 +16,7 @@ public class MetadataRepositoryTests : IDisposable
 
     public void Dispose()
     {
-        Microsoft.Data.Sqlite.SqliteConnection.ClearAllPools();
+        SqlitePool.ReleaseFor(_dbPath);
         foreach (var ext in new[] { "", "-wal", "-shm" })
         {
             var p = _dbPath + ext;

--- a/tests/D365FO.Core.Tests/MethodModifyEngineTests.cs
+++ b/tests/D365FO.Core.Tests/MethodModifyEngineTests.cs
@@ -50,7 +50,7 @@ public sealed class MethodModifyEngineTests : IDisposable
 
     public void Dispose()
     {
-        Microsoft.Data.Sqlite.SqliteConnection.ClearAllPools();
+        SqlitePool.ReleaseFor(_dbPath);
         foreach (var ext in new[] { "", "-wal", "-shm" })
         {
             var p = _dbPath + ext;

--- a/tests/D365FO.Core.Tests/MethodSourceFtsTests.cs
+++ b/tests/D365FO.Core.Tests/MethodSourceFtsTests.cs
@@ -27,11 +27,11 @@ public class MethodSourceFtsTests : IDisposable
 
     public void Dispose()
     {
-        Microsoft.Data.Sqlite.SqliteConnection.ClearAllPools();
+        SqlitePool.ReleaseFor(_dbPath);
         foreach (var ext in new[] { "", "-wal", "-shm" })
         {
             var p = _dbPath + ext;
-            // Windows can keep the handle alive for a moment after ClearAllPools
+            // Windows can keep the handle alive for a moment after the pool is released
             // (observed on CI: IOException "being used by another process").
             // Temp-file cleanup is best-effort — retry briefly, then let the OS
             // temp sweeper have it rather than failing the test run.

--- a/tests/D365FO.Core.Tests/MiniAotEndToEndTests.cs
+++ b/tests/D365FO.Core.Tests/MiniAotEndToEndTests.cs
@@ -31,7 +31,7 @@ public class MiniAotEndToEndTests : IDisposable
 
     public void Dispose()
     {
-        Microsoft.Data.Sqlite.SqliteConnection.ClearAllPools();
+        SqlitePool.ReleaseFor(_dbPath);
         foreach (var ext in new[] { "", "-wal", "-shm" })
         {
             var p = _dbPath + ext;

--- a/tests/D365FO.Core.Tests/ObjectModifyEngineTests.cs
+++ b/tests/D365FO.Core.Tests/ObjectModifyEngineTests.cs
@@ -1,4 +1,4 @@
-using System;
+﻿using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
@@ -67,7 +67,7 @@ public sealed class ObjectModifyEngineTests : IDisposable
     public void Dispose()
     {
         Environment.SetEnvironmentVariable("D365FO_CUSTOM_MODELS", _prevCustomModels);
-        Microsoft.Data.Sqlite.SqliteConnection.ClearAllPools();
+        SqlitePool.ReleaseFor(_dbPath);
         foreach (var ext in new[] { "", "-wal", "-shm" })
         {
             var p = _dbPath + ext;
@@ -85,6 +85,446 @@ public sealed class ObjectModifyEngineTests : IDisposable
         "<AxFormControl i:type=\"AxFormGridControl\" xmlns:i=\"http://www.w3.org/2001/XMLSchema-instance\">" +
         "<Name>Grid</Name><Type>Grid</Type><Controls /></AxFormControl>" +
         "</Controls></Design></AxForm>";
+
+    // ---- kind coverage, batching, query and security --------------------------
+
+    [Fact]
+    public void A_kind_the_bridge_can_write_is_no_longer_refused_by_a_hand_written_list()
+    {
+        // SupportedKinds was five entries while the bridge resolves 41 from the registry, so a
+        // query - which it can write perfectly well - came back "unsupported kind".
+        var capture = new BridgeCapture("<AxQuery><Name>FmVehicleQuery</Name></AxQuery>");
+        using var harness = FakeBridge.Create(capture.Respond);
+
+        var result = ObjectModifyEngine.ModifyCore(new ObjectModifyEngine.ModifyRequest
+        {
+            Operation = ObjectModifyEngine.Operation.SetProperty,
+            Kind = "query",
+            ObjectName = "FmVehicleQuery",
+            Member = "Title",
+            Value = "@SYS1",
+            Model = "FleetCustom",
+        }, _repo, harness.Client, _journalDb);
+
+        Assert.True(result.Ok, result.Error?.Message);
+        Assert.Equal("updateObject", capture.WriteVerb);
+    }
+
+    [Fact]
+    public void An_unknown_kind_names_the_near_misses_instead_of_all_41()
+    {
+        var capture = new BridgeCapture(CustomTableXml);
+        using var harness = FakeBridge.Create(capture.Respond);
+
+        var result = ObjectModifyEngine.ModifyCore(new ObjectModifyEngine.ModifyRequest
+        {
+            Operation = ObjectModifyEngine.Operation.SetProperty,
+            Kind = "securityprivilage",
+            ObjectName = "X",
+            Member = "Label",
+            Value = "@SYS1",
+        }, _repo, harness.Client, _journalDb);
+
+        Assert.False(result.Ok);
+        Assert.Equal("BAD_INPUT", result.Error!.Code);
+        Assert.Null(capture.WriteVerb);
+    }
+
+    [Fact]
+    public void A_batch_applies_every_step_in_one_write()
+    {
+        var capture = new BridgeCapture(CustomTableXml);
+        using var harness = FakeBridge.Create(capture.Respond);
+
+        var result = ObjectModifyEngine.ModifyCore(new ObjectModifyEngine.ModifyRequest
+        {
+            Operation = ObjectModifyEngine.Operation.SetProperty,
+            Kind = "table",
+            ObjectName = "FmVehicle",
+            Member = "batch",
+            Model = "FleetCustom",
+            Batch = new[]
+            {
+                new ObjectModifyEngine.ModifyRequest
+                {
+                    Operation = ObjectModifyEngine.Operation.AddField,
+                    Kind = "table", ObjectName = "FmVehicle", Member = "Note", Type = "Notes",
+                },
+                new ObjectModifyEngine.ModifyRequest
+                {
+                    Operation = ObjectModifyEngine.Operation.AddIndex,
+                    Kind = "table", ObjectName = "FmVehicle", Member = "NoteIdx",
+                    Fields = new[] { "Note" },
+                },
+            },
+        }, _repo, harness.Client, _journalDb);
+
+        Assert.True(result.Ok, result.Error?.Message);
+        // One write, not two: that is the whole point of batching.
+        Assert.Equal(1, capture.WriteCount);
+
+        var written = XDocument.Parse((string)capture.WriteArgs!["xml"]!);
+        Assert.Contains(written.Descendants("AxTableField"), e => e.Element("Name")?.Value == "Note");
+        Assert.Contains(written.Descendants("AxTableIndex"), e => e.Element("Name")?.Value == "NoteIdx");
+    }
+
+    [Fact]
+    public void A_refused_step_discards_the_whole_batch_and_writes_nothing()
+    {
+        var capture = new BridgeCapture(CustomTableXml);
+        using var harness = FakeBridge.Create(capture.Respond);
+
+        var result = ObjectModifyEngine.ModifyCore(new ObjectModifyEngine.ModifyRequest
+        {
+            Operation = ObjectModifyEngine.Operation.SetProperty,
+            Kind = "table",
+            ObjectName = "FmVehicle",
+            Member = "batch",
+            Model = "FleetCustom",
+            Batch = new[]
+            {
+                new ObjectModifyEngine.ModifyRequest
+                {
+                    Operation = ObjectModifyEngine.Operation.AddField,
+                    Kind = "table", ObjectName = "FmVehicle", Member = "Note", Type = "Notes",
+                },
+                // Second step refuses: the field does not exist on the table.
+                new ObjectModifyEngine.ModifyRequest
+                {
+                    Operation = ObjectModifyEngine.Operation.AddIndex,
+                    Kind = "table", ObjectName = "FmVehicle", Member = "BadIdx",
+                    Fields = new[] { "NoSuchField" },
+                },
+            },
+        }, _repo, harness.Client, _journalDb);
+
+        Assert.False(result.Ok);
+        // Nothing written at all - the first step's field must not reach the AOT on its own.
+        Assert.Null(capture.WriteVerb);
+        Assert.Contains("NOTHING was written", result.Error!.Hint);
+    }
+
+    [Fact]
+    public void Add_query_range_refuses_to_guess_between_two_datasources()
+    {
+        var capture = new BridgeCapture(
+            "<AxQuery><Name>FmVehicleQuery</Name><DataSources>" +
+            "<AxQuerySimpleDataSource><Name>FmVehicle</Name></AxQuerySimpleDataSource>" +
+            "<AxQuerySimpleDataSource><Name>FmRental</Name></AxQuerySimpleDataSource>" +
+            "</DataSources></AxQuery>");
+        using var harness = FakeBridge.Create(capture.Respond);
+
+        var result = ObjectModifyEngine.ModifyCore(new ObjectModifyEngine.ModifyRequest
+        {
+            Operation = ObjectModifyEngine.Operation.AddQueryRange,
+            Kind = "query",
+            ObjectName = "FmVehicleQuery",
+            Member = "VehicleId",
+            Model = "FleetCustom",
+        }, _repo, harness.Client, _journalDb);
+
+        // A range on the wrong datasource returns the wrong rows silently, so guessing is worse
+        // than refusing.
+        Assert.False(result.Ok);
+        Assert.Contains("--data-source", result.Error!.Message);
+        Assert.Null(capture.WriteVerb);
+    }
+
+    [Fact]
+    public void Add_query_range_uses_the_only_datasource_without_being_told()
+    {
+        var capture = new BridgeCapture(
+            "<AxQuery><Name>FmVehicleQuery</Name><DataSources>" +
+            "<AxQuerySimpleDataSource><Name>FmVehicle</Name></AxQuerySimpleDataSource>" +
+            "</DataSources></AxQuery>");
+        using var harness = FakeBridge.Create(capture.Respond);
+
+        var result = ObjectModifyEngine.ModifyCore(new ObjectModifyEngine.ModifyRequest
+        {
+            Operation = ObjectModifyEngine.Operation.AddQueryRange,
+            Kind = "query",
+            ObjectName = "FmVehicleQuery",
+            Member = "VehicleId",
+            RangeValue = "!Closed",
+            Model = "FleetCustom",
+        }, _repo, harness.Client, _journalDb);
+
+        Assert.True(result.Ok, result.Error?.Message);
+        var written = XDocument.Parse((string)capture.WriteArgs!["xml"]!);
+        var range = written.Descendants("AxQuerySimpleDataSourceRange").Single();
+        Assert.Equal("VehicleId", range.Element("Field")!.Value);
+        Assert.Equal("!Closed", range.Element("Value")!.Value);
+    }
+
+    [Fact]
+    public void Add_entry_point_writes_a_grant_not_an_access_level()
+    {
+        var capture = new BridgeCapture(
+            "<AxSecurityPrivilege><Name>FmVehicleMaintain</Name></AxSecurityPrivilege>");
+        using var harness = FakeBridge.Create(capture.Respond);
+
+        var result = ObjectModifyEngine.ModifyCore(new ObjectModifyEngine.ModifyRequest
+        {
+            Operation = ObjectModifyEngine.Operation.AddEntryPoint,
+            Kind = "securityprivilege",
+            ObjectName = "FmVehicleMaintain",
+            Member = "FmVehicleListPage",
+            EntryPointType = "MenuItemDisplay",
+            Access = "Update",
+            Model = "FleetCustom",
+        }, _repo, harness.Client, _journalDb);
+
+        Assert.True(result.Ok, result.Error?.Message);
+        var written = XDocument.Parse((string)capture.WriteArgs!["xml"]!);
+        var reference = written.Descendants("AxSecurityEntryPointReference").Single();
+
+        // There is no AccessLevel member in the security model - writing one grants nothing and
+        // reads as a deliberate no-access privilege.
+        Assert.Null(reference.Element("AccessLevel"));
+        var grant = reference.Element("Grant")!;
+        Assert.Equal(new[] { "Read", "Update" }, grant.Elements().Select(e => e.Name.LocalName).ToArray());
+        Assert.Equal("MenuItemDisplay", reference.Element("ObjectType")!.Value);
+    }
+
+    // ---- contract order (the write path had no canonicalisation) --------------
+
+    [Fact]
+    public void A_created_collection_lands_in_contract_order_not_at_the_end()
+    {
+        // AxTable member order ends: DeleteActions, FieldGroups, Fields, FullTextIndexes,
+        // Indexes, Mappings, Relations. This table declares Indexes but no Fields, so a naive
+        // append puts <Fields> AFTER <Indexes> - and DataContractSerializer skips a child that
+        // arrives out of turn, so the field is DROPPED on read while the write reports ok.
+        var capture = new BridgeCapture(
+            "<AxTable><Name>FmVehicle</Name>" +
+            "<Indexes><AxTableIndex><Name>Idx</Name></AxTableIndex></Indexes></AxTable>");
+        using var harness = FakeBridge.Create(capture.Respond);
+
+        var result = ObjectModifyEngine.ModifyCore(new ObjectModifyEngine.ModifyRequest
+        {
+            Operation = ObjectModifyEngine.Operation.AddField,
+            Kind = "table",
+            ObjectName = "FmVehicle",
+            Member = "LicensePlate",
+            Type = "Name",
+            Model = "FleetCustom",
+        }, _repo, harness.Client, _journalDb);
+
+        Assert.True(result.Ok, result.Error?.Message);
+        var written = XDocument.Parse((string)capture.WriteArgs!["xml"]!);
+        Assert.Equal(
+            new[] { "Name", "Fields", "Indexes" },
+            written.Root!.Elements().Select(e => e.Name.LocalName).ToArray());
+    }
+
+    [Fact]
+    public void A_property_added_to_the_root_lands_in_contract_order()
+    {
+        // SetProperty inserted straight after <Name>, which for most properties is too early:
+        // CacheLookup sorts long after Label in the AxTable contract.
+        var capture = new BridgeCapture("<AxTable><Name>FmVehicle</Name><Label>@SYS1</Label></AxTable>");
+        using var harness = FakeBridge.Create(capture.Respond);
+
+        var result = ObjectModifyEngine.ModifyCore(new ObjectModifyEngine.ModifyRequest
+        {
+            Operation = ObjectModifyEngine.Operation.SetProperty,
+            Kind = "table",
+            ObjectName = "FmVehicle",
+            Member = "CacheLookup",
+            Value = "Found",
+            Model = "FleetCustom",
+        }, _repo, harness.Client, _journalDb);
+
+        Assert.True(result.Ok, result.Error?.Message);
+        var written = XDocument.Parse((string)capture.WriteArgs!["xml"]!);
+        Assert.Equal(
+            new[] { "Name", "Label", "CacheLookup" },
+            written.Root!.Elements().Select(e => e.Name.LocalName).ToArray());
+    }
+
+    // ---- table structure ------------------------------------------------------
+
+    [Fact]
+    public void Add_index_is_unique_by_default_and_keeps_the_field_order_given()
+    {
+        var capture = new BridgeCapture(CustomTableXml);
+        using var harness = FakeBridge.Create(capture.Respond);
+
+        var result = ObjectModifyEngine.ModifyCore(new ObjectModifyEngine.ModifyRequest
+        {
+            Operation = ObjectModifyEngine.Operation.AddIndex,
+            Kind = "table",
+            ObjectName = "FmVehicle",
+            Member = "VehicleIdx",
+            Fields = new[] { "VIN", "RecId" },
+        }, _repo, harness.Client, _journalDb);
+
+        Assert.True(result.Ok, result.Error?.Message);
+        var written = XDocument.Parse((string)capture.WriteArgs!["xml"]!);
+        var index = written.Descendants("AxTableIndex").Single(e => e.Element("Name")?.Value == "VehicleIdx");
+        Assert.Equal("No", index.Element("AllowDuplicates")!.Value);
+        Assert.Equal(
+            new[] { "VIN", "RecId" },
+            index.Element("Fields")!.Elements("AxTableIndexField").Select(f => f.Element("DataField")!.Value).ToArray());
+    }
+
+    [Fact]
+    public void Add_index_refuses_a_field_the_table_does_not_have()
+    {
+        var capture = new BridgeCapture(CustomTableXml);
+        using var harness = FakeBridge.Create(capture.Respond);
+
+        var result = ObjectModifyEngine.ModifyCore(new ObjectModifyEngine.ModifyRequest
+        {
+            Operation = ObjectModifyEngine.Operation.AddIndex,
+            Kind = "table",
+            ObjectName = "FmVehicle",
+            Member = "BadIdx",
+            Fields = new[] { "NoSuchField" },
+        }, _repo, harness.Client, _journalDb);
+
+        Assert.False(result.Ok);
+        Assert.Equal("FIELD_NOT_FOUND", result.Error!.Code);
+        Assert.Null(capture.WriteVerb);
+    }
+
+    [Fact]
+    public void Add_relation_pins_the_concrete_constraint_subtype()
+    {
+        var capture = new BridgeCapture(CustomTableXml);
+        using var harness = FakeBridge.Create(capture.Respond);
+
+        var result = ObjectModifyEngine.ModifyCore(new ObjectModifyEngine.ModifyRequest
+        {
+            Operation = ObjectModifyEngine.Operation.AddRelation,
+            Kind = "table",
+            ObjectName = "FmVehicle",
+            Member = "CustAccount",
+            RelatedTable = "CustTable",
+            RelatedField = "AccountNum",
+        }, _repo, harness.Client, _journalDb);
+
+        Assert.True(result.Ok, result.Error?.Message);
+        var written = XDocument.Parse((string)capture.WriteArgs!["xml"]!);
+        var constraint = written.Descendants("AxTableRelationConstraint").Single();
+        var xsi = XNamespace.Get("http://www.w3.org/2001/XMLSchema-instance");
+        Assert.Equal("AxTableRelationConstraintField", (string?)constraint.Attribute(xsi + "type"));
+        Assert.Equal("AccountNum", constraint.Element("RelatedField")!.Value);
+    }
+
+    [Fact]
+    public void Add_delete_action_refuses_an_action_the_platform_does_not_define()
+    {
+        var capture = new BridgeCapture(CustomTableXml);
+        using var harness = FakeBridge.Create(capture.Respond);
+
+        var result = ObjectModifyEngine.ModifyCore(new ObjectModifyEngine.ModifyRequest
+        {
+            Operation = ObjectModifyEngine.Operation.AddDeleteAction,
+            Kind = "table",
+            ObjectName = "FmVehicle",
+            Member = "FmVehicleLine",
+            RelatedTable = "FmVehicleLine",
+            DeleteAction = "CascadeAll",
+        }, _repo, harness.Client, _journalDb);
+
+        Assert.False(result.Ok);
+        Assert.Equal("BAD_INPUT", result.Error!.Code);
+        Assert.Null(capture.WriteVerb);
+    }
+
+    [Fact]
+    public void Rename_field_rewrites_the_index_that_names_it()
+    {
+        var capture = new BridgeCapture(
+            "<AxTable><Name>FmVehicle</Name>" +
+            "<Fields><AxTableField><Name>VehicleId</Name></AxTableField></Fields>" +
+            "<Indexes><AxTableIndex><Name>Idx</Name><Fields>" +
+            "<AxTableIndexField><DataField>VehicleId</DataField></AxTableIndexField>" +
+            "</Fields></AxTableIndex></Indexes></AxTable>");
+        using var harness = FakeBridge.Create(capture.Respond);
+
+        var result = ObjectModifyEngine.ModifyCore(new ObjectModifyEngine.ModifyRequest
+        {
+            Operation = ObjectModifyEngine.Operation.RenameField,
+            Kind = "table",
+            ObjectName = "FmVehicle",
+            Member = "VehicleId",
+            NewName = "VehicleNumber",
+            Model = "FleetCustom",
+        }, _repo, harness.Client, _journalDb);
+
+        Assert.True(result.Ok, result.Error?.Message);
+        var written = XDocument.Parse((string)capture.WriteArgs!["xml"]!);
+        Assert.Equal("VehicleNumber", written.Descendants("AxTableField").Single().Element("Name")!.Value);
+        // Leaving the index behind gives a table that cannot resolve its own index.
+        Assert.Equal("VehicleNumber", written.Descendants("AxTableIndexField").Single().Element("DataField")!.Value);
+    }
+
+    [Fact]
+    public void Remove_index_refuses_a_name_that_is_not_there_and_writes_nothing()
+    {
+        var capture = new BridgeCapture(CustomTableXml);
+        using var harness = FakeBridge.Create(capture.Respond);
+
+        var result = ObjectModifyEngine.ModifyCore(new ObjectModifyEngine.ModifyRequest
+        {
+            Operation = ObjectModifyEngine.Operation.RemoveIndex,
+            Kind = "table",
+            ObjectName = "FmVehicle",
+            Member = "NoSuchIdx",
+        }, _repo, harness.Client, _journalDb);
+
+        Assert.False(result.Ok);
+        Assert.Equal("MEMBER_NOT_FOUND", result.Error!.Code);
+        Assert.Null(capture.WriteVerb);
+    }
+
+    [Fact]
+    public void Remove_control_takes_its_nested_controls_with_it()
+    {
+        var capture = new BridgeCapture(
+            "<AxForm><Name>FmVehicleForm</Name><Design>" +
+            "<Controls><AxFormControlGroup><Name>Grp</Name><Controls>" +
+            "<AxFormControlString><Name>Inner1</Name></AxFormControlString>" +
+            "<AxFormControlString><Name>Inner2</Name></AxFormControlString>" +
+            "</Controls></AxFormControlGroup></Controls></Design></AxForm>");
+        using var harness = FakeBridge.Create(capture.Respond);
+
+        var result = ObjectModifyEngine.ModifyCore(new ObjectModifyEngine.ModifyRequest
+        {
+            Operation = ObjectModifyEngine.Operation.RemoveControl,
+            Kind = "form",
+            ObjectName = "FmVehicleForm",
+            Member = "Grp",
+            Model = "FleetCustom",
+        }, _repo, harness.Client, _journalDb);
+
+        Assert.True(result.Ok, result.Error?.Message);
+        var written = XDocument.Parse((string)capture.WriteArgs!["xml"]!);
+        Assert.DoesNotContain(written.Descendants(),
+            e => e.Name.LocalName.StartsWith("AxFormControl", StringComparison.Ordinal));
+    }
+
+    [Fact]
+    public void A_table_operation_on_a_form_is_refused_by_the_name_the_caller_typed()
+    {
+        var capture = new BridgeCapture(FormXml);
+        using var harness = FakeBridge.Create(capture.Respond);
+
+        var result = ObjectModifyEngine.ModifyCore(new ObjectModifyEngine.ModifyRequest
+        {
+            Operation = ObjectModifyEngine.Operation.AddIndex,
+            Kind = "form",
+            ObjectName = "FmVehicleForm",
+            Member = "Idx",
+            Fields = new[] { "A" },
+        }, _repo, harness.Client, _journalDb);
+
+        Assert.False(result.Ok);
+        Assert.Contains("add-index", result.Error!.Message);
+        Assert.Null(capture.WriteVerb);
+    }
 
     // ---- base-object writes (custom model) ----------------------------------
 
@@ -526,6 +966,9 @@ public sealed class ObjectModifyEngineTests : IDisposable
 
         public JsonObject? WriteArgs { get; private set; }
 
+        /// <summary>How many writes reached the bridge. A batch must produce exactly one.</summary>
+        public int WriteCount { get; private set; }
+
         public JsonObject Respond(JsonObject request)
         {
             var method = (string?)request["method"];
@@ -541,6 +984,7 @@ public sealed class ObjectModifyEngineTests : IDisposable
                 case "updateObject":
                     WriteVerb = method;
                     WriteArgs = (JsonObject?)request["params"]?.DeepClone();
+                    WriteCount++;
                     result = new JsonObject { ["ok"] = true };
                     break;
                 default:

--- a/tests/D365FO.Core.Tests/PropertyStatsTests.cs
+++ b/tests/D365FO.Core.Tests/PropertyStatsTests.cs
@@ -16,7 +16,7 @@ public class PropertyStatsTests : IDisposable
 
     public void Dispose()
     {
-        Microsoft.Data.Sqlite.SqliteConnection.ClearAllPools();
+        SqlitePool.ReleaseFor(_dbPath);
         foreach (var ext in new[] { "", "-wal", "-shm" })
         {
             var p = _dbPath + ext;

--- a/tests/D365FO.Core.Tests/ReferenceResolverTests.cs
+++ b/tests/D365FO.Core.Tests/ReferenceResolverTests.cs
@@ -23,7 +23,7 @@ public class ReferenceResolverTests : IDisposable
 
     public void Dispose()
     {
-        Microsoft.Data.Sqlite.SqliteConnection.ClearAllPools();
+        SqlitePool.ReleaseFor(_dbPath);
         foreach (var ext in new[] { "", "-wal", "-shm" })
         {
             var p = _dbPath + ext;

--- a/tests/D365FO.Core.Tests/ScaffoldFileWriterAtomicityTests.cs
+++ b/tests/D365FO.Core.Tests/ScaffoldFileWriterAtomicityTests.cs
@@ -56,9 +56,7 @@ public sealed class ScaffoldFileWriterAtomicityTests : IDisposable
         Parallel.ForEach(names, Bounded, name =>
             ScaffoldFileWriter.Write(TableDoc(name), Path.Combine(_dir, name + ".xml")));
 
-        Assert.Equal(
-            names.Select(n => n + ".xml").Order().ToArray(),
-            Directory.GetFiles(_dir, "*.xml").Select(Path.GetFileName).Order().ToArray()!);
+        WrittenFilesAssert.ExactlyTheseXml(_dir, names.Select(n => n + ".xml").ToArray());
         Assert.Empty(Directory.GetFiles(_dir, "*.tmp"));
 
         // Every file holds its own document — not a neighbour's, which is what a shared

--- a/tests/D365FO.Core.Tests/SqlitePool.cs
+++ b/tests/D365FO.Core.Tests/SqlitePool.cs
@@ -1,0 +1,91 @@
+using Microsoft.Data.Sqlite;
+
+namespace D365FO.Core.Tests;
+
+/// <summary>
+/// Releases the pooled SQLite handles for ONE database file, so a test can delete its temp
+/// database without disturbing any other test's connections.
+/// </summary>
+/// <remarks>
+/// <para>
+/// Twenty test classes used to call <c>SqliteConnection.ClearAllPools()</c> in <c>Dispose</c>
+/// to let the temp file be deleted. That call is process-wide: it disposes every pooled
+/// connection in the process, including one another test is in the middle of a query on. xUnit
+/// runs collections in parallel, so the loser came back as
+/// <c>ObjectDisposedException: Cannot access a disposed object. Object name: 'SQLitePCL.sqlite3'</c>
+/// from somewhere entirely unrelated to the test that was tearing down — observed on
+/// <c>MethodSourceFtsTests</c>, roughly one full-suite run in ten, and never reproducible when
+/// that assembly ran on its own because the timing windows were too narrow.
+/// </para>
+/// <para>
+/// <c>ClearPool</c> is scoped to one connection string, which is what was wanted all along.
+/// <c>MetadataRepository</c> opens two per database — read-write and read-only — so both are
+/// cleared, and the path is cleared as given and as a full path, since a pool is keyed by the
+/// connection string text rather than by the file it resolves to.
+/// </para>
+/// </remarks>
+internal static class SqlitePool
+{
+    public static void ReleaseFor(string databasePath)
+    {
+        if (string.IsNullOrWhiteSpace(databasePath)) return;
+
+        foreach (var connectionString in PoolKeysFor(databasePath))
+        {
+            try
+            {
+                using var connection = new SqliteConnection(connectionString);
+                SqliteConnection.ClearPool(connection);
+            }
+            catch
+            {
+                // Releasing a pool that was never created is not a failure worth reporting.
+            }
+        }
+    }
+
+    /// <summary>
+    /// Every connection string this codebase opens against one database file. A pool is keyed by
+    /// the connection string TEXT, not by the file it resolves to, so each distinct spelling is
+    /// its own pool and has to be cleared on its own.
+    /// </summary>
+    /// <remarks>
+    /// The bare <c>Data Source={path}</c> form is not hypothetical: tests that seed a database
+    /// with raw SQL open it that way, and missing it left the file locked and the delete in
+    /// <c>Dispose</c> throwing on every single run. If a fourth spelling ever appears, the
+    /// symptom is that same IOException — add it here rather than reaching back for
+    /// <c>ClearAllPools</c>.
+    /// </remarks>
+    private static IEnumerable<string> PoolKeysFor(string databasePath)
+    {
+        foreach (var source in DistinctSources(databasePath))
+        {
+            // What tests use when they open the file directly to seed it.
+            yield return $"Data Source={source}";
+
+            // What MetadataRepository opens: read-write and read-only, private cache.
+            foreach (var mode in new[] { SqliteOpenMode.ReadWriteCreate, SqliteOpenMode.ReadOnly })
+            {
+                yield return new SqliteConnectionStringBuilder
+                {
+                    DataSource = source,
+                    Mode = mode,
+                    Cache = SqliteCacheMode.Private,
+                    Pooling = true,
+                }.ToString();
+            }
+        }
+    }
+
+    private static IEnumerable<string> DistinctSources(string databasePath)
+    {
+        yield return databasePath;
+
+        string? full = null;
+        try { full = Path.GetFullPath(databasePath); }
+        catch { /* an unusable path has no pool to clear */ }
+
+        if (full is not null && !string.Equals(full, databasePath, StringComparison.Ordinal))
+            yield return full;
+    }
+}

--- a/tests/D365FO.Core.Tests/SqlitePoolTests.cs
+++ b/tests/D365FO.Core.Tests/SqlitePoolTests.cs
@@ -1,0 +1,64 @@
+using D365FO.Core.Index;
+using Microsoft.Data.Sqlite;
+using Xunit;
+
+namespace D365FO.Core.Tests;
+
+/// <summary>
+/// <see cref="SqlitePool.ReleaseFor"/> has to cover every connection-string spelling this
+/// codebase opens, because a pool is keyed by the string and not by the file.
+/// </summary>
+/// <remarks>
+/// Miss one and the temp database stays locked, so <c>Dispose</c> throws
+/// <c>IOException: being used by another process</c> — which is exactly what happened when the
+/// helper knew the two <c>MetadataRepository</c> spellings but not the bare
+/// <c>Data Source={path}</c> one a test uses to seed with raw SQL. Reaching back for
+/// <c>ClearAllPools</c> is not the fix: that call is process-wide and disposes connections other
+/// tests are mid-query on, which is the flake this helper exists to remove.
+/// </remarks>
+public class SqlitePoolTests
+{
+    [Fact]
+    public void Release_unlocks_the_file_for_every_spelling_the_codebase_opens()
+    {
+        var dbPath = Path.Combine(Path.GetTempPath(), $"d365fo-pool-{Guid.NewGuid():N}.sqlite");
+
+        // 1. The repository's own two connection strings.
+        var repo = new MetadataRepository(dbPath);
+        repo.EnsureSchema();
+        repo.UpsertModel("Fleet", null, null, true);
+        _ = repo.GetDependencyGraph();
+
+        // 2. The bare spelling a test uses when it seeds the database directly.
+        using (var raw = new SqliteConnection($"Data Source={dbPath}"))
+        {
+            raw.Open();
+            using var cmd = raw.CreateCommand();
+            cmd.CommandText = "SELECT COUNT(*) FROM Models;";
+            cmd.ExecuteScalar();
+        }
+
+        SqlitePool.ReleaseFor(dbPath);
+
+        // The point of the helper: the file is deletable straight away, with no retry loop.
+        var exception = Record.Exception(() =>
+        {
+            foreach (var ext in new[] { "", "-wal", "-shm" })
+            {
+                var p = dbPath + ext;
+                if (File.Exists(p)) File.Delete(p);
+            }
+        });
+
+        Assert.Null(exception);
+        Assert.False(File.Exists(dbPath));
+    }
+
+    [Fact]
+    public void Release_is_harmless_for_a_path_that_was_never_opened()
+    {
+        var never = Path.Combine(Path.GetTempPath(), $"d365fo-pool-never-{Guid.NewGuid():N}.sqlite");
+        Assert.Null(Record.Exception(() => SqlitePool.ReleaseFor(never)));
+        Assert.Null(Record.Exception(() => SqlitePool.ReleaseFor("")));
+    }
+}

--- a/tests/D365FO.Core.Tests/TableMergeAnalyzerTests.cs
+++ b/tests/D365FO.Core.Tests/TableMergeAnalyzerTests.cs
@@ -1,0 +1,118 @@
+using D365FO.Core.Extract;
+using D365FO.Core.Index;
+using Xunit;
+
+namespace D365FO.Core.Tests;
+
+/// <summary>
+/// The merged view has to be the shape the AOS sees, and has to say so when it is not.
+/// </summary>
+/// <remarks>
+/// The roster of extension names used to be returned under a contract that promised a merge.
+/// The failure mode that makes worth testing: a caller reading "field not in the list" as
+/// "field does not exist", when the field is contributed by an extension nobody folded in.
+/// </remarks>
+[Collection(EnvironmentCollectionDefinition.Name)]
+public sealed class TableMergeAnalyzerTests : IDisposable
+{
+    private readonly string _dbPath = Path.Combine(Path.GetTempPath(), $"merge-{Guid.NewGuid():N}.sqlite");
+    private readonly string _workRoot = Path.Combine(Path.GetTempPath(), $"merge-work-{Guid.NewGuid():N}");
+    private readonly MetadataRepository _repo;
+
+    public TableMergeAnalyzerTests()
+    {
+        Directory.CreateDirectory(_workRoot);
+        _repo = new MetadataRepository(_dbPath);
+        _repo.EnsureSchema();
+    }
+
+    public void Dispose()
+    {
+        SqlitePool.ReleaseFor(_dbPath);
+        foreach (var ext in new[] { "", "-wal", "-shm" })
+        {
+            var p = _dbPath + ext;
+            if (File.Exists(p)) { try { File.Delete(p); } catch { } }
+        }
+        if (Directory.Exists(_workRoot)) { try { Directory.Delete(_workRoot, true); } catch { } }
+    }
+
+    private string WriteExtension(string fileName, string xml)
+    {
+        var path = Path.Combine(_workRoot, fileName);
+        File.WriteAllText(path, xml);
+        return path;
+    }
+
+    private void Seed(string extensionPath)
+    {
+        _repo.ApplyExtract(ExtractBatch.Empty("Foundation") with
+        {
+            Publisher = "Microsoft",
+            IsCustom = false,
+            Tables = new[]
+            {
+                new ExtractedTable("FmVehicle", null, "x", new[]
+                {
+                    new ExtractedTableField("VehicleId", "String", "FmVehicleId", null, false),
+                }),
+            },
+        });
+
+        _repo.ApplyExtract(ExtractBatch.Empty("FleetCustom") with
+        {
+            Publisher = "Contoso",
+            IsCustom = true,
+            Extensions = new[]
+            {
+                new ExtractedObjectExtension("Table", "FmVehicle", "FmVehicle.Extension", extensionPath),
+            },
+        });
+    }
+
+    [Fact]
+    public void An_extension_field_appears_in_the_merge_labelled_with_its_contributor()
+    {
+        var path = WriteExtension("FmVehicle.Extension.xml", """
+            <AxTableExtension>
+              <Name>FmVehicle.Extension</Name>
+              <Fields>
+                <AxTableField i:type="AxTableFieldString" xmlns:i="http://www.w3.org/2001/XMLSchema-instance">
+                  <Name>Nickname</Name>
+                  <ExtendedDataType>Name</ExtendedDataType>
+                </AxTableField>
+              </Fields>
+              <Indexes />
+              <Relations />
+            </AxTableExtension>
+            """);
+        Seed(path);
+
+        var merged = TableMergeAnalyzer.Merge(_repo, "FmVehicle");
+
+        Assert.Equal("FmVehicle", merged.Table);
+        Assert.Empty(merged.Unreadable);
+
+        var baseField = Assert.Single(merged.Fields, f => f.Name == "VehicleId");
+        Assert.Equal("FmVehicle", baseField.Origin);
+
+        var added = Assert.Single(merged.Fields, f => f.Name == "Nickname");
+        Assert.Equal("FmVehicle.Extension", added.Origin);
+        Assert.Equal("FleetCustom", added.Model);
+        Assert.Equal("Name", added.Detail);
+    }
+
+    [Fact]
+    public void An_extension_that_cannot_be_read_is_reported_rather_than_dropped()
+    {
+        // A merge missing a contributor is worse than no merge: it answers "that field does not
+        // exist" with the same confidence as a complete one.
+        Seed(Path.Combine(_workRoot, "gone.xml"));
+
+        var merged = TableMergeAnalyzer.Merge(_repo, "FmVehicle");
+
+        Assert.Single(merged.Unreadable);
+        Assert.Contains("FmVehicle.Extension", merged.Unreadable[0]);
+        Assert.DoesNotContain(merged.Fields, f => f.Name == "Nickname");
+    }
+}

--- a/tests/D365FO.Core.Tests/TestIndexIsolationTests.cs
+++ b/tests/D365FO.Core.Tests/TestIndexIsolationTests.cs
@@ -1,0 +1,34 @@
+using D365FO.Core;
+using D365FO.Core.Journal;
+using Xunit;
+
+namespace D365FO.Core.Tests;
+
+/// <summary>
+/// The suite must journal into its own directory, never the one the developer's index uses.
+/// </summary>
+/// <remarks>
+/// Without this, a full run appended into <c>&lt;dirname(D365FO_INDEX_DB)&gt;/journal</c> — the
+/// real undo journal — and the 500-entry cap then pruned the developer's genuine history away.
+/// It cost nothing to notice and there was nothing watching, so it is watched here.
+/// </remarks>
+public class TestIndexIsolationTests
+{
+    [Fact]
+    public void Journal_resolves_under_the_isolated_test_root_not_the_machine_index()
+    {
+        var journalDir = ModificationJournal.ForIndex().JournalDirectory;
+        var testRoot = Path.Combine(Path.GetTempPath(), "d365fo-testrun");
+
+        Assert.StartsWith(testRoot, Path.GetFullPath(journalDir), StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact]
+    public void Index_path_resolves_under_the_isolated_test_root()
+    {
+        var db = Path.GetFullPath(D365FoSettings.FromEnvironment().DatabasePath);
+        var testRoot = Path.Combine(Path.GetTempPath(), "d365fo-testrun");
+
+        Assert.StartsWith(testRoot, db, StringComparison.OrdinalIgnoreCase);
+    }
+}

--- a/tests/D365FO.Core.Tests/WorkflowScaffolderTests.cs
+++ b/tests/D365FO.Core.Tests/WorkflowScaffolderTests.cs
@@ -187,10 +187,11 @@ public class WorkflowScaffolderTests
                 Path.Combine(dir, "ConVehicleTask.xml"));
 
             // Listed, not counted (issue #158): when this went red the message said
-            // "Expected 3, Actual 2" and nothing about which write was missing.
-            Assert.Equal(
-                new[] { "ConVehicleApproval.xml", "ConVehicleReview.xml", "ConVehicleTask.xml" },
-                Directory.GetFiles(dir, "*.xml").Select(Path.GetFileName).Order().ToArray());
+            // "Expected 3, Actual 2" and nothing about which write was missing. Existence is
+            // now asked per path rather than read off a directory enumeration, which is what
+            // made this the flakiest assertion in the suite — see WrittenFilesAssert.
+            WrittenFilesAssert.ExactlyTheseXml(dir,
+                "ConVehicleApproval.xml", "ConVehicleReview.xml", "ConVehicleTask.xml");
         }
         finally
         {

--- a/tests/D365FO.Core.Tests/WrittenFilesAssert.cs
+++ b/tests/D365FO.Core.Tests/WrittenFilesAssert.cs
@@ -1,0 +1,43 @@
+using Xunit;
+
+namespace D365FO.Core.Tests;
+
+/// <summary>
+/// Assertions about which files a write path actually put on disk.
+/// </summary>
+/// <remarks>
+/// Asserting this off a <see cref="Directory.GetFiles(string, string)"/> listing is flaky on
+/// Windows under load. <c>ScaffoldFileWriter</c> publishes by renaming a staged file onto the
+/// target and then takes <c>FileInfo.Length</c> on that target, so a write that returned
+/// normally has PROVEN the file was there. A directory enumeration taken in the same instant
+/// can still be missing the entry the rename just created — this cost roughly one run in ten
+/// of the full suite, always as "Expected 3, Actual 2" with no exception anywhere and no way
+/// to tell a real lost write from an enumeration artefact.
+///
+/// Existence is therefore queried one path at a time, which does not have that window. The
+/// listing is still taken — to catch files nobody asked for, and to put the directory's real
+/// contents into the failure message when something genuinely did go missing.
+/// </remarks>
+internal static class WrittenFilesAssert
+{
+    /// <summary>Exactly <paramref name="expected"/> `.xml` files exist in <paramref name="dir"/>.</summary>
+    public static void ExactlyTheseXml(string dir, params string[] expected)
+    {
+        var listed = Directory.GetFiles(dir, "*.xml")
+            .Select(Path.GetFileName)
+            .Where(n => n is not null)
+            .Select(n => n!)
+            .Order()
+            .ToArray();
+
+        var missing = expected.Where(n => !File.Exists(Path.Combine(dir, n))).Order().ToArray();
+        Assert.True(missing.Length == 0,
+            $"These were never written: [{string.Join(", ", missing)}]. " +
+            $"The directory lists [{string.Join(", ", listed)}].");
+
+        var unexpected = listed.Except(expected, StringComparer.Ordinal).Order().ToArray();
+        Assert.True(unexpected.Length == 0,
+            $"Files nobody asked for: [{string.Join(", ", unexpected)}]. " +
+            $"Expected exactly [{string.Join(", ", expected.Order())}].");
+    }
+}

--- a/tests/Shared/TestIndexIsolation.cs
+++ b/tests/Shared/TestIndexIsolation.cs
@@ -1,0 +1,63 @@
+using System.Runtime.CompilerServices;
+
+namespace D365FO.TestSupport;
+
+/// <summary>
+/// Points the test process at its own SQLite index, so the suite cannot write into the index —
+/// or the journal — of the machine it runs on.
+/// </summary>
+/// <remarks>
+/// <para>
+/// <c>ModificationJournal.ForIndex</c> resolves the journal to
+/// <c>&lt;dirname(D365FO_INDEX_DB)&gt;/journal</c>, and <c>ScaffoldFileWriter.Write</c> journals
+/// every write. On a developer machine with <c>D365FO_INDEX_DB</c> configured — which is the
+/// normal state, and how <c>d365fo init</c> leaves it — that meant every scaffold-writing test in
+/// the suite appended into the developer's REAL undo journal. Measured on this repo's own host:
+/// the journal directory held exactly 500 entries, which is <c>DefaultMaxEntries</c>, and the
+/// newest was a <c>scaffold-write</c> naming a test temp directory. The cap prunes oldest-first,
+/// so a full test run silently evicts the developer's real undo history and replaces it with
+/// entries pointing at directories that no longer exist.
+/// </para>
+/// <para>
+/// It was also a flakiness source. Both test assemblies run as concurrent processes under
+/// <c>dotnet test</c> on the solution, so they appended to and pruned the SAME journal directory
+/// at the same time — two processes each deleting "the oldest entries until under the cap" while
+/// the other is writing them. CI never saw it, because CI has no <c>D365FO_INDEX_DB</c> set.
+/// </para>
+/// <para>
+/// Only the index is redirected. <c>D365FO_PACKAGES_PATH</c> and <c>D365FO_WORKSPACE_PATH</c> are
+/// deliberately left alone: <c>ObjectTypeRegistryAotTests</c> and <c>MetadataContractsAotTests</c>
+/// are inert without them and are the tests that check this repo's claims against a real
+/// installation. Clearing those to match CI would quietly delete that coverage on the one kind of
+/// machine that can provide it.
+/// </para>
+/// </remarks>
+internal static class TestIndexIsolation
+{
+    private static string? _root;
+
+    [ModuleInitializer]
+    internal static void RedirectIndexAndJournal()
+    {
+        _root = Path.Combine(
+            Path.GetTempPath(),
+            "d365fo-testrun",
+            $"{typeof(TestIndexIsolation).Assembly.GetName().Name}-{Guid.NewGuid():N}");
+        Directory.CreateDirectory(_root);
+
+        Environment.SetEnvironmentVariable("D365FO_INDEX_DB", Path.Combine(_root, "index.sqlite"));
+
+        AppDomain.CurrentDomain.ProcessExit += (_, _) =>
+        {
+            try
+            {
+                if (_root is not null && Directory.Exists(_root))
+                    Directory.Delete(_root, recursive: true);
+            }
+            catch
+            {
+                // Best-effort: a temp directory left behind is not worth failing a green run over.
+            }
+        };
+    }
+}


### PR DESCRIPTION
Waves 01 and 02 of the MCP-parity plan, plus the defects each one surfaced.

The plan's thesis: the token argument for a CLI over an MCP server holds only as long as the agent never has to leave the CLI. Every fall back to hand-editing AOT XML costs more than the tool schemas saved, and walks past the grounding, form-pattern and reference gates. So the write surface is the load-bearing wave, and the truth-up is what makes the rest legible.

## Wave 01 — stabilisation

- `prepare test` resolves a **table**, not only a class. `prepare test CustTable.validateWrite` works, dotted form and all. The index stores *declared* members only, so a table that never overrode `validateWrite` has no row for it — which is exactly the method the caller came for; the inherited kernel data methods are now listed beside the table's own overrides, and the answer carries the shape a table test needs (arrange a buffer, assert the verdict **and** the infolog line, keep the accepting case beside the rejecting one).
- README claimed 310+ tests, 19 skills, 29 `generate` commands, 27 adapter tools. Real: 1373, 38, 33, 28. The skill listing is now generated from `skills/_source` so it cannot drift silently again.
- Adds `CHANGELOG.md`, `SECURITY.md`, and a CI **warning ratchet** (baseline 117).

## Wave 02 — the write surface

`modify` goes from 5 operations to 22: `add-index`, `add-relation`, `add-field-group`, `add-delete-action`, `rename-field`, `add-query-range`, `add-entry-point`, seven `remove-*` forms, and `modify batch`.

- **All 41 bridge-writable kinds**, not 5. `SupportedKinds` was hand-written while the bridge resolves collections from `ObjectTypeRegistry.BridgeCollections()` — so `modify property` refused a query, a privilege, a menu item, a view, a report and a tile the layer underneath could write. Same drift as #171, same fix: derive it.
- **`modify batch`** — N changes in one read-edit-write. A refused step discards the batch with *nothing* written, and says so.
- **`get table --merged`** returns the effective schema, each member labelled with its contributor; an unreadable extension is reported, not skipped. Checked against the shipped `VendInvoiceInfoTable`: 126 fields, 11 from 4 extensions.

## Defects found on the way

**From a green suite:**

| | |
|---|---|
| A doc comment was reported as a method's exact signature | `ExtractSignatureLine` skipped blank lines and attributes but not comments — **362 of 621** methods on the shipped `SalesTable`, zero after. Worse than an empty signature: `prepare`/`get` present it as the declaration a CoC wrapper must match. |
| `modify` never canonicalised member order before writing back | `DataContractSerializer` *skips* a child arriving out of turn rather than rejecting it, so an edit creating a missing collection came back `ok` with the change silently absent. |
| GHSA-2m69-gcr7-jv3q (high) in transitive SQLitePCLRaw 2.1.6 | NuGet printed `NU1903` on every build and nothing watched. Bumped to `Microsoft.Data.Sqlite` 10.0.11. |
| The suite wrote into the **developer's** real undo journal | 500 entries — the cap — newest a `scaffold-write` naming a test temp dir. Running the tests silently evicted real history. |
| ~1-in-10 full-suite flake | Process-wide `ClearAllPools()` disposing another test's in-use connection. **0 failures in 14 runs** after. |

**Only findable against a real installation** (this branch was run against the live `IMetadataProvider`):

| | |
|---|---|
| The bridge could not read a table **at all** | `XmlSerializer` refuses any type implementing `IEnumerable` without `Add(object)`; Microsoft's `AccessGrant` does exactly that, so `AxTable`, `AxSecurityPrivilege` and `AxMenuItem*` all failed. `modify` never worked on a real installation for the kinds people use most. Both paths now use `DataContractSerializer` — which `validateArtifact` already used, and already explained. |
| Every `modify remove-*` failed on invocation | `ModifyRemoveSettings` was `abstract`; Spectre constructs settings by reflection, so all seven compiled, registered, appeared in `--help`, then died. `CommandSurfaceTests` now walks all 175 settings types. |
| A delete action was written naming nothing | The member is `<Table>`, not `<RelatedTable>`. The extractor read the same wrong element: **0 delete actions across 214 packages**. |
| The index held 4,896 queries and **zero** datasources | Shipped queries use `AxQuerySimpleRootDataSource`; the extractor matched a name occurring in no shipped query. Only the fixtures use the short spelling — which is why the suite stayed green. |

> ⚠️ The last two need `d365fo index extract` before an existing index reflects them.

## Verification

- **1 580 tests** green (570 CLI + 1 010 Core); **0 failures in 14 consecutive full-suite runs**
- eval catalog 52/52 · knowledge audit clean · K/E/T coverage check ok
- warning ratchet at baseline 117
- published trimmed single-file build matches an ordinary build on all 17 checked commands (bundled native SQLite included — the #182 shape)
- every new operation exercised against the **live** `IMetadataProvider` on a D365FO VM; the AOT was restored to its pre-session state afterwards (214 packages before and after, `diff` against the recorded baseline empty, nothing pre-existing touched)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019D9AMJP7Ct2U4Q3xVeMn8B
