### PR TITLE
Wave 03: BP moniker catalog and table patterns, grounded in the installation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,30 @@ was ported from.
 
 ## [Unreleased]
 
+### Added — grounded knowledge catalogs
+- **`d365fo bp-moniker`** — `validate`, `search`, `suppress`, `extract`. Every Best-Practice
+  moniker has been guessed wrong at least once, and nothing about the spelling separates the real
+  `BPErrorPrivilegeNotCoveredByDuty` from the entirely plausible `BPCheckNamingConventions`; a
+  suppression naming a moniker that does not exist suppresses nothing while looking deliberate.
+  So the catalog never infers — a name is real because an installation declared it.
+  Two sources, extracted from `PackagesLocalDirectory` and shipped as a snapshot so the answer
+  works with no install: canonical names from every model's `AxRuleSet/*.xml`, and message text
+  from the resx resources embedded in `bin/BPExtensions/*.dll`. Measured on this repo's own host:
+  144 rule sets, **409 canonical monikers**, 17 rule assemblies, 726 entries of which 724 carry
+  real message text. The 317 non-canonical entries are resource strings belonging to the upgrade
+  and form-conversion tooling — kept, because their text is searchable, but flagged
+  `canonical: false`, since presence in the catalog is not what makes something a rule.
+  Lookup is deliberately **case-sensitive** (xppbp and the suppression reader match exactly), and
+  a case-only miss is answered with the right casing rather than a flat "no".
+  `D365FO_BP_CATALOG_PATH` points at a snapshot matching an instance's own D365FO version.
+  The resources are read through `PEReader` rather than by loading the assemblies — loading a
+  D365FO rule assembly drags in its dependency graph for the sake of a string table.
+- **`d365fo table-pattern list|spec`** — the decision layer over `generate table`. The patterns,
+  their canonical `TableGroup` and their default fields already existed, but only as a value
+  `--pattern` accepted: an agent choosing a shape could not see what the choices were or what each
+  implied, so it guessed a name (one wasted round trip on the refusal) or skipped `--pattern` and
+  got a table with no `TableGroup` at all.
+
 ### Added — the structural half of `modify`
 - **Seventeen new `modify` sub-commands**, taking the write surface from 5 operations to 22:
   `add-index`, `add-relation`, `add-field-group`, `add-delete-action`, `rename-field`,

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
 [![.NET](https://img.shields.io/badge/.NET-10-purple.svg)](https://dotnet.microsoft.com/)
 [![Platform](https://img.shields.io/badge/platform-Windows%20%7C%20macOS%20%7C%20Linux-lightgrey.svg)]()
-[![Tests](https://img.shields.io/badge/tests-1580-brightgreen.svg)]()
+[![Tests](https://img.shields.io/badge/tests-1595-brightgreen.svg)]()
 [![Successor to d365fo-mcp-server](https://img.shields.io/badge/successor%20to-d365fo--mcp--server-orange.svg)](https://github.com/dynamics365ninja/d365fo-mcp-server)
 
 *Grounded AI development for Dynamics 365 Finance & Operations — works with GitHub Copilot, Claude Code, Codex, Gemini CLI, and any agent with a shell*
@@ -292,6 +292,7 @@ See [docs/TOKEN_ECONOMICS.md](docs/TOKEN_ECONOMICS.md) for the full analysis and
 | **Labels** | `labels search\|resolve\|info\|create\|rename\|delete` — search/resolve plus in-place `*.label.txt` edits, multi-language via `--lang` (mirrors the MCP `labels` tool) |
 | **Journal / undo** | `undo [--steps N] [--dry-run]`, `journal list`, `delete` (kind/name, bridge or on-disk) — deterministic single-command rollback for every write path (mirrors the MCP `undo_last_modification` tool) |
 | **Modify** | `modify property\|method`, `modify add-field\|add-enum-value\|add-control`, `modify add-index\|add-relation\|add-field-group\|add-delete-action`, `modify rename-field`, `modify add-query-range\|remove-query-range`, `modify add-entry-point\|remove-entry-point`, seven `modify remove-*` forms, and `modify batch` (several changes in one read-edit-write) — 22 operations over all 41 bridge-writable kinds, extension-aware and journalled for `undo` |
+| **Patterns & rules** | `table-pattern list\|spec` — table shapes and what each presets · `bp-moniker validate\|search\|suppress\|extract` — Best-Practice rule monikers from names a real installation declares, never a guess |
 | **Analyze** | `analyze completeness`, `analyze integration`, `analyze impact`, `lint`, `suggest edt`, `suggest extension`, `report-integrations` |
 | **Review** | `review diff` |
 | **Models** | `models list`, `models deps`, `models coupling` |

--- a/src/D365FO.Cli/CliApp.cs
+++ b/src/D365FO.Cli/CliApp.cs
@@ -359,6 +359,22 @@ public static class CliApp
             // The CLI's `get_knowledge` equivalent: the verified skills/_source corpus,
             // embedded in the binary and served per-topic / per-section so an agent
             // without skill-file support can still ground itself.
+            cfg.AddBranch("table-pattern", b =>
+            {
+                b.SetDescription("Table shape patterns: what each one is for, and what it presets.");
+                b.AddCommand<TablePatternListCommand>("list").WithDescription("Every pattern with its TableGroup, when to use it, and its default fields.");
+                b.AddCommand<TablePatternSpecCommand>("spec").WithDescription("One pattern in full, with the scaffold call that produces it.");
+            });
+
+            cfg.AddBranch("bp-moniker", b =>
+            {
+                b.SetDescription("Best-Practice rule monikers, from names a real installation declares.");
+                b.AddCommand<BpMonikerValidateCommand>("validate").WithDescription("Is this an exact, real moniker? Case-sensitive, as xppbp is.");
+                b.AddCommand<BpMonikerSearchCommand>("search").WithDescription("Find the rule covering a scenario, by words in its name, message or description.");
+                b.AddCommand<BpMonikerSuppressCommand>("suppress").WithDescription("Render a _BPSuppressions.xml <Diagnostic> block; refuses a moniker the catalog does not know.");
+                b.AddCommand<BpMonikerExtractCommand>("extract").WithDescription("Rebuild the catalog from this installation's rule sets and BP rule assemblies.");
+            });
+
             cfg.AddBranch("knowledge", b =>
             {
                 b.SetDescription("Verified X++/D365FO knowledge topics (the skills/_source corpus), served per topic or per section.");

--- a/src/D365FO.Cli/Commands/Knowledge/BpMonikerCommands.cs
+++ b/src/D365FO.Cli/Commands/Knowledge/BpMonikerCommands.cs
@@ -1,0 +1,250 @@
+using D365FO.Core;
+using D365FO.Core.Knowledge;
+using Spectre.Console.Cli;
+
+namespace D365FO.Cli.Commands.Knowledge;
+
+// `d365fo bp-moniker` — the answer to "is this a real Best-Practice rule?", from names an
+// installation declares rather than from a plausible-looking PascalCase guess.
+//
+// Every moniker has been guessed wrong at least once. BPErrorPrivilegeNotCoveredByDuty is real;
+// BPCheckNamingConventions reads exactly like a rule and is not one. A suppression naming a
+// moniker that does not exist suppresses nothing while looking entirely deliberate, so this
+// never infers a name — it looks one up.
+
+/// <summary><c>d365fo bp-moniker validate</c> — is this an exact, real moniker?</summary>
+public sealed class BpMonikerValidateCommand : Command<BpMonikerValidateCommand.Settings>
+{
+    public sealed class Settings : D365OutputSettings
+    {
+        [CommandArgument(0, "<MONIKER>")]
+        [System.ComponentModel.Description("Moniker to check, e.g. BPErrorPrivilegeNotCoveredByDuty. Matched exactly — xppbp and the suppression reader are case-sensitive.")]
+        public string Moniker { get; init; } = "";
+    }
+
+    public override int Execute(CommandContext ctx, Settings settings)
+    {
+        var kind = OutputMode.Resolve(settings.Output);
+
+        if (!BpMonikerCatalog.IsPopulated)
+        {
+            // An empty catalog cannot refute anything. Saying "not a moniker" here would be the
+            // worst possible answer: confidently wrong, and indistinguishable from a real verdict.
+            return RenderHelpers.Render(kind, ToolResult<object>.Fail(D365FoErrorCodes.NoIndex,
+                "The BP moniker catalog is empty, so this cannot say whether the moniker is real.",
+                $"Run `d365fo bp-moniker extract` on a machine with D365FO_PACKAGES_PATH set, or point {BpMonikerCatalog.PathEnvVar} at a captured snapshot."));
+        }
+
+        var found = BpMonikerCatalog.Find(settings.Moniker);
+        if (found is not null)
+        {
+            return RenderHelpers.Render(kind, ToolResult<object>.Success(new
+            {
+                moniker = found.Name,
+                valid = true,
+                canonical = found.Canonical,
+                found.Message,
+                found.Description,
+                note = found.Canonical
+                    ? null
+                    : "This string ships in a rule assembly but NO rule set declares it — it is not a BP rule, "
+                      + "and suppressing it will have no effect.",
+            }));
+        }
+
+        var caseVariants = BpMonikerCatalog.CaseVariants(settings.Moniker);
+        var near = BpMonikerCatalog.Search(settings.Moniker, 5);
+
+        return RenderHelpers.Render(kind, ToolResult<object>.Success(new
+        {
+            moniker = settings.Moniker,
+            valid = false,
+            caseVariants = caseVariants.Count > 0 ? caseVariants : null,
+            didYouMean = near.Count > 0 ? near.Select(m => m.Name).ToArray() : null,
+            note = caseVariants.Count > 0
+                ? "The name exists with different casing. The moniker is matched exactly, so the casing above is the one to use."
+                : "No rule set in the indexed installation declares this name. Do not suppress it — a suppression naming a "
+                  + "moniker that does not exist suppresses nothing.",
+        }));
+    }
+}
+
+/// <summary><c>d365fo bp-moniker search</c> — which rule covers this scenario?</summary>
+public sealed class BpMonikerSearchCommand : Command<BpMonikerSearchCommand.Settings>
+{
+    public sealed class Settings : D365OutputSettings
+    {
+        [CommandArgument(0, "<QUERY>")]
+        [System.ComponentModel.Description("Words to look for. All of them must appear, in the name, the message or the description — so a scenario can be described in words the rule name does not contain.")]
+        public string Query { get; init; } = "";
+
+        [CommandOption("--limit <N>")]
+        [System.ComponentModel.Description("Maximum matches (default 20).")]
+        public int Limit { get; init; } = 20;
+
+        [CommandOption("--canonical-only")]
+        [System.ComponentModel.Description("Only real BP rules. Without it, rule-assembly strings that no rule set declares are listed too, flagged canonical:false.")]
+        public bool CanonicalOnly { get; init; }
+    }
+
+    public override int Execute(CommandContext ctx, Settings settings)
+    {
+        var kind = OutputMode.Resolve(settings.Output);
+
+        if (!BpMonikerCatalog.IsPopulated)
+        {
+            return RenderHelpers.Render(kind, ToolResult<object>.Fail(D365FoErrorCodes.NoIndex,
+                "The BP moniker catalog is empty.",
+                $"Run `d365fo bp-moniker extract`, or point {BpMonikerCatalog.PathEnvVar} at a captured snapshot."));
+        }
+
+        var hits = BpMonikerCatalog.Search(settings.Query, settings.Limit);
+        if (settings.CanonicalOnly) hits = hits.Where(m => m.Canonical).ToList();
+
+        return RenderHelpers.Render(kind, ToolResult<object>.Success(new
+        {
+            query = settings.Query,
+            count = hits.Count,
+            items = hits.Select(m => new { m.Name, m.Canonical, m.Message, m.Description }),
+        }));
+    }
+}
+
+/// <summary><c>d365fo bp-moniker suppress</c> — render a `_BPSuppressions.xml` block.</summary>
+public sealed class BpMonikerSuppressCommand : Command<BpMonikerSuppressCommand.Settings>
+{
+    public sealed class Settings : D365OutputSettings
+    {
+        [CommandArgument(0, "<MONIKER>")]
+        [System.ComponentModel.Description("Rule to suppress. Refused when the catalog does not know it.")]
+        public string Moniker { get; init; } = "";
+
+        [CommandOption("--path <URI>")]
+        [System.ComponentModel.Description("dynamics:// URI of the element the rule fired on, e.g. dynamics://Table/MyTable/Method/validateWrite. Required — a suppression with no path suppresses the rule everywhere.")]
+        public string? Path { get; init; }
+
+        [CommandOption("--justification <TEXT>")]
+        [System.ComponentModel.Description("Why the rule does not apply here. A reviewer reads this, so a placeholder is emitted when it is omitted.")]
+        public string? Justification { get; init; }
+
+        [CommandOption("--message <TEXT>")]
+        [System.ComponentModel.Description("Exact message xppbp reported. Defaults to the catalog's message template for the rule.")]
+        public string? Message { get; init; }
+
+        [CommandOption("--severity <LEVEL>")]
+        [System.ComponentModel.Description("Warning (default) or Error, matching what xppbp reported.")]
+        public string Severity { get; init; } = "Warning";
+    }
+
+    public override int Execute(CommandContext ctx, Settings settings)
+    {
+        var kind = OutputMode.Resolve(settings.Output);
+
+        if (string.IsNullOrWhiteSpace(settings.Path))
+        {
+            return RenderHelpers.Render(kind, ToolResult<object>.Fail(D365FoErrorCodes.BadInput,
+                "--path is required.",
+                "It is the dynamics:// URI xppbp reported the finding against — without it the block "
+                + "does not identify what is being suppressed."));
+        }
+
+        var known = BpMonikerCatalog.Find(settings.Moniker);
+        if (BpMonikerCatalog.IsPopulated && known is null)
+        {
+            var variants = BpMonikerCatalog.CaseVariants(settings.Moniker);
+            return RenderHelpers.Render(kind, ToolResult<object>.Fail(D365FoErrorCodes.TopicNotFound,
+                $"'{settings.Moniker}' is not a moniker any indexed rule set declares.",
+                variants.Count > 0
+                    ? $"The name exists as: {string.Join(", ", variants)}. Monikers are matched exactly."
+                    : "Find the right one with `d365fo bp-moniker search <words>`. Suppressing a name that does not exist suppresses nothing."));
+        }
+
+        var block = BpMonikerCatalog.SuppressionBlock(
+            settings.Moniker, settings.Path!, settings.Message, settings.Justification, settings.Severity);
+
+        return RenderHelpers.Render(kind, ToolResult<object>.Success(new
+        {
+            moniker = settings.Moniker,
+            canonical = known?.Canonical,
+            block,
+            file = "<Model>/<Model>/AxIgnoreDiagnosticList/<Model>_BPSuppressions.xml",
+            placement = "Add the block inside <IgnoreDiagnostics><Items>. The file is an AOT object like any "
+                      + "other — it belongs to the model whose code raised the finding.",
+        },
+        settings.Justification is null
+            ? new List<string> { "No --justification given; the block carries a TODO placeholder that a reviewer will see." }
+            : null));
+    }
+}
+
+/// <summary><c>d365fo bp-moniker extract</c> — rebuild the catalog from this installation.</summary>
+public sealed class BpMonikerExtractCommand : Command<BpMonikerExtractCommand.Settings>
+{
+    public sealed class Settings : D365OutputSettings
+    {
+        [CommandOption("--packages <PATH>")]
+        [System.ComponentModel.Description("PackagesLocalDirectory to scan. Defaults to D365FO_PACKAGES_PATH.")]
+        public string? Packages { get; init; }
+
+        [CommandOption("--out <PATH>")]
+        [System.ComponentModel.Description("Write the snapshot here. Point D365FO_BP_CATALOG_PATH at it to use a catalog matching this instance's D365FO version instead of the shipped one.")]
+        public string? Out { get; init; }
+    }
+
+    public override int Execute(CommandContext ctx, Settings settings)
+    {
+        var kind = OutputMode.Resolve(settings.Output);
+
+        var packages = settings.Packages ?? D365FoSettings.FromEnvironment().PackagesPath;
+        if (string.IsNullOrWhiteSpace(packages))
+        {
+            return RenderHelpers.Render(kind, ToolResult<object>.Fail(D365FoErrorCodes.PackagesPathNotFound,
+                "No packages path.", "Set D365FO_PACKAGES_PATH or pass --packages <PATH>."));
+        }
+
+        BpMonikerSnapshot snapshot;
+        BpExtractionReport report;
+        try
+        {
+            (snapshot, report) = BpCatalogExtractor.Extract(packages!);
+        }
+        catch (Exception ex)
+        {
+            return RenderHelpers.Render(kind, ToolResult<object>.Fail(D365FoErrorCodes.SourceUnreadable, ex.Message));
+        }
+
+        string? written = null;
+        if (!string.IsNullOrWhiteSpace(settings.Out))
+        {
+            var full = System.IO.Path.GetFullPath(settings.Out!);
+            var dir = System.IO.Path.GetDirectoryName(full);
+            if (!string.IsNullOrEmpty(dir)) Directory.CreateDirectory(dir);
+            File.WriteAllText(full, BpMonikerCatalog.ToJson(snapshot));
+            written = full;
+        }
+
+        var warnings = new List<string>();
+        if (report.CanonicalNames == 0)
+        {
+            warnings.Add("No AxRuleSet/*.xml declared a single moniker — nothing here can tell a real rule from a "
+                       + "resource string. Check that --packages points at a PackagesLocalDirectory.");
+        }
+        if (report.NameOnly > 0)
+        {
+            warnings.Add($"{report.NameOnly} canonical moniker(s) ship no message text in this install. They are still "
+                       + "real rules — absence of a description is not absence of a rule.");
+        }
+
+        return RenderHelpers.Render(kind, ToolResult<object>.Success(new
+        {
+            packagesPath = packages,
+            capturedAt = snapshot.CapturedAt,
+            total = snapshot.Monikers.Count,
+            report,
+            path = written,
+            note = written is null
+                ? "Nothing written — pass --out <PATH> to keep the snapshot."
+                : $"Set {BpMonikerCatalog.PathEnvVar} to this path to use it.",
+        }, warnings.Count > 0 ? warnings : null));
+    }
+}

--- a/src/D365FO.Cli/Commands/Knowledge/TablePatternCommands.cs
+++ b/src/D365FO.Cli/Commands/Knowledge/TablePatternCommands.cs
@@ -1,0 +1,156 @@
+using D365FO.Core;
+using D365FO.Core.Scaffolding;
+using Spectre.Console.Cli;
+
+namespace D365FO.Cli.Commands.Knowledge;
+
+// `d365fo table-pattern` — the decision layer over `generate table`.
+//
+// The patterns, their canonical TableGroup and their default fields already existed, but only
+// as an argument `generate table --pattern` accepts. An agent choosing a shape had no way to see
+// what the choices ARE or what each one implies, so it either guessed a pattern name (and got a
+// refusal listing valid values, one round trip wasted) or skipped --pattern entirely and got a
+// table with no TableGroup at all.
+
+/// <summary><c>d365fo table-pattern list</c> — every pattern, what it is for, what it presets.</summary>
+public sealed class TablePatternListCommand : Command<TablePatternListCommand.Settings>
+{
+    public sealed class Settings : D365OutputSettings
+    {
+    }
+
+    public override int Execute(CommandContext ctx, Settings settings)
+    {
+        var kind = OutputMode.Resolve(settings.Output);
+
+        var items = Enum.GetValues<TablePattern>()
+            .Where(p => p != TablePattern.None)
+            .Select(p => new
+            {
+                pattern = p.ToString(),
+                tableGroup = TablePatternPresets.TableGroupFor(p),
+                whenToUse = TablePatternGuidance.WhenToUse(p),
+                defaultFields = TablePatternPresets.DefaultFieldsFor(p)
+                    .Select(f => new { f.Name, edt = f.Edt, f.Mandatory }),
+            })
+            .ToList();
+
+        return RenderHelpers.Render(kind, ToolResult<object>.Success(new
+        {
+            count = items.Count,
+            items,
+            storage = Enum.GetValues<TableStorage>().Select(s => new
+            {
+                storage = s.ToString(),
+                tableType = TablePatternPresets.TableTypeFor(s),
+                note = TablePatternGuidance.StorageNote(s),
+            }),
+            usage = "d365fo generate table <NAME> --pattern <PATTERN> [--table-type <STORAGE>]",
+        }));
+    }
+}
+
+/// <summary><c>d365fo table-pattern spec</c> — one pattern in full.</summary>
+public sealed class TablePatternSpecCommand : Command<TablePatternSpecCommand.Settings>
+{
+    public sealed class Settings : D365OutputSettings
+    {
+        [CommandArgument(0, "<PATTERN>")]
+        [System.ComponentModel.Description("Pattern name or a known alias — master, setup, config, transactional, worksheet-header, lookup, …")]
+        public string Pattern { get; init; } = "";
+    }
+
+    public override int Execute(CommandContext ctx, Settings settings)
+    {
+        var kind = OutputMode.Resolve(settings.Output);
+
+        if (!TablePatternNormalizer.TryNormalize(settings.Pattern, out var pattern, out var error))
+        {
+            return RenderHelpers.Render(kind, ToolResult<object>.Fail(D365FoErrorCodes.BadInput,
+                error ?? $"Unknown table pattern '{settings.Pattern}'.",
+                "See them all with `d365fo table-pattern list`."));
+        }
+
+        if (pattern == TablePattern.None)
+        {
+            return RenderHelpers.Render(kind, ToolResult<object>.Success(new
+            {
+                pattern = "None",
+                tableGroup = (string?)null,
+                whenToUse = TablePatternGuidance.WhenToUse(pattern),
+                defaultFields = Array.Empty<object>(),
+                note = "No TableGroup is written at all, so the AOT default (Miscellaneous) applies. "
+                     + "Pick a real pattern unless the table genuinely fits none of them.",
+            }));
+        }
+
+        var fields = TablePatternPresets.DefaultFieldsFor(pattern);
+        return RenderHelpers.Render(kind, ToolResult<object>.Success(new
+        {
+            pattern = pattern.ToString(),
+            tableGroup = TablePatternPresets.TableGroupFor(pattern),
+            whenToUse = TablePatternGuidance.WhenToUse(pattern),
+            defaultFields = fields.Select(f => new { f.Name, edt = f.Edt, f.Mandatory }),
+            scaffoldCall = $"d365fo generate table <NAME> --pattern {pattern} --install-to <Model>",
+            note = fields.Count > 0
+                ? "The default fields are a starting point the scaffold writes when --field is not given; "
+                  + "any --field you pass replaces them entirely rather than adding to them."
+                : null,
+        }));
+    }
+}
+
+/// <summary>
+/// What each pattern is for, in the words a developer choosing between them needs.
+/// </summary>
+/// <remarks>
+/// Kept beside the CLI rather than in the scaffolder: the scaffolder needs the TableGroup and the
+/// field defaults, which are facts about the AOT. This is advice about which to pick, which is a
+/// different thing and should not be mistaken for metadata.
+/// </remarks>
+internal static class TablePatternGuidance
+{
+    public static string WhenToUse(TablePattern pattern) => pattern switch
+    {
+        TablePattern.None =>
+            "No group. Only when the table fits none of the others — the AOT default (Miscellaneous) then applies.",
+        TablePattern.Main =>
+            "The master data a module is about: customers, vendors, items. One row per real-world entity, "
+            + "long-lived, referenced by transactions.",
+        TablePattern.Transaction =>
+            "Rows recording that something happened, keyed by date and voucher. Never edited in place after "
+            + "posting; volume grows without bound.",
+        TablePattern.Parameter =>
+            "Module configuration — typically ONE row per company. Reached through a parameters form and a "
+            + "find() that creates the row on first use.",
+        TablePattern.Group =>
+            "A classification other tables point at: customer groups, item groups. Small, hand-maintained, "
+            + "referenced by a relation from the tables it groups.",
+        TablePattern.WorksheetHeader =>
+            "The header of a document being prepared before posting — a journal, an order. Owns the lines and "
+            + "carries the status that decides whether they can still change.",
+        TablePattern.WorksheetLine =>
+            "The lines of such a document, related to the header and deleted with it.",
+        TablePattern.Reference =>
+            "Lookup data referenced by others but not owned by a module — country codes, units. Rarely changes.",
+        TablePattern.Framework =>
+            "Plumbing for a framework rather than business data: state, queues, mappings. Not something a user "
+            + "browses.",
+        TablePattern.Miscellaneous =>
+            "The explicit 'none of the above'. Prefer a specific pattern; this one tells a later reader nothing.",
+        _ => "No guidance recorded for this pattern.",
+    };
+
+    public static string StorageNote(TableStorage storage) => storage switch
+    {
+        TableStorage.RegularTable =>
+            "Persisted, backed by a real SQL table. The default, and what almost every table wants.",
+        TableStorage.TempDB =>
+            "Per-session temporary table in tempdb. Survives across method calls within the session and can be "
+            + "joined server-side — the right choice for a report's data set.",
+        TableStorage.InMemory =>
+            "Held in memory and spilled to a file when it grows. Cheap for small sets, but every row crosses the "
+            + "tier boundary, so it is the wrong choice for anything a query should join.",
+        _ => "",
+    };
+}

--- a/src/D365FO.Core/D365FO.Core.csproj
+++ b/src/D365FO.Core/D365FO.Core.csproj
@@ -31,6 +31,12 @@
          embedded to make that checkable without an installation. -->
     <EmbeddedResource Include="FormPatterns\form-patterns.json" />
     <EmbeddedResource Include="Scaffolding\FormTemplates\*.template.xml" />
+
+    <!-- Best-Practice rule monikers, extracted from a real installation by
+         `d365fo bp-moniker extract`. Shipped so the catalog can answer "is this a real
+         rule?" on a machine with no D365FO install; D365FO_BP_CATALOG_PATH overrides it
+         with a snapshot matching that instance's own D365FO version. -->
+    <EmbeddedResource Include="Knowledge\Data\bp-monikers.json" />
     <!-- Knowledge topics served by `d365fo knowledge` / the MCP `get_knowledge`
          tool. Embedded straight from the single-source skill corpus so a fact is
          corrected in exactly one place (see D365FO.Core/Knowledge/KnowledgeBase.cs). -->

--- a/src/D365FO.Core/Knowledge/BpCatalogExtractor.cs
+++ b/src/D365FO.Core/Knowledge/BpCatalogExtractor.cs
@@ -1,0 +1,201 @@
+// <copyright file="BpCatalogExtractor.cs" company="d365fo-cli contributors">
+// MIT
+// </copyright>
+
+using System.Reflection.Metadata;
+using System.Reflection.PortableExecutable;
+using System.Resources;
+using System.Xml.Linq;
+
+namespace D365FO.Core.Knowledge;
+
+/// <summary>What one extraction run found, so the run can report its own figures.</summary>
+/// <param name="RuleSetFiles">How many <c>AxRuleSet/*.xml</c> were read.</param>
+/// <param name="CanonicalNames">Distinct monikers those rule sets declare.</param>
+/// <param name="ResourceAssemblies">BP rule assemblies scanned for message text.</param>
+/// <param name="WithMessage">Entries that ended up with a real message.</param>
+/// <param name="NameOnly">Canonical entries the install ships no message for.</param>
+/// <param name="NonCanonical">Resource strings that no rule set lists — not BP rules.</param>
+public sealed record BpExtractionReport(
+    int RuleSetFiles,
+    int CanonicalNames,
+    int ResourceAssemblies,
+    int WithMessage,
+    int NameOnly,
+    int NonCanonical);
+
+/// <summary>
+/// Builds the BP moniker catalog from a real <c>PackagesLocalDirectory</c>.
+/// </summary>
+/// <remarks>
+/// <para>Two independent sources, and they answer different questions.</para>
+/// <para>
+/// <b>Canonical names</b> come from every model's <c>&lt;Model&gt;/&lt;Model&gt;/AxRuleSet/*.xml</c>,
+/// a flat list of the monikers that model's rules can raise. The union is the full name set, and
+/// it is the only thing that answers "is this a real BP rule".
+/// </para>
+/// <para>
+/// <b>Message text</b> comes from the resx-backed resources embedded in
+/// <c>bin/BPExtensions/*.dll</c>, keyed by the moniker itself. Coverage is high but not total, and
+/// the extraction also yields strings that are NOT rules — messages belonging to the upgrade and
+/// form-conversion tooling. Those are kept with <c>Canonical = false</c> rather than dropped,
+/// because a searchable message is useful even when the string is not a rule; what matters is that
+/// the distinction is recorded rather than guessed at read time.
+/// </para>
+/// <para>
+/// The resources are read through <see cref="PEReader"/> rather than by loading the assemblies.
+/// Loading a D365FO rule assembly drags in its dependency graph and executes its module
+/// initialisers, which is a lot of risk for a string table.
+/// </para>
+/// </remarks>
+public static class BpCatalogExtractor
+{
+    public static (BpMonikerSnapshot Snapshot, BpExtractionReport Report) Extract(string packagesPath)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(packagesPath);
+        if (!Directory.Exists(packagesPath))
+            throw new DirectoryNotFoundException($"Packages path not found: {packagesPath}");
+
+        var (canonical, ruleSetFiles) = ReadCanonicalNames(packagesPath);
+        var (messages, assemblies) = ReadRuleMessages(packagesPath);
+
+        var names = new SortedSet<string>(canonical, StringComparer.Ordinal);
+        foreach (var key in messages.Keys) names.Add(key);
+
+        var monikers = new List<BpMoniker>(names.Count);
+        foreach (var name in names)
+        {
+            messages.TryGetValue(name, out var message);
+            messages.TryGetValue(name + "Description", out var description);
+            monikers.Add(new BpMoniker(name, canonical.Contains(name), message, description));
+        }
+
+        // A "<Moniker>Description" entry is documentation for its rule, not a rule of its own.
+        monikers.RemoveAll(m => !m.Canonical
+                                && m.Name.EndsWith("Description", StringComparison.Ordinal)
+                                && names.Contains(m.Name[..^"Description".Length]));
+
+        var report = new BpExtractionReport(
+            RuleSetFiles: ruleSetFiles,
+            CanonicalNames: canonical.Count,
+            ResourceAssemblies: assemblies,
+            WithMessage: monikers.Count(m => m.Message is not null),
+            NameOnly: monikers.Count(m => m.Canonical && m.Message is null),
+            NonCanonical: monikers.Count(m => !m.Canonical));
+
+        return (new BpMonikerSnapshot(DateTimeOffset.UtcNow, packagesPath, monikers), report);
+    }
+
+    private static (HashSet<string> Names, int Files) ReadCanonicalNames(string packagesPath)
+    {
+        var names = new HashSet<string>(StringComparer.Ordinal);
+        var files = 0;
+
+        foreach (var ruleSet in Directory.EnumerateFiles(packagesPath, "*.xml", new EnumerationOptions
+        {
+            RecurseSubdirectories = true,
+            MatchCasing = MatchCasing.CaseInsensitive,
+            IgnoreInaccessible = true,
+        }).Where(p => p.Contains($"{Path.DirectorySeparatorChar}AxRuleSet{Path.DirectorySeparatorChar}", StringComparison.OrdinalIgnoreCase)))
+        {
+            files++;
+            try
+            {
+                var doc = XDocument.Load(ruleSet);
+                foreach (var moniker in doc.Descendants().Where(e => e.Name.LocalName == "Moniker"))
+                {
+                    var value = moniker.Value.Trim();
+                    if (value.Length > 0) names.Add(value);
+                }
+            }
+            catch
+            {
+                // One unreadable rule set must not cost the other 143 their names.
+            }
+        }
+
+        return (names, files);
+    }
+
+    private static (Dictionary<string, string> Messages, int Assemblies) ReadRuleMessages(string packagesPath)
+    {
+        var messages = new Dictionary<string, string>(StringComparer.Ordinal);
+        var assemblies = 0;
+
+        var binDir = Path.Combine(packagesPath, "bin", "BPExtensions");
+        if (!Directory.Exists(binDir)) return (messages, 0);
+
+        foreach (var dll in Directory.EnumerateFiles(binDir, "*.dll"))
+        {
+            assemblies++;
+            try
+            {
+                foreach (var (key, value) in ReadEmbeddedStrings(dll))
+                    messages[key] = value;
+            }
+            catch
+            {
+                // A rule assembly with no managed resources, or one this runtime cannot map, is
+                // a gap in message text — never a reason to lose the canonical names.
+            }
+        }
+
+        return (messages, assemblies);
+    }
+
+    /// <summary>Every string in every embedded <c>.resources</c> stream of one assembly.</summary>
+    private static IEnumerable<(string Key, string Value)> ReadEmbeddedStrings(string assemblyPath)
+    {
+        using var file = File.OpenRead(assemblyPath);
+        using var pe = new PEReader(file);
+        if (!pe.HasMetadata) yield break;
+
+        var metadata = pe.GetMetadataReader();
+        var corHeader = pe.PEHeaders.CorHeader;
+        if (corHeader is null) yield break;
+
+        var resourcesRva = corHeader.ResourcesDirectory.RelativeVirtualAddress;
+        if (resourcesRva == 0) yield break;
+
+        var sectionIndex = pe.PEHeaders.GetContainingSectionIndex(resourcesRva);
+        if (sectionIndex < 0) yield break;
+
+        var section = pe.PEHeaders.SectionHeaders[sectionIndex];
+        var image = pe.GetEntireImage().GetContent().ToArray();
+
+        foreach (var handle in metadata.ManifestResources)
+        {
+            var resource = metadata.GetManifestResource(handle);
+
+            // A resource with an Implementation lives in another file; only embedded ones are here.
+            if (!resource.Implementation.IsNil) continue;
+            if (!metadata.GetString(resource.Name).EndsWith(".resources", StringComparison.Ordinal)) continue;
+
+            var start = section.PointerToRawData + (resourcesRva - section.VirtualAddress) + (int)resource.Offset;
+            if (start < 0 || start + 4 > image.Length) continue;
+
+            var length = BitConverter.ToInt32(image, start);
+            if (length <= 0 || start + 4 + length > image.Length) continue;
+
+            List<(string, string)> collected;
+            try
+            {
+                collected = new List<(string, string)>();
+                using var stream = new MemoryStream(image, start + 4, length, writable: false);
+                using var reader = new ResourceReader(stream);
+                foreach (System.Collections.DictionaryEntry entry in reader)
+                {
+                    if (entry.Key is string key && entry.Value is string value && value.Length > 0)
+                        collected.Add((key, value));
+                }
+            }
+            catch
+            {
+                // Not a v1 .resources stream, or a type this runtime will not deserialise.
+                continue;
+            }
+
+            foreach (var pair in collected) yield return pair;
+        }
+    }
+}

--- a/src/D365FO.Core/Knowledge/BpMonikerCatalog.cs
+++ b/src/D365FO.Core/Knowledge/BpMonikerCatalog.cs
@@ -1,0 +1,193 @@
+// <copyright file="BpMonikerCatalog.cs" company="d365fo-cli contributors">
+// MIT
+// </copyright>
+
+using System.Text.Json;
+using System.Text.Json.Serialization;
+
+namespace D365FO.Core.Knowledge;
+
+/// <summary>One Best-Practice rule moniker, as the installation declares it.</summary>
+/// <param name="Name">Exact moniker spelling. Case matters to xppbp and to a suppression file.</param>
+/// <param name="Canonical">
+/// True when some model's <c>AxRuleSet/BPRules.xml</c> lists it. This is the ONLY field that
+/// answers "is this a real BP rule": the message extraction also yields strings belonging to the
+/// upgrade and form-conversion tooling, which are not rules.
+/// </param>
+/// <param name="Message">The rule's message template, with <c>{0}</c>-style placeholders. Null when the install ships none.</param>
+/// <param name="Description">Longer text, where the rule author wrote one.</param>
+public sealed record BpMoniker(
+    string Name,
+    bool Canonical,
+    string? Message = null,
+    string? Description = null);
+
+/// <summary>The catalog as stored on disk.</summary>
+/// <param name="CapturedAt">When the snapshot was taken.</param>
+/// <param name="PackagesPath">Installation it was taken from.</param>
+/// <param name="Monikers">Every entry, canonical or not.</param>
+public sealed record BpMonikerSnapshot(
+    DateTimeOffset CapturedAt,
+    string? PackagesPath,
+    IReadOnlyList<BpMoniker> Monikers);
+
+/// <summary>
+/// Answers "is this a real BP moniker", "which rule covers this scenario", and "render me a
+/// suppression block" from names extracted out of a real D365FO install.
+/// </summary>
+/// <remarks>
+/// <para>
+/// Every moniker has been guessed wrong at least once. A PascalCase name that reads exactly like
+/// a rule — <c>BPCheckNamingConventions</c> — is not one, while
+/// <c>BPErrorPrivilegeNotCoveredByDuty</c> is; nothing about the spelling tells them apart, and a
+/// suppression naming a moniker that does not exist suppresses nothing while looking deliberate.
+/// So this never infers: a name is real because an installation listed it, or it is not in the
+/// catalog.
+/// </para>
+/// <para>
+/// Not every real moniker starts with <c>BP</c> — the shipped suppression files use
+/// <c>MetadataExtensionNamingWithExtensionOnly</c> among others — so a prefix test is not a
+/// substitute for a lookup.
+/// </para>
+/// </remarks>
+public static class BpMonikerCatalog
+{
+    /// <summary>Point at a snapshot captured from this instance's own D365FO version.</summary>
+    public const string PathEnvVar = "D365FO_BP_CATALOG_PATH";
+
+    private static readonly Lazy<BpMonikerSnapshot> Loaded = new(Load, isThreadSafe: true);
+
+    private static readonly JsonSerializerOptions JsonOptions = new()
+    {
+        PropertyNameCaseInsensitive = true,
+        WriteIndented = true,
+        DefaultIgnoreCondition = JsonIgnoreCondition.WhenWritingNull,
+    };
+
+    /// <summary>The active snapshot: the file named by <see cref="PathEnvVar"/>, else the shipped one.</summary>
+    public static BpMonikerSnapshot Snapshot => Loaded.Value;
+
+    private static BpMonikerSnapshot Load()
+    {
+        var overridePath = D365FoSettings.Resolve(PathEnvVar);
+        if (!string.IsNullOrWhiteSpace(overridePath) && File.Exists(overridePath))
+        {
+            try
+            {
+                var json = File.ReadAllText(overridePath!);
+                var parsed = JsonSerializer.Deserialize<BpMonikerSnapshot>(json, JsonOptions);
+                if (parsed is not null) return parsed;
+            }
+            catch
+            {
+                // An unreadable override falls back to the shipped snapshot rather than leaving
+                // the caller with no catalog at all — but see EmptySnapshot on why "empty" is
+                // never silently treated as "this moniker does not exist".
+            }
+        }
+
+        return LoadEmbedded() ?? EmptySnapshot;
+    }
+
+    private static BpMonikerSnapshot? LoadEmbedded()
+    {
+        var assembly = typeof(BpMonikerCatalog).Assembly;
+        var resource = assembly.GetManifestResourceNames()
+            .FirstOrDefault(n => n.EndsWith("bp-monikers.json", StringComparison.OrdinalIgnoreCase));
+        if (resource is null) return null;
+
+        using var stream = assembly.GetManifestResourceStream(resource);
+        if (stream is null) return null;
+        try
+        {
+            return JsonSerializer.Deserialize<BpMonikerSnapshot>(stream, JsonOptions);
+        }
+        catch
+        {
+            return null;
+        }
+    }
+
+    private static BpMonikerSnapshot EmptySnapshot { get; } =
+        new(DateTimeOffset.MinValue, null, Array.Empty<BpMoniker>());
+
+    /// <summary>Is the catalog populated at all? An empty one cannot refute a moniker.</summary>
+    public static bool IsPopulated => Snapshot.Monikers.Count > 0;
+
+    /// <summary>The entry for <paramref name="name"/>, or null. Exact match — case included.</summary>
+    /// <remarks>
+    /// Deliberately case-SENSITIVE. xppbp and the suppression reader match the moniker exactly,
+    /// so reporting <c>bperrorprivilegenotcoveredbyduty</c> as valid would hand back a name that
+    /// suppresses nothing. A near-miss on case is surfaced through <see cref="Search"/> instead.
+    /// </remarks>
+    public static BpMoniker? Find(string name) =>
+        Snapshot.Monikers.FirstOrDefault(m => string.Equals(m.Name, name, StringComparison.Ordinal));
+
+    /// <summary>Entries whose name or message mentions every whitespace-separated term.</summary>
+    /// <remarks>
+    /// Terms are ANDed and matched case-insensitively against name, message and description. A
+    /// scenario is described in words the rule name does not contain ("privilege not in a duty"),
+    /// which is why the message text is searched and not only the name.
+    /// </remarks>
+    public static IReadOnlyList<BpMoniker> Search(string query, int limit = 20)
+    {
+        if (string.IsNullOrWhiteSpace(query)) return Array.Empty<BpMoniker>();
+
+        var terms = query.Split(' ', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries);
+        bool Matches(BpMoniker m)
+        {
+            var haystack = m.Name + " " + (m.Message ?? "") + " " + (m.Description ?? "");
+            return terms.All(t => haystack.Contains(t, StringComparison.OrdinalIgnoreCase));
+        }
+
+        return Snapshot.Monikers
+            .Where(Matches)
+            // Canonical rules first: a caller searching for a rule wants rules, and the
+            // non-canonical entries are resource strings that merely came along for the ride.
+            .OrderByDescending(m => m.Canonical)
+            .ThenBy(m => m.Name, StringComparer.Ordinal)
+            .Take(Math.Clamp(limit, 1, 200))
+            .ToList();
+    }
+
+    /// <summary>Names differing from <paramref name="name"/> only by case — the likeliest typo.</summary>
+    public static IReadOnlyList<string> CaseVariants(string name) =>
+        Snapshot.Monikers
+            .Where(m => string.Equals(m.Name, name, StringComparison.OrdinalIgnoreCase)
+                        && !string.Equals(m.Name, name, StringComparison.Ordinal))
+            .Select(m => m.Name)
+            .ToList();
+
+    /// <summary>
+    /// A <c>&lt;Diagnostic&gt;</c> block for a model's <c>*_BPSuppressions.xml</c>.
+    /// </summary>
+    /// <remarks>
+    /// The element order and names are taken from the shipped
+    /// <c>AxIgnoreDiagnosticList/&lt;Model&gt;_BPSuppressions.xml</c> files, not invented:
+    /// DiagnosticType, Severity, Path, Moniker, Message, Justification. The <c>Path</c> is a
+    /// <c>dynamics://</c> URI naming the exact element the rule fired on.
+    /// </remarks>
+    public static string SuppressionBlock(
+        string moniker, string path, string? message = null, string? justification = null, string severity = "Warning")
+    {
+        static string Escape(string value) =>
+            value.Replace("&", "&amp;").Replace("<", "&lt;").Replace(">", "&gt;");
+
+        var text = message ?? Find(moniker)?.Message ?? moniker;
+        var why = justification ?? "TODO: say why this rule does not apply here.";
+
+        return string.Join(Environment.NewLine,
+            "<Diagnostic>",
+            "\t<DiagnosticType>BestPractices</DiagnosticType>",
+            $"\t<Severity>{Escape(severity)}</Severity>",
+            $"\t<Path>{Escape(path)}</Path>",
+            $"\t<Moniker>{Escape(moniker)}</Moniker>",
+            $"\t<Message>{Escape(text)}</Message>",
+            $"\t<Justification>{Escape(why)}</Justification>",
+            "</Diagnostic>");
+    }
+
+    /// <summary>Serialise a snapshot for <c>bp-moniker extract</c>.</summary>
+    public static string ToJson(BpMonikerSnapshot snapshot) =>
+        JsonSerializer.Serialize(snapshot, JsonOptions);
+}

--- a/src/D365FO.Core/Knowledge/Data/bp-monikers.json
+++ b/src/D365FO.Core/Knowledge/Data/bp-monikers.json
@@ -1,0 +1,3890 @@
+{
+ "CapturedAt": "2026-09-01T13:20:08.1141595+00:00",
+ "PackagesPath": null,
+ "Monikers": [
+  {
+   "Name": "ActionPaneButtonSkippedFix",
+   "Canonical": false,
+   "Message": "Adjusted button Skip property to No"
+  },
+  {
+   "Name": "ActionPaneDeleteEmptyActionPaneTab",
+   "Canonical": false,
+   "Message": "Deleting empty action pane tab {0} from action pane {1}."
+  },
+  {
+   "Name": "ActionPaneDeleteEmptyButtonGroup",
+   "Canonical": false,
+   "Message": "Deleting empty button group {0} from action pane tab {1} in action pane {2}."
+  },
+  {
+   "Name": "ActionPaneDuplicateCommandButtonRemoval",
+   "Canonical": false,
+   "Message": "Deleting button {0} from button group {1} in action pane tab {2} in action pane {3}."
+  },
+  {
+   "Name": "ActionPaneMoveButtonGroupUpOneLevel",
+   "Canonical": false,
+   "Message": "Moving non-empty button group {0} from action pane tab {1} to action pane {2}."
+  },
+  {
+   "Name": "ActionPaneRedundantButtonDetectorDescription",
+   "Canonical": false,
+   "Message": "Detect redundant command buttons in action pane."
+  },
+  {
+   "Name": "ActionPaneSeparatorButtonControlRemoval",
+   "Canonical": false,
+   "Message": "Deleting separator button {0} from button group {1} in action pane tab {2} in action pane {3}."
+  },
+  {
+   "Name": "ActionPaneTODOMoveButtonCodeAndRemoveControl",
+   "Canonical": false,
+   "Message": "[Action Pane Rule] Please consider moving this button code to the task override method and remove the control {0}."
+  },
+  {
+   "Name": "ActionPaneTODORemoveControlReferences",
+   "Canonical": false,
+   "Message": "[Action Pane Rule] Please consider moving all references to the form task override method and remove the control: {0}"
+  },
+  {
+   "Name": "ActionPaneTabHasImageFixDescription",
+   "Canonical": false,
+   "Message": "Action pane has an image when it should not, adjusted to ImageLocation=Symbol and NormalImage set to blank."
+  },
+  {
+   "Name": "ActionPaneTooManyButtonsCannotMoveUp",
+   "Canonical": false,
+   "Message": "Total buttons in action pane {0} is {1} which is greater the maximum number that can be moved {2}."
+  },
+  {
+   "Name": "ActionPaneUpdateActionPaneStyle",
+   "Canonical": false,
+   "Message": "Updating action pane {0} setting Style from {1} to {2}."
+  },
+  {
+   "Name": "AdditiveEnumValueDetectorDescription",
+   "Canonical": false,
+   "Message": "Checks that enum items are added using extension model"
+  },
+  {
+   "Name": "AdditiveFormControlDetectorDescription",
+   "Canonical": false,
+   "Message": "Checks that form controls are added using extension model"
+  },
+  {
+   "Name": "AdditiveFormDataSourceDetectorDescription",
+   "Canonical": false,
+   "Message": "Checks that form data sources are added using extension model"
+  },
+  {
+   "Name": "AdditiveGlobalMethodDetectorDescription",
+   "Canonical": false,
+   "Message": "Checks for additive Global methods."
+  },
+  {
+   "Name": "AdditiveMenuElementDetectorDescription",
+   "Canonical": false,
+   "Message": "Checks that menu elements items are added using extension model"
+  },
+  {
+   "Name": "AdditiveSecurityDutyPrivilegeDetectorDescription",
+   "Canonical": false,
+   "Message": "Checks that security duty privileges are added using extension model"
+  },
+  {
+   "Name": "AdditiveSecurityRoleDutyDetectorDescription",
+   "Canonical": false,
+   "Message": "Checks that security role duties are added using extension model"
+  },
+  {
+   "Name": "AdditiveSecurityRolePermissionFormControlDetectorDescription",
+   "Canonical": false,
+   "Message": "Checks that security role form control permissions are added using extension model"
+  },
+  {
+   "Name": "AdditiveSecurityRolePermissionFormDetectorDescription",
+   "Canonical": false,
+   "Message": "Checks that security role form permissions are added using extension model"
+  },
+  {
+   "Name": "AdditiveSecurityRolePermissionServerMethodDetectorDescription",
+   "Canonical": false,
+   "Message": "Checks that security role server method permissions are added using extension model"
+  },
+  {
+   "Name": "AdditiveSecurityRolePermissionTableDetectorDescription",
+   "Canonical": false,
+   "Message": "Checks that security role table permissions are added using extension model"
+  },
+  {
+   "Name": "AdditiveSecurityRolePermissionTableFieldDetectorDescription",
+   "Canonical": false,
+   "Message": "Checks that security role table field permissions are added using extension model"
+  },
+  {
+   "Name": "AdditiveSecurityRolePrivilegeDetectorDescription",
+   "Canonical": false,
+   "Message": "Checks that security role privileges are added using extension model"
+  },
+  {
+   "Name": "AdditiveSecurityRoleSubRoleDetectorDescription",
+   "Canonical": false,
+   "Message": "Checks that security role sub roles are added using extension model"
+  },
+  {
+   "Name": "AdditiveTableDeleteActionDetectorDescription",
+   "Canonical": false,
+   "Message": "Checks that table delete actions are added using extension model"
+  },
+  {
+   "Name": "AdditiveTableFieldDetectorDescription",
+   "Canonical": false,
+   "Message": "Checks that table fields are added using extension model"
+  },
+  {
+   "Name": "AdditiveTableFieldGroupDetectorDescription",
+   "Canonical": false,
+   "Message": "Checks that table field groups are added using extension model"
+  },
+  {
+   "Name": "AdditiveTableFieldGroupFieldDetectorDescription",
+   "Canonical": false,
+   "Message": "Checks that table field group fields are added using extension model"
+  },
+  {
+   "Name": "AdditiveTableIndexDetectorDescription",
+   "Canonical": false,
+   "Message": "Checks that table indexes are added using extension model"
+  },
+  {
+   "Name": "AdditiveTableIndexFieldDetectorDescription",
+   "Canonical": false,
+   "Message": "Checks that table index fields are added using extension model"
+  },
+  {
+   "Name": "AdditiveTableInstanceMethodDetectorDescription",
+   "Canonical": false,
+   "Message": "Checks that table instance methods are added using extension model"
+  },
+  {
+   "Name": "AdditiveTableRelationDetectorDescription",
+   "Canonical": false,
+   "Message": "Checks that table relations are added using extension model"
+  },
+  {
+   "Name": "AdditiveTableStaticMethodDetectorDescription",
+   "Canonical": false,
+   "Message": "Checks that table static methods are added using extension model"
+  },
+  {
+   "Name": "AggregateDimensionComplexityAnalysisDescription",
+   "Canonical": false,
+   "Message": "This rule checks for cases of aggregate dimensions with views using too many tables."
+  },
+  {
+   "Name": "ArrangeWhenNever",
+   "Canonical": false,
+   "Message": "Updating {0}.ArrangeMethod to None.",
+   "Description": "Detect forms or containers that need ArrangeMethod set to None."
+  },
+  {
+   "Name": "AttributeIsDateFieldDescription",
+   "Canonical": false,
+   "Message": "This rule checks for attributes where the key column is a date field in dimensions where the dimension type is not Time. To analyze by date, instead of creating an attribute for the date field, add a relation to a time dimension."
+  },
+  {
+   "Name": "AttributeIsRealFieldDescription",
+   "Canonical": false,
+   "Message": "This rule scans for attributes on real columns. These are slow to process as since the possible set of values is very large."
+  },
+  {
+   "Name": "BICompanyRelationUpdatedDescription",
+   "Canonical": false,
+   "Message": "Relationship and relationship constraints for dimension '{0}'  of meausre group '{1}' has been updated."
+  },
+  {
+   "Name": "BPAggregateDimensionComplexity",
+   "Canonical": true,
+   "Message": "Dimension '{0}' uses view '{1}' which uses {2} table instances. To avoid performance issues in aggregate queries, do not use views that use more than {3} table instances in aggregate measurements or aggregate dimensions."
+  },
+  {
+   "Name": "BPAttributeIsDateField",
+   "Canonical": true,
+   "Message": "Dimension attribute '{1}' of dimension '{0}' contains a date field as an attribute key. If this is a date dimension, set the dimension type to 'Time'. Otherwise, remove the attribute and create a dimension relation to a date dimension using the date field as the RelatedField for the dimension relation constraint.  "
+  },
+  {
+   "Name": "BPAttributeIsRealField",
+   "Canonical": true,
+   "Message": "Dimension attribute '{1}' of dimension '{0}' is using a field of type 'Real' for the key. This may result in poor performance."
+  },
+  {
+   "Name": "BPBreakpointStatementUsage",
+   "Canonical": true,
+   "Message": "BPBreakpointStatementUsage: The \"breakpoint\" statement has been deprecated and has no effect.",
+   "Description": "Reports the usage of \"breakpoint\" statements, which has been deprecated and has no effect."
+  },
+  {
+   "Name": "BPCalculationInWrongMeasureGroup",
+   "Canonical": true,
+   "Message": "Calculated measure '{0}' in measure group '{2}' references measures '{1}' that are not in same measure group. Move the calculated measure to the same measure group as the measures that the calculated measure uses."
+  },
+  {
+   "Name": "BPCheckAddressModel",
+   "Canonical": true,
+   "Message": "Field {0} of table {1} is not part of address location model",
+   "Description": "This rule fails if a table field is of type AddressZipCodeId or AddressStateId. Usage of these types indicates that the code did not uptake the newer Address framework."
+  },
+  {
+   "Name": "BPCheckAlternateKeyAbsent",
+   "Canonical": true,
+   "Message": "Table {0} does not have an alternate key",
+   "Description": "This rule verifies that tables have alternate keys."
+  },
+  {
+   "Name": "BPCheckBaseTableModified",
+   "Canonical": true,
+   "Message": "{0} is a base table and must not be modified",
+   "Description": "This rule discourages the customization (over-layering) of a list of specific base tables shipped by Microsoft."
+  },
+  {
+   "Name": "BPCheckBatchJobsEnabled",
+   "Canonical": true,
+   "Message": "Custom job is not batch-enabled in class {0}",
+   "Description": "This rule makes sure all classes that extend RunBaseBatch have the method canGoBatch returning true."
+  },
+  {
+   "Name": "BPCheckCodeRefactoring",
+   "Canonical": false,
+   "Message": "Number of Lines found in class method {0} is greater than {2} within class {1}",
+   "Description": "TODO"
+  },
+  {
+   "Name": "BPCheckDimensionModel",
+   "Canonical": true,
+   "Message": "Field {0} of table {1} is not part of financial dimension framework",
+   "Description": "This rule fails if a table field is of type Dimension or LedgerAccount. Usage of these types indicates that the code did not uptake the newer Financial Dimension framework."
+  },
+  {
+   "Name": "BPCheckDisplayMethodCached",
+   "Canonical": true,
+   "Message": "Display method {0} on control {1} in form {2} not cached",
+   "Description": "For each control bound to a data method, this rules fails when one of these conditions is true:\r\n1. The property \"Cache Data Method\" = Auto, and the corresponding table display/edit method does not have the \"SysClientCacheDataMethodAttribute\", and the init method of the data source does not use CacheAddMethod.\r\n2. The property \"Cache Data Method\" = No, and the init method of the data source does not use CacheAddMethod."
+  },
+  {
+   "Name": "BPCheckEmptyLoop",
+   "Canonical": true,
+   "Message": "Empty loop found in method {0} in class {1}",
+   "Description": "This rule fails if it finds loops with no statements."
+  },
+  {
+   "Name": "BPCheckEmptyTableMethod",
+   "Canonical": false,
+   "Message": "{0} table has an empty method {1}",
+   "Description": "TODO"
+  },
+  {
+   "Name": "BPCheckEnumModifed",
+   "Canonical": false,
+   "Message": "Enum {0} has been modified",
+   "Description": "TODO"
+  },
+  {
+   "Name": "BPCheckEnumUpgradeIssue",
+   "Canonical": true,
+   "Message": "Enum {0} may have upgrade issues",
+   "Description": "When customizing(over-layering) an Enum, new Enum values must be greater than or equal to the maximum existing value + 10. This rule does not apply to Extensible Enums."
+  },
+  {
+   "Name": "BPCheckFunctionCallwithSelect",
+   "Canonical": true,
+   "Message": "Function call found in select statement in method {0}",
+   "Description": "This rule fails if a function call is found within a select statement."
+  },
+  {
+   "Name": "BPCheckInsertMethodInLoop",
+   "Canonical": true,
+   "Message": "Insert method can be replaced with RecordInsertList in method {0}",
+   "Description": "This rules fails if it finds a call to \"insert\" nested inside a loop. It is recommended to use InsertRecordList."
+  },
+  {
+   "Name": "BPCheckInvalidExecuteQuery",
+   "Canonical": true,
+   "Message": "Add range after super() should not be added in executeQuery method for form {0}",
+   "Description": "This rule fails if a call to addRange is found after a call to \"super()\" in the ExecuteQuery method."
+  },
+  {
+   "Name": "BPCheckInvalidInitFormMethodInfo",
+   "Canonical": true,
+   "Message": "Form element statements should not be used before super() in init method of form {0}(Exception can be granted because call seems to be initializing number sequences by calling the method numberSeqPreInit)",
+   "Description": "This rule fails if it finds method \"numberSeqPreInit\" is called before the call to super() in the init method of a form"
+  },
+  {
+   "Name": "BPCheckInvalidInitFormMethodWarning",
+   "Canonical": true,
+   "Message": "Form element statements should not be used before super() in init method of form {0}",
+   "Description": "This rule fails if it finds \"element\" or \"this\" statements before the call to super() in the init method of a form."
+  },
+  {
+   "Name": "BPCheckLargeMCCCode",
+   "Canonical": false,
+   "Message": "MCC code is higher than 20 in method {0}",
+   "Description": "TODO"
+  },
+  {
+   "Name": "BPCheckLockQueryRange",
+   "Canonical": false,
+   "Message": "Range should be locked or hidden in form {0}",
+   "Description": "Finds references To queryBuildRange.status(RangeStatus::Locked)"
+  },
+  {
+   "Name": "BPCheckMissingDeleteActions",
+   "Canonical": true,
+   "Message": "Delete actions missing in table {0} which is related to table {1} with relation name  {2}",
+   "Description": "This rule validates that either a delete action or the OnDelete property on a table relation have been set."
+  },
+  {
+   "Name": "BPCheckMissingIndexOnCode",
+   "Canonical": false,
+   "Message": "Missing index on {1} field  in table {0}",
+   "Description": "TODO"
+  },
+  {
+   "Name": "BPCheckNestedLoopinCode",
+   "Canonical": true,
+   "Message": "Nested data access loop found in {0} method",
+   "Description": "This rule fails if it finds a \"while select\" loop nested within another data access loop."
+  },
+  {
+   "Name": "BPCheckNewQuerywithForm",
+   "Canonical": true,
+   "Message": "Data source query overridden in form method {0}",
+   "Description": "This rule fails if it finds the statement \"new Query()\" in the init or executeQuery method of a form."
+  },
+  {
+   "Name": "BPCheckNoTTSBlock",
+   "Canonical": false,
+   "Message": "Tts block with try statement does not explicitly catch exceptions in method {0}",
+   "Description": "Finds references tts statment for Insert/Update/Delete"
+  },
+  {
+   "Name": "BPCheckNoTTSTryBlock",
+   "Canonical": true,
+   "Message": "Tts block with try statement does not explicitly catch exceptions in method {0}",
+   "Description": "This rule fails if it finds a try statement within a tts block that is not handled correctly."
+  },
+  {
+   "Name": "BPCheckNoValidateMethod",
+   "Canonical": false,
+   "Message": "Validate method is missing before CRUD operation in {0} method.",
+   "Description": "Finds references Validate() before Insert/Update/Delete"
+  },
+  {
+   "Name": "BPCheckNumberofNewFields",
+   "Canonical": true,
+   "Message": "Number of new fields in base table {0} is greater than 10",
+   "Description": "This rule verifies that no more than 10 fields were added to a table in the process of customizing(over-layering) that table."
+  },
+  {
+   "Name": "BPCheckObjectModified",
+   "Canonical": false,
+   "Message": "{0} is modified {1}",
+   "Description": "(Not used in Ax6)"
+  },
+  {
+   "Name": "BPCheckObjectNew",
+   "Canonical": false,
+   "Message": "{0} is a new {1}",
+   "Description": "(Not used in Ax6)"
+  },
+  {
+   "Name": "BPCheckPackReturnsConnull",
+   "Canonical": true,
+   "Message": "Container pack method returns connull in a Runbase derived class",
+   "Description": "This rule fails if a container pack method returns connull in a Runbase derived class."
+  },
+  {
+   "Name": "BPCheckParametersModified",
+   "Canonical": true,
+   "Message": "Parameter {0} in method {1} is modified inside the method.",
+   "Description": "This rule fails if a parameter of a method is modified inside a method."
+  },
+  {
+   "Name": "BPCheckPassiveJoinUse",
+   "Canonical": true,
+   "Message": "Use passive join on the datasource {1} which is bound to a tab page control on the form {0}.",
+   "Description": "For all tab pages (child controls of a tab control) that are bound to their own data source, link type of the data source must be a passive join."
+  },
+  {
+   "Name": "BPCheckRiskProfile",
+   "Canonical": false,
+   "Message": "{0} is a risk profile class",
+   "Description": "TODO"
+  },
+  {
+   "Name": "BPCheckSQLBufferSize",
+   "Canonical": false,
+   "Message": "Method {0} from Class {1} has a high Buffer Size of {2}",
+   "Description": "TODO"
+  },
+  {
+   "Name": "BPCheckSQLCode",
+   "Canonical": true,
+   "Message": "SQL code found in method {0}",
+   "Description": "This rule fails if your X++ code contains direct SQL code."
+  },
+  {
+   "Name": "BPCheckSQLQueryInInit",
+   "Canonical": true,
+   "Message": "Data access while loop was found in init method of form {0}",
+   "Description": "This rule fails if a SQL query with while loop is found in the init method of a form. This has the potential of causing performance problems when initializing the form."
+  },
+  {
+   "Name": "BPCheckSelectForUpdateAbsent",
+   "Canonical": true,
+   "Message": "Select forupdate is used in method '{0}', but no update operation was found.",
+   "Description": "This rule fails if selectForUpdateis used for selecting records and no update is being performed. This rule does not apply for OCC enabled tables."
+  },
+  {
+   "Name": "BPCheckSelectwithJoin",
+   "Canonical": false,
+   "Message": "Nested select statement in {0} method can be joined",
+   "Description": "This rule fails if it finds nested select statements that are not joined."
+  },
+  {
+   "Name": "BPCheckSkipStatementValidation",
+   "Canonical": true,
+   "Message": "Set-based operation must invoke Skip statements in method {0} in class {1}; otherwise, execution will fall back to a row by row operation.",
+   "Description": "This rule fails if it finds a set-based operation without skip statements."
+  },
+  {
+   "Name": "BPCheckSysObsoleteAttributeParametersMismatch",
+   "Canonical": true,
+   "Message": "All parameters for attribute SysObsolete need to be defined for the {0} {1}.",
+   "Description": "This rule fails if all the parameters for the attribute are not defined."
+  },
+  {
+   "Name": "BPCheckTablePropertyMismatch",
+   "Canonical": true,
+   "Message": "{0} table has an invalid combination of table group and cache lookup",
+   "Description": "This rule fails when a table belongs to a table group and does not have the appropriate cache lookup set."
+  },
+  {
+   "Name": "BPCheckValidDateEffectiveIndex",
+   "Canonical": false,
+   "Message": "{0} table has an invalid combination of table group and cache lookup",
+   "Description": "Finds if the method is static and the parameter passed is map/set/etc"
+  },
+  {
+   "Name": "BPCheckValidateLocalVariable",
+   "Canonical": false,
+   "Message": "Use string and real EDT types instead of generic variable types for class fields, local variables, method parameters and method return types.",
+   "Description": "This rule fails if it finds a local variable, class variables, method parameters or method return value of the following type: \r\nString N or Real\r\nCode must use EDTs instead."
+  },
+  {
+   "Name": "BPCheckValidateStaticMethod",
+   "Canonical": false,
+   "Message": "Map or set should not be passed as parameter to the static method {0}",
+   "Description": "This rule fails if a map or set is passed as a parameter to a static method."
+  },
+  {
+   "Name": "BPClientLocalFileAccess",
+   "Canonical": true,
+   "Message": "BPClientLocalFileAccess: Invalid call to {0}. Accessing the local file system on the client is not allowed. ",
+   "Description": "Reports calls to APIs that access local files. Files cannot be created on the server tier."
+  },
+  {
+   "Name": "BPColumnStoreIndexNeededForTable",
+   "Canonical": true,
+   "Message": "To reduce the time needed to get data for this in-memory aggregate measurement  define a column store index for the table '{0}' and include the following fields: {1}.  If the table will never has more than a small number of records, this warning can be ignored."
+  },
+  {
+   "Name": "BPDeprecatedAPIXDSServices_setXDSState",
+   "Canonical": false,
+   "Message": "XDSServices.setXDSState() is no longer supported, use unchecked(Uncheck::XDS) instead."
+  },
+  {
+   "Name": "BPDeprecatedApiCallInQueryMetadata",
+   "Canonical": true,
+   "Message": "The method {0} is deprecated, use {1} instead.",
+   "Description": "Detects references to deprecated methods in query metadata."
+  },
+  {
+   "Name": "BPDeprecatedApiCallInQueryMetadataFixDescription",
+   "Canonical": false,
+   "Message": "Fixing the {0} query range. Changing the value from {1} to {2}."
+  },
+  {
+   "Name": "BPDeprecatedClass",
+   "Canonical": true,
+   "Message": "BPDeprecatedClass: {0} has been deprecated and should not be used.",
+   "Description": "Reports occurrences of deprecated classes and informs to not use it."
+  },
+  {
+   "Name": "BPDeprecatedClassMethod",
+   "Canonical": true,
+   "Message": "BPDeprecatedClassMethod: {0} has been deprecated and should not be used.",
+   "Description": "Reports the usage of deprecated class methods."
+  },
+  {
+   "Name": "BPDeprecatedControl",
+   "Canonical": true,
+   "Message": "BPDeprecatedControl: The '{0}' control has been deprecated and should not be used.",
+   "Description": "Reports the usage of deprecated controls."
+  },
+  {
+   "Name": "BPDeprecatedControlMethod",
+   "Canonical": true,
+   "Message": "BPDeprecatedControlMethod: The \"{0}\" control method has been deprecated and should not be used. ",
+   "Description": "Reports the usage of deprecated control methods."
+  },
+  {
+   "Name": "BPDeprecatedDataSourceMethod",
+   "Canonical": true,
+   "Message": "BPDeprecatedDataSourceMethod: The \"{0}\" data source method has been deprecated and should not be used.",
+   "Description": "Reports the usage of deprecated data source methods."
+  },
+  {
+   "Name": "BPDeprecatedEdtFileIO",
+   "Canonical": true,
+   "Message": "FilenameOpen, FilenameSave, FilePath, and derived EDTs are no longer supported in AX7. Please update your code to use the File class instead for file management.",
+   "Description": "Detects use of the deprecated file IO EDTs: FilenameOpen, FilenameSave, FilePath"
+  },
+  {
+   "Name": "BPDeprecatedFormAndControlPropertySweeper",
+   "Canonical": true,
+   "Message": "BPDeprecatedFormAndControlPropertySweeper: The {0} property has been deprecated and should not be used.",
+   "Description": "Reports the usage of deprecated properties in forms and form controls."
+  },
+  {
+   "Name": "BPDeprecatedFormMethod",
+   "Canonical": true,
+   "Message": "BPDeprecatedFormMethod: The \"{0}\" form method has been deprecated and should not be used.",
+   "Description": "Reports the usage of deprecated form methods."
+  },
+  {
+   "Name": "BPDeprecatedUOMProductParameter",
+   "Canonical": true,
+   "Message": "BPDeprecatedUOMProductParameter: The product parameter in UnitOfMeasureConverter class method '{0}' is deprecated, use the EcoResProductUnitConverter class instead.",
+   "Description": "Reports the usage of deprecated product parameter in the UnitOfMeasureConverter class."
+  },
+  {
+   "Name": "BPDeprecatedUseObsoleteMethodsWhenWarehouseTransactionsEnabled",
+   "Canonical": true,
+   "Message": "{0}",
+   "Description": "Detects usage of the methods which will not be called the same way they were before the activation of the \"Warehouse-specific inventory transactions\" feature."
+  },
+  {
+   "Name": "BPDeprecatedUseObsoleteWHSContainerTransFields",
+   "Canonical": true,
+   "Message": "BPDeprecatedUseObsoleteWHSContainerTransFields: Detected a usage of the {0} field. This field is not populated for the warehouse containers using the warehouse-specific inventory transactions.",
+   "Description": "Detects usage of WHSContainerTrans.InventTransIdFrom and WHSContainerTrans.InventTransIdTo fields."
+  },
+  {
+   "Name": "BPDeprecatedUseObsoleteWHSWorkInventTransFields",
+   "Canonical": true,
+   "Message": "BPDeprecatedUseObsoleteWHSWorkInventTransFields: Detected a usage of the {0} field. This field is not populated for the warehouse works using the warehouse-specific inventory transactions.",
+   "Description": "Detects usage of WHSWorkInventTrans.InventTransIdFrom and WHSWorkInventTrans.InventTransIdTo fields."
+  },
+  {
+   "Name": "BPDimensionForCalculatedMeasureNotFound",
+   "Canonical": true,
+   "Message": "Calculated measure '{0}' in measure group '{2}' references dimensions '{1}' not related to the Measurement, which may lead to unexpected errors at runtime."
+  },
+  {
+   "Name": "BPDimensionHasNoHierarchies",
+   "Canonical": true,
+   "Message": "Dimension '{0}' does not contain any hierarchies despite having more than four attributes. It may be difficult for users to analyze data if there are no hierarchies. Consider creating one or more hierarchies."
+  },
+  {
+   "Name": "BPDimensionOnTransactionTable",
+   "Canonical": true,
+   "Message": "Dimension '{0}' is based on a table in the '{1}' table group and has attributes on non enumeration fields. These tables are expected to contain many records. Measurements that use this dimension may not perform well. Consider removing all non-enumeration based attribute fields from this dimension."
+  },
+  {
+   "Name": "BPEmptyCompoundStatement",
+   "Canonical": true,
+   "Message": "Empty Compound statement {...}.",
+   "Description": "Checks that compound statements are non-empty."
+  },
+  {
+   "Name": "BPEnumOnlyDimension",
+   "Canonical": true,
+   "Message": "Dimension '{0}' contains only ENUM attributes. If all attributes in a dimension are enumerations the key columns for the key attribute of the dimension must contain each of the attribute fields. You may also consider modeling the attributes as independant dimensions if they attributes are not co-related."
+  },
+  {
+   "Name": "BPErrorActionPaneButtonSkipped",
+   "Canonical": true,
+   "Message": "[BPErrorActionPaneButtonSkipped] Buttons inside ActionPanes/ActionPaneTabs must not set Skip=Yes.",
+   "Description": "Reports when a button inside an ActionPane or ActionPaneTab uses Skip = Yes."
+  },
+  {
+   "Name": "BPErrorActionPaneTabHasImage",
+   "Canonical": true,
+   "Message": "[BPErrorActionPaneTabHasImage] Action pane {0} in form {1} has an image, should use ImageLocation = Symbol and empty NormalImage",
+   "Description": "Reports when an action pane has an image defined."
+  },
+  {
+   "Name": "BPErrorAllFormDataSourceTablesAreExpectedToBeSaveDataPerCompany",
+   "Canonical": true,
+   "Message": "BPErrorAllFormDataSourceTablesAreExpectedToBeSaveDataPerCompany: The design property '{0}' is enabled, but the property '{1}' on all the data sources has an an incorrect value. Set the design property '{0}' to No to prevent the form from restarting in the previous company.",
+   "Description": "Reports that forms with the SetCompany property enabled do not contain any data sources with tables which have the SaveDataPerCompany property enabled."
+  },
+  {
+   "Name": "BPErrorAllFormDataSourceTablesAreNotExpectedToBeSaveDataPerCompany",
+   "Canonical": true,
+   "Message": "BPErrorAllFormDataSourceTablesAreNotExpectedToBeSaveDataPerCompany: The design property '{0}' is disabled, but the property '{1}' on all the data sources has an incorrect value. Set the design property '{0}' to Yes to ensure that the form restarts in the previous company. ",
+   "Description": "Reports that forms with the SetCompany property disabled do not contain any data sources with tables which have the SaveDataPerCompany property disabled"
+  },
+  {
+   "Name": "BPErrorCaptionIsCopyOfDataGroupLabel",
+   "Canonical": true,
+   "Message": "BPErrorCaptionIsCopyOfDataGroupLabel: The Caption property value of the group control is a copy of the Label property value for its associated table data group.",
+   "Description": "Reports when the Caption property value of the group control is a copy of the Label property value for its associated table data group."
+  },
+  {
+   "Name": "BPErrorCaptionNotDefined",
+   "Canonical": true,
+   "Message": "BPErrorCaptionNotDefined: No value is given for the Caption property.",
+   "Description": "Reports when no value is given for the Caption property."
+  },
+  {
+   "Name": "BPErrorCheckBoxToggleStyleGrid",
+   "Canonical": true,
+   "Message": "It is not recommended to use a Toggle style checkbox control in a grid presentation.  Using Style=Auto or Style=Checkbox is suggested."
+  },
+  {
+   "Name": "BPErrorClassNewNotProtected",
+   "Canonical": true,
+   "Message": "BPErrorClassNewNotProtected: The constructor (i.e. the 'new' method) should be protected. In addition, private constructors are allowed on final classes.",
+   "Description": "Checks that constructors are protected."
+  },
+  {
+   "Name": "BPErrorControlHelpIsCopyOfEnumHelp",
+   "Canonical": true,
+   "Message": "BPErrorControlHelpIsCopyOfEnumHelp: The control's help text is the same as the help information for the base enum.",
+   "Description": "Reports when the control's help text is the same as the help text for its base enum."
+  },
+  {
+   "Name": "BPErrorControlHelpIsCopyOfExtendedHelp",
+   "Canonical": true,
+   "Message": "BPErrorControlHelpIsCopyOfExtendedHelp: The control help text is a copy of the help for its extended data type.",
+   "Description": "Reports when the control's help text is the same as the help text for its extended data type."
+  },
+  {
+   "Name": "BPErrorControlLabelIsCopyOfEnumLabel",
+   "Canonical": true,
+   "Message": "BPErrorControlLabelIsCopyOfEnumLabel: The label of the control is a copy of the label for its base enum, which is not allowed.",
+   "Description": "Reports when the label of the control is a copy of the label for its base enun, because such a copy is not allowed."
+  },
+  {
+   "Name": "BPErrorControlLabelIsCopyOfExtendedLabel",
+   "Canonical": true,
+   "Message": "BPErrorControlLabelIsCopyOfExtendedLabel: The label of the control is a copy of the label for its extended data type, which is not allowed.",
+   "Description": "Reports when the label of the control is a copy of the label for its extended data type, because such a copy is not allowed."
+  },
+  {
+   "Name": "BPErrorControlsNotInSpecificDesign",
+   "Canonical": true,
+   "Message": "BPErrorControlsNotInSpecificDesign: The control is not specified in a design.",
+   "Description": "Checks that all controls are included in a design."
+  },
+  {
+   "Name": "BPErrorCustomFilterGroupHasToggleCheckbox",
+   "Canonical": true,
+   "Message": "BPErrorCustomFilterGroupHasToggleCheckbox: A custom filter group should not have a toggle checkbox.",
+   "Description": "Reports that a group with the CustomFilter style or with the CustomFilters or CustomAndQuickfilters pattern has a checkbox with the Toggle style."
+  },
+  {
+   "Name": "BPErrorCustomFilterGroupInputControlUnbound",
+   "Canonical": true,
+   "Message": "The control {0} inside this custom filter group (group with Style=CustomFilter) must not have any value specified for its DataSource, DataField, ReferenceField, and DataGroup properties. Set the values to empty.",
+   "Description": "Detects that a control for a custom filter group is unbound."
+  },
+  {
+   "Name": "BPErrorDataSourceOnWorkspaceStyleForm",
+   "Canonical": true,
+   "Message": "BPErrorDataSourceOnWorkspaceStyleForm: Form '{0}' with Style=Workspace should not have data sources.",
+   "Description": "Reports that forms with Style=Workspace should not contain data sources."
+  },
+  {
+   "Name": "BPErrorDeveloperDocumentationNotDefined",
+   "Canonical": true,
+   "Message": "BPErrorDeveloperDocumentationNotDefined: The mandatory property DeveloperDocumentation is not specified.",
+   "Description": "Checks if the mandatory property DeveloperDocumentation is specified."
+  },
+  {
+   "Name": "BPErrorDimensionBaseTypeUse",
+   "Canonical": true,
+   "Message": "BPErrorDimensionBaseTypeUse: The extended data type '{0}' should not be directly used. Please use a subtype instead.",
+   "Description": "Fields should not use the LedgerDimensionBase extended data type outside of the financial dimension framework."
+  },
+  {
+   "Name": "BPErrorDimensionFieldNameDAVC",
+   "Canonical": true,
+   "Message": "BPErrorDimensionFieldNameDAVC: Fields named '{0}' should be changed to '{1}'.",
+   "Description": "BPErrorDimensionFieldNameDAVCDescription: No field should be named 'DimensionAttributeValueCombination', it should be changed to 'LedgerDimension'."
+  },
+  {
+   "Name": "BPErrorDimensionLedgerDimBaseType",
+   "Canonical": true,
+   "Message": "Fields with '{0}' in the name must derive from '{1}'.",
+   "Description": "Checks if field containing 'LedgerDimension' in the name is derived from 'LedgerDimensionBase'."
+  },
+  {
+   "Name": "BPErrorDimensionLedgerDimName",
+   "Canonical": true,
+   "Message": "BPErrorDimensionLedgerDimName: Fields derived from '{0}' must have '{1}' in their names.",
+   "Description": "Checks whether fields deriving from 'LedgerDimensionBase' have 'LedgerDimension' in their names."
+  },
+  {
+   "Name": "BPErrorDimensionNameDAVCRelation",
+   "Canonical": true,
+   "Message": "BPErrorDimensionNameDAVCRelation: Fields with '{0}' in name should have relationship to the '{1}' table.",
+   "Description": "Checks if a field has LedgerDimension in the name, it has a relationship to DimensionAttributeValueCombination table."
+  },
+  {
+   "Name": "BPErrorDimensionRelationName",
+   "Canonical": true,
+   "Message": "BPErrorDimensionRelationName: Fields in a relationship to '{0}' must have '{1}' in their name.",
+   "Description": "Checks if the field having relationship to DimensionAttributeValueCombination table has LedgerDimension in the name."
+  },
+  {
+   "Name": "BPErrorDimensionRelationType",
+   "Canonical": true,
+   "Message": "BPErrorDimensionRelationType: Fields in a relationship to '{0}' must derive from '{1}'.",
+   "Description": "Checks if the field having relationship to DimensionAttributeValueCombination table is derived from LedgerDimensionBase."
+  },
+  {
+   "Name": "BPErrorDimensionTypeDAVCRelation",
+   "Canonical": true,
+   "Message": "BPErrorDimensionTypeDAVCRelation: Fields derived from '{0}' must have a relationship to the '{1}' table.",
+   "Description": "Checks if a field is derieved from LedgerDimensionBase, it has a relationship to DimensionAttributeValueCombination table."
+  },
+  {
+   "Name": "BPErrorDisplayEditNoExtendedReturnType",
+   "Canonical": true,
+   "Message": "BPErrorDisplayEditNoExtendedReturnType: Display and Edit methods must return values of an extended data type.",
+   "Description": "Checks if the return types of display and edit methods are extended data types."
+  },
+  {
+   "Name": "BPErrorDropDialogButtonInvalidTarget",
+   "Canonical": true,
+   "Message": "BPErrorDropDialogButtonInvalidTarget: Drop dialog button '{0}' references a form whose style is not DropDialog. Please ensure that the target form uses style DropDialog.",
+   "Description": "Reports when a DropDialogButton in a form references a form whose style is not DropDialog."
+  },
+  {
+   "Name": "BPErrorDutyHasNoPrivileges",
+   "Canonical": true,
+   "Message": "BPErrorDutyHasNoPrivileges: The duty '{0}' has no privilege references.",
+   "Description": "All duties should have at least one privilege."
+  },
+  {
+   "Name": "BPErrorDutyNotCoveredByRole",
+   "Canonical": true,
+   "Message": "BPErrorDutyNotCoveredByRole: The duty '{0}' is not referenced on any role.",
+   "Description": "All duties should be part of a role."
+  },
+  {
+   "Name": "BPErrorEDTNotMigrated",
+   "Canonical": true,
+   "Message": "BPErrorEDTNotMigrated: The relation under the extended data type (EDT) '{0}' must be migrated to table relation. Consider using EDT relation migration tool.",
+   "Description": "Checks if all EDT relations have been migrated to table relations."
+  },
+  {
+   "Name": "BPErrorEdtFormHelpIsLookup",
+   "Canonical": true,
+   "Message": "BPErrorEdtFormHelpIsLookup: The FormHelp form '{0}' for this extended data type has the wrong style. Choose a form that has either its Style property set to Lookup or its Pattern set to CustomLookup.",
+   "Description": "Reports that a FormHelp form for an extended data type is not a lookup form."
+  },
+  {
+   "Name": "BPErrorEdtHelpIsCopyOfEnumHelp",
+   "Canonical": true,
+   "Message": "BPErrorEdtHelpIsCopyOfEnumHelp: The HelpText property value of the extended data type is the same as the Help property value on its base enum. Make each value specific to its intended use.",
+   "Description": "Reports when the HelpText property value of the extended data type is the same as the Help property value on its base enum."
+  },
+  {
+   "Name": "BPErrorEdtHelpIsCopyOfExtendedHelp",
+   "Canonical": true,
+   "Message": "BPErrorEdtHelpIsCopyOfExtendedHelp: The HelpText property value of the extended data type is the same as the HelpText property value on extended data type it is extending from.",
+   "Description": "Reports when the HelpText property value of the extended data type is the same as the HelpText property value on extended data type it is extending from."
+  },
+  {
+   "Name": "BPErrorEdtLabelIsCopyOfEnumLabel",
+   "Canonical": true,
+   "Message": "BPErrorEdtLabelIsCopyOfEnumLabel: The Label property value of the extended data type is the same as the Label property value on its base enum.",
+   "Description": "Reports when the Label property value of the extended data type is the same as the Label property value on its base enum. Make each value specific to its intended use."
+  },
+  {
+   "Name": "BPErrorEdtLabelIsCopyOfExtendedLabel",
+   "Canonical": true,
+   "Message": "BPErrorEdtLabelIsCopyOfExtendedLabel: The Label property value of the extended data type is the same as the Label property value on the extended data type it is extending from.",
+   "Description": "Reports when the Label property value of the extended data type is the same as the Label property value on the extended data type it is extending from."
+  },
+  {
+   "Name": "BPErrorEdtSameLabelAndHelp",
+   "Canonical": true,
+   "Message": "BPErrorEdtSameLabelAndHelp: The extended data type has the same string value for its Label and HelpText properties. Give each property a value that is specific to its intended use.",
+   "Description": "Reports when an extended data type has the same string value for its Label and HelpText properties."
+  },
+  {
+   "Name": "BPErrorEdtStringNotLeftJustified",
+   "Canonical": true,
+   "Message": "BPErrorEdtStringNotLeftJustified: A string extended data type has its Adjustment property set to 'Right', when it should be set to 'Left'.",
+   "Description": "Reports when a string extended data type has its Adjustment property set to 'Right', when it should be set to 'Left'."
+  },
+  {
+   "Name": "BPErrorEmptyTableMethod",
+   "Canonical": true,
+   "Message": "{0} table has an empty {1} method.",
+   "Description": "This rule checks for table methods with no source code."
+  },
+  {
+   "Name": "BPErrorEnumSameLabelAndHelp",
+   "Canonical": true,
+   "Message": "BPErrorEnumSameLabelAndHelp: The base enum has the same string value for its Label and Help properties. Give each property a value that is specific to its intended use.",
+   "Description": "Reports when a base enum has the same string value for its Label and Help properties."
+  },
+  {
+   "Name": "BPErrorFieldHelpIsCopyOfEnumHelp",
+   "Canonical": true,
+   "Message": "BPErrorFieldHelpIsCopyOfEnumHelp: The Help property value of the field is the same as the Help property value of its base enum. ",
+   "Description": "Reports when the Help property value of the field is the same as the Help property value of its base enum."
+  },
+  {
+   "Name": "BPErrorFieldHelpIsCopyOfExtendedHelp",
+   "Canonical": true,
+   "Message": "BPErrorFieldHelpIsCopyOfExtendedHelp: The Help property value of the field is the same as the HelpText property value of its extended data type.",
+   "Description": "Reports when the Help property value of the field is the same as the HelpText property value of its extended data type."
+  },
+  {
+   "Name": "BPErrorFieldLabelIsCopyOfEnumHelp",
+   "Canonical": true,
+   "Message": "BPErrorFieldLabelIsCopyOfEnumHelp: The Label property value of the field is a copy of the Help property value for its base enum.",
+   "Description": "Reports when the Label property value of the field is a copy of the Help property value for its base enum."
+  },
+  {
+   "Name": "BPErrorFieldLabelIsCopyOfEnumLabel",
+   "Canonical": true,
+   "Message": "BPErrorFieldLabelIsCopyOfEnumLabel: The Label property value of the field is a copy of Label property value for its base enum.",
+   "Description": "Reports when the Label property value of the field is a copy of the Label property value for its base enum."
+  },
+  {
+   "Name": "BPErrorFieldLabelIsCopyOfExtendedHelp",
+   "Canonical": true,
+   "Message": "BPErrorFieldLabelIsCopyOfExtendedHelp: The Label property value of the field is a copy of the HelpText property value of its extended data type.",
+   "Description": "Reports when the Label property value of the field is a copy of the HelpText property value of its extended data type."
+  },
+  {
+   "Name": "BPErrorFieldLabelIsCopyOfExtendedLabel",
+   "Canonical": true,
+   "Message": "BPErrorFieldLabelIsCopyOfExtendedLabel: The Label property value of the field is a copy of the Label property value for its extended data type.",
+   "Description": "Reports when the Label property value of the field is a copy of the Label property value for its extended data type."
+  },
+  {
+   "Name": "BPErrorFilterPropertiesControlsCannotHaveOverrides",
+   "Canonical": true,
+   "Message": "BPErrorFilterPropertiesControlsCannotHaveOverrides: Form control '{0}' on form '{1}' has one or more of these properties defined: 'FilterDataSource', 'FilterControl' and 'FilterExpression'. A control with these properties must not have method overrides.",
+   "Description": "Reports when a form control has filter properties and it has modified or selection changed overrides."
+  },
+  {
+   "Name": "BPErrorFilterPropertiesOnlyOnTemplatedForms",
+   "Canonical": true,
+   "Message": "BPErrorFilterPropertiesOnlyOnTemplatedForms: Form control '{0}' on form '{1}' has one or more of these properties defined: 'FilterDataSource', 'FilterControl' and 'FilterExpression'. These properties can only be applied in forms with 'ListPage' or 'DetailsPage' template.",
+   "Description": "Reports when a form control has filter properties and its host form is not a templated form."
+  },
+  {
+   "Name": "BPErrorFormCaptionIsEmpty",
+   "Canonical": true,
+   "Message": "BPErrorFormCaptionIsEmpty: The caption of a form should not be empty.",
+   "Description": "Reports that a form has an empty caption."
+  },
+  {
+   "Name": "BPErrorFormDataSourceJoinLimit",
+   "Canonical": true,
+   "Message": "BPErrorFormDataSourceJoinLimit: Too many joins ('{0}') in a single query datasource tree. The recommended limit is '{1}'. Consider reducing the number of joins in this form.",
+   "Description": "Checks whether the join trees exceed the recommended limit."
+  },
+  {
+   "Name": "BPErrorFormDataSourceMustNotBeUsingEntities",
+   "Canonical": true,
+   "Message": "The form data source '{0}' can't be bound to a data entity.",
+   "Description": "Reports when the form data source is bound to a data entity."
+  },
+  {
+   "Name": "BPErrorFormDataSourceTableUnknown",
+   "Canonical": false,
+   "Message": "BPErrorFormDataSourceTableUnknown: Table on data source '{0}' is unknown.",
+   "Description": "Reports that forms do not contain data sources without a valid table reference."
+  },
+  {
+   "Name": "BPErrorFormDisplayMethodHasRequiredArgs",
+   "Canonical": true,
+   "Message": "Display method on form '{0}' cannot have required parameters.",
+   "Description": "Detects when a display method on a table has a required parameter."
+  },
+  {
+   "Name": "BPErrorFormGridValidTimeStateColumnsNotFound",
+   "Canonical": true,
+   "Message": "BPErrorFormGridValidTimeStateColumnsNotFound: Form '{0}' contains a data source which has its ValidTimeStateAutoQuery property set to DateRange, therefore the form must also have a grid with the date fields ValidFrom and ValidTo.",
+   "Description": "Reports when a form contains a data source which has its ValidTimeStateAutoQuery property set to DateRange, yet the form lacks the thereby required grid with the date fields ValidFrom and ValidTo."
+  },
+  {
+   "Name": "BPErrorFormPartControlTargetFormWithoutFormPartStyle",
+   "Canonical": true,
+   "Message": "BPErrorFormPartControlTargetFormWithoutFormPartStyle: The forms used in form parts need to have have style of FormPart.",
+   "Description": "Reports that a form has form parts that do not have style of FormPart."
+  },
+  {
+   "Name": "BPErrorFormPartLocationPreviewPane",
+   "Canonical": true,
+   "Message": "BPErrorFormPartLocationPreviewPane: Form part '{0}' has PartLocation=PreviewPane",
+   "Description": "Checks that the Form.Parts collection does not have any PartLocation=PreviewPane."
+  },
+  {
+   "Name": "BPErrorFormRealControlNumberOfDecimals",
+   "Canonical": true,
+   "Message": "BPErrorFormRealControlNumberOfDecimals: The MinNoOfDecimals property value is equal to or greater than the value of the NoOfDecimals property in a form control of the real data type.",
+   "Description": "Reports when the MinNoOfDecimals property value is equal to or greater than the value of the NoOfDecimals property in a form control of the real data type."
+  },
+  {
+   "Name": "BPErrorFormSplitterGroupNotEmpty",
+   "Canonical": true,
+   "Message": "BPErrorFormSplitterGroupNotEmpty: Group control modeled as a splitter is left empty.",
+   "Description": "Checks that a group control modeled as a splitter is left empty."
+  },
+  {
+   "Name": "BPErrorFormStringTitleFieldWithDesignStyleAuto",
+   "Canonical": true,
+   "Message": "BPErrorFormStringTitleFieldWithDesignStyleAuto: String '{0}' has Style set to TitleField. TitleField should not be used on a form with Style=Auto. Use an appropriate form pattern.",
+   "Description": "Checks that a form with Auto style does not have any fields with the TitleField style."
+  },
+  {
+   "Name": "BPErrorFormWorkflowEnabledWithNoActionPane",
+   "Canonical": true,
+   "Message": "BPErrorFormWorkflowEnabledWithNoActionPane: WorkFlow enabled form has an action pane control.",
+   "Description": "Checks that a workflow enabled form has an action pane control."
+  },
+  {
+   "Name": "BPErrorHelpDefined",
+   "Canonical": true,
+   "Message": "BPErrorHelpDefined: Help is defined on a control that cannot display help.",
+   "Description": "Reports when help is defined on a control that cannot display help."
+  },
+  {
+   "Name": "BPErrorHelpIsText",
+   "Canonical": true,
+   "Message": "BPErrorHelpIsText: Property '{0}' must have a label ID as its value, and '{1}' is not a label ID.",
+   "Description": "Reports when property must have a label ID as its value, but does not have a label ID as its present value."
+  },
+  {
+   "Name": "BPErrorHorizontalFieldsButtonGroupButtonLimit",
+   "Canonical": true,
+   "Message": "BPErrorHorizontalFieldsButtonGroupButtonLimit: Since it is using the HorizontalFieldsAndButtonGroup pattern, the group control '{0}' should not have more than three buttons.",
+   "Description": "Detects that a group using the HorizontalFieldsAndButtonGroup pattern contains more than three buttons."
+  },
+  {
+   "Name": "BPErrorLabelAndHelpAreEqual",
+   "Canonical": true,
+   "Message": "BPErrorLabelAndHelpAreEqual: The string values for the Label and Help or HelpText properties are the same. Make each value specific to its intended use.",
+   "Description": "Reports when the string values for the Label and Help or HelpText properties are the same."
+  },
+  {
+   "Name": "BPErrorLabelIsText",
+   "Canonical": true,
+   "Message": "BPErrorLabelIsText: Property '{0}' must have a label ID as its value, and '{1}' is not a label ID.",
+   "Description": "Reports when property must have a label ID as its value, but does not have a label ID as its present value."
+  },
+  {
+   "Name": "BPErrorLabelNotDefined",
+   "Canonical": true,
+   "Message": "BPErrorLabelNotDefined: No label is given for the '{0}' property.",
+   "Description": "Reports when a property is missing a label."
+  },
+  {
+   "Name": "BPErrorLabelWrongEndSign",
+   "Canonical": true,
+   "Message": "BPErrorLabelWrongEndSign: A label may not end with a period ('.').",
+   "Description": "Reports when a label ends with a period ('.')."
+  },
+  {
+   "Name": "BPErrorMenuHasImage",
+   "Canonical": true,
+   "Message": "[BPErrorMenuHasImage] Menu {0} has an image defined, should use ImageLocation = Symbol and empty NormalImage",
+   "Description": "Reports when a menu or sub menu has a NormalImage defined."
+  },
+  {
+   "Name": "BPErrorMenuItemNotCoveredByPrivilege",
+   "Canonical": true,
+   "Message": "BPErrorMenuItemNotCoveredByPrivilege: '{0}' '{1}' is not covered by privilege.",
+   "Description": "All Menu Item should be covered by at least one privilege"
+  },
+  {
+   "Name": "BPErrorMethodDeleteFromNotUsed",
+   "Canonical": true,
+   "Message": "Consider modifying your code to delete a set of data records with one 'delete_from' statement. The 'while select ... .delete()' code design, which loops around a call to a singleton delete method, might be less efficient.",
+   "Description": "Detects a call to the 'delete' method within a 'while select' statement, where a 'delete_from' set-based statement might be more efficient."
+  },
+  {
+   "Name": "BPErrorMethodLabelInSingleQuotes",
+   "Canonical": true,
+   "Message": "Use double-quotation marks when referring to labels, instead of using single-quotation marks.",
+   "Description": "Checks that a label is delimited by double-quotation marks."
+  },
+  {
+   "Name": "BPErrorMethodUnbalancedTtsbeginCommit",
+   "Canonical": true,
+   "Message": "{0}",
+   "Description": "Detects unpaired ttsBegin or ttsCommit statements. The transaction statements must be balanced within the same scope."
+  },
+  {
+   "Name": "BPErrorMissingOrUnsupportedImage",
+   "Canonical": true,
+   "Message": "[BPErrorMissingOrUnsupportedImage] A missing or unsupported image is being used by '{0}' in form '{1}'.",
+   "Description": "Reports when a missing or unsupported image is used by a control."
+  },
+  {
+   "Name": "BPErrorNavigationBarMenuExtensionInvalidType",
+   "Canonical": true,
+   "Message": "BPErrorNavigationBarMenuExtensionInvalidType: '{0}' contains elements other than MenuItems adjust your menu structure.",
+   "Description": "Checks that Navigtaion Bar menus don't have invalid types"
+  },
+  {
+   "Name": "BPErrorNavigationBarMenuInvalidType",
+   "Canonical": true,
+   "Message": "BPErrorNavigationBarMenuInvalidType: '{0}' contains elements other than MenuItems adjust your menu structure.",
+   "Description": "Checks that Navigtaion Bar menus don't have invalid types"
+  },
+  {
+   "Name": "BPErrorNeitherControlInSpecificDesign",
+   "Canonical": true,
+   "Message": "BPErrorNeitherControlInSpecificDesign: No control is specified in design.",
+   "Description": "Checks if any control is specified in the design."
+  },
+  {
+   "Name": "BPErrorNormalImagePropertyInvalid",
+   "Canonical": true,
+   "Message": "BPErrorNormalImagePropertyInvalid: The NormalImage property on the control does not correspond to a valid symbol name.",
+   "Description": "Reports that the NormalImage property on a control does not correspond to a valid symbol name."
+  },
+  {
+   "Name": "BPErrorNotAllowedDisplayMethod",
+   "Canonical": true,
+   "Message": "Display methods can be declared only on tables, forms, form datasources, reports, and report designs.",
+   "Description": "Detects display methods declared outside their permitted contexts: tables, forms, form datasources, reports, and report designs."
+  },
+  {
+   "Name": "BPErrorNotAllowedEditMethod",
+   "Canonical": true,
+   "Message": "Edit methods can be declared only on tables, forms, and form datasources.",
+   "Description": "Detects edit methods declared outside the legal context: tables, forms, and form datasources."
+  },
+  {
+   "Name": "BPErrorPreventDenyGrant",
+   "Canonical": true,
+   "Message": "Resource '{0}' grant is set to 'NoAccess'.",
+   "Description": "An explicit global Deny trumps all other explicit and inferred access to the resource. This could conflict with other user role assignments."
+  },
+  {
+   "Name": "BPErrorPreventRedundantChildNodeGrant",
+   "Canonical": true,
+   "Message": "Resource '{0}' is granted with same access as parent '{1}' and is redundant.",
+   "Description": "Resource grant is redundant when it maches the grant to parent resource. Resources inherit access from parent implicitely when not specified."
+  },
+  {
+   "Name": "BPErrorPreventRedundantEntryPointFormControlOverrideGrant",
+   "Canonical": true,
+   "Message": "Form control '{0}' has NeededPermission set to '{1}' which is already granted by entry point context '{2}' and makes this redundant.",
+   "Description": "At runtime form control access is inferred based on entry point context. For instance if the entry point grants 'Update' and the control's NeededPermission is set to 'Read' there is no need to define an entry point form control override."
+  },
+  {
+   "Name": "BPErrorPreventRedundantEntryPointUnsetGrant",
+   "Canonical": true,
+   "Message": "Entry point '{0}' grant is set to 'Unset'",
+   "Description": "Entry point grant that has not been set is redundant."
+  },
+  {
+   "Name": "BPErrorPreventRedundantUnsetGrant",
+   "Canonical": true,
+   "Message": "Resource '{0}' grant is set to 'Unset'.",
+   "Description": "Grants set to 'Unset' are redundant when they have no child nodes."
+  },
+  {
+   "Name": "BPErrorPrivilegeIsEmpty",
+   "Canonical": true,
+   "Message": "BPErrorPrivilegeIsEmpty: The privilege '{0}' is empty.",
+   "Description": "All privileges should grant at least one resouce."
+  },
+  {
+   "Name": "BPErrorPrivilegeNotCoveredByDuty",
+   "Canonical": true,
+   "Message": "BPErrorPrivilegeNotCoveredByDuty: The privilege '{0}' is not referenced on any duty.",
+   "Description": "All privileges should be part of a duty."
+  },
+  {
+   "Name": "BPErrorSegmentedEntryControlCheckAccountTypeNotDefined",
+   "Canonical": true,
+   "Message": "BPErrorSegmentedEntryControlCheckAccountTypeNotDefined: The Segmented Entry control is using the DimensionDynamicAccountController Controller class so it must also specify the Account Type field.",
+   "Description": "Checks if a Segmented Entry control uses the DimensionDynamicAccountController Controller class and if the Account Type field has a value."
+  },
+  {
+   "Name": "BPErrorSegmentedEntryControlCheckUseCustomLookupMethodNotDefined",
+   "Canonical": true,
+   "Message": "BPErrorSegmentedEntryControlCheckUseCustomLookupMethodNotDefined: The Segmented Entry control has a 'lookup' method so it must also override the 'checkUseCustomLookup' method.",
+   "Description": "Checks if a Segmented Entry control overrides the 'lookup' method but does not override the 'checkUseCustomLookup' method."
+  },
+  {
+   "Name": "BPErrorSegmentedEntryControlControllerNotDefined",
+   "Canonical": true,
+   "Message": "BPErrorSegmentedEntryControlControllerNotDefined: The Segmented Entry Control's Controller property is not set.",
+   "Description": "Reports when the Controller property is not set on a Segmented Entry Control."
+  },
+  {
+   "Name": "BPErrorSelectUsingFirstOnly",
+   "Canonical": true,
+   "Message": "Consider using the 'firstonly' keyword for select from '{0}' since additional data rows are unused here.",
+   "Description": "Detects a 'select' statement that could be more efficient by adding the 'firstonly' keyword."
+  },
+  {
+   "Name": "BPErrorSizeToAvailableControlsInsideColumn",
+   "Canonical": true,
+   "Message": "Control {0} has a flexible width or height due to its property settings of WidthMode/HeightMode=SizeToAvailable (or WidthMode/HeightMode=Auto for a Tab or Grid) and is inside of a container with ColumnsMode=Fill, which is not a supported layout configuration."
+  },
+  {
+   "Name": "BPErrorSubMenuMenuItemNotAllowed",
+   "Canonical": true,
+   "Message": "BPErrorSubMenuMenuItemNotAllowed: The submenu '{0}' references menu item '{1}'. Menu items are not allowed on submenus.",
+   "Description": "Reports when a submenu references a menu item; menu items are not allowed on submenus."
+  },
+  {
+   "Name": "BPErrorSuppressionListMissingJustification",
+   "Canonical": true,
+   "Message": "BPErrorSuppressionListMissingJustification: The rule '{0}' with path '{1}' cannot be suppresed without a justification.",
+   "Description": "Reports that every suppressed best practice rule has a justification."
+  },
+  {
+   "Name": "BPErrorTableDelConfigKeyConflict",
+   "Canonical": true,
+   "Message": "BPErrorTableDelConfigKeyConflict: Table '{0}' with the 'DEL_' prefix has configuration '{1}' instead of SysDeletedObjects.",
+   "Description": "Checks that tables with the 'DEL_' prefix have the 'SysDeletedObjects' configuration key."
+  },
+  {
+   "Name": "BPErrorTableDelPrefixConflict",
+   "Canonical": true,
+   "Message": "BPErrorTableDelPrefixConflict: The table with SysDeletedObjects configuration key has no 'DEL_' prefix.",
+   "Description": "Checks if a table with SysDeletedObjects configuration key uses the 'DEL_' prefix."
+  },
+  {
+   "Name": "BPErrorTableDeleteActionBothDirections",
+   "Canonical": true,
+   "Message": "BPErrorTableDeleteActionBothDirections: The table does not have delete actions in both directions.",
+   "Description": "Checks if tables have delete actions in both directions."
+  },
+  {
+   "Name": "BPErrorTableDeleteActionUnknownTable",
+   "Canonical": true,
+   "Message": "BPErrorTableDeleteActionUnknownTable: The delete action is related to an unknown table.",
+   "Description": "Checks if the delete action is related to an unknown table."
+  },
+  {
+   "Name": "BPErrorTableDisplayMethodHasRequiredArgs",
+   "Canonical": true,
+   "Message": "Display methods on table '{0}' cannot have required parameters.",
+   "Description": "Detects when a display method on a form has a required parameter."
+  },
+  {
+   "Name": "BPErrorTableDuplicateUITextField",
+   "Canonical": true,
+   "Message": "BPErrorTableDuplicateUITextField: Fields must have unique labels. '{0}' has the same label.",
+   "Description": "Reports when a string is used as a label for more than one field in a table. Each field label must be unique."
+  },
+  {
+   "Name": "BPErrorTableEditMethodWrongNumberArgs",
+   "Canonical": true,
+   "Message": "BPErrorTableEditMethodWrongNumberArgs: The table edit method must have a boolean 'set' parameter, and a parameter that matches the type of the control which uses the method.",
+   "Description": "Checks if the table edit method has a boolean 'set' parameter, and a parameter that matches the type of the control which uses the method."
+  },
+  {
+   "Name": "BPErrorTableFieldConfigurationKeyIsCopyOfEDT",
+   "Canonical": true,
+   "Message": "BPErrorTableFieldConfigurationKeyIsCopyOfEDT: The table field's configuration key is the same as the extended datatype's configuration key.",
+   "Description": "Checks whether a table field's configuration key is the same as the extended data type configuration key."
+  },
+  {
+   "Name": "BPErrorTableFieldConfigurationKeyIsCopyOfEnumeration",
+   "Canonical": true,
+   "Message": "BPErrorTableFieldConfigurationKeyIsCopyOfEnumeration: Enumeration field configuration key should not be same as configuration key of enumeration.",
+   "Description": "Checks whether a table field's configuration key is a copy of the enumeration type's configuration key."
+  },
+  {
+   "Name": "BPErrorTableFieldDelConfigKeyConflict",
+   "Canonical": true,
+   "Message": "BPErrorTableFieldDelConfigKeyConflict: Field '{0}' with the 'DEL_' prefix has configuration '{1}' instead of 'SysDeletedObjects'.",
+   "Description": "Checks that fields in a table with the 'DEL_' prefix have the 'SysDeletedObjects' configuration key."
+  },
+  {
+   "Name": "BPErrorTableFieldHasSameNameAsMethod",
+   "Canonical": true,
+   "Message": "BPErrorTableFieldHasSameNameAsMethod: Fields cannot have the same name as display or edit methods.",
+   "Description": "Checks whether fields have the same name as display or edit methods."
+  },
+  {
+   "Name": "BPErrorTableFieldLabelAndHelpAreEqual",
+   "Canonical": true,
+   "Message": "BPErrorTableFieldLabelAndHelpAreEqual: A table's field has the same value for its Label and HelpText properties.",
+   "Description": "Reports when a table's field has the same value for its Label and HelpText properties."
+  },
+  {
+   "Name": "BPErrorTableFieldNotDefinedUsingType",
+   "Canonical": true,
+   "Message": "BPErrorTableFieldNotDefinedUsingType: Field must be defined using a type.",
+   "Description": "Checks that table fields are defined using a type."
+  },
+  {
+   "Name": "BPErrorTableFieldNotInFieldGroup",
+   "Canonical": true,
+   "Message": "BPErrorTableFieldNotInFieldGroup: The table's field is not a member of a field group.",
+   "Description": "Reports when the table's field is not a member of a field group."
+  },
+  {
+   "Name": "BPErrorTableFieldSelfLinkThruEdtRelation",
+   "Canonical": true,
+   "Message": "BPErrorTableFieldSelfLinkThruEdtRelation: A field cannot relate to itself through an extended data type (EDT). Set the IgnoreEDTRelation property to Yes.",
+   "Description": "Reports when a field relates to itself through an extended data type (EDT). This is not supported. The IgnoreEDTRelation property value must be changed to Yes."
+  },
+  {
+   "Name": "BPErrorTableFieldUsesTableId",
+   "Canonical": true,
+   "Message": "BPErrorTableFieldUsesTableId: Table fields that refer to table IDs must use RefTableId or an extended data type derived from it.",
+   "Description": "Checks if a table field directly uses TableId extended data type. The field should instead use RefTableId or a derived extended data type."
+  },
+  {
+   "Name": "BPErrorTableIndexDelConfigKeyConflict",
+   "Canonical": true,
+   "Message": "BPErrorTableIndexDelConfigKeyConflict: An index with the 'DEL_' prefix has configuration instead of SysDelete.",
+   "Description": "Checks if an index with the 'DEL_' prefix has configuration instead of SysDelete."
+  },
+  {
+   "Name": "BPErrorTableIndexFieldDeprecated",
+   "Canonical": true,
+   "Message": "BPErrorTableIndexFieldDeprecated: A non-deprecated index has a deprecated field.",
+   "Description": "Checks if non-deprecated indexes have deprecated fields."
+  },
+  {
+   "Name": "BPErrorTableIndexWithoutFields",
+   "Canonical": true,
+   "Message": "BPErrorTableIndexWithoutFields: The index has no fields.",
+   "Description": "Checks that indexes have fields."
+  },
+  {
+   "Name": "BPErrorTableMissingFormRef",
+   "Canonical": true,
+   "Message": "BPErrorTableMissingFormRef: No form ref is specified.",
+   "Description": "Checks if form ref is specified."
+  },
+  {
+   "Name": "BPErrorTableMissingGroupAutoReport",
+   "Canonical": true,
+   "Message": "BPErrorTableMissingGroupAutoReport: The table has no fields in the AutoReport field group.",
+   "Description": "Checks that a table has fields in the AutoReport field group."
+  },
+  {
+   "Name": "BPErrorTableMultipleCompositionRelations",
+   "Canonical": true,
+   "Message": "BPErrorTableMultipleCompositionRelations: There are more than one composition relations in this table.",
+   "Description": "Checks if there are more than one composition relations in this table."
+  },
+  {
+   "Name": "BPErrorTableNaturalKeyWithRecordID",
+   "Canonical": true,
+   "Message": "BPErrorTableNaturalKeyWithRecordID: The RecordID field is part of the NaturalKey index.",
+   "Description": "Checks if RecordID field is part of the NaturalKey index."
+  },
+  {
+   "Name": "BPErrorTableNoCaching",
+   "Canonical": true,
+   "Message": "BPErrorTableNoCaching: No caching is set up for the table.",
+   "Description": "Checks if caching is set up for the Table."
+  },
+  {
+   "Name": "BPErrorTableNoClusteredIndex",
+   "Canonical": true,
+   "Message": "BPErrorTableNoClusteredIndex: This table has no clustered index.",
+   "Description": "Checks if the table has a clustered index."
+  },
+  {
+   "Name": "BPErrorTableNoPrimaryIndex",
+   "Canonical": true,
+   "Message": "BPErrorTableNoPrimaryIndex: The table has no primary index.",
+   "Description": "Checks if the table has a primary index."
+  },
+  {
+   "Name": "BPErrorTableOneIndexNotCluster",
+   "Canonical": true,
+   "Message": "BPErrorTableOneIndexNotCluster: The table has only one index and that index is not defined as a clustered index.",
+   "Description": "Checks that if only one index is provided for a table, that index is a clustered index."
+  },
+  {
+   "Name": "BPErrorTableOverlappingIndex",
+   "Canonical": true,
+   "Message": "BPErrorTableOverlappingIndex: The index is overlapped by another index.",
+   "Description": "Checks if an index is overlapped by another index."
+  },
+  {
+   "Name": "BPErrorTablePrimaryIndexNotUnique",
+   "Canonical": true,
+   "Message": "BPErrorTablePrimaryIndexNotUnique: The primary index is not unique.",
+   "Description": "Checks that a primary index is unique."
+  },
+  {
+   "Name": "BPErrorTablePrimaryKeyEditable",
+   "Canonical": true,
+   "Message": "BPErrorTablePrimaryKeyEditable: The primary key must not be editable.",
+   "Description": "Checks if the primary key is editable."
+  },
+  {
+   "Name": "BPErrorTablePrimaryKeyNotMandatory",
+   "Canonical": true,
+   "Message": "BPErrorTablePrimaryKeyNotMandatory: The primary key must be mandatory.",
+   "Description": "Checks if the primary key is mandatory."
+  },
+  {
+   "Name": "BPErrorTableRelationNoFields",
+   "Canonical": true,
+   "Message": "BPErrorTableRelationNoFields: Relation '{0}' has no fields.",
+   "Description": "Checks if the table relation has relationship constraints. "
+  },
+  {
+   "Name": "BPErrorTableRelationshipForeignKeyToShort",
+   "Canonical": true,
+   "Message": "BPErrorTableRelationshipForeignKeyToShort: If Adjustment is set to 'Left', the field's StringSize for must be greater than or equal to the size of its related field of table.",
+   "Description": "Checks that the table field's 'StringSize' is greater than or equal to the size of its related field of table if the adjustment property is set to 'Left'."
+  },
+  {
+   "Name": "BPErrorTableRelationshipPropertiesCompleteness",
+   "Canonical": true,
+   "Message": "BPErrorTableRelationshipPropertiesCompleteness: Relation properties [{0}] for table relation '{1}' are not set.",
+   "Description": "Checks table relationship for completeness by verifying if all required properties or the relationship are specified."
+  },
+  {
+   "Name": "BPErrorTableRelationshipPropertiesCorrectness",
+   "Canonical": true,
+   "Message": "The relation property named '{0}' has a value of '{1}', but the value should be '{2}'.",
+   "Description": "Checks the correctness of table relationship properties."
+  },
+  {
+   "Name": "BPErrorTableReplacementKeyNotSpecified",
+   "Canonical": true,
+   "Message": "BPErrorTableReplacementKeyNotSpecified: Tables having multiple alternate keys must specify a replacement key.",
+   "Description": "Checks if tables having multiple alternate keys specify replacement keys."
+  },
+  {
+   "Name": "BPErrorTableSysDeleteFieldIndex",
+   "Canonical": true,
+   "Message": "BPErrorTableSysDeleteFieldIndex: The unique index contains field(s) with the 'SysDelete' configuration key. Remove these fields from the index.",
+   "Description": "Checks if a unique index contains fields with the 'SysDelete' configuration key."
+  },
+  {
+   "Name": "BPErrorTableTPFIntegrity",
+   "Canonical": true,
+   "Message": "BPErrorTableTPFIntegrity: The AOSAuthorization property is not applied consistently in the chain of inheritance. Ensure that all tables have either authorization enabled or disabled.",
+   "Description": "Checks the usage of AOSAuthorization property for a table in chain of inheritance."
+  },
+  {
+   "Name": "BPErrorTableTitleField1NotDeclared",
+   "Canonical": true,
+   "Message": "BPErrorTableTitleField1NotDeclared: No field has been specified for the Title Field1 property.",
+   "Description": "Checks if a field has been specified for the Title Field1 property."
+  },
+  {
+   "Name": "BPErrorTableTitleField2NotDeclared",
+   "Canonical": true,
+   "Message": "BPErrorTableTitleField2NotDeclared: No field has been specified for the 'Title Field2' property.",
+   "Description": "Checks if a field has been specified for the 'Title Field2' property."
+  },
+  {
+   "Name": "BPErrorTableTitleFieldDeprecated",
+   "Canonical": true,
+   "Message": "BPErrorTableTitleFieldDeprecated: A deprecated field is used as a title field.",
+   "Description": "Checks if a a deprecated field is used as title field."
+  },
+  {
+   "Name": "BPErrorTableUnknownFormRef",
+   "Canonical": true,
+   "Message": "BPErrorTableUnknownFormRef: The form ref specified is not known.",
+   "Description": "Checks if an unknown form ref is specified."
+  },
+  {
+   "Name": "BPErrorTypeExtendsRecId",
+   "Canonical": true,
+   "Message": "BPErrorTypeExtendsRecId: The extended data type (EDT) inherits directly from the RecId EDT. Instead, it must inherit from the RefRecId EDT.",
+   "Description": "Reports when an application extended data type (EDT) inherits directly from the RecId EDT."
+  },
+  {
+   "Name": "BPErrorTypeExtendsTableId",
+   "Canonical": true,
+   "Message": "BPErrorTypeExtendsTableId: The extended data type (EDT) inherits directly from the TableId EDT. Instead, it must inherit from the RefTableId EDT.",
+   "Description": "Reports when an application extended data type (EDT) inherits directly from the TableId EDT."
+  },
+  {
+   "Name": "BPErrorTypeFieldsIncompatible",
+   "Canonical": true,
+   "Message": "BPErrorTypeFieldsIncompatible: The fields in the relation '{0}' are incompatible. '{1}.{2}' is '{3}' characters too short.",
+   "Description": "Checks the compatibility of fields in table relationships."
+  },
+  {
+   "Name": "BPErrorUnknownLabel",
+   "Canonical": true,
+   "Message": "Unknown label '{0}'. Labels are case-insensitive, but it is recommended to use upper casing when referring to legacy labels (such as the label id @SYS12345) and exact casing for modern labels (such as 'MyLabelId' in @MyLabelFile:MyLabelId).",
+   "Description": "Reports when a label does not exist."
+  },
+  {
+   "Name": "BPErrorUnsupportedButtonDisplayValue",
+   "Canonical": true,
+   "Message": "[BPErrorUnsupportedButtonDisplayValue] Button {0} in form {1} uses unsupported button display value of {2}.",
+   "Description": "Reports when a button uses an unsupported button display value."
+  },
+  {
+   "Name": "BPErrorUnsupportedButtonDisplayValueInAppBarTabOrMenu",
+   "Canonical": true,
+   "Message": "[BPErrorUnsupportedButtonDisplayValueInAppBarTabOrMenu] One of the following properties for button {0} in form {1} is not supported: ButtonDisplay={2}, ImageLocation={3}, NormalImage={4}",
+   "Description": "Reports when a button inside an app bar tab or menu is not using ButtonDisplay=TextOnly, ImageLocation=Symbol or a non-empty NormalImage."
+  },
+  {
+   "Name": "BPErrorWebsiteHostControlUrlInvalid",
+   "Canonical": true,
+   "Message": "BPErrorWebsiteHostControlUrlInvalid: Control '{0}' has an invalid or insecure URL value",
+   "Description": "Checks that the URL value of Website Host controls are empty or are valid HTTPS URLs"
+  },
+  {
+   "Name": "BPForbiddenMethod",
+   "Canonical": true,
+   "Message": "The method '{0}' can cause dangerous side-effects and should not be used.",
+   "Description": "Reports when the code calls a method which can have dangerous side effects, and the method should not be called."
+  },
+  {
+   "Name": "BPFormatSpecifierInvalid",
+   "Canonical": true,
+   "Message": "The number of parameters ({0}) doesn't match with the number of format specifiers: ({1}).",
+   "Description": "Verifies the number of format specifiers equals the number of parameters"
+  },
+  {
+   "Name": "BPFormatSpecifierIsZero",
+   "Canonical": true,
+   "Message": "The format specifier %0 cannot be used.",
+   "Description": "Verifies the format specifier %0 is not used."
+  },
+  {
+   "Name": "BPIncrementalDimensionDataSourceContainsAggregates",
+   "Canonical": true
+  },
+  {
+   "Name": "BPIncrementalMeasureGroupDataSourceContainsAggregates",
+   "Canonical": true
+  },
+  {
+   "Name": "BPIndentationError",
+   "Canonical": true,
+   "Message": "The language element at ({0}, {1}) is not indented correctly. The element should start in column '{2}'.",
+   "Description": "Checks that X++ code has the correct column indentation for maintainability and consistency."
+  },
+  {
+   "Name": "BPInfopartToForm",
+   "Canonical": true,
+   "Message": "Infopart {0} needs to be upgraded to a form."
+  },
+  {
+   "Name": "BPLocalVariableNotUsed",
+   "Canonical": true,
+   "Message": "The local {0} '{1}' is not used.",
+   "Description": "Checks that all local variables and functions are actually used."
+  },
+  {
+   "Name": "BPMDXCalculatedMeasure",
+   "Canonical": true,
+   "Message": "Measure '{1}' of Measure group '{0}' has calculated measures implemented using MDX scripts. This may be an aggregate measurement upgraded from AX2012. Please consider re-coding MDX expressions using Rainier method expressions. Hard coded MDX expressions may have upgrade implications in future releases."
+  },
+  {
+   "Name": "BPMeasureForCalculatedMeasureNotFound",
+   "Canonical": true,
+   "Message": "Calculated measure '{0}' in measure group '{2}' references measures '{1}' not present within the Measurement, which may lead to unexpected errors at runtime."
+  },
+  {
+   "Name": "BPMeasureGroupComplexity",
+   "Canonical": true,
+   "Message": "Measure Group '{0}' uses view '{1}' which uses {2} table instances. To avoid performance issues in aggregate queries, do not use views that use more than {3} table instances in aggregate measurements or aggregate dimensions."
+  },
+  {
+   "Name": "BPMeasureGroupConstraintFieldAllowsNull",
+   "Canonical": true,
+   "Message": "The field set for the RelatedField property on the dimension relation constraint '{2}' for the relationship between Dimension '{1}' and Measure group '{0}' is a field that is not set as mandatory. Any data rows where the constraint field is empty will be categorized under the 'Unknown' member and may not be useful in the analysis.  Consider setting the field mandatory."
+  },
+  {
+   "Name": "BPMeasureGroupWithManyRelatedDimensions",
+   "Canonical": true,
+   "Message": "Measure Group '{0}' is sliceable by too many dimensions to be useful.  Consider limiting the number of related dimensions to no more than ten. \r\nClient tools such as Power view or Excel may not provide a good experience if there are too many slicers. "
+  },
+  {
+   "Name": "BPMeasureGroupWithOnlyOneMeasure",
+   "Canonical": true,
+   "Message": "Measure Group '{0}' has only one measure present in the measure group. Does this aggregate measure group is providing enough business value? Either add more measures or delete this measure group."
+  },
+  {
+   "Name": "BPMeasureIsAmountCur",
+   "Canonical": true,
+   "Message": "Measure '{0}' in measure group '{1}' is based on a field whose EDT is AmountCur. Data across entities with different local currencies will be added together. If there is an AmountMST field available, use that field for the measure instead of the AmountCur field."
+  },
+  {
+   "Name": "BPNestedStatementsShouldBeInBraces",
+   "Canonical": true,
+   "Message": "When statements are nested, such as under if and while, enclose the body of nested statements in braces {...} even when the body contains only one statement.",
+   "Description": "Checks that nested statements are enclosed in braces."
+  },
+  {
+   "Name": "BPNonContiguousFormatSpecifiers",
+   "Canonical": true,
+   "Message": "Not all specifier numbers are used in the format string. The following is/are not used : {0}.",
+   "Description": "Verifies that there are no gaps in the argument specifiers in format strings."
+  },
+  {
+   "Name": "BPODataActionCollectionNotSpecified",
+   "Canonical": true,
+   "Message": "BPODataActionCollectionNotSpecified: A matching SysODataCollectionAttribute could not be found.",
+   "Description": "Checks that SysODataCollectionAttribute is specified for OData Actions containing collection parameters or return types."
+  },
+  {
+   "Name": "BPODataActionNameAlreadyUsed",
+   "Canonical": true,
+   "Message": "BPODataActionNameAlreadyUsed: The Action name '{0}' is already specified in another SysODataActionAttribute.",
+   "Description": "Checks that OData Action names are unique."
+  },
+  {
+   "Name": "BPODataActionNameInvalid",
+   "Canonical": true,
+   "Message": "BPODataActionNameInvalid: The 'name' parameter value '{0}' is not a valid identifier. Update to a valid OData identifier.",
+   "Description": "Checks that OData Action names are valid OData identifiers."
+  },
+  {
+   "Name": "BPODataActionNameNotSpecified",
+   "Canonical": true,
+   "Message": "BPODataActionNameNotSpecified: The 'name' parameter is not specified.",
+   "Description": "Checks that OData Action names are specified."
+  },
+  {
+   "Name": "BPODataActionParameterTypeInvalid",
+   "Canonical": true,
+   "Message": "BPODataActionParameterTypeInvalid: The parameter type for parameter '{0}' is not a valid OData parameter type.",
+   "Description": "Checks that OData Action parameters are valid OData types."
+  },
+  {
+   "Name": "BPODataActionReturnTypeInvalid",
+   "Canonical": true,
+   "Message": "BPODataActionReturnTypeInvalid: The return type is not a valid OData return type.",
+   "Description": "Checks that OData Action return types are valid OData types."
+  },
+  {
+   "Name": "BPODataFieldNameConflicts",
+   "Canonical": true,
+   "Message": "BPODataFieldNameConflicts: The field has the same name as another view field.",
+   "Description": "Checks that OData Properties do not conflict due to view fields."
+  },
+  {
+   "Name": "BPODataRelationLinesEmpty",
+   "Canonical": true,
+   "Message": "BPODataRelationLinesEmpty: The relation has no lines.",
+   "Description": "Checks that view relationship lines are specified on OData Relationships."
+  },
+  {
+   "Name": "BPODataRelationPropertyInvalid",
+   "Canonical": true,
+   "Message": "BPODataRelationPropertyInvalid: The value '{0}' in the relation property '{0}' is not a valid identifier. Change the name to a valid OData identifier.",
+   "Description": "Checks that generated OData Property names from view relationships are valid OData identifiers."
+  },
+  {
+   "Name": "BPODataRelationPropertyNotSpecified",
+   "Canonical": true,
+   "Message": "BPODataRelationPropertyNotSpecified: The relation property named '{0}' is not specified.",
+   "Description": "Checks that view relationship metadata is specified for OData Resources."
+  },
+  {
+   "Name": "BPODataRelationRelatedRoleNameAlreadyUsed",
+   "Canonical": true,
+   "Message": "BPODataRelationRelatedRoleNameAlreadyUsed: The RelatedTableRole property on relation '{0}' defined on view '{1}' specifies the same name as a field, display or edit method, or relationship role already defined on the view.",
+   "Description": "Checks that view relationship metadata does not generate conflict OData Properties."
+  },
+  {
+   "Name": "BPODataRelationRoleNameAlreadyUsed",
+   "Canonical": true,
+   "Message": "BPODataRelationRoleNameAlreadyUsed: The Role property on relation '{0}' defined on view '{1}' specifies the same name as a field, display or edit method, or relationship role already defined on view '{2}.'",
+   "Description": "Checks that view relationship metadata does not generate conflict OData Properties."
+  },
+  {
+   "Name": "BPParameterNotUsed",
+   "Canonical": true,
+   "Message": "The parameter '{0}' is not used.",
+   "Description": "Checks that all parameters of a method are used."
+  },
+  {
+   "Name": "BPPrintStatementUsage",
+   "Canonical": true,
+   "Message": "BPPrintStatementUsage: Print statements are for debugging only and should not appear in production code.",
+   "Description": "Reports the usage of 'print' statements, which are for debugging and should not appear in production code."
+  },
+  {
+   "Name": "BPReportLabelNotFound",
+   "Canonical": true,
+   "Message": "The label '{0}' cannot be loaded. Verify the label is defined and that the value for the label has been set.",
+   "Description": "Checks that labels used in reports can loaded."
+  },
+  {
+   "Name": "BPTablePrimaryKeyIsNotAlternateKey",
+   "Canonical": true,
+   "Message": "The index '{1}' specified as Primary key on table '{2}' is not described as an Alternate key.",
+   "Description": "Checks that the index referenced as Primary key on a table, is also described as an Alternate key."
+  },
+  {
+   "Name": "BPTablePrimaryKeyIsNowAlternateKey",
+   "Canonical": false,
+   "Message": "The index '{0}' specified as Primary key on table '{1}' is now also an Alternate key."
+  },
+  {
+   "Name": "BPTableWithRecIdIndexMissingReplacementKey",
+   "Canonical": true,
+   "Message": "The table '{1}' has the RecId index enabled, but the Replacement Key is not specified even though at least one Alternate key exists.",
+   "Description": "Checks that the Replacement key is specified for tables with RecId index enabled and at least one Alternate key exists."
+  },
+  {
+   "Name": "BPTableWithRecIdIndexReplacementKeyEqualsPrimaryKey",
+   "Canonical": false,
+   "Message": "The Primary key has been chosen as Replacement key on table '{0}'."
+  },
+  {
+   "Name": "BPTestTransactionModelAutoRollbackNotUsed",
+   "Canonical": true,
+   "Message": "Use the enumeration value '{0}' instead of '{1}', on the attribute '{2}' that decorates a class.",
+   "Description": "Detects when the SysTestTransaction attribute on a class should switch to using the enum value TestTransactionMode::AutoRollback, which provide better performance on test execution."
+  },
+  {
+   "Name": "BPUnderscoresOnlyForParameters",
+   "Canonical": true,
+   "Message": "The use of underscores as a prefix is restricted to method and function parameters (rename '{0}' to '{1}').",
+   "Description": "Checks that underscore (\"_\") is only used for parameters and not for any other constructs."
+  },
+  {
+   "Name": "BPUnnecessaryStrFmtCall",
+   "Canonical": true,
+   "Message": "The call to strfmt is unnecessary since the format string does not contain any placeholders and no arguments are provided.",
+   "Description": "Raises a warning when unnecessary calls to the strFmt function are made, such as strFmt('hello')"
+  },
+  {
+   "Name": "BPUnrelatedMeasureGroup",
+   "Canonical": true,
+   "Message": "Measure Group '{0}' is not sliceable by any dimension other than system dimensions. Does this measurement is meeting business needs? Either add dimensions to this measure group or delete the measure group."
+  },
+  {
+   "Name": "BPUnusedStrFmtArgument",
+   "Canonical": true,
+   "Message": "The placeholder '%{0}' to strFmt is not used in the format string.",
+   "Description": "Verifies the highest format specifier isn't lower than the given parameters."
+  },
+  {
+   "Name": "BPUpgradeCodeBudgetCheckResultDisplayMethod",
+   "Canonical": true,
+   "Message": "This display method should return the BudgetCheckResult directly"
+  },
+  {
+   "Name": "BPUpgradeCodeColumnsModeQualifiedCall",
+   "Canonical": true,
+   "Message": "The enum parameter for FormDesign.columns/FormContainer.columns and FormDesign.columnsMode/FormContainer.columnsMode has been changed to 'ColumnsMode' from the previous 'AutoMode'."
+  },
+  {
+   "Name": "BPUpgradeCodeComplicatedQualifiedCall",
+   "Canonical": true,
+   "Message": "{0} has been deprecated, use {1} instead."
+  },
+  {
+   "Name": "BPUpgradeCodeDeprecatedAPIWithFix",
+   "Canonical": true,
+   "Message": "{0} has been deprecated, use {1} instead."
+  },
+  {
+   "Name": "BPUpgradeCodeDeprecatedAPIWithTodo",
+   "Canonical": true,
+   "Message": "{0} has been deprecated. {1}."
+  },
+  {
+   "Name": "BPUpgradeCodeDeprecatedAPIWithoutFix",
+   "Canonical": true,
+   "Message": "{0} has been deprecated, review and remove or fix the code."
+  },
+  {
+   "Name": "BPUpgradeCodeDeprecatedAPIs",
+   "Canonical": true,
+   "Message": "{0}.{1} has been deprecated."
+  },
+  {
+   "Name": "BPUpgradeCodeDeprecatedFrameType",
+   "Canonical": true,
+   "Message": "FormFrameType::{0} is deprecated. Use FormFrameType::Auto instead."
+  },
+  {
+   "Name": "BPUpgradeCodeDeprecatedPopupMenu",
+   "Canonical": true,
+   "Message": "The PopupMenu API has been deprecated.  Please use the ContextMenu APIs instead."
+  },
+  {
+   "Name": "BPUpgradeCodeDeprecatedPopupMenuOverride",
+   "Canonical": true,
+   "Message": "The context() and showContextMenu() overrides have been deprecated.  Please use getContextMenuOptions() and selectedMenuOption() instead."
+  },
+  {
+   "Name": "BPUpgradeCodeDialogIsOnServer",
+   "Canonical": true,
+   "Message": "The API Dialog.IsOnServer has been deprecated, remove the call and fix related code."
+  },
+  {
+   "Name": "BPUpgradeCodeDimensionEntryControl",
+   "Canonical": true,
+   "Message": "{2} has been deprecated, use DimensionEntryControl instead."
+  },
+  {
+   "Name": "BPUpgradeCodeEmptyOverrideMethod",
+   "Canonical": true,
+   "Message": "Override method {0} is empty. An empty override method in a table or view might reduce performance at run time."
+  },
+  {
+   "Name": "BPUpgradeCodeExtensibilityAdditiveGlobalMethod",
+   "Canonical": true,
+   "Message": "The Global class has been over-layered by the additional method '{0}'. To avoid this over-layering, the method should be moved to a separate class."
+  },
+  {
+   "Name": "BPUpgradeCodeExtensibilityAdditiveTableInstanceMethod",
+   "Canonical": true,
+   "Message": "Table '{0}' has been over-layered by the additional method '{1}'. To avoid this over-layering, the method should be moved to an extension class."
+  },
+  {
+   "Name": "BPUpgradeCodeExtensibilityAdditiveTableStaticMethod",
+   "Canonical": true,
+   "Message": "Table '{0}' has been over-layered by the additional static method '{1}'. To avoid this over-layering, the method should be moved to an extension class."
+  },
+  {
+   "Name": "BPUpgradeCodeFixedPatternQualifiedCall",
+   "Canonical": true,
+   "Message": "Statement {0} has been deprecated, it should be updated to {1}."
+  },
+  {
+   "Name": "BPUpgradeCodeFormDataSourceDeprecatedApi",
+   "Canonical": true,
+   "Message": "Form datasource method {2} is deprecated and should be replaced with {3}."
+  },
+  {
+   "Name": "BPUpgradeCodeFormRunDeprecatedApi",
+   "Canonical": true,
+   "Message": "The {2} method has been deprecated and no longer needed. You can safely remove calls to this method.”"
+  },
+  {
+   "Name": "BPUpgradeCodeFormRunInOverrideMethodParameter",
+   "Canonical": true,
+   "Message": "For override method, FormRun type should be updated to xFormRun."
+  },
+  {
+   "Name": "BPUpgradeCodeGroupStyleBorderlessGridContainer",
+   "Canonical": false,
+   "Message": "Group control '{0}' has its Style property set to BorderlessGridContainer, which is deprecated. The value is assigned in source code. Fix the form by deleting group control '{0}'. Then move all children of the group control to its parent node."
+  },
+  {
+   "Name": "BPUpgradeCodeGroupStyleMarginlessContainer",
+   "Canonical": true,
+   "Message": "In code, group {0} has its Style property set to MarginlessContainer, but that value is deprecated. Update the code to use Style=Auto, and have HeightMode and WidthMode set to SizeToAvailable."
+  },
+  {
+   "Name": "BPUpgradeCodeGroupTableOfContentStyle",
+   "Canonical": true,
+   "Message": "Group control '{0}' has its Style property set to '{1}' which is a deprecated value. The value is assigned in source code. Deprecated values are TOCTopicFastTabs, TOCTopicSimple, and TOCTopicList. Update the Style property value to 'Auto'."
+  },
+  {
+   "Name": "BPUpgradeCodeImageListApplBudgetControlResult",
+   "Canonical": true,
+   "Message": "Removing use of type ImageListAppl_BudgetControlResult"
+  },
+  {
+   "Name": "BPUpgradeCodeInfologUrlLookup",
+   "Canonical": true,
+   "Message": "infolog.urllookup is deprecated, use browser.navigate instead."
+  },
+  {
+   "Name": "BPUpgradeCodeInvalidParameterInOverrideMethod",
+   "Canonical": true,
+   "Message": "Parameter {4} in the override method {3}.{4} must match the one of the base."
+  },
+  {
+   "Name": "BPUpgradeCodeLateBoundCall",
+   "Canonical": true,
+   "Message": "A late bound call {0}.{1} is made. In source system (AX 2012) it is possible to dynamically call methods where the number and type of the parameters does not match with the method definition. This is not supported in AX 7, where the number and types of parameters have to match. Even if the parameters do match, the late bound call is extremely expensive. Mitigation: Use a class or interface hierarchy to provide a type safe fast call, or use the IS and AS operators to cast to a known type before calling."
+  },
+  {
+   "Name": "BPUpgradeCodeOverrideMethodModifier",
+   "Canonical": true,
+   "Message": "{0}: cannot change access modifiers when overriding '{1}' inherited member {2}.",
+   "Description": "Detect override methods with access modifer changed."
+  },
+  {
+   "Name": "BPUpgradeCodeRenamedClass",
+   "Canonical": true,
+   "Message": "Class {0} has been deprecated, use {1} instead."
+  },
+  {
+   "Name": "BPUpgradeCodeRenamedTable",
+   "Canonical": true,
+   "Message": "Table {0} has been deprecated, use {1} instead."
+  },
+  {
+   "Name": "BPUpgradeCodeRunBaseMissingMethod",
+   "Canonical": true,
+   "Message": "Class {0} should override the {1} method. Override the {1} to ensure that the class can compile."
+  },
+  {
+   "Name": "BPUpgradeCodeRunBaseRunCalled",
+   "Canonical": true,
+   "Message": "Methods should call the {0} method instead of the {1} method on Runbase derived classes. Change the code from calling run to call runOperation."
+  },
+  {
+   "Name": "BPUpgradeCodeSessionIsServer",
+   "Canonical": true,
+   "Message": "The Session::IsServer method is deprecated, and you must remove it from your code.",
+   "Description": "Detects use of the deprecated method Session::IsServer."
+  },
+  {
+   "Name": "BPUpgradeCodeSourceDocumentAttribute",
+   "Canonical": true,
+   "Message": "Source document attribute {0} can no longer take an intrinsic (like enumNum, classNum, tableNum) that returns a number as its parameter, the attribute  should be replaced by {1}. Also replace all enumNum, classNum or tableNum in the attribute parametters by enumStr, classStr or tableStr."
+  },
+  {
+   "Name": "BPUpgradeCodeSysEntryPointAttribute",
+   "Canonical": true,
+   "Message": "SysEntryPoint attribute has been deprecated, you can safely remove the attribute."
+  },
+  {
+   "Name": "BPUpgradeCodeSysFormSplitter",
+   "Canonical": true,
+   "Message": "SysFormSplitter is deprecated. {0} and all of its references should be removed."
+  },
+  {
+   "Name": "BPUpgradeCodeSysTestDatasetAttributeQualifiedCall",
+   "Canonical": true,
+   "Message": "{0} has been deprecated, use {1} instead."
+  },
+  {
+   "Name": "BPUpgradeCodeSystemDate",
+   "Canonical": true,
+   "Message": "Method {0} has been deprecated, use {1} instead.",
+   "Description": "Detects usage of the deprecated systemdate API."
+  },
+  {
+   "Name": "BPUpgradeCodeTextIo",
+   "Canonical": true,
+   "Message": "Classes Io, CommaIo, CommaTextIo, TextIo and AsciiIo are deprecated. Upgrade to new AX7 equivalents and fix related code."
+  },
+  {
+   "Name": "BPUpgradeCodeTimeNow",
+   "Canonical": true,
+   "Message": "Method {0} has been deprecated, use {1} instead.",
+   "Description": "Detects usage of the deprecated timenow API."
+  },
+  {
+   "Name": "BPUpgradeCodeToday",
+   "Canonical": true,
+   "Message": "Method {0} has been deprecated, use {1} instead.",
+   "Description": "Detects usage of the deprecated today API."
+  },
+  {
+   "Name": "BPUpgradeCodeXSessionAPI",
+   "Canonical": true,
+   "Message": "API {0} has been changed."
+  },
+  {
+   "Name": "BPUpgradeMetadataActionPaneRedundantButton",
+   "Canonical": true,
+   "Message": "At least one CommandButton that duplicates a framework-provided button has been found under ActionPane {0} and should be removed.  ActionPane (standard or strip) CommandButtons with the following commands are considered redundant: Refresh, ExportToMicrosoftExcel, DocumentHandling, EditRecord, and ToggleEditRecordMode.  CommandButtons with New and DeleteRecord commands are also considered redundant for standard ActionPanes. Additionally, any ActionPane of type Strip that is the first control under Design should be changed to type Standard."
+  },
+  {
+   "Name": "BPUpgradeMetadataBICompanyRelationNoConstraint",
+   "Canonical": true,
+   "Message": "Relation for dimension {0] using Aggregate Dimension 'Company' should have a relation constraint defined.",
+   "Description": "Detects relations to the 'Company' Aggregate Dimension which are missing the relation constraint."
+  },
+  {
+   "Name": "BPUpgradeMetadataBudgetCheckResultImageControl",
+   "Canonical": true,
+   "Message": "Image control for BudgetCheckResult should be a ComboBox control"
+  },
+  {
+   "Name": "BPUpgradeMetadataBudgetCreateTransfer",
+   "Canonical": true,
+   "Message": "Removing menu item buttons that point to the BudgetCreateTransfer menu item"
+  },
+  {
+   "Name": "BPUpgradeMetadataDeleteAction",
+   "Canonical": true,
+   "Message": "DeleteAction {1} has no explicit relation set."
+  },
+  {
+   "Name": "BPUpgradeMetadataDeprecatedArrangeWhen",
+   "Canonical": true,
+   "Message": "ArrangeWhen is deprecated, for {0} use ArrangeMethod=None in place of ArrangeWhen=Never."
+  },
+  {
+   "Name": "BPUpgradeMetadataDeprecatedFrameType",
+   "Canonical": true,
+   "Message": "Form control {0} uses a deprecated FrameType value. Use FrameType=Auto instead."
+  },
+  {
+   "Name": "BPUpgradeMetadataDeprecatedIndexTabStyle",
+   "Canonical": true,
+   "Message": "IndexTabs is no longer a supported tab style, {0} should use the Tabs style instead."
+  },
+  {
+   "Name": "BPUpgradeMetadataDeprecatedSysDateLookUp",
+   "Canonical": true,
+   "Message": "The SysDateLookUp form is deprecated. {0} and all its references should be removed."
+  },
+  {
+   "Name": "BPUpgradeMetadataDeprecatedUserLicenseType",
+   "Canonical": true,
+   "Message": "User license type 'Functional' is no longer supported, please use 'Enterprise' instead."
+  },
+  {
+   "Name": "BPUpgradeMetadataDeprecatedWidthHeightMode",
+   "Canonical": true,
+   "Message": "Column is no longer a supported height or width mode, {0} should use the SizeToAvailable mode instead."
+  },
+  {
+   "Name": "BPUpgradeMetadataEDTRelation",
+   "Canonical": true,
+   "Message": "EDT relation found in field {1} of table {0}. It should be migrated to a regular table relation."
+  },
+  {
+   "Name": "BPUpgradeMetadataExtensibilityAdditiveEnumValue",
+   "Canonical": true,
+   "Message": "Enum '{0}' has been over-layered by the additional enum value '{1}'. To avoid this over-layering, the enum value should be moved to the corresponding enum extension."
+  },
+  {
+   "Name": "BPUpgradeMetadataExtensibilityAdditiveFormControl",
+   "Canonical": true,
+   "Message": "Form '{0}' has been over-layered by the additional control '{1}'. To avoid this over-layering, the control should be moved to the corresponding form extension."
+  },
+  {
+   "Name": "BPUpgradeMetadataExtensibilityAdditiveFormDataSource",
+   "Canonical": true,
+   "Message": "Form '{0}' has been over-layered by the additional data source '{1}'. To avoid this over-layering, the data source should be moved to the corresponding form extension."
+  },
+  {
+   "Name": "BPUpgradeMetadataExtensibilityAdditiveMenuElement",
+   "Canonical": true,
+   "Message": "Menu '{0}' has been over-layered by the additional menu element '{1}'. To avoid this over-layering, the menu element should be moved to the corresponding menu extension."
+  },
+  {
+   "Name": "BPUpgradeMetadataExtensibilityAdditiveSecurityDutyPrivilege",
+   "Canonical": true,
+   "Message": "Security duty '{0}' has been over-layered by the additional privilege '{1}'. To avoid this over-layering, the privilege should be moved to the corresponding security duty extension."
+  },
+  {
+   "Name": "BPUpgradeMetadataExtensibilityAdditiveSecurityRoleDuty",
+   "Canonical": true,
+   "Message": "Security role '{0}' has been over-layered by the additional duty '{1}'. To avoid this over-layering, the duty should be moved to the corresponding security role extension."
+  },
+  {
+   "Name": "BPUpgradeMetadataExtensibilityAdditiveSecurityRolePermissionForm",
+   "Canonical": true,
+   "Message": "Security role '{0}' has been over-layered by the additional form permission '{1}'. To avoid this over-layering, the form permission should be moved to the corresponding security role extension."
+  },
+  {
+   "Name": "BPUpgradeMetadataExtensibilityAdditiveSecurityRolePermissionFormControl",
+   "Canonical": true,
+   "Message": "Security role '{0}' has been over-layered by the additional form control permission '{1}'. To avoid this over-layering, the form control permission should be moved to the corresponding security role extension."
+  },
+  {
+   "Name": "BPUpgradeMetadataExtensibilityAdditiveSecurityRolePermissionServerMethod",
+   "Canonical": true,
+   "Message": "Security role '{0}' has been over-layered by the additional server method permission '{1}'. To avoid this over-layering, the server method permission should be moved to the corresponding security role extension."
+  },
+  {
+   "Name": "BPUpgradeMetadataExtensibilityAdditiveSecurityRolePermissionTable",
+   "Canonical": true,
+   "Message": "Security role '{0}' has been over-layered by the additional table permission '{1}'. To avoid this over-layering, the table permission should be moved to the corresponding security role extension."
+  },
+  {
+   "Name": "BPUpgradeMetadataExtensibilityAdditiveSecurityRolePermissionTableField",
+   "Canonical": true,
+   "Message": "Security role '{0}' has been over-layered by the additional table field permission '{1}'. To avoid this over-layering, the table field permission should be moved to the corresponding security role extension."
+  },
+  {
+   "Name": "BPUpgradeMetadataExtensibilityAdditiveSecurityRolePrivilege",
+   "Canonical": true,
+   "Message": "Security role '{0}' has been over-layered by the additional privilege '{1}'. To avoid this over-layering, the privilege should be moved to the corresponding security role extension."
+  },
+  {
+   "Name": "BPUpgradeMetadataExtensibilityAdditiveSecurityRoleSubRole",
+   "Canonical": true,
+   "Message": "Security role '{0}' has been over-layered by the additional sub role '{1}'. To avoid this over-layering, the sub role should be moved to the corresponding security role extension."
+  },
+  {
+   "Name": "BPUpgradeMetadataExtensibilityAdditiveTableDeleteAction",
+   "Canonical": true,
+   "Message": "Table '{0}' has been over-layered by the additional delete action '{1}'. To avoid this over-layering, the delete action should be moved to the corresponding table extension."
+  },
+  {
+   "Name": "BPUpgradeMetadataExtensibilityAdditiveTableField",
+   "Canonical": true,
+   "Message": "Table '{0}' has been over-layered by the additional field '{1}'. To avoid this over-layering, the field should be moved to the corresponding table extension."
+  },
+  {
+   "Name": "BPUpgradeMetadataExtensibilityAdditiveTableFieldGroup",
+   "Canonical": true,
+   "Message": "Table '{0}' has been over-layered by the additional field group '{1}'. To avoid this over-layering, the field group should be moved to the corresponding table extension."
+  },
+  {
+   "Name": "BPUpgradeMetadataExtensibilityAdditiveTableFieldGroupField",
+   "Canonical": true,
+   "Message": "Table field group '{0}\\{1}' has been over-layered by the additional field '{2}'. To avoid this over-layering, the field group field should be moved to the corresponding table extension."
+  },
+  {
+   "Name": "BPUpgradeMetadataExtensibilityAdditiveTableIndex",
+   "Canonical": true,
+   "Message": "Table '{0}' has been over-layered by the additional index '{1}'. To avoid this over-layering, the index should be moved to the corresponding table extension."
+  },
+  {
+   "Name": "BPUpgradeMetadataExtensibilityAdditiveTableIndexField",
+   "Canonical": true,
+   "Message": "Table index field '{0}\\{1}' has been over-layered by the additional index field '{2}'. To avoid this over-layering, the index field should be moved to the corresponding table extension."
+  },
+  {
+   "Name": "BPUpgradeMetadataExtensibilityAdditiveTableRelation",
+   "Canonical": true,
+   "Message": "Table '{0}' has been over-layered by the additional relation '{1}'. To avoid this over-layering, the relation should be moved to the corresponding table extension."
+  },
+  {
+   "Name": "BPUpgradeMetadataExtensibilityFormControlEnabledChanged",
+   "Canonical": true,
+   "Message": "Form control '{0}' has been over-layered by changing Enabled '{2}' -> '{3}'. To avoid this over-layering, the customization should be moved to the corresponding form extension."
+  },
+  {
+   "Name": "BPUpgradeMetadataExtensibilityFormControlHelpTextChanged",
+   "Canonical": true,
+   "Message": "Form control '{0}' has been over-layered by changing HelpText '{2}' -> '{3}'. To avoid this over-layering, the customization should be moved to the corresponding form extension."
+  },
+  {
+   "Name": "BPUpgradeMetadataExtensibilityFormControlLabelChanged",
+   "Canonical": true,
+   "Message": "Form control '{0}' has been over-layered by changing Label '{2}' -> '{3}'. To avoid this over-layering, the customization should be moved to the corresponding form extension."
+  },
+  {
+   "Name": "BPUpgradeMetadataExtensibilityFormControlVisibleChanged",
+   "Canonical": true,
+   "Message": "Form control '{0}' has been over-layered by changing Visible '{2}' -> '{3}'. To avoid this over-layering, the customization should be moved to the corresponding form extension."
+  },
+  {
+   "Name": "BPUpgradeMetadataExtensibilityIdenticalEnum",
+   "Canonical": true,
+   "Message": "Enum '{0}' has been over-layered between model '{1}' and '{2}' but both enums are identical. To avoid this over-layering, the enum should be deleted from model '{1}'."
+  },
+  {
+   "Name": "BPUpgradeMetadataExtensibilityIdenticalForm",
+   "Canonical": true,
+   "Message": "Form '{0}' has been over-layered between model '{1}' and '{2}' but both forms are identical. To avoid this over-layering, the form should be deleted from model '{1}'."
+  },
+  {
+   "Name": "BPUpgradeMetadataExtensibilityIdenticalMenu",
+   "Canonical": true,
+   "Message": "Menu '{0}' has been over-layered between model '{1}' and '{2}' but both menus are identical. To avoid this over-layering, the menu should be deleted from model '{1}'."
+  },
+  {
+   "Name": "BPUpgradeMetadataExtensibilityIdenticalSecurityDuty",
+   "Canonical": true,
+   "Message": "Security duty '{0}' has been over-layered between model '{1}' and '{2}' but both security roles are identical. To avoid this over-layering, the security role should be deleted from model '{1}'."
+  },
+  {
+   "Name": "BPUpgradeMetadataExtensibilityIdenticalSecurityRole",
+   "Canonical": true,
+   "Message": "Security role '{0}' has been over-layered between model '{1}' and '{2}' but both security roles are identical. To avoid this over-layering, the security role should be deleted from model '{1}'."
+  },
+  {
+   "Name": "BPUpgradeMetadataExtensibilityIdenticalTable",
+   "Canonical": true,
+   "Message": "Table '{0}' has been over-layered between model '{1}' and '{2}' but both tables are identical. To avoid this over-layering, the table should be deleted from model '{1}'."
+  },
+  {
+   "Name": "BPUpgradeMetadataFormPartMenuitem",
+   "Canonical": true,
+   "Message": "FormPart has been deprecated, menu item {0} should be updated to point to its coresponding form."
+  },
+  {
+   "Name": "BPUpgradeMetadataFormPatternDetailsMaster",
+   "Canonical": true,
+   "Message": "Form {0} is being upgraded to the DetailsMaster form pattern."
+  },
+  {
+   "Name": "BPUpgradeMetadataFormPatternDetailsTransaction",
+   "Canonical": true,
+   "Message": "Form {0} is being upgraded to the DetailsTransaction form pattern."
+  },
+  {
+   "Name": "BPUpgradeMetadataFormPatternDialog",
+   "Canonical": true,
+   "Message": "Form {0} is being upgraded to the Dialog form pattern."
+  },
+  {
+   "Name": "BPUpgradeMetadataFormPatternDropDialog",
+   "Canonical": true,
+   "Message": "Form {0} is being upgraded to the DropDialog form pattern."
+  },
+  {
+   "Name": "BPUpgradeMetadataFormPatternFormPartFactBoxCard",
+   "Canonical": true,
+   "Message": "Form {0} is being upgraded to the FormPartFactBoxCard form pattern."
+  },
+  {
+   "Name": "BPUpgradeMetadataFormPatternFormPartFactBoxGrid",
+   "Canonical": true,
+   "Message": "Form {0} is being upgraded to the FormPartFactBoxGrid form pattern."
+  },
+  {
+   "Name": "BPUpgradeMetadataFormPatternListPage",
+   "Canonical": true,
+   "Message": "Form {0} is being upgraded to the ListPage form pattern."
+  },
+  {
+   "Name": "BPUpgradeMetadataFormPatternLookup",
+   "Canonical": true,
+   "Message": "Form {0} is being upgraded to the Lookup form pattern."
+  },
+  {
+   "Name": "BPUpgradeMetadataFormPatternSimpleList",
+   "Canonical": true,
+   "Message": "Form {0} is being upgraded to the SimpleList form pattern."
+  },
+  {
+   "Name": "BPUpgradeMetadataFormPatternSimpleListDetails",
+   "Canonical": true,
+   "Message": "Form {0} is being upgraded to the SimpleListDetails form pattern."
+  },
+  {
+   "Name": "BPUpgradeMetadataFormPatternTableOfContents",
+   "Canonical": true,
+   "Message": "Form {0} is being upgraded to the TableOfContents form pattern."
+  },
+  {
+   "Name": "BPUpgradeMetadataFormPatternTaskSingle",
+   "Canonical": true,
+   "Message": "Form {0} is being upgraded to the TaskSingle form pattern."
+  },
+  {
+   "Name": "BPUpgradeMetadataFormPatternVersionNotActive",
+   "Canonical": true,
+   "Message": "The version of the pattern '{0}' applied to '{1}' is not active. Please apply the latest version by removing the pattern and applying it again."
+  },
+  {
+   "Name": "BPUpgradeMetadataFormPatternWizard",
+   "Canonical": true,
+   "Message": "Form {0} is being upgraded to the Wizard form pattern."
+  },
+  {
+   "Name": "BPUpgradeMetadataFormSubpatterns",
+   "Canonical": true,
+   "Message": "Applying subpattern {2} to {1} on form {0}."
+  },
+  {
+   "Name": "BPUpgradeMetadataGroupHiddenHeaderControls",
+   "Canonical": true,
+   "Message": "Group control {0} has its FrameOptionButton property set to {1}, but has its FrameType property set to None. This combination hides the group header controls. Update the FrameType to Auto so the frame option button controls in the group header are visible."
+  },
+  {
+   "Name": "BPUpgradeMetadataGroupStyleBorderlessGridContainer",
+   "Canonical": false,
+   "Message": "Group control '{0}' has its Style property set to 'BorderlessGridContainer' which is a deprecated value. Fix the form by deleting the '{0}' group control. Then move all children of the group control to its parent node '{1}'."
+  },
+  {
+   "Name": "BPUpgradeMetadataGroupStyleMarginlessContainer",
+   "Canonical": true,
+   "Message": "The property Style=MarginlessContainer for group {0} has been deprecated. Update to Style=Auto, and set HeightMode and WidthMode to SizeToAvailable."
+  },
+  {
+   "Name": "BPUpgradeMetadataGroupTableOfContentStyle",
+   "Canonical": true,
+   "Message": "Group control {0} has its Style property set to {1} which is a deprecated value. Deprecated values are TOCTopicFastTabs, TOCTopicSimple and TOCTopicList. Update the Style property value to 'Auto'."
+  },
+  {
+   "Name": "BPUpgradeMetadataGroupTopLeftMode",
+   "Canonical": true,
+   "Message": "Group control '{0}' had its TopMode or LeftMode property, or both, set to a non-default value. This property is no longer supported. Make any necessary adjustments to correct the position of the group control."
+  },
+  {
+   "Name": "BPUpgradeMetadataGroupWithinGroup",
+   "Canonical": true,
+   "Message": "Group control '{0}' only has group controls as its children. Both '{0}' and one of its child group controls have their Caption or DataGroup property set to a non-empty string value and its FrameType property set to a value other than 'None'. This pattern of having groups with label within groups with label is not recommended."
+  },
+  {
+   "Name": "BPUpgradeMetadataImproperDialogCaption",
+   "Canonical": true,
+   "Message": "A static text {0} of type MainInstruction is found in the form, remove the static text control and ensure the value in Form.Design.Caption contains the caption you want for this form."
+  },
+  {
+   "Name": "BPUpgradeMetadataListPageFormDetailForm",
+   "Canonical": true,
+   "Message": "Menu item {0} should be fixed to point to its detail form instead of list page form {1}."
+  },
+  {
+   "Name": "BPUpgradeMetadataRenamedTableInMetadata",
+   "Canonical": true,
+   "Message": "Table {0} has been deprecated, use {1} instead."
+  },
+  {
+   "Name": "BPUpgradeMetadataReportDataMethodExpression",
+   "Canonical": true,
+   "Message": "Data method expression in Report '{0}', Control '{1}', Property '{2}' is deprecated."
+  },
+  {
+   "Name": "BPUpgradeMetadataSecurityDutyDisabled",
+   "Canonical": true,
+   "Message": "Disabling security duties is not supported. Security duty {0} will be deleted."
+  },
+  {
+   "Name": "BPUpgradeMetadataSecurityPrivilegeDisabled",
+   "Canonical": true,
+   "Message": "Disabling security privileges is not supported. Security privilege {0} will be deleted."
+  },
+  {
+   "Name": "BPUpgradeMetadataSecurityRoleDisabled",
+   "Canonical": true,
+   "Message": "Disabling security roles is not supported. Security role {0} will be deleted."
+  },
+  {
+   "Name": "BPUpgradeMetadataSegmentedEntryControl",
+   "Canonical": true,
+   "Message": "Segmented entry control {0} should be converted to the new segmented entry control."
+  },
+  {
+   "Name": "BPUpgradeMetadataTabColumnsMode",
+   "Canonical": true,
+   "Message": "TabPage {0} should use ColumnsMode=Fill as the default for Tabs/FastTab style TabPages where no children are WidthMode=SizeToAvailable, Grids, or ActionPane Toolbars with WidthMode=Auto or WidthMode=SizeToAvailable."
+  },
+  {
+   "Name": "BPUpgradeMetadataVerticalButtonGroup",
+   "Canonical": true,
+   "Message": "Vertical button group {0} should be moved the tool bar or application bar."
+  },
+  {
+   "Name": "BPUpgradeOkCancelFormsToDialog",
+   "Canonical": true,
+   "Message": "Form with 'OK' or 'Cancel' buttons {0} should use Style=Dialog."
+  },
+  {
+   "Name": "BPUpgradeSourceDocumentProcessorFacadeParameters",
+   "Canonical": true,
+   "Message": "Statement {0} has been deprecated, it should be updated to {1}."
+  },
+  {
+   "Name": "BPUpgradeTableInstanceMethodToClassStaticMethod",
+   "Canonical": true,
+   "Message": "Instance table method {0}.{1} has been replaced with static class method {2}::{3}",
+   "Description": "Detects calls to instance table methods that have been replaced with call to static class methods."
+  },
+  {
+   "Name": "BPWarningDisplayMethodUpdateUnpredictable",
+   "Canonical": true,
+   "Message": "The display method '{0}' in '{1}' may not update as expected. ",
+   "Description": "Checks that the values used for computing a display method's value are observable - form properties, data source fields, and fields with the FormObservable attribute are observable."
+  },
+  {
+   "Name": "BPWarningFieldMissingFormObservableAttribute",
+   "Canonical": true,
+   "Message": "The field '{0}' in '{1}' is used by the display method '{2}' in '{3}' and does not have the FormObservable attribute.",
+   "Description": "Checks that fields that contribute to the value of a display method have the FormObservable attribute. This allows the system to refresh a display method when a field that it depends on changes. "
+  },
+  {
+   "Name": "BPWarningFormDesignOrControlsWithCustomPattern",
+   "Canonical": true,
+   "Message": "BPWarningFormDesignOrControlsWithCustomPattern: '{0}' is using the 'Custom' pattern. Please apply one of the other available patterns.",
+   "Description": "Checks whether the custom pattern is applied to the form design and controls."
+  },
+  {
+   "Name": "BPWarningMainMenuDepthExceeded",
+   "Canonical": true,
+   "Message": "BPWarningMainMenuDepthExceeded: '{0}' is at a depth of '{1}', but the maximum rendered menu depth is '{2}'. Adjust your menu structure such that its depth does not exceed this limit.",
+   "Description": "Checks that main menus don't exceed maximum preferred depth."
+  },
+  {
+   "Name": "BPXmlDocDuplicateTag",
+   "Canonical": true,
+   "Message": "BPXmlDocDuplicateTag: Duplicate '{0}' tag found."
+  },
+  {
+   "Name": "BPXmlDocIllegalTag",
+   "Canonical": true,
+   "Message": "BPXmlDocIllegalTag: Tag '{0}' is not allowed here.",
+   "Description": "Checks the XML documentation for illegal tags."
+  },
+  {
+   "Name": "BPXmlDocMalformed",
+   "Canonical": true,
+   "Message": "BPXmlDocMalformed: The XML documentation for '{0}' is not well-formed.",
+   "Description": "Checks if the XML documentation is malformed."
+  },
+  {
+   "Name": "BPXmlDocNoDocumentationComments",
+   "Canonical": true,
+   "Message": "BPXmlDocNoDocumentationComments: No XML documentation headers are provided for '{0}'.",
+   "Description": "Checks if XML documentation is missing."
+  },
+  {
+   "Name": "BPXmlDocNoHelpfulInformation",
+   "Canonical": true,
+   "Message": "BPXmlDocNoHelpfulInformation: No helpful information is provided in the '{0}' tag for '{1}'.",
+   "Description": "Checks if XML documentation tags are empty."
+  },
+  {
+   "Name": "BPXmlDocNoReturns",
+   "Canonical": true,
+   "Message": "BPXmlDocNoReturns: The documentation header contains no 'returns' tag, yet the method '{0}' returns a non-void value.",
+   "Description": "Checks whether the return tag exists in XML documentation when method has a return type other than void."
+  },
+  {
+   "Name": "BPXmlDocNoSummaryTag",
+   "Canonical": true,
+   "Message": "BPXmlDocNoSummaryTag: No summary tag is provided.",
+   "Description": "Checks if the summary tag is provided in XML documentation."
+  },
+  {
+   "Name": "BPXmlDocParameterDuplicated",
+   "Canonical": true,
+   "Message": "BPXmlDocParameterDuplicated: Parameter '{0}' is described more than once."
+  },
+  {
+   "Name": "BPXmlDocParameterNotDescribed",
+   "Canonical": true,
+   "Message": "BPXmlDocParameterNotDescribed: Parameter '{0}' is not described in any '{1}' tag.",
+   "Description": "Checks whether parameter tags are provided for all the parameters."
+  },
+  {
+   "Name": "BPXmlDocParameterTagMustHaveOneAttributeCalledName",
+   "Canonical": true,
+   "Message": "BPXmlDocParameterTagMustHaveOneAttributeCalledName: The documentation header for a parameter must have exactly one attribute called 'name'.",
+   "Description": "Checks whether parameter tags have 'name' attribute."
+  },
+  {
+   "Name": "BPXmlDocReturnsVoid",
+   "Canonical": true,
+   "Message": "BPXmlDocReturnsVoid: The documentation header contains a 'returns' tag, yet the method '{0}' returns void.",
+   "Description": "Checks the return tag of XML documentation and matches it with actual return type of the method."
+  },
+  {
+   "Name": "BPXmlDocTagDoesNotDesignateExistingParameter",
+   "Canonical": true,
+   "Message": "BPXmlDocTagDoesNotDesignateExistingParameter: Name '{0}' in the '{1}' tag is not a parameter for this method.",
+   "Description": "Checks the parameter tags of XML documentation and matches them with method parameters. "
+  },
+  {
+   "Name": "BPXmlDocTagMustBeChild",
+   "Canonical": true,
+   "Message": "BPXmlDocTagMustBeChild: Tag '{0}' must not contain children."
+  },
+  {
+   "Name": "BudgetCheckResultDisplayMethodDescription",
+   "Canonical": false,
+   "Message": "Changing display method to return the BudgetCheckResult directly"
+  },
+  {
+   "Name": "BudgetCheckResultsImageControlDescription",
+   "Canonical": false,
+   "Message": "Changing BudgetCheckResults image control to combobox control"
+  },
+  {
+   "Name": "BudgetCreateTransferDescription",
+   "Canonical": false,
+   "Message": "Detect menu item buttons that point to the BudgetCreateTransfer menu item."
+  },
+  {
+   "Name": "COD",
+   "Canonical": false,
+   "Message": "C.O.D"
+  },
+  {
+   "Name": "CalculateInWrongMeasureGroupDescription",
+   "Canonical": false,
+   "Message": "This rule scans for calculated measures which are defined in a different measure group than the measures that are used in the calculation."
+  },
+  {
+   "Name": "ChangedIgnoreEDTRelationToYes",
+   "Canonical": false,
+   "Message": "The IgnoreEDTRelation property was changed from No to Yes."
+  },
+  {
+   "Name": "CheckBoxToggleStyleGridDescription",
+   "Canonical": false,
+   "Message": "Show a warning if the CheckBox style is set as Toggle is inside a grid"
+  },
+  {
+   "Name": "ColumnHeightModeUpdate",
+   "Canonical": false,
+   "Message": "Updating control {0}.HeightMode from Column to SizeToAvailable."
+  },
+  {
+   "Name": "ColumnModeDeprecatedDescription",
+   "Canonical": false,
+   "Message": "Detect width mode or height mode using option Column."
+  },
+  {
+   "Name": "ColumnStoreIndexNeededForMeasurementTable",
+   "Canonical": false,
+   "Message": "This rule checks if columns store indexes are defined for the tables used by an AggregateMeasurement"
+  },
+  {
+   "Name": "ColumnWidthModeUpdate",
+   "Canonical": false,
+   "Message": "Updating control {0}.WidthMode from Column to SizeToAvailable."
+  },
+  {
+   "Name": "ColumnsModeQualifiedCallDetectorDescription",
+   "Canonical": false,
+   "Message": "Detects calls to 'columnsMode' and 'columns' functions for FormDesign and FormContainer using the 'AutoMode' enum argument."
+  },
+  {
+   "Name": "ComplicatedQualifiedCallDetectorDescription",
+   "Canonical": false,
+   "Message": "Detect calls to deprecated, complicated qualified call like DimensionHierarchy::find(custLedgerAccounts.DimensionHierarchy_RU).dimensionAttrExt_RU()."
+  },
+  {
+   "Name": "CopiedStandardProperties",
+   "Canonical": false,
+   "Message": "Copied standard properties for {0} in form {1}"
+  },
+  {
+   "Name": "CustomizedFormPropertiesDetectorDescription",
+   "Canonical": false,
+   "Message": "Checks for changes in HelpText, Visible, Enabled, Label, Caption properties on forms and form controls"
+  },
+  {
+   "Name": "DECAddedToDesignRoot",
+   "Canonical": false,
+   "Message": "Dimension Entry control {0} was added at the Design root of form {1}. This control will need to be moved to a TabPage or Group control."
+  },
+  {
+   "Name": "DECAddingControlToForm",
+   "Canonical": false,
+   "Message": "Adding new Dimension Entry control named '{0}' to form '{1}'."
+  },
+  {
+   "Name": "DECApplyingRule",
+   "Canonical": false,
+   "Message": "Applying rule on '{0}' dimension defaulting controller in '{1}' form."
+  },
+  {
+   "Name": "DECControlAlreadyExists",
+   "Canonical": false,
+   "Message": "The Dimension Entry control '{0}' already exists on form {1}. The code was not upgraded"
+  },
+  {
+   "Name": "DECCouldNotUpgradeCode",
+   "Canonical": false,
+   "Message": "[Dimension Entry control] Could not upgrade this code automatically. Replace this based on the migration guidance."
+  },
+  {
+   "Name": "DECExtensionPropertyValueNotSet",
+   "Canonical": false,
+   "Message": "Extension property '{0}' for Dimension Entry control '{1}' in form '{2}' could not be set to {3}."
+  },
+  {
+   "Name": "DECExtensionPropertyValueSet",
+   "Canonical": false,
+   "Message": "Extension property '{0}' for Dimension Entry control '{1}' in form '{2}' set to {3}."
+  },
+  {
+   "Name": "DECFixControllerMethodUsage",
+   "Canonical": false,
+   "Message": "[Dimension Entry control] Fix controller method usage for this method based on the migration guidance."
+  },
+  {
+   "Name": "DECMethodCallRetained",
+   "Canonical": false,
+   "Message": "Method call '{0}' retained for Dimension Entry control '{1}' in form '{2}."
+  },
+  {
+   "Name": "DECNewControlCreated",
+   "Canonical": false,
+   "Message": "Created new Dimension Entry control named '{0}'."
+  },
+  {
+   "Name": "DECNewControlCreationError",
+   "Canonical": false,
+   "Message": "Failed to create the '{0}' Dimension Entry control in form '{1}'."
+  },
+  {
+   "Name": "DECNoConstructor",
+   "Canonical": false,
+   "Message": "A constructor was never called for existing controller '{0}' on form '{1}'. The control will need to be manually upgraded based on upgrade guidance."
+  },
+  {
+   "Name": "DECPropertyValueSet",
+   "Canonical": false,
+   "Message": "Property '{0}' for Dimension Entry control '{1}' in form '{2}' set to {3}."
+  },
+  {
+   "Name": "DECRemovingStatement",
+   "Canonical": false,
+   "Message": "Removing '{0}' statement in form '{1}'."
+  },
+  {
+   "Name": "DECReplaceCode",
+   "Canonical": false,
+   "Message": "Statement '{0}' replaced with '{1}' for Dimension Entry control '{2}' in form '{3}'."
+  },
+  {
+   "Name": "DECReplaceConstructorMethod",
+   "Canonical": false,
+   "Message": "Constructor method '{0}' replaced with '{1}' for Dimension Entry control '{2}' in form '{3}'."
+  },
+  {
+   "Name": "DECTODOConstructorNotSupported",
+   "Canonical": false,
+   "Message": "[Dimension Entry control] The constructor called by this control is not supported by the upgrade script"
+  },
+  {
+   "Name": "DECTODOManualDataUpgrade",
+   "Canonical": false,
+   "Message": "[Dimension Entry control] Replace this based on the migration guidance."
+  },
+  {
+   "Name": "DECTODOMethodMayBeRemoved",
+   "Canonical": false,
+   "Message": "[Dimension Entry control] This method can be removed if there is no custom implementation"
+  },
+  {
+   "Name": "DECTODOSetControllerClass",
+   "Canonical": false,
+   "Message": "[Dimension Entry control] Set the controller class property on the control based on the migration guidance."
+  },
+  {
+   "Name": "DECTODOUpdateDataSourceProperties",
+   "Canonical": false,
+   "Message": "[Dimension Entry control] Update the 'Data Source' and 'Data Field' properties on the associated form control and remove this statement."
+  },
+  {
+   "Name": "DECUpdateMethodName",
+   "Canonical": false,
+   "Message": "Method name changed from '{0}' to '{1}' for Dimension Entry control '{2}' in form '{3}'."
+  },
+  {
+   "Name": "DataEntityDimensionFieldAssociatedFieldPropertyUnused",
+   "Canonical": true,
+   "Message": "The field '{0}' should not have a value set for the {2} property, set the property on the '{1}' field instead."
+  },
+  {
+   "Name": "DataEntityDimensionFieldDataSourceIsReadOnly",
+   "Canonical": true,
+   "Message": "The '{1}' data source must have the Is Read Only property set to Yes in order to hook up dimension field '{0}'."
+  },
+  {
+   "Name": "DataEntityDimensionFieldDataSourceJoinMode",
+   "Canonical": true,
+   "Message": "The '{1}' data source must have the Join Mode property set to OuterJoin in order to hook up dimension field '{0}'."
+  },
+  {
+   "Name": "DataEntityDimensionFieldDataSourceMismatch",
+   "Canonical": true,
+   "Message": "The '{0}' entity field must be mapped to the '{1}' field on the '{2}' data source."
+  },
+  {
+   "Name": "DataEntityDimensionFieldDataSourceMultipleRelations",
+   "Canonical": true,
+   "Message": "Dimension fields '{0}' and '{1}' both have relations to the '{2}' data source, but dimension fields must join to different backing data sources."
+  },
+  {
+   "Name": "DataEntityDimensionFieldDataSourceUseRelations",
+   "Canonical": true,
+   "Message": "The '{1}' data source must have the Use Relations property set to No in order to hook up dimension field '{0}'."
+  },
+  {
+   "Name": "DataEntityDimensionFieldIncorrectAccessModifier",
+   "Canonical": true,
+   "Message": "The '{0}' entity field must have the Access Modifier property set to Private or Internal."
+  },
+  {
+   "Name": "DataEntityDimensionFieldMissingAssociatedField",
+   "Canonical": true,
+   "Message": "Add a field named '{1}' mapped to the '{2}' field on the data source '{3}' in order to hook up dimension field '{0}'."
+  },
+  {
+   "Name": "DataEntityDimensionFieldMissingJoinRelation",
+   "Canonical": true,
+   "Message": "Missing relation between field '{0}' and a data source mapped to the {1} data entity."
+  },
+  {
+   "Name": "DataEntityDuplicateLabelCheck",
+   "Canonical": true,
+   "Message": "DataEntityDuplicateLabelCheck: The data entity '{0}' uses the same label value as the following data entities: {1}"
+  },
+  {
+   "Name": "DataEntityFieldHelpTextPropertyCheck",
+   "Canonical": true,
+   "Message": "DataEntityFieldHelpTextPropertyCheck: The field '{0}' has the same help text '{1}' as the backing data source '{2}' field '{3}'."
+  },
+  {
+   "Name": "DataEntityFieldLabelPropertyCheck",
+   "Canonical": true,
+   "Message": "DataEntityFieldLabelPropertyCheck: The field '{0}' has the same label '{1}' as the backing data source '{2}' field '{3}'."
+  },
+  {
+   "Name": "DataEntityFieldNamePropertyCheck",
+   "Canonical": true,
+   "Message": "DataEntityFieldNameCheck: The data entity '{0}' has an array field '{1}' which contains invaid characters in it's name. Please remove '_' or any other numeric value from the field."
+  },
+  {
+   "Name": "DataEntityNotToUseRecIDAsKeyColumnCheck",
+   "Canonical": true,
+   "Message": "The data entity '{0}' should not have RecId as an entity key column"
+  },
+  {
+   "Name": "DataEntityPublicEntityNameSameAsMethodNameCheck",
+   "Canonical": true,
+   "Message": "Data entity {0} contains method name {1} the same to the public entity name"
+  },
+  {
+   "Name": "DataEntityPublicFieldDefinedOnStagingTableCheck",
+   "Canonical": true,
+   "Message": "DataEntityPublicFieldDefinedOnStagingTableCheck: The data entity '{0}' has public field '{1}' that is not defined on the staging table '{2}', regenerate staging table manually."
+  },
+  {
+   "Name": "DataEntityPublicFieldEdtMatchOnStagingTableCheck",
+   "Canonical": true,
+   "Message": "DataEntityPublicFieldEdtMatchOnStagingTableCheck: The data entity '{0}' has public field '{1}' with EDT '{2}', but corresponding field in the staging table '{3}' has EDT '{4}'."
+  },
+  {
+   "Name": "DataEntityPublicFieldEnumTypeEqualsStagingTableCheck",
+   "Canonical": true,
+   "Message": "DataEntityPublicFieldEnumTypeEqualsStagingTableCheck: The data entity '{0}' has public field '{1}' with enum type = '{2}', but corresponding field in the staging table '{3}' has enum type = '{4}'."
+  },
+  {
+   "Name": "DataEntityPublicFieldStringSizeEqualsStagingTableCheck",
+   "Canonical": true,
+   "Message": "DataEntityPublicFieldStringSizeEqualsStagingTableCheck: The data entity '{0}' has public field '{1}' with string size = '{2}', but corresponding field in the staging table '{3}' has string size = '{4}'."
+  },
+  {
+   "Name": "DataEntityRelationPropertyValuesCheck",
+   "Canonical": true,
+   "Message": "DataEntityRelationPropertyValuesCheck: Relation properties [{0}] for data entity relation '{1}' are not set."
+  },
+  {
+   "Name": "DataEntitySecurityPrivilegeCheck",
+   "Canonical": true,
+   "Message": "DataEntitySecurityPrivilegeCheck: The data entity '{0}' is not assigned to a security privilege."
+  },
+  {
+   "Name": "DataEntityStagingTableNotToUseRecIDAsKeyColumnCheck",
+   "Canonical": true,
+   "Message": "The staging table '{0}' should not have RecId as a staging index column"
+  },
+  {
+   "Name": "DataEntityUnmappedFieldLabelPropertyCheck",
+   "Canonical": true,
+   "Message": "DataEntityUnmappedFieldLabelPropertyCheck: The label for field '{0}' is not set."
+  },
+  {
+   "Name": "DataEntityUsingDuplicateStagingTableCheck",
+   "Canonical": true,
+   "Message": "DataEntityUsingDuplicateStagingTableCheck: The data entity '{0}' uses the same staging table '{1}' as the following data entities: {2}"
+  },
+  {
+   "Name": "DeleteActionDeleted",
+   "Canonical": false,
+   "Message": "Delete action {1} has been deleted from table {0}."
+  },
+  {
+   "Name": "DeleteActionDetectorDescription",
+   "Canonical": false,
+   "Message": "Detects delete actions with no explicit relation."
+  },
+  {
+   "Name": "DeleteActionMoved",
+   "Canonical": false,
+   "Message": "The OnDelete value of relation {1} on table {0} has been set according to delete action {3} on table {2}."
+  },
+  {
+   "Name": "DeprecatedAPIDescription",
+   "Canonical": false,
+   "Message": "Detect calls to special deprecated APIs."
+  },
+  {
+   "Name": "DeprecatedAPIWithFixDetectorDescription",
+   "Canonical": false,
+   "Message": "Detect calls to deprecated APIs that can be fixed automatically."
+  },
+  {
+   "Name": "DeprecatedAPIWithTodoDetectorDescription",
+   "Canonical": false,
+   "Message": "Detect calls to deprecated APIs that can be fixed manually."
+  },
+  {
+   "Name": "DeprecatedAPIWithTodo_DocuRef_Completefilename",
+   "Canonical": false,
+   "Message": "DocuRef.Completefilename has been deprecated, use the File Upload control instead."
+  },
+  {
+   "Name": "DeprecatedAPIWithoutFixDetectorDescription",
+   "Canonical": false,
+   "Message": "Detect calls to deprecated APIs that cannot be fixed automatically."
+  },
+  {
+   "Name": "DeprecatedFrameTypeCodeDescription",
+   "Canonical": false,
+   "Message": "Detects the usage of deprecated FormFrameType enumeration values in code."
+  },
+  {
+   "Name": "DeprecatedFrameTypeDescription",
+   "Canonical": false,
+   "Message": "Detects form controls that use deprecated FrameType values: Thin, Raised3D, Sunken3D, Edged3D, Edged3DLine, ShortSolidBlack, LongSolidBlack, ShortSolidBackgroundColor, LongSolidBackgroundColor, BoldCaption."
+  },
+  {
+   "Name": "DeprecatedFrameTypeSetToAuto",
+   "Canonical": false,
+   "Message": "Setting FrameType property of form control {0} to Auto."
+  },
+  {
+   "Name": "DeprecatedUserLicenseTypeDescription",
+   "Canonical": false,
+   "Message": "Detects the usage of deprecated UserLicenseType::Functional or UserLicenseType::SelfServe or UserLicenseType::Task enumeration value in metadata."
+  },
+  {
+   "Name": "DeprecatedUserLicenseTypeSetFixDescription",
+   "Canonical": false,
+   "Message": "Menu Item {0} uses an unsupported value '{2}' for property {1}, changed to '{3}'."
+  },
+  {
+   "Name": "DialogIsOnServerDetectorDescription",
+   "Canonical": false,
+   "Message": "Detect usage of deprecated API Dialog.IsOnServer"
+  },
+  {
+   "Name": "DimensionEntryControlDetectorDescription",
+   "Canonical": false,
+   "Message": "Detect usage of dimension defaulting controller in a form."
+  },
+  {
+   "Name": "DimensionForCalculatedMeasureNotFoundDescription",
+   "Canonical": false,
+   "Message": "This rule scans the mdx text of MDX based calculated measures and checks that the dimensions used in the calculatation exist in the measurement."
+  },
+  {
+   "Name": "DimensionHasNoHierarchiesDescription",
+   "Canonical": false,
+   "Message": "This rule scans for dimensions with more than four attribute and no dimension hierarchies."
+  },
+  {
+   "Name": "DimensionOnTransTableDescription",
+   "Canonical": false,
+   "Message": "This rule scans for dimensions where the dimension table is in the Transaction, TransactionHeader or TransactionLine table group.  Such dimensions are slow to process."
+  },
+  {
+   "Name": "EDTFormHelpFormMissingArgumentException",
+   "Canonical": false,
+   "Message": "EDTFormHelpFormMissingArgumentException: The FormHelp property for an extended data type specifies a form '{0}' that does not exist.",
+   "Description": "Reports when the FormHelp property for an extended data type specifies a form that does not exist."
+  },
+  {
+   "Name": "EDTRelationDetectorDescription",
+   "Canonical": false,
+   "Message": "Detects EDT relations that should be migrated to regular table relations."
+  },
+  {
+   "Name": "EDTRelationMigratedToExistingRelation",
+   "Canonical": false,
+   "Message": "EDT relation found on field {0} of table {1} has been migrated to relation {2} on the same table."
+  },
+  {
+   "Name": "EDTRelationMigratedToNewRelation",
+   "Canonical": false,
+   "Message": "EDT relation found in field {0} of table {1} migrated to new table relation."
+  },
+  {
+   "Name": "EDTSelfRelationSetToIgnore",
+   "Canonical": false,
+   "Message": "EDT relation on field {0} of table {1} is a self relation; field property IgnoreEDTRelation set to 'Yes'."
+  },
+  {
+   "Name": "EmptyOverrideMethodDescription",
+   "Canonical": false,
+   "Message": "Detect empty methods that override base methods."
+  },
+  {
+   "Name": "EnumOnlyDimensionsDescription",
+   "Canonical": false,
+   "Message": "This rule scans for dimensions where all the attributes other than the key attribute are enumerations and verifies if the key attribute's key columns are correctly set."
+  },
+  {
+   "Name": "ExceptionInfoPartFieldDSNotFound",
+   "Canonical": false,
+   "Message": "No datasource found for field {0}"
+  },
+  {
+   "Name": "ExceptionInfopartDerivedDS",
+   "Canonical": false,
+   "Message": "In current metamodel only FormDataSourceRoot or FormDataSourceDerived can have child derived data sources."
+  },
+  {
+   "Name": "ExceptionInfopartLayoutGroupMissingDS",
+   "Canonical": false,
+   "Message": "Layout {0} is missing datasource value"
+  },
+  {
+   "Name": "ExceptionInfopartNoCompilationUnitFound",
+   "Canonical": false,
+   "Message": "No compilation unit found for entity:{0} "
+  },
+  {
+   "Name": "ExceptionInfopartNoDSFound",
+   "Canonical": false,
+   "Message": "No datasource was found for Infopart "
+  },
+  {
+   "Name": "ExceptionInfopartNoEntityFoundForDS",
+   "Canonical": false,
+   "Message": "No table, map or view found for datasource {0}"
+  },
+  {
+   "Name": "ExceptionInfopartQueryTypeNotCorrect",
+   "Canonical": false,
+   "Message": "The infopart query {0} should be a simple or aggregate query"
+  },
+  {
+   "Name": "ExtensionClassNamingWithExtensionOnly",
+   "Canonical": true,
+   "Message": "Extension class '{0}' is using a generic name which is not sufficient to avoid conflicts across models.",
+   "Description": "Checks whether an extension class is only adding the term _Extension to the element it is extending."
+  },
+  {
+   "Name": "ExtensionPropertySet",
+   "Canonical": false,
+   "Message": "Extension property '{0}' set for '{1}' in form '{2}'"
+  },
+  {
+   "Name": "FieldMethodsProcessed",
+   "Canonical": false,
+   "Message": "Processed field methods for {0} in form {1}"
+  },
+  {
+   "Name": "FixedPatternQualifiedCallDetectorDescription",
+   "Canonical": false,
+   "Message": "Detect deprecated code like CompanyInfo::find().partyOKATOasOfDate_RU()."
+  },
+  {
+   "Name": "FormDataSourceDeprecatedApiDescription",
+   "Canonical": false,
+   "Message": "Detect usage of deprecated form datasource method findRecord and findValue."
+  },
+  {
+   "Name": "FormPartMenuitemDetectorDescription",
+   "Canonical": false,
+   "Message": "Detect display menu item that points to a form part."
+  },
+  {
+   "Name": "FormPartMenuitemFixDesc",
+   "Canonical": false,
+   "Message": "Setting {0}.Object to Form {1}."
+  },
+  {
+   "Name": "FormPartMenuitemFixerDeleteFormPart",
+   "Canonical": false,
+   "Message": "Deleting the form part {0}."
+  },
+  {
+   "Name": "FormPatternApplied",
+   "Canonical": false,
+   "Message": "Upgrading form {0} to the {1} {2} Guideline pattern."
+  },
+  {
+   "Name": "FormPatternDetectorDescription",
+   "Canonical": false,
+   "Message": "Detects forms that can be automatically upgraded to a Guideline pattern."
+  },
+  {
+   "Name": "FormPatternNewControlsAddedTODO",
+   "Canonical": false,
+   "Message": "Control '{0}' is added to the form to make it conform to the '{1}' form pattern.Control '{0}' is empty and needs to be populated with children."
+  },
+  {
+   "Name": "FormPatternNewControlsAddedTODOFixDescription",
+   "Canonical": false,
+   "Message": "Add a TODO statement to the class declaration to notify the developer about new container controls that were added to the form. The controls have no child controls, but children must be added. The controls were added for conformance to a specific form pattern."
+  },
+  {
+   "Name": "FormPatternVersionApplied",
+   "Canonical": false,
+   "Message": "Upgrading form {0} to the {1} {2} pattern. "
+  },
+  {
+   "Name": "FormPatternVersionNotActiveDescription",
+   "Canonical": false,
+   "Message": "Checks that the PatternVersion specifed on the FormDesign or FormControl is the active version of the pattern."
+  },
+  {
+   "Name": "FormRunApiDeprecatedTODOComment",
+   "Canonical": false,
+   "Message": "The lockWindowUpdate method is deprecated and no longer needed. You can safely remove calls to this method"
+  },
+  {
+   "Name": "FormRunDeprecatedApiDescription",
+   "Canonical": false,
+   "Message": "Detect usage of deprecated API for formRun."
+  },
+  {
+   "Name": "FormRunInOverrideMethodParameterDetectorDescription",
+   "Canonical": false,
+   "Message": "Check if override method parameter is of type FormRun."
+  },
+  {
+   "Name": "FormSubpatternApplied",
+   "Canonical": false,
+   "Message": "Applying subpatterns to the form {0}"
+  },
+  {
+   "Name": "FormSubpatternDetectorDescription",
+   "Canonical": false,
+   "Message": "Detects forms that can be automatically upgraded to use subpatterns."
+  },
+  {
+   "Name": "Function",
+   "Canonical": false,
+   "Message": "function"
+  },
+  {
+   "Name": "GroupDeprecatedTableOfContentStyle",
+   "Canonical": false,
+   "Message": "Detects a group control that has its Style property set to a deprecated value. Deprecated values include TOCTopicList, TOCTopicSimple, and TOCTopicFastTabs."
+  },
+  {
+   "Name": "GroupDeprecatedTableOfContentStyleUpdate",
+   "Canonical": false,
+   "Message": "On the group named {0}, update the Style property to Auto."
+  },
+  {
+   "Name": "GroupHiddenHeaderControlsDescription",
+   "Canonical": false,
+   "Message": "Detect Group control that has FrameOptionButton property set to a non-default value and has FrameType property set to None causing the group header along with frameoptionbutton to be hidden. Non-default values for FrameOptionButton are Radio, Check and Hide."
+  },
+  {
+   "Name": "GroupLeftModeUpdate",
+   "Canonical": false,
+   "Message": "Set the LeftMode property to AutoLeft on the '{0}' group control."
+  },
+  {
+   "Name": "GroupStyleBorderlessGridContainerDescription",
+   "Canonical": false,
+   "Message": "Detects a group control that has its Style property set to BorderlessGridContainer."
+  },
+  {
+   "Name": "GroupStyleBorderlessGridContainerTODOComments",
+   "Canonical": false,
+   "Message": "Remove all references in source code to the control '{0}' which has its Style property set to the deprecated value of BorderlessGridContainer. Also, delete the group control from metadata and move all its children to its parent node."
+  },
+  {
+   "Name": "GroupStyleBorderlessGridContainerUpdate",
+   "Canonical": false,
+   "Message": "Remove the group control '{0}' because its Style property is set to BorderlessGridContainer."
+  },
+  {
+   "Name": "GroupStyleMarginlessContainerDescription",
+   "Canonical": false,
+   "Message": "Detects group controls which have their Style property set to MarginlessContainer."
+  },
+  {
+   "Name": "GroupStyleMarginlessContainerUpdate",
+   "Canonical": false,
+   "Message": "On the group named {0}, update the style to Auto, and set the HeightMode and WidthMode properties to SizeToAvailable."
+  },
+  {
+   "Name": "GroupTopLeftModeDetectorDescription",
+   "Canonical": false,
+   "Message": "Detects a group control that has its TopMode or LeftMode property, or both, set to a non-default value."
+  },
+  {
+   "Name": "GroupTopLeftModeToDo",
+   "Canonical": false,
+   "Message": "Group control {0} had {1} property set to {2}. This property is no longer respected. Make any necessary adjustments to correct the position of the group control."
+  },
+  {
+   "Name": "GroupTopModeUpdate",
+   "Canonical": false,
+   "Message": "Set the TopMode property to Auto on the '{0}' group control."
+  },
+  {
+   "Name": "GroupWithinGroupDetectorDescription",
+   "Canonical": false,
+   "Message": "Detects a group control having only group controls as its children. Both the parent group control and one of its children have their Caption or DataGroup property set to a non-empty string value, and the FrameType property not set to 'None'. "
+  },
+  {
+   "Name": "IdenticalEnumDetectorDescription",
+   "Canonical": false,
+   "Message": "Checks for identical over-layered enums"
+  },
+  {
+   "Name": "IdenticalFormDetectorDescription",
+   "Canonical": false,
+   "Message": "Checks for identical over-layered forms"
+  },
+  {
+   "Name": "IdenticalMenuDetectorDescription",
+   "Canonical": false,
+   "Message": "Checks for identical over-layered menus"
+  },
+  {
+   "Name": "IdenticalSecurityRoleDetectorDescription",
+   "Canonical": false,
+   "Message": "Checks for identical over-layered security roles"
+  },
+  {
+   "Name": "IdenticalTableDetectorDescription",
+   "Canonical": false,
+   "Message": "Checks for identical over-layered tables"
+  },
+  {
+   "Name": "ImageListApplBudgetControlResultDescription",
+   "Canonical": false,
+   "Message": "Removing use of type ImageListAppl_BudgetControlResult"
+  },
+  {
+   "Name": "ImproperDialogCaptionDeleteControlMessage",
+   "Canonical": false,
+   "Message": "Deleting control {0}."
+  },
+  {
+   "Name": "ImproperDialogCaptionDetectorDescription",
+   "Canonical": false,
+   "Message": "Checks conflict between dialog caption and main instruction static text in a form."
+  },
+  {
+   "Name": "ImproperDialogCaptionSetCaptionMessage",
+   "Canonical": false,
+   "Message": "Setting form caption to {0}."
+  },
+  {
+   "Name": "ImproperDialogCaptionTodo",
+   "Canonical": false,
+   "Message": "[Dialog Caption] Two conflicting captions are defined on this form - 1) Ensure the value in Form.Design.Caption contains the caption you want for this form; and, 2) Remove the now redundant static text main instruction control {0}."
+  },
+  {
+   "Name": "IncrementalDimensionDataSourceContainsAggregatesDescription",
+   "Canonical": false,
+   "Message": "This rule checks for dimension data sources which have a top level view data source containing a grouping of fields, or a union of data sources. This results in the incremental update logic of a materialized view unable to resolve to a unique key."
+  },
+  {
+   "Name": "IncrementalMeasureGroupDataSourceContainsAggregatesDescription",
+   "Canonical": false,
+   "Message": "This rule checks for measure group data sources which have a top level view data source containing a grouping of fields, or a union of data sources. This results in the incremental update logic of a materialized view unable to resolve to a unique key."
+  },
+  {
+   "Name": "IndexTabsDeprecatedDescription",
+   "Canonical": false,
+   "Message": "Detect Tabs with style as IndexTabs."
+  },
+  {
+   "Name": "IndexTabsUpdateStyle",
+   "Canonical": false,
+   "Message": "Updating Tab {0}.Style from IndexTabs to Tab"
+  },
+  {
+   "Name": "InfologUrlLookupDetectorDescription",
+   "Canonical": false,
+   "Message": "Detect usage of infolog.urllookup."
+  },
+  {
+   "Name": "InfopartCreateNewFormFix",
+   "Canonical": false,
+   "Message": "Creating new form {0}"
+  },
+  {
+   "Name": "InfopartDeleteInfopartFix",
+   "Canonical": false,
+   "Message": "Deleting infopart {0}"
+  },
+  {
+   "Name": "InfopartFormPartReferenceFix",
+   "Canonical": false,
+   "Message": "Fixing part reference {0} on form {1} that points to infopart {2}"
+  },
+  {
+   "Name": "InfopartMenuItemFix",
+   "Canonical": false,
+   "Message": "Fixing menu item {0} that points to infopart {1}"
+  },
+  {
+   "Name": "InfopartNotFound",
+   "Canonical": false,
+   "Message": "No infoparts found."
+  },
+  {
+   "Name": "InfopartToFormDescription",
+   "Canonical": false,
+   "Message": "Converts Infoparts to Forms. Also updates all the related menu items to point to the new form"
+  },
+  {
+   "Name": "InvalidParameterInOverrideMethodDetectorDescription",
+   "Canonical": false,
+   "Message": "Check if override method parameter is of same type as the base."
+  },
+  {
+   "Name": "LateBoundCallDescription",
+   "Canonical": false,
+   "Message": "Detects late bound calls."
+  },
+  {
+   "Name": "ListPageCopyFormPart",
+   "Canonical": false,
+   "Message": "Copying form part {0} from the list page form to the detail form."
+  },
+  {
+   "Name": "ListPageCopyGrid",
+   "Canonical": false,
+   "Message": "Copying grid {0} from the list page form to the detail form."
+  },
+  {
+   "Name": "ListPageDefaultActionButtonUnexpectedType",
+   "Canonical": false,
+   "Message": "ListPage Grid.DefaultAction button not found or not of type menu function button so corresponding Details Form could not be found."
+  },
+  {
+   "Name": "ListPageDefaultActionMenuItemNotFound",
+   "Canonical": false,
+   "Message": "ListPage Grid.DefaultAction button MenuItem not found so corresponding Details Form could not be found."
+  },
+  {
+   "Name": "ListPageDefaultActionMenuItemObjectIsNotSet",
+   "Canonical": false,
+   "Message": "ListPage Grid.DefaultAction button MenuItem.Object is not set so corresponding Details Form could not be found."
+  },
+  {
+   "Name": "ListPageDefaultActionMenuItemObjectTypeIsNotForm",
+   "Canonical": false,
+   "Message": "ListPage Grid.DefaultAction button MenuItem.ObjectType is not Form so corresponding Details Form could not be found."
+  },
+  {
+   "Name": "ListPageDefaultActionMenuNameIsEmpty",
+   "Canonical": false,
+   "Message": "ListPage Grid.DefaultAction button MenuItemName is empty so corresponding Details Form could not be found."
+  },
+  {
+   "Name": "ListPageDefaultButtonHasCode",
+   "Canonical": false,
+   "Message": "Default action menu function button has unexpected override method {0} implemented. Detail form cannot be found."
+  },
+  {
+   "Name": "ListPageDetailFormNotFound",
+   "Canonical": false,
+   "Message": "DetailsForm not found corresponding to ListPage."
+  },
+  {
+   "Name": "ListPageDetailFormStylsIsUnexpected",
+   "Canonical": false,
+   "Message": "This form was expected to be a DetailsForm corresponding to a ListPage but the Style is not DetailsForm*."
+  },
+  {
+   "Name": "ListPageFormDetailFormDetectorDescription",
+   "Canonical": false,
+   "Message": "Detect list page/detail form pattern and merge columns from the listpage form to the detail form."
+  },
+  {
+   "Name": "ListPageFormNotFound",
+   "Canonical": false,
+   "Message": "ListPage form not found."
+  },
+  {
+   "Name": "ListPageGridDataSourceIsInvalid",
+   "Canonical": false,
+   "Message": "ListPage Grid.Datasource is invalid."
+  },
+  {
+   "Name": "ListPageGridDataSourceTableIsInvalid",
+   "Canonical": false,
+   "Message": "ListPage Grid.Datasource points to an invalid table."
+  },
+  {
+   "Name": "ListPageGridDataSourceTableIsMissing",
+   "Canonical": false,
+   "Message": "List page form grid's data source table is not set."
+  },
+  {
+   "Name": "ListPageMoreThanOneGridFoundWithTheSameDataSource",
+   "Canonical": false,
+   "Message": "More than one grid found with the same data source in the detail form."
+  },
+  {
+   "Name": "ListPageNoGridControlFoundInDetailForm",
+   "Canonical": false,
+   "Message": "This DetailsForm corresponding to a ListPage did not have any Grid."
+  },
+  {
+   "Name": "ListPageNoGridControlFoundWithSameDataSourceInDetailForm",
+   "Canonical": false,
+   "Message": "This DetailsForm corresponding to a ListPage did not have a GridView Grid with the same data source as the ListPage Grid."
+  },
+  {
+   "Name": "ListPageNoGridFound",
+   "Canonical": false,
+   "Message": "ListPage Grid not found."
+  },
+  {
+   "Name": "ListPageNoMenuItemFound",
+   "Canonical": false,
+   "Message": "No menu item found."
+  },
+  {
+   "Name": "ListPageTODOManualMerge",
+   "Canonical": false,
+   "Message": "[List Page rule] The unique grid columns and buttons on ListPage {0} cannot be added automatically to the corresponding DetailsForm {1}, please review and merge them manually."
+  },
+  {
+   "Name": "ListPageTODOReviewMenuFunctionButtons",
+   "Canonical": false,
+   "Message": "[List Page rule] Please review and consider adding the following menu function buttons from ListPage {1} onto this corresponding DetailsForm: {0}."
+  },
+  {
+   "Name": "ListPageTODOReviewNotMergedControls",
+   "Canonical": false,
+   "Message": "[List Page rule] Please review and consider merging the following controls from ListPage {1} onto this corresponding DetailsForm: {0}. They could not be merged automatically since they have a diferent data source or do not have DataField property."
+  },
+  {
+   "Name": "ListPageUpdatingMenuItem",
+   "Canonical": false,
+   "Message": "Updating menu item {0} currently pointing to ListPage {1} to point to corresponding DetailsForm {2}."
+  },
+  {
+   "Name": "MDXCalculatedMeasureDescription",
+   "Canonical": false,
+   "Message": "This rule scans for calculated measures that have MDX text set in the Expression property. Convert these to use measure expressions instead to avoid problems in future upgrades."
+  },
+  {
+   "Name": "MeasureForCalculatedMeasureNotFoundDescription",
+   "Canonical": false,
+   "Message": "This rule scans MDX calculated measures and checks if the measures used in the calculation exist in the measurement"
+  },
+  {
+   "Name": "MeasureGroupComplexityDescription",
+   "Canonical": false,
+   "Message": "This rule checks for cases of measure groups with views using too many tables."
+  },
+  {
+   "Name": "MeasureGroupConstraintFieldAllowsNullDescription",
+   "Canonical": false,
+   "Message": "This rule checks if the RelatedField property on a dimension relation constraint is set to a field that is not mandatory. Non-mandatory fields can have null values. Data for rows with null values will be grouped into the dimension's Unknown member."
+  },
+  {
+   "Name": "MeasureGroupWithManyDimensionsDescription",
+   "Canonical": false,
+   "Message": "This rule scans for measure groups that are related to more than ten dimensions."
+  },
+  {
+   "Name": "MeasureGroupWithOneMeasureDescription",
+   "Canonical": false,
+   "Message": "This rule scans for measure groups with fewer than two measures."
+  },
+  {
+   "Name": "MeasureIsAmountCurDescription",
+   "Canonical": false,
+   "Message": "This rule scans for measures on fields where the extended data type extends from AmountCur. These field values will be in different currencies and should not be aggregated together."
+  },
+  {
+   "Name": "MenuHasImageFixDescription",
+   "Canonical": false,
+   "Message": "Menu '{0}' has an image when it should not, adjusted to ImageLocation=Symbol and NormalImage set to blank."
+  },
+  {
+   "Name": "MenuItemsNotFound",
+   "Canonical": false,
+   "Message": "No display menu items found."
+  },
+  {
+   "Name": "MetadataExtensionNamingWithExtensionOnly",
+   "Canonical": true,
+   "Message": "Metadata Extension '{0}' is using a generic name which is not sufficient to avoid conflicts across models.",
+   "Description": "Checks whether a metadata extension is only adding the term Extension to the element it is extending."
+  },
+  {
+   "Name": "MissingOrUnsupportedImageFixDescription",
+   "Canonical": false,
+   "Message": "Adjusted NormalImage ({0}), ButtonDisplay ({1}) and ImageLocation ({2}) to '{3}', '{4}', '{5}' respectively."
+  },
+  {
+   "Name": "MissingPublicModifierDescription",
+   "Canonical": false,
+   "Message": "Checks that all methods that are called from outside of the elment are not marked as private."
+  },
+  {
+   "Name": "MissingPublicModifierDiagnosticItem",
+   "Canonical": false,
+   "Message": "MissingPublicModifierDiagnosticItem: Call to private method '{0}' in '{1}' requires public modifier."
+  },
+  {
+   "Name": "NormalImageValues",
+   "Canonical": false,
+   "Message": "Absence\r\nAccept\r\nAction\r\nActionCenter\r\nAdd\r\nAddMultiple\r\nAddPerson\r\nAddressBook\r\nAirFare\r\nAirplane\r\nAlignCenter\r\nAlignLeft\r\nAlignRight\r\nArchive\r\nAreaChart\r\nAssign\r\nAttach\r\nBack\r\nBackSpaceQWERTYLg\r\nBalloon\r\nBankManagement\r\nBarChart\r\nBarChartHorz\r\nBarChartVert\r\nBenefitManagement\r\nBirthdayCake\r\nBlocked2\r\nBlueSquare\r\nBold\r\nBroom\r\nBudgetPlanning\r\nBulletedList\r\nBusinessDocumentManagement\r\nBusinessProcess\r\nBusinessProcessModel\r\nCalculate\r\nCalculationUnitBased\r\nCalculatorSign\r\nCalendar\r\nCalendarLock\r\nCamera\r\nCancel\r\nCaretDown\r\nCaretDownLeft\r\nCaretDownRight\r\nCaretLeft\r\nCaretRight\r\nCaretUp\r\nCaretUpLeft\r\nCaretUpRight\r\nCarRental\r\nCash\r\nCashDrawer\r\nCatalogManagement\r\nCategoryAndProductManagement\r\nCellPhone\r\nCertificate\r\nChannelDeployment\r\nCheckbox\r\nCheckboxFill\r\nCheckboxIndeterminate\r\nCheckboxWithBox\r\nCheckList\r\nCheckmark\r\nCheckmarkUnderline\r\nChevronDown\r\nChevronDownBold\r\nChevronDownMedium\r\nChevronLeft\r\nChevronLeftBold\r\nChevronLeftMedium\r\nChevronRight\r\nChevronRightBold\r\nChevronRightMedium\r\nChevronUp\r\nChevronUpBold\r\nChevronUpMedium\r\nChildof\r\nChromeClose\r\nCircle\r\nCirclePlus\r\nClear\r\nClearFormatting\r\nClearSelection\r\nClick\r\nClose\r\nClosePane\r\nCloud\r\nCloudEnvironment\r\nCodeAnalysis\r\nCoffeeScript\r\nCollapseAll\r\nCollapseMenu\r\nComment\r\nCompanyDirectory\r\nCompare\r\nCompareTime\r\nCompensationManagement\r\nCompleted\r\nConference\r\nConnectContacts\r\nContactInfo\r\nCopy\r\nCostAdministration\r\nCostAnalysis\r\nCostControl\r\nCostControlLedgerAdmin\r\nCostManagement\r\nCount\r\nCourseManagement\r\nCreditCard\r\nCreditManagement\r\nCurrentRental\r\nCustomerInvoicing\r\nCustomList\r\nDarkGraySquare\r\nDashKey\r\nDatabaseSource\r\nDataManagement\r\nDay\r\nDecreaseIndent\r\nDelete\r\nDeliver\r\nDeliveryLine\r\nDelveLogo\r\nDesign\r\nDetails\r\nDevelopmentAndTesting\r\nDiagnostic\r\nDiagnosticFramework\r\nDiamond\r\nDislike\r\nDistribute\r\nDocument\r\nDone\r\nDown\r\nDownload\r\nDraft\r\nDropDownArrow\r\nEdit\r\nEditEvent\r\nEditing\r\nElectronicReporting\r\nEmoji2\r\nEmployeeSelfService\r\nEntertainment\r\nError\r\nEvent\r\nEventAccepted\r\nEventDateMissed\r\nEventDeclined\r\nExcelDocument\r\nExcelLogo\r\nExpandAll\r\nExpenses\r\nExport\r\nFabricMovetoFolder\r\nFacebookLogo\r\nFamily\r\nFavorite\r\nFeedback\r\nFieldCorrect\r\nFieldHelp\r\nFieldReadOnly\r\nFilter\r\nFilterAscending\r\nFilterDescending\r\nFilterSolid\r\nFinancialInsights\r\nFinancialPeriodClose\r\nFind\r\nFirst\r\nFixedAssetManagement\r\nFlag\r\nFont\r\nFontDecrease\r\nFontIncrease\r\nForklift\r\nForward\r\nFullView\r\nFunnelChart\r\nGeneralJournalProcessing\r\nGenerate\r\nGenericApp\r\nGenericDocument\r\nGenericScan\r\nGift\r\nGlimmer\r\nGlobe\r\nGo\r\nGreenCheck\r\nGreenCircle\r\nGreenSquare\r\nGripperBarHorizontal\r\nGripperBarVertical\r\nGroup\r\nGroupedAscending\r\nGroupedDescending\r\nGroupedList\r\nGuidedWorkout\r\nHalfStarLeft\r\nHalfStarRight\r\nHeaderView\r\nHelp\r\nHide\r\nHideItem\r\nHighlight\r\nHighPriority\r\nHoloLens\r\nHome\r\nHotel\r\nHumanResources\r\nImage\r\nImport\r\nIncreaseIndent\r\nInfo\r\nInformation\r\nInsights\r\nInstrumentCalibrationProcessing\r\nInternet\r\nInUse\r\nInventSite\r\nInvoice\r\nItalic\r\nKanbanJobCompleted\r\nKanbanJobCreated\r\nKanbanJobInProgress\r\nKanbanJobPlanned\r\nKanbanJobPrepared\r\nLast\r\nLayout\r\nLeave\r\nLedgerBudgetsAndForecasts\r\nLibrary\r\nLicensingEstimator\r\nLightbulb\r\nLightBulbOn\r\nLike\r\nLineChart\r\nLinesView\r\nLink\r\nLinkedInLogo\r\nList\r\nLock\r\nLocked\r\nMachineOperations\r\nMail\r\nManage\r\nManagerSelfService\r\nMandatory\r\nManyPeople\r\nMap\r\nMasterPlanning\r\nMeal\r\nMessage\r\nMicrosoftOffice\r\nMileage\r\nMinimize\r\nMonth\r\nMore\r\nMoreOptions\r\nMove\r\nMoveAllLeft\r\nMoveAllRight\r\nMoveLeft\r\nMoveRight\r\nMovie\r\nMultiSelect\r\nNavigationPane\r\nNew\r\nNext\r\nNotAvailable\r\nNote\r\nNumberSymbol\r\nOffboarding\r\nOfflineAvailability\r\nOK\r\nOnboarding\r\nOneDriveLogo\r\nOnOff\r\nOpenEnrollment\r\nOpenPane\r\nOperations\r\nOrangeSquare\r\nOrderLineMultipleDeliveries\r\nOrganization\r\nOutboundWorkMonitoring\r\nOutboundWorkPlanning\r\nOutlineHalfStarLeft\r\nOutlineHalfStarRight\r\nOutlineQuarterStarLeft\r\nOutlineQuarterStarRight\r\nOutlineStarLeftHalf\r\nOutlineStarRightHalf\r\nOutlineThreeQuarterStarLeft\r\nOutlineThreeQuarterStarRight\r\nOutlookLogo\r\nPage\r\nPageLeft\r\nPageRemove\r\nPageRight\r\nPause\r\nPauseListView12\r\nPayroll\r\nPayTender\r\nPeople\r\nPeopleAdd\r\nPeopleBlock\r\nPerformance\r\nPerformanceManagement\r\nPermission\r\nPerson\r\nPersonalize\r\nPhone\r\nPickup\r\nPieChart\r\nPin\r\nPlaceholderSolid\r\nPlannedDocument\r\nPlay\r\nPlaySolid\r\nPointerHand\r\nPopout\r\nPopoutExpand\r\nPowerApps\r\nPowerAutomate\r\nPowerBILogo\r\nPresence\r\nPrevious\r\nPricingAndDiscountManagement\r\nPrint\r\nProcess\r\nProcessing\r\nProcessMap\r\nProductionFloorManagement\r\nProductMeasure\r\nProductReadinessForDiscreteManufacturing\r\nProductReadinessForLeanManufacturingAndReplinishment\r\nProductReadinessForProcessManufacturing\r\nProducts\r\nProductVariantModelDefinition\r\nProgressInnerLoop\r\nProgressOuterLoop\r\nProjectManagement\r\nPublish\r\nPurchaseOrderPreparation\r\nPurchaseReceiptAndFollowup\r\nQualityOrderProcessing\r\nQuantity\r\nQuarterStarLeft\r\nQuarterStarRight\r\nQuestion\r\nQuestionaire\r\nQueueManager\r\nQuotes\r\nRadioDot\r\nRadioEmpty\r\nRadioFilled\r\nReceipt\r\nRecent\r\nRecruitmentManagement\r\nRecurringEvent\r\nRecycleBin\r\nRedact\r\nRedDiamond\r\nRedEye\r\nRedEyeHide\r\nRedo\r\nRedSquare\r\nRedX\r\nRefresh\r\nRelated\r\nRelease\r\nReleasedProductMaintenance\r\nRemove\r\nRemoveLink\r\nRename\r\nReport\r\nReportProgress\r\nReportScrap\r\nRequired\r\nReservationManagement\r\nResizeToBigger\r\nResizeToSmaller\r\nResourceLifecycleManagement\r\nRestore\r\nRetailIT\r\nRetailStoreFinancials\r\nRetailStoreManagement\r\nReturn\r\nRevenueManagement\r\nRibbon\r\nSad\r\nSalesOrderProcessingAndInquiry\r\nSalesReturnProcessing\r\nSanitize\r\nSave\r\nSaveAs\r\nScheduleEventAction\r\nScrollUpDown\r\nSearchCampaigns\r\nSelectAll\r\nSemanticZoom\r\nSend\r\nSettings\r\nShare\r\nSharepointLogo\r\nShop\r\nShow\r\nSignOut\r\nSizingGuide\r\nSkipTab\r\nSkypeCheck\r\nSkypeCircleCheck\r\nSkypeCircleClock\r\nSkypeCircleMinus\r\nSkypeClock\r\nSkypeLogo\r\nSkypeMessage\r\nSkypeMinus\r\nSmiley\r\nSort\r\nSortDown\r\nSortUp\r\nSplitObject\r\nStackColumn\r\nStackColumnAndLine\r\nStackedLineChart\r\nStar\r\nStarEmpty\r\nStartBundle\r\nStatusCircleErrorX\r\nStop\r\nStore\r\nSubmit\r\nSummary\r\nSummaryField\r\nSwitch\r\nSwitchUser\r\nSync\r\nSystemAdmin\r\nTag\r\nTakeBreak\r\nTask\r\nTaskView\r\nTemporaryUser\r\nThreeQuarterStarLeft\r\nThreeQuarterStarRight\r\nThumbnailView\r\nThumbsDown\r\nThumbsUp\r\nTimeEntry\r\nTimer\r\nTimeSheet\r\nToggleList\r\nTools\r\nTotal\r\nTrackers\r\nTransition\r\nTranslate\r\nTransport\r\nTrash\r\nTriangle\r\nTripleColumnEdit\r\nTwitterLogo\r\nUnderline\r\nUndo\r\nUneditable\r\nUnfavorite\r\nUnlock\r\nUnlocked\r\nUnpin\r\nUp\r\nUpgradeAnalysis\r\nUpload\r\nUser\r\nUsers\r\nVehicle\r\nVendorInvoiceEntry\r\nVendorPayments\r\nVendorPortalPurchaseOrderConfirmation\r\nView\r\nViewAll\r\nViewEdit\r\nViewNotifications\r\nWaffle\r\nWaffleOffice365\r\nWait\r\nWarning\r\nWebSearch\r\nWeek\r\nWMSStore\r\nWordDocument\r\nWordLogo\r\nWorkflow\r\nWorkforceManagement\r\nWorkspace\r\nWorkspace_BankManagement\r\nWorkspace_BenefitManagement\r\nWorkspace_BudgetPlanning\r\nWorkspace_CatalogManagement\r\nWorkspace_CategoryAndProductManagement\r\nWorkspace_ChannelDeployment\r\nWorkspace_CompensationManagement\r\nWorkspace_CostAdministration\r\nWorkspace_CostAnalysis\r\nWorkspace_CostControl\r\nWorkspace_CostControlLedgerAdmin\r\nWorkspace_CourseManagement\r\nWorkspace_CreditAndCollectionsManagement\r\nWorkspace_CustomerInvoicing\r\nWorkspace_DataManagement\r\nWorkspace_ElectronicReporting\r\nWorkspace_EmployeeSelfService\r\nWorkspace_FinancialPeriodClose\r\nWorkspace_FixedAssetManagement\r\nWorkspace_GeneralJournalProcessing\r\nWorkspace_LedgerBudgetsAndForecasts\r\nWorkspace_ManagerSelfService\r\nWorkspace_MasterPlanning\r\nWorkspace_OutboundWorkMonitoring\r\nWorkspace_OutboundWorkPlanning\r\nWorkspace_Payroll\r\nWorkspace_PricingAndDiscountManagement\r\nWorkspace_ProductionFloorManagement\r\nWorkspace_ProductReadinessForDiscreteManufacturing\r\nWorkspace_ProductReadinessForLeanManufacturingAndReplinishment\r\nWorkspace_ProductReadinessForProcessManufacturing\r\nWorkspace_ProductVariantModelDefinition\r\nWorkspace_ProjectManagement\r\nWorkspace_PurchaseOrderPreparation\r\nWorkspace_PurchaseReceiptAndFollowup\r\nWorkspace_Questionaire\r\nWorkspace_RecruitmentManagement\r\nWorkspace_ReleasedProductMaintenance\r\nWorkspace_ReservationManagement\r\nWorkspace_ResourceLifecycleManagement\r\nWorkspace_RetailIT\r\nWorkspace_RetailStoreFinancials\r\nWorkspace_RetailStoreManagement\r\nWorkspace_SalesOrderProcessingAndInquiry\r\nWorkspace_SalesReturnProcessing\r\nWorkspace_SystemAdmin\r\nWorkspace_TimeEntry\r\nWorkspace_VendorInvoiceEntry\r\nWorkspace_VendorPayments\r\nWorkspace_VendorPortalPurchaseOrderConfirmation\r\nWorkspace_WorkforceManagement\r\nYammerLogo\r\nYellowExclamationPoint\r\nYellowSquare\r\nYellowTriangle\r\nZoom\r\nZoomIn\r\nZoomOut"
+  },
+  {
+   "Name": "PopupMenuDeprecatedDescription",
+   "Canonical": false,
+   "Message": "The PopupMenu API has been deprecated.  Please use the ContextMenu APIs instead."
+  },
+  {
+   "Name": "PopupMenuDeprecatedOverrideDescription",
+   "Canonical": false,
+   "Message": "The context() and showContextMenu() overrides have been deprecated.  Please use getContextMenuOptions() and selectedMenuOption() instead."
+  },
+  {
+   "Name": "RenamedClassDetectorDescription",
+   "Canonical": false,
+   "Message": "Detect calls on deprecated classes that have been renamed."
+  },
+  {
+   "Name": "RenamedTableDetectorDescription",
+   "Canonical": false,
+   "Message": "Detect calls on deprecated tables that have been renamed."
+  },
+  {
+   "Name": "RenamedTableInMetadataDetectorDescription",
+   "Canonical": false,
+   "Message": "Detect data sources, table relations that point to a deprecated table."
+  },
+  {
+   "Name": "ReportDataMethodExpressionDetectorDescription",
+   "Canonical": false,
+   "Message": "[BP Report Data Method Expression] Replace deprecated data method expression in Report '{0}', Control '{1}', Property '{2}'."
+  },
+  {
+   "Name": "ResourceSymbolMapping",
+   "Canonical": false,
+   "Message": "10001,Standard,Text\r\n10001,,Text\r\n10001,Strip,Text\r\n10006,Standard,Text\r\n10006,,Text\r\n10006,Strip,Text\r\n10008,Standard,Text\r\n10008,,Text\r\n10008,Strip,Text\r\n10009,Strip,Add\r\n10009,,Add\r\n10009,Standard,New\r\n10010,Strip,Text\r\n10010,Standard,Text\r\n10010,,Text\r\n10011,Standard,Text\r\n10011,Strip,Edit\r\n10011,,Edit\r\n10012,Standard,Text\r\n10012,,Text\r\n10012,Strip,Text\r\n10013,Standard,Text\r\n10013,,Text\r\n10013,Strip,Text\r\n10014,Standard,Text\r\n10014,,Text\r\n10014,Strip,Text\r\n10015,Standard,Text\r\n10015,,Text\r\n10015,Strip,Text\r\n10016,Standard,Text\r\n10016,,Text\r\n10016,Strip,Text\r\n10017,Strip,Cancel\r\n10017,,Cancel\r\n10017,Standard,Text\r\n10018,Standard,Text\r\n10018,Strip,Text\r\n10018,,Text\r\n10019,Standard,Text\r\n10019,Strip,Text\r\n10019,,Text\r\n10022,Standard,Text\r\n10022,Strip,OK\r\n10022,,OK\r\n10025,Standard,Text\r\n10025,Strip,Text\r\n10025,,Text\r\n10026,Standard,Text\r\n10026,Strip,Text\r\n10026,,Text\r\n10029,Standard,Text\r\n10029,Strip,Text\r\n10029,,Text\r\n10032,Strip,Text\r\n10032,,Text\r\n10032,Standard,Text\r\n10034,Standard,Text\r\n10034,,Text\r\n10034,Strip,Text\r\n10038,Standard,Text\r\n10038,,Text\r\n10038,Strip,Text\r\n10039,Strip,Text\r\n10039,,Text\r\n10039,Standard,Text\r\n1004,Standard,Text\r\n1004,,Text\r\n1004,Strip,Text\r\n10040,Standard,Text\r\n10040,Strip,Edit\r\n10040,,Edit\r\n10041,Strip,Map\r\n10041,,Map\r\n10041,Standard,Text\r\n10042,Strip,Edit\r\n10042,Standard,Text\r\n10042,,Edit\r\n10045,Standard,Text\r\n10045,,Text\r\n10045,Strip,Text\r\n1005,,Find\r\n1005,Standard,Text\r\n1005,Strip,Find\r\n10052,Strip,Text\r\n10052,,Text\r\n10052,Standard,Text\r\n10054,Standard,Text\r\n10054,,Text\r\n10054,Strip,Text\r\n10056,Standard,Text\r\n10056,,Text\r\n10056,Strip,Text\r\n10059,Strip,Text\r\n10059,,Text\r\n10059,Standard,Text\r\n1006,Strip,Text\r\n1006,,Text\r\n1006,Standard,Text\r\n10064,Standard,Text\r\n10064,,Text\r\n10064,Strip,Text\r\n10065,Strip,Text\r\n10065,Standard,Text\r\n10065,,Text\r\n10066,Strip,Text\r\n10066,Standard,Text\r\n10066,,Text\r\n10068,Standard,Text\r\n10068,,Text\r\n10068,Strip,Text\r\n10069,Standard,Text\r\n10069,,Text\r\n10069,Strip,Text\r\n1007,Strip,Save\r\n1007,,Save\r\n1007,Standard,Text\r\n10072,,Text\r\n10072,Standard,Text\r\n10072,Strip,Text\r\n10075,Strip,Text\r\n10075,,Text\r\n10075,Standard,Text\r\n10078,Standard,Text\r\n10078,,Text\r\n10078,Strip,Text\r\n10080,Strip,Text\r\n10080,,Text\r\n10080,Standard,Text\r\n10081,Standard,Text\r\n10081,,Text\r\n10081,Strip,Text\r\n10083,Standard,Text\r\n10083,,Text\r\n10083,Strip,Text\r\n10089,Standard,Text\r\n10089,,Text\r\n10089,Strip,Text\r\n1009,,Next\r\n1009,Standard,Text\r\n1009,Strip,Next\r\n10090,Standard,Text\r\n10090,,Text\r\n10090,Strip,Text\r\n10091,Standard,Text\r\n10091,Strip,Text\r\n10091,,Text\r\n10092,Standard,Text\r\n10092,,Text\r\n10092,Strip,Text\r\n10093,Standard,Text\r\n10093,,Text\r\n10093,Strip,Text\r\n10094,Standard,Text\r\n10094,,Text\r\n10094,Strip,Text\r\n10095,Standard,Text\r\n10095,,Text\r\n10095,Strip,Text\r\n10096,Standard,Text\r\n10096,,Text\r\n10096,Strip,Text\r\n10097,Strip,Text\r\n10097,,Text\r\n10097,Standard,Text\r\n1010,,Text\r\n1010,Standard,Text\r\n1010,Strip,Text\r\n10101,Standard,Text\r\n10101,,Text\r\n10101,Strip,Text\r\n10103,Standard,Text\r\n10103,Strip,Text\r\n10103,,Text\r\n10106,Standard,Text\r\n10106,Strip,Text\r\n10106,,Text\r\n10117,Standard,Text\r\n10117,,Text\r\n10117,Strip,Text\r\n10119,Standard,Text\r\n10119,,Text\r\n10119,Strip,Text\r\n10121,Standard,Text\r\n10121,Strip,Delete\r\n10121,,Delete\r\n10125,Standard,Text\r\n10125,,Text\r\n10125,Strip,Text\r\n1013,,Last\r\n1013,Standard,Text\r\n1013,Strip,Last\r\n10134,Standard,Text\r\n10134,,Text\r\n10134,Strip,Text\r\n1014,,First\r\n1014,Standard,Text\r\n1014,Strip,First\r\n10156,Standard,Text\r\n10156,Strip,Text\r\n10156,,Text\r\n1017,Strip,Document\r\n1017,,Document\r\n1017,Standard,Text\r\n10173,Standard,Text\r\n10173,Strip,Text\r\n10173,,Text\r\n10197,Standard,Text\r\n10197,,Text\r\n10197,Strip,Text\r\n1020,Standard,Delete\r\n1020,Strip,Delete\r\n1020,,Delete\r\n1023,,Copy\r\n1023,Strip,Copy\r\n1023,Standard,Text\r\n1024,,Text\r\n1024,Strip,Text\r\n1024,Standard,Text\r\n10245,Standard,Text\r\n10245,,Text\r\n10245,Strip,Text\r\n10275,Standard,Text\r\n10275,,Text\r\n10275,Strip,Text\r\n10285,Strip,Text\r\n10285,Standard,Text\r\n10285,,Text\r\n10286,Standard,Text\r\n10286,Strip,Text\r\n10286,,Text\r\n10298,Standard,Text\r\n10298,Strip,Text\r\n10298,,Text\r\n1030,Standard,Text\r\n1030,Strip,Text\r\n1030,,Text\r\n1031,Standard,Text\r\n1031,Strip,Text\r\n1031,,Text\r\n10314,Standard,Text\r\n10314,,Text\r\n10314,Strip,Text\r\n10325,Standard,Text\r\n10325,,Text\r\n10325,Strip,Text\r\n10345,Standard,Text\r\n10345,Strip,Text\r\n10345,,Text\r\n10353,Standard,Text\r\n10353,,Text\r\n10353,Strip,Text\r\n10358,Standard,Text\r\n10358,,Text\r\n10358,Strip,Text\r\n1036,Strip,Text\r\n1036,Standard,Text\r\n1036,,Text\r\n1040,Strip,Edit\r\n1040,,Edit\r\n1040,Standard,Text\r\n10406,Standard,Text\r\n10406,Strip,Cancel\r\n10406,,Cancel\r\n10414,Standard,Text\r\n10414,,Text\r\n10414,Strip,Text\r\n10416,Standard,Text\r\n10416,,Text\r\n10416,Strip,Text\r\n10418,Standard,Text\r\n10418,,Text\r\n10418,Strip,Text\r\n10423,Standard,Text\r\n10423,,Text\r\n10423,Strip,Text\r\n10424,Standard,Text\r\n10424,,Text\r\n10424,Strip,Text\r\n10428,Standard,Text\r\n10428,Strip,Text\r\n10428,,Text\r\n10430,Standard,Text\r\n10430,,Text\r\n10430,Strip,Text\r\n10431,Standard,Text\r\n10431,,Text\r\n10431,Strip,Text\r\n10432,Standard,Text\r\n10432,,Text\r\n10432,Strip,Text\r\n10433,Standard,Text\r\n10433,,Text\r\n10433,Strip,Text\r\n10434,Standard,Text\r\n10434,Strip,Text\r\n10434,,Text\r\n10436,Standard,Text\r\n10436,,Text\r\n10436,Strip,Text\r\n10438,Strip,Text\r\n10438,Standard,Text\r\n10438,,Text\r\n10439,Standard,Text\r\n10439,,Text\r\n10439,Strip,Text\r\n10440,Standard,Text\r\n10440,,Text\r\n10440,Strip,Text\r\n10442,Standard,Text\r\n10442,Strip,Attach\r\n10442,,Attach\r\n10446,Standard,Text\r\n10446,,Text\r\n10446,Strip,Text\r\n10448,Standard,Text\r\n10448,,Text\r\n10448,Strip,Text\r\n10450,Standard,Text\r\n10450,,Text\r\n10450,Strip,Text\r\n10451,Standard,Text\r\n10451,,Text\r\n10451,Strip,Text\r\n10456,Standard,Text\r\n10456,,Text\r\n10456,Strip,Text\r\n10458,Standard,Text\r\n10458,,Text\r\n10458,Strip,Text\r\n10464,Standard,Text\r\n10464,Strip,Text\r\n10464,,Text\r\n10465,Standard,Text\r\n10465,Strip,Text\r\n10465,,Text\r\n10467,Standard,Text\r\n10467,,Text\r\n10467,Strip,Text\r\n10468,Standard,Text\r\n10468,Strip,Text\r\n10468,,Text\r\n10470,Standard,Text\r\n10470,,Text\r\n10470,Strip,Text\r\n10474,Standard,Text\r\n10474,Strip,Text\r\n10474,,Text\r\n10477,Standard,Text\r\n10477,,Text\r\n10477,Strip,Text\r\n10482,Standard,Text\r\n10482,,Text\r\n10482,Strip,Text\r\n10483,Standard,Text\r\n10483,,Text\r\n10483,Strip,Text\r\n10490,Standard,Text\r\n10490,Strip,Text\r\n10490,,Text\r\n10495,Standard,Text\r\n10495,Strip,Text\r\n10495,,Text\r\n10498,Standard,Text\r\n10498,Strip,Text\r\n10498,,Text\r\n10502,Standard,Text\r\n10502,,Text\r\n10502,Strip,Text\r\n10507,Standard,Text\r\n10507,,Text\r\n10507,Strip,Text\r\n10509,Standard,Text\r\n10509,Strip,Text\r\n10509,,Text\r\n10510,Strip,Text\r\n10510,Standard,Text\r\n10510,,Text\r\n10511,Standard,Text\r\n10511,,Text\r\n10511,Strip,Text\r\n10512,Standard,Text\r\n10512,,Text\r\n10512,Strip,Text\r\n10513,Standard,Text\r\n10513,,Text\r\n10513,Strip,Text\r\n10514,Standard,Text\r\n10514,,Text\r\n10514,Strip,Text\r\n10516,Standard,Text\r\n10516,,Text\r\n10516,Strip,Text\r\n10517,Standard,Text\r\n10517,,Text\r\n10517,Strip,Text\r\n10518,Standard,Text\r\n10518,Strip,Text\r\n10518,,Text\r\n10520,Standard,Text\r\n10520,,Text\r\n10520,Strip,Text\r\n10521,Standard,Text\r\n10521,,Text\r\n10521,Strip,Text\r\n10530,Standard,Text\r\n10530,,Text\r\n10530,Strip,Text\r\n10540,Standard,Text\r\n10540,,Text\r\n10540,Strip,Text\r\n10542,Standard,Text\r\n10542,Strip,Text\r\n10542,,Text\r\n10543,Standard,Text\r\n10543,,Text\r\n10543,Strip,Text\r\n10547,Standard,Text\r\n10547,,Text\r\n10547,Strip,Text\r\n10554,Standard,Text\r\n10554,Strip,Text\r\n10554,,Text\r\n10555,Standard,Text\r\n10555,,Text\r\n10555,Strip,Text\r\n10562,Standard,Text\r\n10562,Strip,Text\r\n10562,,Text\r\n10563,Standard,Text\r\n10563,,Text\r\n10563,Strip,Text\r\n10565,Standard,Text\r\n10565,,Text\r\n10565,Strip,Text\r\n10569,Standard,Text\r\n10569,Strip,Text\r\n10569,,Text\r\n10575,Standard,Text\r\n10575,Strip,Text\r\n10575,,Text\r\n10576,Standard,Text\r\n10576,,Text\r\n10576,Strip,Text\r\n10577,Standard,Text\r\n10577,,Text\r\n10577,Strip,Text\r\n10582,Standard,Text\r\n10582,,Text\r\n10582,Strip,Text\r\n10583,Standard,Text\r\n10583,,Text\r\n10583,Strip,Text\r\n10585,Standard,Text\r\n10585,,Text\r\n10585,Strip,Text\r\n10586,Standard,Text\r\n10586,Strip,Text\r\n10586,,Text\r\n10602,Standard,Text\r\n10602,,Text\r\n10602,Strip,Text\r\n10603,Standard,Text\r\n10603,,Text\r\n10603,Strip,Text\r\n10604,Standard,Text\r\n10604,,Text\r\n10604,Strip,Text\r\n10605,Standard,Text\r\n10605,Strip,Text\r\n10605,,Text\r\n10610,Standard,Text\r\n10610,Strip,Document\r\n10610,,Document\r\n10612,Standard,Text\r\n10612,,Text\r\n10612,Strip,Text\r\n10615,Standard,Text\r\n10615,,Text\r\n10615,Strip,Text\r\n10617,Standard,Text\r\n10617,,Text\r\n10617,Strip,Text\r\n10625,Standard,Text\r\n10625,Strip,Text\r\n10625,,Text\r\n10629,Standard,Text\r\n10629,,Text\r\n10629,Strip,Text\r\n1063,Standard,Text\r\n1063,,Text\r\n1063,Strip,Text\r\n10630,Standard,Text\r\n10630,Strip,Text\r\n10630,,Text\r\n10631,Standard,Text\r\n10631,,Text\r\n10631,Strip,Text\r\n10639,Standard,Text\r\n10639,,Text\r\n10639,Strip,Text\r\n1064,Standard,Text\r\n1064,,Text\r\n1064,Strip,Text\r\n10641,Strip,Text\r\n10641,,Text\r\n10641,Standard,Text\r\n10642,Standard,Text\r\n10642,Strip,Text\r\n10642,,Text\r\n10646,Standard,Text\r\n10646,,Text\r\n10646,Strip,Text\r\n10647,Standard,Text\r\n10647,,Text\r\n10647,Strip,Text\r\n10649,Strip,Text\r\n10649,Standard,Text\r\n10649,,Text\r\n1065,,Next\r\n1065,Standard,Text\r\n1065,Strip,Next\r\n10656,Standard,Text\r\n10656,Strip,Text\r\n10656,,Text\r\n10657,Standard,Text\r\n10657,,Text\r\n10657,Strip,Text\r\n10659,Standard,Text\r\n10659,Strip,Text\r\n10659,,Text\r\n1066,,Previous\r\n1066,Standard,Text\r\n1066,Strip,Previous\r\n10663,Standard,Text\r\n10663,,Text\r\n10663,Strip,Text\r\n10664,Standard,Text\r\n10664,,Text\r\n10664,Strip,Text\r\n10665,Standard,Text\r\n10665,,Text\r\n10665,Strip,Text\r\n10667,Standard,Text\r\n10667,,Text\r\n10667,Strip,Text\r\n10668,Standard,Text\r\n10668,,Text\r\n10668,Strip,Text\r\n1067,Strip,Up\r\n1067,Standard,Text\r\n1067,,Up\r\n10671,Standard,Text\r\n10671,Strip,Text\r\n10671,,Text\r\n10672,Standard,Text\r\n10672,,Text\r\n10672,Strip,Text\r\n10676,Standard,Text\r\n10676,Strip,Text\r\n10676,,Text\r\n1068,Strip,Down\r\n1068,Standard,Text\r\n1068,,Down\r\n10681,Standard,Text\r\n10681,,Text\r\n10681,Strip,Text\r\n10686,Standard,Text\r\n10686,,Text\r\n10686,Strip,Text\r\n10688,Standard,Text\r\n10688,,Text\r\n10688,Strip,Text\r\n10691,Standard,Text\r\n10691,,Text\r\n10691,Strip,Text\r\n10692,Standard,Text\r\n10692,Strip,Text\r\n10692,,Text\r\n10693,Standard,Text\r\n10693,Strip,Text\r\n10693,,Text\r\n10694,Strip,Text\r\n10694,Standard,Text\r\n10694,,Text\r\n10695,Standard,Text\r\n10695,Strip,Text\r\n10695,,Text\r\n10698,Standard,Text\r\n10698,,Text\r\n10698,Strip,Text\r\n10700,Standard,Text\r\n10700,Strip,Print\r\n10700,,Print\r\n10701,Standard,Text\r\n10701,Strip,Text\r\n10701,,Text\r\n10702,Standard,Text\r\n10702,,Text\r\n10702,Strip,Text\r\n10703,Standard,Text\r\n10703,,Text\r\n10703,Strip,Text\r\n10704,Standard,Text\r\n10704,,Text\r\n10704,Strip,Text\r\n10705,Standard,Text\r\n10705,,Text\r\n10705,Strip,Text\r\n10709,Strip,Text\r\n10709,,Text\r\n10709,Standard,Text\r\n10710,Standard,Text\r\n10710,,Text\r\n10710,Strip,Text\r\n10712,Standard,Text\r\n10712,Strip,Calendar\r\n10712,,Calendar\r\n10715,Standard,Text\r\n10715,Strip,Text\r\n10715,,Text\r\n10716,Standard,Text\r\n10716,,Text\r\n10716,Strip,Text\r\n10719,Standard,Text\r\n10719,Strip,Text\r\n10719,,Text\r\n10720,Standard,Text\r\n10720,,Text\r\n10720,Strip,Text\r\n10724,Standard,Text\r\n10724,,Text\r\n10724,Strip,Text\r\n10726,Strip,Text\r\n10726,Standard,Text\r\n10726,,Text\r\n10728,Standard,Text\r\n10728,,Text\r\n10728,Strip,Text\r\n10730,Strip,Text\r\n10730,,Text\r\n10730,Standard,Text\r\n10731,Standard,Text\r\n10731,,Text\r\n10731,Strip,Text\r\n10738,Standard,Text\r\n10738,,Text\r\n10738,Strip,Text\r\n10741,Standard,Text\r\n10741,Strip,Text\r\n10741,,Text\r\n10747,Standard,Text\r\n10747,,Text\r\n10747,Strip,Text\r\n10752,Standard,Text\r\n10752,,Text\r\n10752,Strip,Text\r\n10754,Standard,Text\r\n10754,,Text\r\n10754,Strip,Text\r\n10758,Standard,Text\r\n10758,,Text\r\n10758,Strip,Text\r\n10759,Standard,Text\r\n10759,Strip,Text\r\n10759,,Text\r\n10760,Standard,Text\r\n10760,Strip,Text\r\n10760,,Text\r\n10761,Standard,Text\r\n10761,Strip,Text\r\n10761,,Text\r\n10767,Standard,Text\r\n10767,Strip,Text\r\n10767,,Text\r\n10768,Standard,Text\r\n10768,Strip,Text\r\n10768,,Text\r\n10769,Standard,Text\r\n10769,,Text\r\n10769,Strip,Text\r\n10775,Standard,Text\r\n10775,,Text\r\n10775,Strip,Text\r\n10776,Standard,Text\r\n10776,,Text\r\n10776,Strip,Text\r\n10777,Standard,Text\r\n10777,Strip,Text\r\n10777,,Text\r\n10778,Standard,Text\r\n10778,,Text\r\n10778,Strip,Text\r\n1078,Strip,Text\r\n1078,,Text\r\n1078,Standard,Text\r\n10783,Standard,Text\r\n10783,,Text\r\n10783,Strip,Text\r\n10785,Standard,Text\r\n10785,,Text\r\n10785,Strip,Text\r\n10788,Standard,Text\r\n10788,Strip,Text\r\n10788,,Text\r\n10793,Standard,Text\r\n10793,,Text\r\n10793,Strip,Text\r\n10795,Standard,Text\r\n10795,,Text\r\n10795,Strip,Text\r\n10803,Strip,Text\r\n10803,,Text\r\n10803,Standard,Text\r\n10805,Standard,Text\r\n10805,Strip,Text\r\n10805,,Text\r\n10807,Standard,Text\r\n10807,,Text\r\n10807,Strip,Text\r\n10809,Standard,Text\r\n10809,,Text\r\n10809,Strip,Text\r\n10810,Standard,Text\r\n10810,,Text\r\n10810,Strip,Text\r\n10811,Standard,Text\r\n10811,,Text\r\n10811,Strip,Text\r\n10812,Standard,Text\r\n10812,,Text\r\n10812,Strip,Text\r\n10815,Standard,Text\r\n10815,,Text\r\n10815,Strip,Text\r\n10816,Standard,Text\r\n10816,,Text\r\n10816,Strip,Text\r\n10818,Standard,Text\r\n10818,,Text\r\n10818,Strip,Text\r\n10821,Standard,Text\r\n10821,,Text\r\n10821,Strip,Text\r\n10822,Standard,Text\r\n10822,Strip,Text\r\n10822,,Text\r\n10824,Standard,Text\r\n10824,Strip,Text\r\n10824,,Text\r\n10825,Standard,Text\r\n10825,,Text\r\n10825,Strip,Text\r\n10828,Standard,Text\r\n10828,Strip,Text\r\n10828,,Text\r\n10829,Standard,Text\r\n10829,,Text\r\n10829,Strip,Text\r\n1083,,Print\r\n1083,Strip,Print\r\n1083,Standard,Text\r\n10830,Standard,Text\r\n10830,,Text\r\n10830,Strip,Text\r\n10831,Standard,Text\r\n10831,,Text\r\n10831,Strip,Text\r\n10832,Standard,Text\r\n10832,Strip,Total\r\n10832,,Total\r\n10835,Standard,Text\r\n10835,Strip,Text\r\n10835,,Text\r\n10836,Standard,Text\r\n10836,,Text\r\n10836,Strip,Text\r\n10837,Standard,Text\r\n10837,,Text\r\n10837,Strip,Text\r\n10838,Standard,Text\r\n10838,,Text\r\n10838,Strip,Text\r\n10839,Standard,Text\r\n10839,Strip,Text\r\n10839,,Text\r\n1084,Standard,Text\r\n1084,,Text\r\n1084,Strip,Text\r\n10841,Strip,Text\r\n10841,Standard,Text\r\n10841,,Text\r\n10842,Standard,Text\r\n10842,Strip,Text\r\n10842,,Text\r\n10843,Standard,Text\r\n10843,,Text\r\n10843,Strip,Text\r\n10845,Standard,Text\r\n10845,,Text\r\n10845,Strip,Text\r\n10847,Standard,Text\r\n10847,Strip,Text\r\n10847,,Text\r\n10848,Standard,Text\r\n10848,,Text\r\n10848,Strip,Text\r\n1085,,Document\r\n1085,Standard,Text\r\n1085,Strip,Document\r\n10850,Standard,Text\r\n10850,Strip,Text\r\n10850,,Text\r\n10858,Strip,Text\r\n10858,,Text\r\n10858,Standard,Text\r\n10859,Standard,Text\r\n10859,,Text\r\n10859,Strip,Text\r\n1086,,Open\r\n1086,Standard,Text\r\n1086,Strip,Open\r\n10861,Standard,Text\r\n10861,,Text\r\n10861,Strip,Text\r\n10862,Strip,Text\r\n10862,,Text\r\n10862,Standard,Text\r\n10865,Standard,Text\r\n10865,Strip,Text\r\n10865,,Text\r\n10866,Standard,New\r\n10866,Strip,New\r\n10866,,New\r\n10867,Standard,Text\r\n10867,,Text\r\n10867,Strip,Text\r\n10870,Strip,Text\r\n10870,Standard,Text\r\n10870,,Text\r\n10871,Standard,Text\r\n10871,Strip,Text\r\n10871,,Text\r\n10872,Standard,Text\r\n10872,,Text\r\n10872,Strip,Text\r\n10874,Standard,Text\r\n10874,,Text\r\n10874,Strip,Text\r\n10875,Standard,Text\r\n10875,,Text\r\n10875,Strip,Text\r\n10879,Standard,New\r\n10879,Strip,New\r\n10879,,New\r\n10880,Standard,Text\r\n10880,,Text\r\n10880,Strip,Text\r\n10881,Standard,New\r\n10881,Strip,New\r\n10881,,New\r\n10882,Standard,Text\r\n10882,,Text\r\n10882,Strip,Text\r\n10884,Standard,Text\r\n10884,,Text\r\n10884,Strip,Text\r\n1089,,Cancel\r\n1089,Standard,Text\r\n1089,Strip,Cancel\r\n10890,Standard,Text\r\n10890,,Text\r\n10890,Strip,Text\r\n10891,Standard,New\r\n10891,Strip,New\r\n10891,,New\r\n10895,Standard,Text\r\n10895,,Text\r\n10895,Strip,Text\r\n10896,Standard,Text\r\n10896,,Text\r\n10896,Strip,Text\r\n10897,Standard,Text\r\n10897,,Text\r\n10897,Strip,Text\r\n10898,Standard,Text\r\n10898,,Text\r\n10898,Strip,Text\r\n10899,Standard,Text\r\n10899,,Text\r\n10899,Strip,Text\r\n10900,Standard,Text\r\n10900,,Text\r\n10900,Strip,Text\r\n10901,Standard,Text\r\n10901,,Text\r\n10901,Strip,Text\r\n10902,Standard,Text\r\n10902,,Text\r\n10902,Strip,Text\r\n10906,Standard,Text\r\n10906,Strip,Text\r\n10906,,Text\r\n1091,Standard,Text\r\n1091,,Text\r\n1091,Strip,Text\r\n10913,Standard,Text\r\n10913,,Text\r\n10913,Strip,Text\r\n10915,Standard,Text\r\n10915,,Text\r\n10915,Strip,Text\r\n10926,Standard,Text\r\n10926,Strip,Text\r\n10926,,Text\r\n10932,Strip,Text\r\n10932,Standard,Text\r\n10932,,Text\r\n10937,Standard,Text\r\n10937,,Text\r\n10937,Strip,Text\r\n1094,,Text\r\n1094,Strip,Text\r\n1094,Standard,Text\r\n10941,Standard,Text\r\n10941,,Text\r\n10941,Strip,Text\r\n10956,Standard,Text\r\n10956,,Text\r\n10956,Strip,Text\r\n10957,Standard,Text\r\n10957,,Text\r\n10957,Strip,Text\r\n1096,,Text\r\n1096,Standard,Text\r\n1096,Strip,Text\r\n10989,Standard,Text\r\n10989,,Text\r\n10989,Strip,Text\r\n1099,Standard,Text\r\n1099,,Text\r\n1099,Strip,Text\r\n10992,Standard,Text\r\n10992,Strip,Text\r\n10992,,Text\r\n10995,Standard,Text\r\n10995,Strip,Text\r\n10995,,Text\r\n10998,Standard,Text\r\n10998,,Text\r\n10998,Strip,Text\r\n11002,Standard,Text\r\n11002,Strip,Find\r\n11002,,Find\r\n11004,Standard,Text\r\n11004,,Text\r\n11004,Strip,Text\r\n11016,Standard,Text\r\n11016,Strip,Text\r\n11016,,Text\r\n11019,Standard,Text\r\n11019,,Text\r\n11019,Strip,Text\r\n11030,Standard,Text\r\n11030,,Text\r\n11030,Strip,Text\r\n11032,Standard,Text\r\n11032,,Text\r\n11032,Strip,Text\r\n11038,Standard,Text\r\n11038,Strip,Text\r\n11038,,Text\r\n11039,Standard,Text\r\n11039,,Text\r\n11039,Strip,Text\r\n11044,Standard,Text\r\n11044,Strip,Text\r\n11044,,Text\r\n11045,Standard,New\r\n11045,Strip,New\r\n11045,,New\r\n11046,Strip,Text\r\n11046,Standard,Text\r\n11046,,Text\r\n11047,Standard,Text\r\n11047,Strip,Text\r\n11047,,Text\r\n11050,Strip,Text\r\n11050,Standard,Text\r\n11050,,Text\r\n11054,Standard,Text\r\n11054,,Text\r\n11054,Strip,Text\r\n11055,Standard,Text\r\n11055,,Text\r\n11055,Strip,Text\r\n11057,Standard,Text\r\n11057,,Text\r\n11057,Strip,Text\r\n11066,Standard,Text\r\n11066,,Text\r\n11066,Strip,Text\r\n11071,Standard,Text\r\n11071,,Text\r\n11071,Strip,Text\r\n11076,Strip,Text\r\n11076,Standard,Text\r\n11076,,Text\r\n11083,Standard,Text\r\n11083,Strip,Text\r\n11083,,Text\r\n11084,Standard,Text\r\n11084,Strip,Text\r\n11084,,Text\r\n11090,Standard,Text\r\n11090,Strip,HighPriority\r\n11090,,HighPriority\r\n11095,Standard,Text\r\n11095,,Text\r\n11095,Strip,Text\r\n11096,Standard,Text\r\n11096,,Text\r\n11096,Strip,Text\r\n11098,Standard,Text\r\n11098,Strip,Refresh\r\n11098,,Refresh\r\n11112,Standard,Text\r\n11112,,Text\r\n11112,Strip,Text\r\n11113,Standard,Text\r\n11113,,Text\r\n11113,Strip,Text\r\n11114,Standard,Text\r\n11114,Strip,Text\r\n11114,,Text\r\n11121,Standard,Text\r\n11121,Strip,Text\r\n11121,,Text\r\n11125,Standard,Text\r\n11125,,Text\r\n11125,Strip,Text\r\n11128,Strip,Text\r\n11128,Standard,Text\r\n11128,,Text\r\n11130,Standard,Text\r\n11130,,Text\r\n11130,Strip,Text\r\n11132,Standard,Text\r\n11132,,Text\r\n11132,Strip,Text\r\n11133,Standard,Text\r\n11133,Strip,Text\r\n11133,,Text\r\n11134,Standard,Text\r\n11134,Strip,Text\r\n11134,,Text\r\n11136,Standard,Text\r\n11136,,Text\r\n11136,Strip,Text\r\n11137,Standard,Text\r\n11137,,Text\r\n11137,Strip,Text\r\n11141,Standard,Text\r\n11141,,Text\r\n11141,Strip,Text\r\n11142,Standard,Text\r\n11142,Strip,Cancel\r\n11142,,Cancel\r\n11153,Strip,Upload\r\n11153,Standard,Text\r\n11153,,Upload\r\n11156,Standard,Text\r\n11156,,Text\r\n11156,Strip,Text\r\n11164,Strip,Text\r\n11164,Standard,Text\r\n11164,,Text\r\n11165,Standard,Text\r\n11165,,Text\r\n11165,Strip,Text\r\n11166,Standard,Text\r\n11166,,Text\r\n11166,Strip,Text\r\n11167,Standard,Text\r\n11167,,Text\r\n11167,Strip,Text\r\n11182,Strip,New\r\n11182,Standard,New\r\n11182,,New\r\n11208,Standard,Text\r\n11208,Strip,Text\r\n11208,,Text\r\n11210,Standard,Text\r\n11210,,Text\r\n11210,Strip,Text\r\n11217,Standard,Text\r\n11217,,Text\r\n11217,Strip,Text\r\n11229,Standard,Text\r\n11229,,Text\r\n11229,Strip,Text\r\n11232,Standard,Text\r\n11232,,Text\r\n11232,Strip,Text\r\n11233,Standard,Text\r\n11233,,Text\r\n11233,Strip,Text\r\n11243,Standard,Text\r\n11243,,Text\r\n11243,Strip,Text\r\n11253,Strip,Text\r\n11253,,Text\r\n11253,Standard,Text\r\n11260,Standard,Text\r\n11260,,Text\r\n11260,Strip,Text\r\n11261,Standard,Text\r\n11261,,Text\r\n11261,Strip,Text\r\n11263,Standard,Text\r\n11263,,Text\r\n11263,Strip,Text\r\n11264,Standard,Text\r\n11264,,Text\r\n11264,Strip,Text\r\n11265,Strip,Text\r\n11265,Standard,Text\r\n11265,,Text\r\n11268,Standard,Text\r\n11268,,Text\r\n11268,Strip,Text\r\n11276,Standard,Text\r\n11276,,Text\r\n11276,Strip,Text\r\n11277,Standard,Text\r\n11277,,Text\r\n11277,Strip,Text\r\n11278,Standard,Text\r\n11278,,Text\r\n11278,Strip,Text\r\n11279,Standard,Text\r\n11279,,Text\r\n11279,Strip,Text\r\n11280,Standard,Text\r\n11280,,Text\r\n11280,Strip,Text\r\n11281,Standard,Text\r\n11281,,Text\r\n11281,Strip,Text\r\n11282,Standard,Text\r\n11282,,Text\r\n11282,Strip,Text\r\n11287,Strip,Text\r\n11287,Standard,Text\r\n11287,,Text\r\n11288,Standard,Text\r\n11288,,Text\r\n11288,Strip,Text\r\n11290,Standard,Text\r\n11290,,Text\r\n11290,Strip,Text\r\n11292,Standard,Text\r\n11292,Strip,Text\r\n11292,,Text\r\n11293,Standard,Text\r\n11293,Strip,Text\r\n11293,,Text\r\n11294,Standard,Text\r\n11294,Strip,Text\r\n11294,,Text\r\n11295,Standard,Text\r\n11295,,Text\r\n11295,Strip,Text\r\n11296,Standard,Text\r\n11296,,Text\r\n11296,Strip,Text\r\n11297,Standard,Text\r\n11297,,Text\r\n11297,Strip,Text\r\n11298,Standard,Text\r\n11298,,Text\r\n11298,Strip,Text\r\n11300,Strip,Edit\r\n11300,Standard,Text\r\n11300,,Edit\r\n11307,Standard,Text\r\n11307,,Text\r\n11307,Strip,Text\r\n11312,Standard,Text\r\n11312,,Text\r\n11312,Strip,Text\r\n11314,Standard,Text\r\n11314,,Text\r\n11314,Strip,Text\r\n11316,Standard,Text\r\n11316,,Text\r\n11316,Strip,Text\r\n11321,Standard,Text\r\n11321,Strip,Text\r\n11321,,Text\r\n11322,Standard,Text\r\n11322,,Text\r\n11322,Strip,Text\r\n11323,Standard,Text\r\n11323,Strip,Text\r\n11323,,Text\r\n11324,Strip,Text\r\n11324,,Text\r\n11324,Standard,Text\r\n11325,Strip,Text\r\n11325,,Text\r\n11325,Standard,Text\r\n11328,Strip,Text\r\n11328,Standard,Text\r\n11328,,Text\r\n11329,Strip,Text\r\n11329,Standard,Text\r\n11329,,Text\r\n11338,Standard,Text\r\n11338,Strip,Text\r\n11338,,Text\r\n11339,Standard,Text\r\n11339,,Text\r\n11339,Strip,Text\r\n11340,Standard,Text\r\n11340,Strip,Accept\r\n11340,,Accept\r\n11342,Strip,Text\r\n11342,Standard,Text\r\n11342,,Text\r\n11343,Standard,Text\r\n11343,,Text\r\n11343,Strip,Text\r\n11344,Standard,Text\r\n11344,,Text\r\n11344,Strip,Text\r\n11345,Standard,Text\r\n11345,Strip,Calculate\r\n11345,,Calculate\r\n11349,Standard,Text\r\n11349,Strip,Up\r\n11349,,Up\r\n11350,Standard,Text\r\n11350,Strip,Down\r\n11350,,Down\r\n11353,Strip,Text\r\n11353,Standard,Text\r\n11353,,Text\r\n11355,Standard,Text\r\n11355,Strip,Text\r\n11355,,Text\r\n11359,Standard,Text\r\n11359,,Text\r\n11359,Strip,Text\r\n11360,Standard,Text\r\n11360,Strip,Text\r\n11360,,Text\r\n11362,Strip,Text\r\n11362,Standard,Text\r\n11362,,Text\r\n11363,Standard,Text\r\n11363,Strip,Text\r\n11363,,Text\r\n11364,Standard,Text\r\n11364,Strip,Text\r\n11364,,Text\r\n11366,Standard,Text\r\n11366,Strip,Text\r\n11366,,Text\r\n11370,Standard,Text\r\n11370,,Text\r\n11370,Strip,Text\r\n11373,Strip,Text\r\n11373,,Text\r\n11373,Standard,Text\r\n11374,Standard,Text\r\n11374,,Text\r\n11374,Strip,Text\r\n11376,Standard,Text\r\n11376,,Text\r\n11376,Strip,Text\r\n11378,Strip,Text\r\n11378,,Text\r\n11378,Standard,Text\r\n11379,Strip,Text\r\n11379,,Text\r\n11379,Standard,Text\r\n11386,Strip,Text\r\n11386,,Text\r\n11386,Standard,Text\r\n11389,Standard,Text\r\n11389,,Text\r\n11389,Strip,Text\r\n11390,Standard,Text\r\n11390,,Text\r\n11390,Strip,Text\r\n11391,Standard,Text\r\n11391,,Text\r\n11391,Strip,Text\r\n11393,Standard,Text\r\n11393,,Text\r\n11393,Strip,Text\r\n11394,Standard,Text\r\n11394,,Text\r\n11394,Strip,Text\r\n11396,Standard,Text\r\n11396,,Text\r\n11396,Strip,Text\r\n11397,Standard,Text\r\n11397,,Text\r\n11397,Strip,Text\r\n11398,Standard,Text\r\n11398,Strip,Text\r\n11398,,Text\r\n11399,Standard,Text\r\n11399,,Text\r\n11399,Strip,Text\r\n11400,Strip,Delete\r\n11400,Standard,Delete\r\n11400,,Delete\r\n11403,Standard,Text\r\n11403,,Text\r\n11403,Strip,Text\r\n11418,Standard,Text\r\n11418,,Text\r\n11418,Strip,Text\r\n11419,Standard,Text\r\n11419,,Text\r\n11419,Strip,Text\r\n11420,Strip,Play\r\n11420,Standard,Text\r\n11420,,Play\r\n11421,Strip,New\r\n11421,Standard,New\r\n11421,,New\r\n11430,Strip,Text\r\n11430,Standard,Text\r\n11430,,Text\r\n11431,Strip,Text\r\n11431,Standard,Text\r\n11431,,Text\r\n11436,Strip,Find\r\n11436,,Find\r\n11436,Standard,Text\r\n11437,,Text\r\n11437,Strip,Text\r\n11437,Standard,Text\r\n11438,Strip,Delete\r\n11438,Standard,Delete\r\n11438,,Delete\r\n11439,Strip,Text\r\n11439,Standard,Text\r\n11439,,Text\r\n11440,Standard,Text\r\n11440,,Text\r\n11440,Strip,Text\r\n12003,Strip,Text\r\n12003,,Text\r\n12003,Standard,Text\r\n12005,Standard,Text\r\n12005,,Text\r\n12005,Strip,Text\r\n12009,Standard,Text\r\n12009,,Text\r\n12009,Strip,Text\r\n12017,Standard,Text\r\n12017,Strip,Text\r\n12017,,Text\r\n12020,Standard,Text\r\n12020,,Text\r\n12020,Strip,Text\r\n12021,Standard,Text\r\n12021,Strip,Text\r\n12021,,Text\r\n12026,Standard,Text\r\n12026,,Text\r\n12026,Strip,Text\r\n12027,Standard,Text\r\n12027,,Text\r\n12027,Strip,Text\r\n12039,Standard,Text\r\n12039,,Text\r\n12039,Strip,Text\r\n12040,Standard,Text\r\n12040,Strip,Text\r\n12040,,Text\r\n12052,Standard,Text\r\n12052,,Text\r\n12052,Strip,Text\r\n12057,Strip,Accept\r\n12057,Standard,Text\r\n12057,,Accept\r\n12059,Strip,Cancel\r\n12059,Standard,Text\r\n12059,,Cancel\r\n12060,Standard,Text\r\n12060,Strip,Text\r\n12060,,Text\r\n12064,Strip,Text\r\n12064,Standard,Text\r\n12064,,Text\r\n12078,Strip,Text\r\n12078,,Text\r\n12078,Standard,Text\r\n12081,,Text\r\n12081,Standard,Text\r\n12081,Strip,Text\r\n12083,,Text\r\n12083,Standard,Text\r\n12083,Strip,Text\r\n12099,Standard,Text\r\n12099,Strip,Refresh\r\n12099,,Refresh\r\n12115,Standard,Text\r\n12115,,Text\r\n12115,Strip,Text\r\n12122,Standard,Text\r\n12122,,Text\r\n12122,Strip,Text\r\n12124,,Text\r\n12124,Standard,Text\r\n12124,Strip,Text\r\n12130,Standard,Text\r\n12130,,Text\r\n12130,Strip,Text\r\n12133,Standard,Text\r\n12133,,Text\r\n12133,Strip,Text\r\n12134,Standard,Text\r\n12134,,Text\r\n12134,Strip,Text\r\n12137,Strip,Text\r\n12137,,Text\r\n12137,Standard,Text\r\n12139,Standard,Text\r\n12139,,Text\r\n12139,Strip,Text\r\n12140,Standard,Text\r\n12140,,Text\r\n12140,Strip,Text\r\n12141,Standard,Text\r\n12141,,Text\r\n12141,Strip,Text\r\n12143,Standard,Text\r\n12143,,Text\r\n12143,Strip,Text\r\n12145,Standard,Text\r\n12145,Strip,Text\r\n12145,,Text\r\n12146,Standard,Text\r\n12146,Strip,Text\r\n12146,,Text\r\n12148,Standard,Text\r\n12148,Strip,Text\r\n12148,,Text\r\n12149,Standard,Text\r\n12149,,Text\r\n12149,Strip,Text\r\n12155,Standard,Text\r\n12155,Strip,Text\r\n12155,,Text\r\n12156,Standard,Text\r\n12156,Strip,Text\r\n12156,,Text\r\n12158,Standard,Text\r\n12158,Strip,Text\r\n12158,,Text\r\n12159,Standard,Text\r\n12159,Strip,Text\r\n12159,,Text\r\n12160,Standard,Text\r\n12160,Strip,Text\r\n12160,,Text\r\n12161,Standard,Text\r\n12161,Strip,Text\r\n12161,,Text\r\n12163,Standard,Text\r\n12163,Strip,Text\r\n12163,,Text\r\n12164,Standard,Text\r\n12164,Strip,Text\r\n12164,,Text\r\n12165,Standard,Text\r\n12165,,Text\r\n12165,Strip,Text\r\n12167,Strip,Calendar\r\n12167,,Calendar\r\n12167,Standard,Text\r\n12171,Standard,Text\r\n12171,Strip,Text\r\n12171,,Text\r\n12179,Standard,Text\r\n12179,Strip,Text\r\n12179,,Text\r\n12182,Standard,Text\r\n12182,Strip,Text\r\n12182,,Text\r\n12185,Standard,Text\r\n12185,Strip,Text\r\n12185,,Text\r\n12186,Strip,Text\r\n12186,,Text\r\n12186,Standard,Text\r\n12187,Standard,Text\r\n12187,Strip,Text\r\n12187,,Text\r\n12188,Standard,Text\r\n12188,Strip,Text\r\n12188,,Text\r\n12189,Standard,Text\r\n12189,,Text\r\n12189,Strip,Text\r\n12191,Standard,Text\r\n12191,,Text\r\n12191,Strip,Text\r\n12192,Standard,Text\r\n12192,Strip,Text\r\n12192,,Text\r\n12193,Strip,Text\r\n12193,,Text\r\n12193,Standard,Text\r\n12194,Standard,Text\r\n12194,,Text\r\n12194,Strip,Text\r\n12195,Strip,Text\r\n12195,,Text\r\n12195,Standard,Text\r\n12196,Strip,Find\r\n12196,Standard,Text\r\n12196,,Find\r\n12198,Standard,Text\r\n12198,,Text\r\n12198,Strip,Text\r\n12199,Standard,Text\r\n12199,Strip,Text\r\n12199,,Text\r\n12201,Strip,Text\r\n12201,Standard,Text\r\n12201,,Text\r\n12206,Standard,Text\r\n12206,Strip,Text\r\n12206,,Text\r\n12207,Strip,Text\r\n12207,,Text\r\n12207,,Text\r\n12207,Standard,Text\r\n12212,Standard,Text\r\n12212,,Text\r\n12212,Strip,Text\r\n12214,Standard,Text\r\n12214,Strip,Text\r\n12214,,Text\r\n12218,Standard,Text\r\n12218,Strip,Text\r\n12218,,Text\r\n12219,Standard,Text\r\n12219,,Text\r\n12219,Strip,Text\r\n12221,Standard,Text\r\n12221,Strip,Text\r\n12221,,Text\r\n12222,Strip,Text\r\n12222,,Text\r\n12222,Standard,Text\r\n12226,Standard,Text\r\n12226,,Text\r\n12226,Strip,Text\r\n12228,Standard,Text\r\n12228,,Text\r\n12228,Strip,Text\r\n12229,Standard,Text\r\n12229,Strip,Text\r\n12229,,Text\r\n12233,Standard,Text\r\n12233,,Text\r\n12233,Strip,Text\r\n12237,Strip,Distribute\r\n12237,,Distribute\r\n12237,Standard,Text\r\n12238,Strip,Text\r\n12238,,Text\r\n12238,Standard,Text\r\n12241,Strip,Text\r\n12241,Standard,Text\r\n12241,,Text\r\n12243,Standard,Text\r\n12243,Strip,Text\r\n12243,,Text\r\n12244,Standard,Text\r\n12244,,Text\r\n12244,Strip,Text\r\n12246,Standard,Text\r\n12246,,Text\r\n12246,Strip,Text\r\n12259,Standard,Text\r\n12259,Strip,Text\r\n12259,,Text\r\n12260,Standard,Text\r\n12260,,Text\r\n12260,Strip,Text\r\n12269,Standard,Text\r\n12269,Strip,Text\r\n12269,,Text\r\n12270,Standard,Text\r\n12270,Strip,Text\r\n12270,,Text\r\n12275,Standard,Text\r\n12275,,Text\r\n12275,Strip,Text\r\n12276,Standard,Text\r\n12276,Strip,Text\r\n12276,,Text\r\n12278,Strip,Text\r\n12278,,Text\r\n12278,Standard,Text\r\n12280,Standard,Text\r\n12280,Strip,Text\r\n12280,,Text\r\n12283,Standard,Text\r\n12283,Strip,Text\r\n12283,,Text\r\n12295,Standard,Text\r\n12295,,Text\r\n12295,Strip,Text\r\n12297,Standard,Text\r\n12297,Strip,Text\r\n12297,,Text\r\n12303,Standard,Text\r\n12303,,Text\r\n12303,Strip,Text\r\n12310,Standard,Text\r\n12310,Strip,Text\r\n12310,,Text\r\n12312,Standard,Text\r\n12312,Strip,Text\r\n12312,,Text\r\n12313,Standard,Text\r\n12313,Strip,Text\r\n12313,,Text\r\n12317,Standard,Text\r\n12317,,Text\r\n12317,Strip,Text\r\n12318,Standard,Text\r\n12318,Strip,Text\r\n12318,,Text\r\n12322,Standard,Text\r\n12322,,Text\r\n12322,Strip,Text\r\n12334,Standard,Text\r\n12334,,Text\r\n12334,Strip,Text\r\n12337,Standard,Text\r\n12337,Strip,Text\r\n12337,,Text\r\n12340,Standard,Text\r\n12340,Strip,Text\r\n12340,,Text\r\n12342,Strip,Delete\r\n12342,,Delete\r\n12342,Standard,Delete\r\n12344,Standard,Text\r\n12344,,Text\r\n12344,Strip,Text\r\n12345,Standard,Text\r\n12345,Strip,Text\r\n12345,,Text\r\n12351,Standard,Text\r\n12351,Strip,Text\r\n12351,,Text\r\n12354,Standard,Text\r\n12354,,Text\r\n12354,Strip,Text\r\n12356,Standard,Text\r\n12356,Strip,Text\r\n12356,,Text\r\n12357,Standard,Text\r\n12357,,Text\r\n12357,Strip,Text\r\n12358,Standard,Text\r\n12358,,Text\r\n12358,Strip,Text\r\n12361,Standard,Text\r\n12361,Strip,Text\r\n12361,,Text\r\n12363,Standard,Text\r\n12363,Strip,Text\r\n12363,,Text\r\n12368,Standard,Text\r\n12368,Strip,Text\r\n12368,,Text\r\n12371,Standard,Text\r\n12371,,Text\r\n12371,Strip,Text\r\n12373,Standard,Text\r\n12373,,Text\r\n12373,Strip,Text\r\n12374,Standard,Text\r\n12374,Strip,Text\r\n12374,,Text\r\n12378,Standard,Text\r\n12378,,Text\r\n12378,Strip,Text\r\n12380,Strip,Text\r\n12380,Standard,Text\r\n12380,,Text\r\n12382,Standard,Text\r\n12382,,Text\r\n12382,Strip,Text\r\n12383,Standard,Text\r\n12383,Strip,Text\r\n12383,,Text\r\n12384,Standard,Text\r\n12384,,Text\r\n12384,Strip,Text\r\n12385,Standard,Text\r\n12385,Strip,Text\r\n12385,,Text\r\n12386,Standard,Text\r\n12386,Strip,Text\r\n12386,,Text\r\n12399,Standard,Text\r\n12399,,Text\r\n12399,Strip,Text\r\n12400,Strip,Edit\r\n12400,,Edit\r\n12400,Standard,Text\r\n12403,Standard,Text\r\n12403,Strip,Text\r\n12403,,Text\r\n12404,Standard,Text\r\n12404,Strip,Text\r\n12404,,Text\r\n12409,,Text\r\n12409,Standard,Text\r\n12409,Strip,Text\r\n12410,,Text\r\n12410,Standard,Text\r\n12410,Strip,Text\r\n12412,Standard,Text\r\n12412,Strip,Text\r\n12412,,Text\r\n12413,Standard,Text\r\n12413,Strip,Text\r\n12413,,Text\r\n12414,Standard,Text\r\n12414,Strip,Text\r\n12414,,Text\r\n12415,Standard,Text\r\n12415,Strip,Text\r\n12415,,Text\r\n12417,Standard,Text\r\n12417,,Text\r\n12417,Strip,Text\r\n12418,Strip,Text\r\n12418,,Text\r\n12418,Standard,Text\r\n12420,Standard,New\r\n12420,Strip,New\r\n12420,,New\r\n12422,Strip,Text\r\n12422,Standard,Text\r\n12422,,Text\r\n12423,Standard,Text\r\n12423,Strip,Text\r\n12423,,Text\r\n12425,Standard,Text\r\n12425,Strip,Text\r\n12425,,Text\r\n12427,Standard,Text\r\n12427,Strip,Text\r\n12427,,Text\r\n12430,Standard,Text\r\n12430,,Text\r\n12430,Strip,Text\r\n12436,Standard,Text\r\n12436,,Text\r\n12436,Strip,Text\r\n12437,Standard,Text\r\n12437,,Text\r\n12437,Strip,Text\r\n12438,Standard,Text\r\n12438,Strip,Text\r\n12438,,Text\r\n12439,Standard,Text\r\n12439,,Text\r\n12439,Strip,Text\r\n12440,Strip,Text\r\n12440,,Text\r\n12440,Standard,Text\r\n12443,Standard,Text\r\n12443,Strip,Text\r\n12443,,Text\r\n12446,Standard,Text\r\n12446,,Text\r\n12446,Strip,Text\r\n12449,Strip,Text\r\n12449,,Text\r\n12449,Standard,Text\r\n12450,Standard,Text\r\n12450,,Text\r\n12450,Strip,Text\r\n12451,Strip,Text\r\n12451,Standard,Text\r\n12451,,Text\r\n12453,Strip,Text\r\n12453,Standard,Text\r\n12453,,Text\r\n12454,Standard,Text\r\n12454,,Text\r\n12454,Strip,Text\r\n12455,Standard,Text\r\n12455,,Text\r\n12455,Strip,Text\r\n12458,Standard,Text\r\n12458,Strip,Text\r\n12458,,Text\r\n12461,Standard,Text\r\n12461,,Text\r\n12461,Strip,Text\r\n12462,Standard,Text\r\n12462,,Text\r\n12462,Strip,Text\r\n12465,Standard,Text\r\n12465,Strip,Text\r\n12465,,Text\r\n12469,Standard,Text\r\n12469,Strip,Undo\r\n12469,,Undo\r\n12470,Strip,Find\r\n12470,Standard,Text\r\n12470,,Find\r\n12471,Strip,Info\r\n12471,,Info\r\n12471,Standard,Text\r\n12474,Strip,Text\r\n12474,,Text\r\n12474,Standard,Text\r\n12476,Standard,Text\r\n12476,Strip,Text\r\n12476,,Text\r\n12487,Standard,Text\r\n12487,,Text\r\n12487,Strip,Text\r\n12489,Strip,Add\r\n12489,,Add\r\n12489,Standard,New\r\n12490,Standard,Text\r\n12490,Strip,Text\r\n12490,,Text\r\n12501,Standard,Text\r\n12501,Strip,Accept\r\n12501,,Accept\r\n12508,Standard,Text\r\n12508,,Text\r\n12508,Strip,Text\r\n12509,Standard,Text\r\n12509,Strip,Text\r\n12509,,Text\r\n12511,Standard,Text\r\n12511,,Text\r\n12511,Strip,Text\r\n12519,Standard,Text\r\n12519,Strip,Text\r\n12519,,Text\r\n12536,Standard,Text\r\n12536,Strip,Text\r\n12536,,Text\r\n12541,Standard,Delete\r\n12541,Strip,Delete\r\n12541,,Delete\r\n12544,Standard,Text\r\n12544,Strip,Text\r\n12544,,Text\r\n12545,Strip,Text\r\n12545,Standard,Text\r\n12545,,Text\r\n12553,Standard,Text\r\n12553,Strip,Text\r\n12553,,Text\r\n12561,Standard,Text\r\n12561,,Text\r\n12561,Strip,Text\r\n12566,Standard,Text\r\n12566,Strip,Text\r\n12566,,Text\r\n12572,Standard,Text\r\n12572,,Text\r\n12572,Strip,Text\r\n12576,Strip,New\r\n12576,,New\r\n12576,Standard,New\r\n12578,Standard,Text\r\n12578,Strip,Text\r\n12578,,Text\r\n12580,Strip,Sync\r\n12580,Standard,Text\r\n12580,,Sync\r\n12582,Standard,Text\r\n12582,Strip,Text\r\n12582,,Text\r\n12583,Standard,Text\r\n12583,,Text\r\n12583,Strip,Text\r\n12584,Standard,Text\r\n12584,,Text\r\n12584,Strip,Text\r\n12586,Standard,Text\r\n12586,Strip,Text\r\n12586,,Text\r\n12587,Standard,Text\r\n12587,Strip,Text\r\n12587,,Text\r\n12588,Standard,Text\r\n12588,,Text\r\n12588,Strip,Text\r\n12592,Standard,Text\r\n12592,Strip,Text\r\n12592,,Text\r\n12595,Standard,Text\r\n12595,Strip,Text\r\n12595,,Text\r\n12604,Standard,Text\r\n12604,Strip,Text\r\n12604,,Text\r\n12607,Standard,Text\r\n12607,,Text\r\n12607,Strip,Text\r\n12612,Standard,Text\r\n12612,,Text\r\n12612,Strip,Text\r\n12613,Standard,Text\r\n12613,Strip,Text\r\n12613,,Text\r\n12614,Standard,Text\r\n12614,Strip,Text\r\n12614,,Text\r\n12615,Standard,Text\r\n12615,Strip,Text\r\n12615,,Text\r\n12627,Strip,Accept\r\n12627,,Accept\r\n12627,Standard,Text\r\n12642,Standard,Text\r\n12642,,Text\r\n12642,Strip,Text\r\n12644,Standard,Text\r\n12644,Strip,Text\r\n12644,,Text\r\n12645,Standard,Text\r\n12645,Strip,Text\r\n12645,,Text\r\n12646,Standard,Text\r\n12646,Strip,Text\r\n12646,,Text\r\n12647,Standard,Text\r\n12647,Strip,Text\r\n12647,,Text\r\n12648,Standard,Text\r\n12648,Strip,Text\r\n12648,,Text\r\n12649,Standard,Text\r\n12649,Strip,Text\r\n12649,,Text\r\n12650,Standard,Text\r\n12650,Strip,Text\r\n12650,,Text\r\n12651,Standard,Text\r\n12651,Strip,Text\r\n12651,,Text\r\n12652,Standard,Text\r\n12652,Strip,Text\r\n12652,,Text\r\n12653,Standard,Text\r\n12653,Strip,Text\r\n12653,,Text\r\n12654,Standard,Text\r\n12654,Strip,Text\r\n12654,,Text\r\n12669,Standard,Text\r\n12669,Strip,Text\r\n12669,,Text\r\n12670,Standard,Text\r\n12670,Strip,Text\r\n12670,,Text\r\n12671,Standard,Text\r\n12671,Strip,Text\r\n12671,,Text\r\n12672,Standard,Text\r\n12672,Strip,Text\r\n12672,,Text\r\n12714,,Text\r\n12714,Standard,Text\r\n12714,Strip,Text\r\n12720,Strip,Delete\r\n12720,,Delete\r\n12720,Standard,Delete\r\n12721,,Play\r\n12721,Standard,Text\r\n12721,Strip,Play\r\n12723,Standard,Text\r\n12723,,Text\r\n12723,Strip,Text\r\n12729,Standard,Text\r\n12729,Strip,Text\r\n12729,,Text\r\n12730,Standard,Text\r\n12730,Strip,Text\r\n12730,,Text\r\n12731,Standard,Text\r\n12731,,Text\r\n12731,Strip,Text\r\n12732,Standard,Text\r\n12732,,Text\r\n12732,Strip,Text\r\n12733,Standard,Text\r\n12733,,Text\r\n12733,Strip,Text\r\n12734,Standard,Text\r\n12734,,Text\r\n12734,Strip,Text\r\n12744,Standard,Text\r\n12744,,Text\r\n12744,Strip,Text\r\n12745,Standard,Text\r\n12745,,Text\r\n12745,Strip,Text\r\n12746,Standard,Text\r\n12746,Strip,Text\r\n12746,,Text\r\n12747,Standard,Text\r\n12747,Strip,Text\r\n12747,,Text\r\n12751,Standard,Text\r\n12751,Strip,Text\r\n12751,,Text\r\n12769,Standard,Text\r\n12769,,Text\r\n12769,Strip,Text\r\n12770,Standard,Text\r\n12770,,Text\r\n12770,Strip,Text\r\n12775,Standard,Text\r\n12775,,Text\r\n12775,Strip,Text\r\n12787,Standard,Text\r\n12787,,Text\r\n12787,Strip,Text\r\n12788,Standard,Text\r\n12788,,Text\r\n12788,Strip,Text\r\n12789,Strip,Add\r\n12789,,Add\r\n12789,Standard,New\r\n12790,Strip,Edit\r\n12790,,Edit\r\n12790,Standard,Text\r\n12795,Standard,Text\r\n12795,,Text\r\n12795,Strip,Text\r\n12820,Strip,Refresh\r\n12820,,Refresh\r\n12820,Standard,Text\r\n12828,Standard,Text\r\n12828,Strip,Text\r\n12828,,Text\r\n12839,Standard,Text\r\n12839,,Text\r\n12839,Strip,Text\r\n12842,Standard,Text\r\n12842,,Text\r\n12842,Strip,Text\r\n12844,Standard,Text\r\n12844,,Text\r\n12844,Strip,Text\r\n12851,Standard,Text\r\n12851,Strip,Text\r\n12851,,Text\r\n12859,Standard,Text\r\n12859,,Text\r\n12859,Strip,Text\r\n12860,Standard,Text\r\n12860,,Text\r\n12860,Strip,Text\r\n12877,Standard,Text\r\n12877,,Text\r\n12877,Strip,Text\r\n1303,Standard,Text\r\n1303,,Text\r\n1303,Strip,Text\r\n2500,Strip,Document\r\n2500,,Document\r\n2500,Standard,Text\r\n2522,,Accept\r\n2522,Strip,Accept\r\n2522,Standard,Text\r\n2550,Strip,Forward\r\n2550,,Forward\r\n2550,Standard,Text\r\n2582,Strip,Up\r\n2582,,Up\r\n2582,Standard,Text\r\n2583,,Down\r\n2583,Strip,Down\r\n2583,Standard,Text\r\n2585,Standard,Text\r\n2585,Strip,Text\r\n2585,,Text\r\n2600,Strip,Text\r\n2600,,Text\r\n2600,Standard,Text\r\n2610,Strip,Text\r\n2610,,Text\r\n2610,Standard,Text\r\n2628,Strip,Edit\r\n2628,,Edit\r\n2628,Standard,Text\r\n2631,Standard,Text\r\n2631,,Text\r\n2631,Strip,Text\r\n27000,Standard,Text\r\n27000,Strip,Text\r\n27000,,Text\r\n3016,Standard,Text\r\n3016,Strip,Text\r\n3016,,Text\r\n3025,Standard,Text\r\n3025,Strip,Lock\r\n3025,,Lock\r\n3026,Standard,Text\r\n3026,,Text\r\n3026,Strip,Text\r\n3031,Standard,Text\r\n3031,,Text\r\n3031,Strip,Text\r\n3048,,Text\r\n3048,Standard,Text\r\n3048,Strip,Text\r\n3051,,Previous\r\n3051,Standard,Text\r\n3051,Strip,Previous\r\n3059,,Print\r\n3059,Standard,Text\r\n3059,Strip,Print\r\n3060,,Next\r\n3060,Standard,Text\r\n3060,Strip,Next\r\n3061,Strip,Edit\r\n3061,Standard,Text\r\n3061,,Edit\r\n3068,,Calculate\r\n3068,Standard,Text\r\n3068,Strip,Calculate\r\n3080,,Next\r\n3080,Standard,Text\r\n3080,Strip,Next\r\n3089,,Text\r\n3089,Standard,Text\r\n3089,Strip,Text\r\n3091,,Text\r\n3091,Standard,Text\r\n3091,Strip,Text\r\n3092,,Text\r\n3092,Standard,Text\r\n3092,Strip,Text\r\n3093,,Text\r\n3093,Standard,Text\r\n3093,Strip,Text\r\n3094,,Text\r\n3094,Standard,Text\r\n3094,Strip,Text\r\n3095,,Text\r\n3095,Standard,Text\r\n3095,Strip,Text\r\n3096,,Text\r\n3096,Standard,Text\r\n3096,Strip,Text\r\n3097,,BulletedList\r\n3097,Standard,Text\r\n3097,Strip,BulletedList\r\n3098,,DecreaseIndent\r\n3098,Standard,Text\r\n3098,Strip,DecreaseIndent\r\n3099,,IncreaseIndent\r\n3099,Standard,Text\r\n3099,Strip,IncreaseIndent\r\n3105,,Text\r\n3105,Standard,Text\r\n3105,Strip,Text\r\n3119,,Refresh\r\n3119,Standard,Text\r\n3119,Strip,Refresh\r\n3146,,Text\r\n3146,Standard,Text\r\n3146,Strip,Text\r\n3148,,Text\r\n3148,Standard,Text\r\n3148,Strip,Text\r\n3150,,Calculate\r\n3150,Standard,Text\r\n3150,Strip,Calculate\r\n3151,Strip,Delete\r\n3151,Standard,Delete\r\n3151,,Delete\r\n3200,Strip,Edit\r\n3200,,Edit\r\n3200,Standard,Text\r\n3203,Strip,Find\r\n3203,,Find\r\n3203,Standard,Text\r\n3206,,Back\r\n3206,Standard,Text\r\n3206,Strip,Back\r\n3208,,Forward\r\n3208,Standard,Text\r\n3208,Strip,Forward\r\n3215,Standard,Text\r\n3215,,Text\r\n3215,Strip,Text\r\n3220,,Down\r\n3220,Strip,Down\r\n3220,Standard,Text\r\n3221,Strip,Down\r\n3221,,Down\r\n3221,Standard,Text\r\n3222,Standard,Text\r\n3222,,Down\r\n3222,Strip,Down\r\n3223,,Up\r\n3223,Strip,Up\r\n3223,Standard,Text\r\n3224,Standard,Text\r\n3224,,Up\r\n3224,Strip,Up\r\n3403,,Text\r\n3403,Standard,Text\r\n3403,Strip,Text\r\n3404,,Text\r\n3404,Standard,Text\r\n3404,Strip,Text\r\n3405,Strip,Up\r\n3405,,Up\r\n3405,Standard,Text\r\n3406,Strip,Down\r\n3406,,Down\r\n3406,Standard,Text\r\n3455,Standard,Text\r\n3455,Strip,Text\r\n3455,,Text\r\n3464,Standard,Text\r\n3464,,Text\r\n3464,Strip,Text\r\n3476,Standard,Text\r\n3476,Strip,Text\r\n3476,,Text\r\n3478,Standard,Text\r\n3478,,Text\r\n3478,Strip,Text\r\n3481,Standard,Text\r\n3481,,Text\r\n3481,Strip,Text\r\n3486,Standard,Text\r\n3486,,Text\r\n3486,Strip,Text\r\n3488,Standard,Text\r\n3488,,Text\r\n3488,Strip,Text\r\n3489,Standard,Text\r\n3489,,Text\r\n3489,Strip,Text\r\n401,Standard,Text\r\n401,,Text\r\n401,Strip,Text\r\n7525,Standard,Text\r\n7525,Strip,Text\r\n7525,,Text\r\n7526,Standard,Text\r\n7526,Strip,Text\r\n7526,,Text\r\n7609,Standard,Text\r\n7609,Strip,Text\r\n7609,,Text\r\n7622,,Delete\r\n7622,Standard,Delete\r\n7622,Strip,Delete\r\n7625,,Text\r\n7625,Standard,Text\r\n7625,Strip,Text\r\n7655,Strip,Text\r\n7655,Standard,Text\r\n7655,,Text\r\n7680,Standard,Text\r\n7680,,Text\r\n7680,Strip,Text\r\n7682,Standard,Text\r\n7682,,Text\r\n7682,Strip,Text\r\n7695,Strip,Settings\r\n7695,,Settings\r\n7695,Standard,Text\r\n7696,Standard,Text\r\n7696,Strip,Edit\r\n7696,,Edit\r\n7697,Standard,Text\r\n7697,,Find\r\n7697,Strip,Find\r\n7698,Strip,New\r\n7698,,New\r\n7698,Standard,New\r\n7716,Standard,Text\r\n7716,,Text\r\n7716,Strip,Text\r\n7733,Standard,Text\r\n7733,,Text\r\n7733,Strip,Text\r\n7735,Standard,Text\r\n7735,,Text\r\n7735,Strip,Text\r\n7851,Strip,Text\r\n7851,,Text\r\n7851,Standard,Text\r\n7855,Standard,Text\r\n7855,Strip,Text\r\n7855,,Text\r\n7865,Standard,Text\r\n7865,,Text\r\n7865,Strip,Text\r\n7867,Standard,Text\r\n7867,,Text\r\n7867,Strip,Text\r\n7886,,Text\r\n7886,Standard,Text\r\n7886,Strip,Text\r\n7887,,Text\r\n7887,Standard,Text\r\n7887,Strip,Text\r\n8003,Strip,OK\r\n8003,Standard,Text\r\n8003,,OK\r\n8008,Strip,Text\r\n8008,Standard,Text\r\n8008,,Text\r\n8030,,Text\r\n8030,Standard,Text\r\n8030,Strip,Text\r\n8031,,Stop\r\n8031,Standard,Text\r\n8031,Strip,Stop\r\n8032,,Text\r\n8032,Standard,Text\r\n8032,Strip,Text\r\n8035,Standard,Text\r\n8035,,Text\r\n8035,Strip,Text\r\n8037,Standard,Text\r\n8037,,Text\r\n8037,Strip,Text\r\n808,Strip,Edit\r\n808,,Edit\r\n808,Standard,Text\r\n815,Strip,Text\r\n815,Standard,Text\r\n815,,Text\r\n818,Standard,Text\r\n818,,Text\r\n818,Strip,Text\r\n850,Standard,Text\r\n850,,Text\r\n850,Strip,Text\r\n867,Standard,Text\r\n867,,Text\r\n867,Strip,Text\r\n869,Strip,Clear\r\n869,,Clear\r\n869,Standard,Text\r\n890,Strip,Text\r\n890,,Text\r\n890,Standard,Text\r\n891,Strip,Text\r\n891,,Text\r\n891,Standard,Text\r\n894,Strip,Text\r\n894,,Text\r\n894,Standard,Text\r\n898,Standard,Text\r\n898,Strip,Text\r\n898,,Text\r\n901,Strip,Text\r\n901,Standard,Text\r\n901,,Text\r\n913,Standard,Text\r\n913,,Text\r\n913,Strip,Text\r\n915,Strip,Text\r\n915,,Text\r\n915,Standard,Text\r\n925,Strip,Text\r\n925,,Text\r\n925,Standard,Text\r\n930,,Info\r\n930,Standard,Text\r\n930,Strip,Info\r\n966,Standard,Text\r\n966,Strip,Text\r\n966,,Text\r\n999,,Find\r\n999,Standard,Text\r\n999,Strip,Find"
+  },
+  {
+   "Name": "RunBaseMissingMethod",
+   "Canonical": false,
+   "Message": "Method {0} was missing and has been added to class {1}."
+  },
+  {
+   "Name": "RunBaseMissingMethodDetectorDescription",
+   "Canonical": false,
+   "Message": "Detects that a RunBase derived class is missing a method override."
+  },
+  {
+   "Name": "RunBaseRunCalledDetectorDescription",
+   "Canonical": false,
+   "Message": "Detects that an instance of a RunBase class call the run method."
+  },
+  {
+   "Name": "SECAddingCommentControllerAssignment",
+   "Canonical": false,
+   "Message": "Adding comment for '{0}' controller assignment in form '{1}'."
+  },
+  {
+   "Name": "SECAddingCommentForControllerMethodCall",
+   "Canonical": false,
+   "Message": "Adding comment for '{0}' controller object, '{1}' statement in form '{2}'."
+  },
+  {
+   "Name": "SECAddingControllerMapping",
+   "Canonical": false,
+   "Message": "Adding controller mapping for '{0}' in form '{1}'."
+  },
+  {
+   "Name": "SECAddingNewInstance",
+   "Canonical": false,
+   "Message": "Adding new SEC named '{0}' in form '{1}'."
+  },
+  {
+   "Name": "SECApplyingRule",
+   "Canonical": false,
+   "Message": "Applying rule on '{0}' segmented entry control in '{1}' form."
+  },
+  {
+   "Name": "SECControlAddedToForm",
+   "Canonical": false,
+   "Message": "AxFormSegmentedEntryControl {0} was added to form '{1}'."
+  },
+  {
+   "Name": "SECControllerControlMapping",
+   "Canonical": false,
+   "Message": "/* '{0}' controller object is used with '{1}' segmented entry controls.*/"
+  },
+  {
+   "Name": "SECExtensionPropertyNotFound",
+   "Canonical": false,
+   "Message": "Extension property '{0}' not found for '{1}' control in form '{2}'."
+  },
+  {
+   "Name": "SECInvalidBaseClassError",
+   "Canonical": false,
+   "Message": "Deprecated SEC does not derive from the AxFormSegmentedEntryControl class in form '{0}'."
+  },
+  {
+   "Name": "SECMethodsAddedToControl",
+   "Canonical": false,
+   "Message": "Methods added to control '{0}' in form '{1}'"
+  },
+  {
+   "Name": "SECNewControlCreated",
+   "Canonical": false,
+   "Message": "Created new FormSegmentedEntryControl named '{0}' for '{1}' in form '{2}'."
+  },
+  {
+   "Name": "SECNewControlCreationError",
+   "Canonical": false,
+   "Message": "Failed to create the '{0}' segmented entry control in form '{1}'."
+  },
+  {
+   "Name": "SECPropertyBlankError",
+   "Canonical": false,
+   "Message": "DataSource or ReferenceField property is blank for SEC '{0}' in form '{1}'."
+  },
+  {
+   "Name": "SECRemovingControllerAssignment",
+   "Canonical": false,
+   "Message": "Removing '{0}' controller assignment in form '{1}'."
+  },
+  {
+   "Name": "SECRemovingMethodCall",
+   "Canonical": false,
+   "Message": "Removing '{0}' call in form '{1}'."
+  },
+  {
+   "Name": "SECReplacingControllerMethodCall",
+   "Canonical": false,
+   "Message": "Replacing '{0}' method call in form '{1}'."
+  },
+  {
+   "Name": "SECTODOController",
+   "Canonical": false,
+   "Message": "[Segmented entry control] Replace this based on the migration guidance"
+  },
+  {
+   "Name": "SECTODOFixControllerUsage",
+   "Canonical": false,
+   "Message": "[Segmented entry control] Fix controller usage, if any, in this method based on the migration guidance and additionally override the checkUseCustomLookup() method for cases where custom server forms should be shown for the lookup instead of the default form"
+  },
+  {
+   "Name": "SECTODOMoveMethodStatements",
+   "Canonical": false,
+   "Message": "[Segmented entry control] For custom implementation, code in this method needs to be moved elsewhere based on the migration guidance"
+  },
+  {
+   "Name": "SECTODORemoveMethod",
+   "Canonical": false,
+   "Message": "[Segmented entry control] This method can be removed if there is no custom implementation"
+  },
+  {
+   "Name": "SECTODORemoveStatement",
+   "Canonical": false,
+   "Message": "[Segmented entry control] This statement can be removed if there is no custom logic"
+  },
+  {
+   "Name": "SecurityDutyDisabledDescription",
+   "Canonical": false,
+   "Message": "Deleting disabled security duty {0}."
+  },
+  {
+   "Name": "SecurityDutyDisabledDetectorDescription",
+   "Canonical": false,
+   "Message": "Detects disabled security duties."
+  },
+  {
+   "Name": "SecurityPrivilegeDisabledDescription",
+   "Canonical": false,
+   "Message": "Deleting disabled security privilege {0}."
+  },
+  {
+   "Name": "SecurityPrivilegeDisabledDetectorDescription",
+   "Canonical": false,
+   "Message": "Detects disabled security privileges."
+  },
+  {
+   "Name": "SecurityRoleDisabledDescription",
+   "Canonical": false,
+   "Message": "Deleting disabled security role {0}."
+  },
+  {
+   "Name": "SecurityRoleDisabledDetectorDescription",
+   "Canonical": false,
+   "Message": "Detects disabled security roles."
+  },
+  {
+   "Name": "SegmentedEntryControlDetectorDescription",
+   "Canonical": false,
+   "Message": "Detects segmented entry control in a form."
+  },
+  {
+   "Name": "SizeToAvailableControlsInsideColumn",
+   "Canonical": false,
+   "Message": "Detects containers which have their ColumnsMode property set to Fill, and have flexible width/height children. Flexible means WidthMode/HeightMode=SizeToAvailable or WidthMode/HeightMode=Auto for a Tab or Grid."
+  },
+  {
+   "Name": "SourceDocumentAttributeDetectorDescription",
+   "Canonical": false,
+   "Message": "Detect usage of deprecated source document attribute."
+  },
+  {
+   "Name": "SourceDocumentProcessorFacadeParameterDescription",
+   "Canonical": false,
+   "Message": "Updates source document processor facade method calls to remove unused parameters."
+  },
+  {
+   "Name": "SubMenuHasImageFixDescription",
+   "Canonical": false,
+   "Message": "Submenu '{0}' in menu '{1}' has an image when it should not, adjusted to ImageLocation=Symbol and NormalImage set to blank."
+  },
+  {
+   "Name": "SubPatternVersionApplied",
+   "Canonical": false,
+   "Message": "Upgrading control {0} to the {1} {2} pattern."
+  },
+  {
+   "Name": "SysDateLookUpDetectorDescription",
+   "Canonical": false,
+   "Message": "Detects that a date type of extended data type has its FormHelp property set to the deprecated SysDateLookUp form."
+  },
+  {
+   "Name": "SysEntryPointAttributeDetectorDescription",
+   "Canonical": false,
+   "Message": "Detect usage of deprecated sys entry point attribute."
+  },
+  {
+   "Name": "SysFormSplitterDetectorDescription",
+   "Canonical": false,
+   "Message": "Detect splitter control in a form or class."
+  },
+  {
+   "Name": "SysTestDatasetAttributeDetectorDescription",
+   "Canonical": false,
+   "Message": "Detect calls to deprecated attribute APIs used in the test framework."
+  },
+  {
+   "Name": "TabsUpdateColumnsMode",
+   "Canonical": false,
+   "Message": "Updating TabPage {0}.ColumnsMode from the default to ColumnsMode=Fill.",
+   "Description": "Detect TabPage controls that need ColumnsMode set to Fill."
+  },
+  {
+   "Name": "TextIoDetected",
+   "Canonical": false,
+   "Message": "Detect the use of deprecated Io classes and upgrate to the AX 7 equivalents."
+  },
+  {
+   "Name": "TextIoUpgradeAppendConstructor",
+   "Canonical": false,
+   "Message": "{0}::constructForMode({1}{3} /*, appendStream*/);\r\n// TODO: Step 1: Uncomment the `appendStream` parameter.\r\n//       You need to provide a System.IO.Stream variable to read and/or append data.\r\n//       If you receive a file from user, use the following code before calling the construct:\r\n//       System.IO.Stream appendStream = File::UseFileFromURL(File::GetFileFromUser());\r\n// TODO: Step 2: Use `constructForAppend` instead of the `constructForMode`.\r\n//       `constructForMode` is obsolete and must not be used after the migration is complete.\r\n// TODO: Step 3: Use the following code when the writing is complete and file is ready to be sent back to the user:\r\n//       File::SendFileToUser(appendStream, {2})"
+  },
+  {
+   "Name": "TextIoUpgradeReadConstructor",
+   "Canonical": false,
+   "Message": "{0}::constructForMode({1}{2} /*, readStream*/);\r\n// TODO: Step 1: Uncomment the `readStream` parameter.\r\n//       You need to provide a System.IO.Stream variable to read data from.\r\n//       If you receive a file from user, use the following code before calling the construct:\r\n//       System.IO.Stream readStream = File::UseFileFromURL(File::GetFileFromUser());\r\n// TODO: Step 2: Use `constructForRead` instead of the `constructForMode`.\r\n//       `constructForMode` is obsolete and must not be used after the migration is complete"
+  },
+  {
+   "Name": "TextIoUpgradeUnknownConstructor",
+   "Canonical": false,
+   "Message": "{0}::constructForMode({1}{3} /*, stream*/);\r\n// TODO: Step 1: Determine the use of the constructed IO instance above.\r\n//       If it is used only for writing, delete the `stream` parameter and go to Step 2.\r\n//       If it is used for reading or appending, uncomment the `stream` parameter.\r\n//       You need to provide a System.IO.Stream variable to read and/or append data.\r\n//       If you receive a file from user, use the following code before calling the construct:\r\n//       System.IO.Stream stream = File::UseFileFromURL(File::GetFileFromUser());\r\n// TODO: Step 2: Use `constructForRead`, `constructForWrite` or `constructForAppend` instead of the `constructForMode`.\r\n//       `constructForMode` is obsolete and must not be used after the migration is complete.\r\n// TODO: Step 3: If you wrote or appended data, use the following code to sent the file back to the user when writing is complete:\r\n//       File::SendFileToUser(stream, {2})"
+  },
+  {
+   "Name": "TextIoUpgradeWriteConstructor",
+   "Canonical": false,
+   "Message": "{0}::constructForWrite({2});\r\n// TODO: Use the following code when the writing is complete and file is ready to be sent to the user:\r\n// File::SendFileToUser(ioVariable.getStream(), {1})"
+  },
+  {
+   "Name": "TtsStatementsFollowedByBreakContinueReturn",
+   "Canonical": false,
+   "Message": "The 'ttsbegin' statement is followed by a '{0}' statment, which may prevent its corresponding '{1}' statement from from being executed."
+  },
+  {
+   "Name": "TwCDisplayDataRecordLevelSecurity",
+   "Canonical": true,
+   "Message": "Method '{0}' is considered a security risk. Verify that the data displayed in the form is fetched with proper record level security in place.",
+   "Description": "Detects form methods that are a security risk due to improper record level security."
+  },
+  {
+   "Name": "TwCForceLiteralsKeyword",
+   "Canonical": true,
+   "Message": "Only literal values should be passed as arguments to query expression '{0}'.",
+   "Description": "Reports when non-literal arguments are passed to Query.literals() or QueryRun.literals() methods."
+  },
+  {
+   "Name": "TwCParametersMustBeValidated",
+   "Canonical": true,
+   "Message": "All parameters that are passed to method '{0}' must be validated.",
+   "Description": "Detects parameters which the method neglects to validate."
+  },
+  {
+   "Name": "TwCParametersShouldBeLiteral",
+   "Canonical": true,
+   "Message": "Only parameters that are constants can be passed to method '{0}'.",
+   "Description": "Detects methods which should be called only with constants for the parameter values."
+  },
+  {
+   "Name": "UnbalancedTtsStatement",
+   "Canonical": false,
+   "Message": "The '{0}' statement does not have a clear and unconditional corresponding '{1}' statement within the same method and scope."
+  },
+  {
+   "Name": "UnrelatedMeasureGroupDescription",
+   "Canonical": false,
+   "Message": "This rule scans for measure groups that have relations only to Date, Company, and Currency dimensions. Usually this means that the necessary dimensions have not yet been added to the measure group."
+  },
+  {
+   "Name": "UnsupportedButtonDisplayValueFixDescription",
+   "Canonical": false,
+   "Message": "Button {0} is using an unsupported value for propert ButtonDisplay, changed to Auto."
+  },
+  {
+   "Name": "UnsupportedButtonDisplayValueInAppBarTabOrMenuFixDescription",
+   "Canonical": false,
+   "Message": "Button {0} uses an unsupported value for property ButtonDisplay, changed to Auto, ImageLocation=Symbol and NormalImage=<blank>"
+  },
+  {
+   "Name": "UpgradeOKCancelFormsToDialogDescription",
+   "Canonical": false,
+   "Message": "Detect forms with OK and Cancel buttons and change the Design.Style=Dialog"
+  },
+  {
+   "Name": "UpgradeOkCancelChangingFormDesignStyleToDialog",
+   "Canonical": false,
+   "Message": "Changing {0} Form.Design.Style to Dialog"
+  },
+  {
+   "Name": "UpgradeOkCancelEnsureNoDataChangesPersistedOnCancel",
+   "Canonical": false,
+   "Message": "[OK Cancel button rule] TODO: This form was automatically migrated to have Style=Dialog.  Please examine this form and ensure no data changes are persisted on cancel, particularly in the grid"
+  },
+  {
+   "Name": "UseOfObsoleteClassWhenWarehouseTransactionsEnabledDetected",
+   "Canonical": false,
+   "Message": "Detected a class {0} which extends class {1}. The class {1} will not be used the same way as it was before the activation of the \"Warehouse-specific inventory transactions\" feature."
+  },
+  {
+   "Name": "UseOfObsoleteMethodWhenWarehouseTransactionsEnabledDetected",
+   "Canonical": false,
+   "Message": "Detected a method {0}.{1} extending a class {2}. This method will not be used the same way as it was before the activation of the \"Warehouse-specific inventory transactions\" feature."
+  },
+  {
+   "Name": "Variable",
+   "Canonical": false,
+   "Message": "variable"
+  },
+  {
+   "Name": "VerticalButtonGroupDetectorDescription",
+   "Canonical": false,
+   "Message": "Detects vertical button group in form."
+  },
+  {
+   "Name": "VerticalButtonGroupMissingControlsProperty",
+   "Canonical": false,
+   "Message": "[Vertical Button Group Rule] Parent control {0} does not have the Controls property."
+  },
+  {
+   "Name": "VerticalButtonGroupMoveToNewActionPane",
+   "Canonical": false,
+   "Message": "[Vertical Button Group Rule] Moving the vertical button group {0} to a new action pane."
+  },
+  {
+   "Name": "VerticalButtonGroupRulePleaseFixComment",
+   "Canonical": false,
+   "Message": "[Vertical Button Group Rule] Please manually fix the vertical button group [{0}] in this form, it does not conform to any well known rules. The button group does not have any data source or its data source is not part of any root or linked data source query."
+  },
+  {
+   "Name": "VerticalButtonGroupRulePleaseReviewAppBarComment",
+   "Canonical": false,
+   "Message": "[Vertical Button Group Rule] Please review placement of buttongroup [{0}] in the application bar."
+  },
+  {
+   "Name": "VerticalButtonGroupRulePleaseReviewToolBarComment",
+   "Canonical": false,
+   "Message": "[Vertical Button Group Rule] Please review placement of toolbar created for buttongroup [{0}]."
+  },
+  {
+   "Name": "ViewDimensionEnabledTypeBackingEntityRecIdIndex",
+   "Canonical": true,
+   "Message": "Dimension enabled type views' backing entity table must have RecId index or RecId must be the first field in an index."
+  },
+  {
+   "Name": "ViewDimensionEnabledTypeConfigurationKeyMustMatchBackingEntity",
+   "Canonical": true,
+   "Message": "Dimension enabled type views must have the same ConfigurationKey property as the backing entity table."
+  },
+  {
+   "Name": "ViewDimensionEnabledTypeFieldNotBoundToBackingEntityDataSource",
+   "Canonical": true,
+   "Message": "Dimension enabled type view field '{0}' must be bound to the 'BackingEntity' data source."
+  },
+  {
+   "Name": "ViewDimensionEnabledTypeFieldWrongType",
+   "Canonical": true,
+   "Message": "Dimension enabled type view field '{0}' must be bound to a field of type '{1}'."
+  },
+  {
+   "Name": "ViewDimensionEnabledTypeLabelAndSingularLabelMustDiffer",
+   "Canonical": true,
+   "Message": "Dimension enabled type views must have differing values for the Label and SingularLabel properties."
+  },
+  {
+   "Name": "ViewDimensionEnabledTypeMissingField",
+   "Canonical": true,
+   "Message": "Dimension enabled type view field '{0}' is missing."
+  },
+  {
+   "Name": "ViewDimensionEnabledTypeMissingNameIndex",
+   "Canonical": true,
+   "Message": "Dimension enabled type views must have an index on the Name field that is enabled and where Name is the first field in the index."
+  },
+  {
+   "Name": "ViewDimensionEnabledTypeMissingOneOfValidToValidFrom",
+   "Canonical": true,
+   "Message": "Dimension enabled type views must have either both 'ValidFrom' and 'ValidTo' fields or neither."
+  },
+  {
+   "Name": "ViewDimensionEnabledTypeMissingProperty",
+   "Canonical": true,
+   "Message": "Dimension enabled type views must specify a value for the {0} property."
+  },
+  {
+   "Name": "ViewDimensionEnabledTypeMissingValueIndex",
+   "Canonical": true,
+   "Message": "Dimension enabled type views must have an index on the Value field that is enabled, has AllowDuplicates set to No, and where Value is the first field in the index. No index is created in the database: The information is used at runtime for discovering the Name and Value fields."
+  },
+  {
+   "Name": "ViewDimensionEnabledTypeNotInDimensionEssentials",
+   "Canonical": true,
+   "Message": "Dimension enabled type views must be included in the DimensionEssentials security priviledge if possible."
+  },
+  {
+   "Name": "ViewDimensionEnabledTypeRootDataSourceMustBeNamedBackingEntity",
+   "Canonical": true,
+   "Message": "Dimension enabled type views must have a root data source named 'BackingEntity'."
+  },
+  {
+   "Name": "ViewDimensionEnabledTypeRootDataSourceReferencesNonTable",
+   "Canonical": true,
+   "Message": "Dimension enabled type views' root data source should reference a table directly for best performance of financial reporting."
+  },
+  {
+   "Name": "ViewDimensionEnabledTypeUnexpectedField",
+   "Canonical": true,
+   "Message": "Dimension enabled type view field '{0}' should not be present."
+  },
+  {
+   "Name": "XSessionAPIDetectorDescription",
+   "Canonical": false,
+   "Message": "Detect APIs in XSession class that have been changed."
+  },
+  {
+   "Name": "agrmt",
+   "Canonical": false,
+   "Message": "agrmt"
+  },
+  {
+   "Name": "avg",
+   "Canonical": false,
+   "Message": "avg"
+  },
+  {
+   "Name": "dr",
+   "Canonical": false,
+   "Message": "dr"
+  },
+  {
+   "Name": "etc",
+   "Canonical": false,
+   "Message": "etc"
+  },
+  {
+   "Name": "excl",
+   "Canonical": false,
+   "Message": "excl"
+  },
+  {
+   "Name": "incl",
+   "Canonical": false,
+   "Message": "incl"
+  },
+  {
+   "Name": "jr",
+   "Canonical": false,
+   "Message": "jr"
+  },
+  {
+   "Name": "max",
+   "Canonical": false,
+   "Message": "max"
+  },
+  {
+   "Name": "min",
+   "Canonical": false,
+   "Message": "min"
+  },
+  {
+   "Name": "mr",
+   "Canonical": false,
+   "Message": "mr"
+  },
+  {
+   "Name": "mrs",
+   "Canonical": false,
+   "Message": "mrs"
+  },
+  {
+   "Name": "ms",
+   "Canonical": false,
+   "Message": "ms"
+  },
+  {
+   "Name": "mth",
+   "Canonical": false,
+   "Message": "mth"
+  },
+  {
+   "Name": "no",
+   "Canonical": false,
+   "Message": "no"
+  },
+  {
+   "Name": "pcs",
+   "Canonical": false,
+   "Message": "pcs"
+  },
+  {
+   "Name": "pct",
+   "Canonical": false,
+   "Message": "pct"
+  },
+  {
+   "Name": "prof",
+   "Canonical": false,
+   "Message": "prof"
+  },
+  {
+   "Name": "qtr",
+   "Canonical": false,
+   "Message": "qtr"
+  },
+  {
+   "Name": "qty",
+   "Canonical": false,
+   "Message": "qty"
+  },
+  {
+   "Name": "reference",
+   "Canonical": false,
+   "Message": "ref"
+  },
+  {
+   "Name": "rep",
+   "Canonical": false,
+   "Message": "rep"
+  },
+  {
+   "Name": "sr",
+   "Canonical": false,
+   "Message": "sr"
+  }
+ ]
+}

--- a/tests/D365FO.Core.Tests/BpMonikerCatalogTests.cs
+++ b/tests/D365FO.Core.Tests/BpMonikerCatalogTests.cs
@@ -1,0 +1,100 @@
+using D365FO.Core.Knowledge;
+using Xunit;
+
+namespace D365FO.Core.Tests;
+
+/// <summary>
+/// The catalog exists to stop a moniker being guessed, so what it must never do is answer
+/// confidently when it does not know.
+/// </summary>
+public class BpMonikerCatalogTests
+{
+    [Fact]
+    public void The_shipped_snapshot_is_populated_and_mostly_canonical()
+    {
+        // A snapshot that failed to embed would make every `validate` answer "not a moniker",
+        // which is the one wrong answer that reads exactly like a right one.
+        Assert.True(BpMonikerCatalog.IsPopulated, "the shipped bp-monikers.json did not load");
+        Assert.True(BpMonikerCatalog.Snapshot.Monikers.Count(m => m.Canonical) > 300,
+            "far fewer canonical monikers than a real installation declares — the rule-set scan probably found nothing");
+    }
+
+    [Fact]
+    public void A_real_moniker_is_canonical_and_carries_the_installations_own_message()
+    {
+        var found = BpMonikerCatalog.Find("BPErrorPrivilegeNotCoveredByDuty");
+
+        Assert.NotNull(found);
+        Assert.True(found!.Canonical);
+        Assert.Contains("duty", found.Message, StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact]
+    public void A_name_that_reads_exactly_like_a_rule_is_not_one()
+    {
+        // This is the whole point: nothing about the spelling distinguishes it from the real
+        // moniker above, so only a lookup can tell them apart.
+        Assert.Null(BpMonikerCatalog.Find("BPCheckNamingConventions"));
+    }
+
+    [Fact]
+    public void Lookup_is_case_sensitive_and_offers_the_right_casing()
+    {
+        // xppbp and the suppression reader match exactly, so a case-insensitive "yes" would hand
+        // back a name that suppresses nothing.
+        Assert.Null(BpMonikerCatalog.Find("bperrorprivilegenotcoveredbyduty"));
+
+        var variants = BpMonikerCatalog.CaseVariants("bperrorprivilegenotcoveredbyduty");
+        Assert.Contains("BPErrorPrivilegeNotCoveredByDuty", variants);
+    }
+
+    [Fact]
+    public void Search_matches_words_the_rule_name_does_not_contain()
+    {
+        // "not referenced on any duty" is in the message, not the name.
+        var hits = BpMonikerCatalog.Search("privilege referenced duty", 10);
+        Assert.Contains(hits, m => m.Name == "BPErrorPrivilegeNotCoveredByDuty");
+    }
+
+    [Fact]
+    public void Search_puts_real_rules_before_resource_strings()
+    {
+        var hits = BpMonikerCatalog.Search("duty", 50);
+        var firstNonCanonical = hits.ToList().FindIndex(m => !m.Canonical);
+        if (firstNonCanonical < 0) return; // nothing non-canonical matched; ordering is moot
+
+        Assert.DoesNotContain(hits.Skip(firstNonCanonical), m => m.Canonical);
+    }
+
+    [Fact]
+    public void A_suppression_block_has_the_element_order_the_shipped_files_use()
+    {
+        var block = BpMonikerCatalog.SuppressionBlock(
+            "BPErrorPrivilegeNotCoveredByDuty",
+            "dynamics://SecurityPrivilege/MyPrivilege",
+            justification: "Deliberate.");
+
+        var order = new[] { "DiagnosticType", "Severity", "Path", "Moniker", "Message", "Justification" };
+        var positions = order.Select(e => block.IndexOf("<" + e + ">", StringComparison.Ordinal)).ToArray();
+
+        Assert.DoesNotContain(-1, positions);
+        Assert.Equal(positions.OrderBy(p => p).ToArray(), positions);
+        Assert.Contains("dynamics://SecurityPrivilege/MyPrivilege", block);
+    }
+
+    [Fact]
+    public void A_suppression_block_escapes_what_would_break_the_file()
+    {
+        var block = BpMonikerCatalog.SuppressionBlock(
+            "BPSomething", "dynamics://Table/T", message: "a < b & c > d");
+
+        Assert.Contains("a &lt; b &amp; c &gt; d", block);
+    }
+
+    [Fact]
+    public void An_omitted_justification_leaves_something_a_reviewer_will_notice()
+    {
+        var block = BpMonikerCatalog.SuppressionBlock("BPSomething", "dynamics://Table/T");
+        Assert.Contains("TODO", block);
+    }
+}


### PR DESCRIPTION
Wave 03, first slice — the two catalogs that can be **extracted from a real D365FO install** rather than authored, so neither ships as a plausible-looking guess.

## `d365fo bp-moniker validate | search | suppress | extract`

Every Best-Practice moniker has been guessed wrong at least once, and nothing about the spelling separates the real `BPErrorPrivilegeNotCoveredByDuty` from the entirely plausible `BPCheckNamingConventions`. A suppression naming a moniker that does not exist **suppresses nothing while looking deliberate** — so the catalog never infers a name, it looks one up.

Two sources, both from `PackagesLocalDirectory`, shipped as a snapshot so the answer works on a machine with no install:

- **canonical names** from every model's `AxRuleSet/*.xml` — the only field that answers *"is this a BP rule"*;
- **message text** from the resx resources embedded in `bin/BPExtensions/*.dll`, read through `PEReader` rather than by loading the assemblies (loading a D365FO rule assembly drags in its dependency graph for the sake of a string table).

Measured on the host this was extracted from:

| | |
|---|---:|
| rule-set files | 144 |
| **canonical monikers** | **409** |
| rule assemblies scanned | 17 |
| entries with real message text | 724 of 726 |
| non-canonical (upgrade/form-conversion strings) | 317 |

The non-canonical entries are kept — their text is searchable — but flagged `canonical: false`, since presence in the catalog is not what makes something a rule.

Design decisions worth flagging for review:

- **Lookup is case-sensitive.** xppbp and the suppression reader match exactly, so a case-insensitive "yes" would hand back a name that suppresses nothing. A case-only miss is answered *with the right casing* rather than a flat no.
- **An empty catalog refuses to answer.** Reporting "not a moniker" when nothing is loaded would be confidently wrong and indistinguishable from a real verdict.
- Not every real moniker starts with `BP` — the shipped suppression files use `MetadataExtensionNamingWithExtensionOnly` among others — so a prefix test is not a substitute for a lookup.
- `D365FO_BP_CATALOG_PATH` points at a snapshot matching an instance's own D365FO version.

`suppress` renders a `<Diagnostic>` block whose element order is taken from the shipped `AxIgnoreDiagnosticList/<Model>_BPSuppressions.xml` files, not invented; it refuses a moniker the catalog does not know, and leaves a `TODO` justification a reviewer will see when none is given.

## `d365fo table-pattern list | spec`

The decision layer over `generate table`. The patterns, their canonical `TableGroup` and their default fields already existed — but only as a value `--pattern` accepted. An agent choosing a shape could not see what the choices *were* or what each implied, so it either guessed a pattern name (one round trip wasted on the refusal) or skipped `--pattern` entirely and got a table with no `TableGroup` at all.

## Verification

- 1 595 tests green (576 CLI + 1 019 Core)
- eval catalog 52/52 · knowledge audit clean · warning ratchet at baseline 117
- both commands exercised against this repo's live installation; the shipped snapshot is verified to answer with `D365FO_PACKAGES_PATH` unset

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019D9AMJP7Ct2U4Q3xVeMn8B
