### PR TITLE
Wave 03: the seven SSRS report shapes, as recipes grounded in the installation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,6 +37,20 @@ was ported from.
   `D365FO_BP_CATALOG_PATH` points at a snapshot matching an instance's own D365FO version.
   The resources are read through `PEReader` rather than by loading the assemblies — loading a
   D365FO rule assembly drags in its dependency graph for the sake of a string table.
+- **`d365fo report-pattern list|spec`** — the seven SSRS shapes as implementation recipes:
+  object roster, base classes, the one `generate report` call that produces the stack, what still
+  has to be written by hand, and the checks worth running. `generate report` could already build
+  every one; what was missing was the layer that says WHICH — and getting it wrong is expensive in
+  a way a form-pattern violation is not, because there is no pattern XML to validate a report
+  against. A pre-processed requirement built on `SRSReportDataProviderBase` simply behaves wrong
+  in batch with nothing failing anywhere.
+  Every base class was **counted in this installation** rather than recalled —
+  `SrsReportRunController` 152, `SRSReportDataProviderBase` 95,
+  `SrsReportDataProviderPreProcessTempDB` 88, `SrsReportDataContractUIBuilder` 59,
+  `SrsPrintMgmtFormLetterController` 6 — and each recipe names shipped reference objects to read
+  instead of working from prose. `ReportRecipesAotTests` resolves all 11 of them against a real
+  `PackagesLocalDirectory` and asserts each extends the base its recipe claims; it is inert where
+  there is no install, rather than passing vacuously.
 - **`d365fo table-pattern list|spec`** — the decision layer over `generate table`. The patterns,
   their canonical `TableGroup` and their default fields already existed, but only as a value
   `--pattern` accepted: an agent choosing a shape could not see what the choices were or what each

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
 [![.NET](https://img.shields.io/badge/.NET-10-purple.svg)](https://dotnet.microsoft.com/)
 [![Platform](https://img.shields.io/badge/platform-Windows%20%7C%20macOS%20%7C%20Linux-lightgrey.svg)]()
-[![Tests](https://img.shields.io/badge/tests-1595-brightgreen.svg)]()
+[![Tests](https://img.shields.io/badge/tests-1613-brightgreen.svg)]()
 [![Successor to d365fo-mcp-server](https://img.shields.io/badge/successor%20to-d365fo--mcp--server-orange.svg)](https://github.com/dynamics365ninja/d365fo-mcp-server)
 
 *Grounded AI development for Dynamics 365 Finance & Operations — works with GitHub Copilot, Claude Code, Codex, Gemini CLI, and any agent with a shell*
@@ -292,7 +292,7 @@ See [docs/TOKEN_ECONOMICS.md](docs/TOKEN_ECONOMICS.md) for the full analysis and
 | **Labels** | `labels search\|resolve\|info\|create\|rename\|delete` — search/resolve plus in-place `*.label.txt` edits, multi-language via `--lang` (mirrors the MCP `labels` tool) |
 | **Journal / undo** | `undo [--steps N] [--dry-run]`, `journal list`, `delete` (kind/name, bridge or on-disk) — deterministic single-command rollback for every write path (mirrors the MCP `undo_last_modification` tool) |
 | **Modify** | `modify property\|method`, `modify add-field\|add-enum-value\|add-control`, `modify add-index\|add-relation\|add-field-group\|add-delete-action`, `modify rename-field`, `modify add-query-range\|remove-query-range`, `modify add-entry-point\|remove-entry-point`, seven `modify remove-*` forms, and `modify batch` (several changes in one read-edit-write) — 22 operations over all 41 bridge-writable kinds, extension-aware and journalled for `undo` |
-| **Patterns & rules** | `table-pattern list\|spec` — table shapes and what each presets · `bp-moniker validate\|search\|suppress\|extract` — Best-Practice rule monikers from names a real installation declares, never a guess |
+| **Patterns & rules** | `report-pattern list\|spec` — the seven SSRS shapes as recipes · `table-pattern list\|spec` — table shapes and what each presets · `bp-moniker validate\|search\|suppress\|extract` — Best-Practice rule monikers from names a real installation declares, never a guess |
 | **Analyze** | `analyze completeness`, `analyze integration`, `analyze impact`, `lint`, `suggest edt`, `suggest extension`, `report-integrations` |
 | **Review** | `review diff` |
 | **Models** | `models list`, `models deps`, `models coupling` |

--- a/src/D365FO.Cli/CliApp.cs
+++ b/src/D365FO.Cli/CliApp.cs
@@ -359,6 +359,13 @@ public static class CliApp
             // The CLI's `get_knowledge` equivalent: the verified skills/_source corpus,
             // embedded in the binary and served per-topic / per-section so an agent
             // without skill-file support can still ground itself.
+            cfg.AddBranch("report-pattern", b =>
+            {
+                b.SetDescription("SSRS report shapes as implementation recipes: object roster, base classes, one scaffold call.");
+                b.AddCommand<ReportPatternListCommand>("list").WithDescription("The seven shapes and when each applies.");
+                b.AddCommand<ReportPatternSpecCommand>("spec").WithDescription("One shape in full, with shipped reference objects to read.");
+            });
+
             cfg.AddBranch("table-pattern", b =>
             {
                 b.SetDescription("Table shape patterns: what each one is for, and what it presets.");

--- a/src/D365FO.Cli/Commands/Knowledge/ReportPatternCommands.cs
+++ b/src/D365FO.Cli/Commands/Knowledge/ReportPatternCommands.cs
@@ -1,0 +1,82 @@
+using D365FO.Core;
+using D365FO.Core.Knowledge;
+using Spectre.Console.Cli;
+
+namespace D365FO.Cli.Commands.Knowledge;
+
+// `d365fo report-pattern` — which of the seven SSRS shapes to build, and what each one costs.
+//
+// `generate report` could already produce every one of them. What was missing was the decision:
+// an agent asked for "a report of open sales orders grouped by customer with totals" had to infer
+// the shape, and inferring it wrong is expensive in a way a form pattern violation is not —
+// there is no pattern XML to validate a report against, so a pre-processed requirement built as a
+// plain DP simply behaves wrong in batch, with nothing failing anywhere.
+
+/// <summary><c>d365fo report-pattern list</c> — the seven shapes and when each applies.</summary>
+public sealed class ReportPatternListCommand : Command<ReportPatternListCommand.Settings>
+{
+    public sealed class Settings : D365OutputSettings
+    {
+    }
+
+    public override int Execute(CommandContext ctx, Settings settings)
+    {
+        var kind = OutputMode.Resolve(settings.Output);
+
+        return RenderHelpers.Render(kind, ToolResult<object>.Success(new
+        {
+            count = ReportRecipes.List().Count,
+            items = ReportRecipes.List().Select(r => new
+            {
+                r.Id,
+                r.Title,
+                r.WhenToUse,
+                objects = r.Roster.Count,
+                r.ScaffoldCall,
+            }),
+            note = "Unlike a form pattern there is no pattern XML to validate a report against, so these are "
+                 + "recipes, not specs: an object roster, the base classes, one scaffold call, and the checks "
+                 + "worth running. `report-pattern spec <id>` has the rest.",
+        }));
+    }
+}
+
+/// <summary><c>d365fo report-pattern spec</c> — one shape in full.</summary>
+public sealed class ReportPatternSpecCommand : Command<ReportPatternSpecCommand.Settings>
+{
+    public sealed class Settings : D365OutputSettings
+    {
+        [CommandArgument(0, "<PATTERN>")]
+        [System.ComponentModel.Description("Recipe id: simple-list | grouped-with-totals | header-detail | pre-process | query-based | print-mgmt-form-letter | ui-builder-dialog")]
+        public string Pattern { get; init; } = "";
+    }
+
+    public override int Execute(CommandContext ctx, Settings settings)
+    {
+        var kind = OutputMode.Resolve(settings.Output);
+
+        var recipe = ReportRecipes.Find(settings.Pattern);
+        if (recipe is null)
+        {
+            return RenderHelpers.Render(kind, ToolResult<object>.Fail(D365FoErrorCodes.TopicNotFound,
+                $"No report recipe called '{settings.Pattern}'.",
+                $"Available: {string.Join(", ", ReportRecipes.Ids())}."));
+        }
+
+        return RenderHelpers.Render(kind, ToolResult<object>.Success(new
+        {
+            recipe.Id,
+            recipe.Title,
+            recipe.WhenToUse,
+            roster = recipe.Roster.Select(o => new { o.Kind, o.Role, o.Extends, o.Naming }),
+            recipe.ScaffoldCall,
+            methodGuidance = recipe.MethodGuidance,
+            checks = recipe.Checks,
+            referenceObjects = recipe.ReferenceObjects.Count > 0 ? recipe.ReferenceObjects : null,
+            readTheReference = recipe.ReferenceObjects.Count > 0
+                ? $"Shipped objects of this exact shape — read one with `d365fo read class {recipe.ReferenceObjects[0]}` "
+                  + "rather than working from this description alone."
+                : null,
+        }));
+    }
+}

--- a/src/D365FO.Core/Knowledge/ReportRecipes.cs
+++ b/src/D365FO.Core/Knowledge/ReportRecipes.cs
@@ -1,0 +1,244 @@
+// <copyright file="ReportRecipes.cs" company="d365fo-cli contributors">
+// MIT
+// </copyright>
+
+namespace D365FO.Core.Knowledge;
+
+/// <summary>One object an SSRS report shape needs, and what it is for.</summary>
+/// <param name="Kind">AOT type — AxTable, AxClass, AxReport, AxMenuItemOutput.</param>
+/// <param name="Role">Its job in the stack: TmpTable, Contract, DP, Controller, UIBuilder, Report, MenuItem.</param>
+/// <param name="Extends">Base class, where the role has one. The spelling is the AOT's own.</param>
+/// <param name="Naming">The convention shipped reports follow for this role.</param>
+public sealed record ReportRosterEntry(string Kind, string Role, string? Extends, string Naming);
+
+/// <summary>An implementation recipe for one report shape.</summary>
+/// <param name="Id">Stable identifier used as the command argument.</param>
+/// <param name="Title">One-line name.</param>
+/// <param name="WhenToUse">The decision this recipe answers.</param>
+/// <param name="Roster">Every object the shape needs.</param>
+/// <param name="ScaffoldCall">The one <c>generate report</c> call that produces it.</param>
+/// <param name="MethodGuidance">What still has to be written by hand afterwards.</param>
+/// <param name="Checks">What to run before believing it works.</param>
+/// <param name="ReferenceObjects">Shipped objects of this exact shape, to read rather than guess from.</param>
+public sealed record ReportRecipe(
+    string Id,
+    string Title,
+    string WhenToUse,
+    IReadOnlyList<ReportRosterEntry> Roster,
+    string ScaffoldCall,
+    IReadOnlyList<string> MethodGuidance,
+    IReadOnlyList<string> Checks,
+    IReadOnlyList<string> ReferenceObjects);
+
+/// <summary>
+/// The seven SSRS report shapes, as implementation recipes.
+/// </summary>
+/// <remarks>
+/// <para>
+/// Unlike a form pattern there is no pattern XML to validate a report against, so a recipe is
+/// not a spec — it is the object roster, the base classes, the single scaffold call that produces
+/// the stack, and the checks worth running afterwards. <c>generate report</c> could already build
+/// every one of these; what was missing was the layer that says WHICH to build, so an agent
+/// either picked by guesswork or produced a default-shaped report for a requirement that needed
+/// pre-processing.
+/// </para>
+/// <para>
+/// Every base class and naming convention here was counted in this installation's own
+/// ApplicationSuite/Foundation rather than recalled: <c>SrsReportRunController</c> 152,
+/// <c>SRSReportDataProviderBase</c> 95, <c>SrsReportDataProviderPreProcessTempDB</c> 88,
+/// <c>SrsReportDataContractUIBuilder</c> 59, <c>SrsPrintMgmtFormLetterController</c> 6. The
+/// casing is the AOT's own and is reproduced exactly — note that the DP base is <c>SRS</c> in
+/// capitals while every other class in the stack is <c>Srs</c>. X++ resolves either, so this is
+/// a readability and consistency matter, not a compile one, but a scaffold that emits the shipped
+/// spelling produces files that diff cleanly against their neighbours.
+/// </para>
+/// </remarks>
+public static class ReportRecipes
+{
+    private const string TmpNaming = "<Report>Tmp, a table with TableType=TempDB. InMemory designs fine and returns nothing at run time.";
+    private const string ContractNaming = "<Report>Contract, decorated [DataContractAttribute], one [DataMemberAttribute] parm method per parameter.";
+    private const string ReportNaming = "<Report> — the AxReport name carries NO DP/Contract/Controller/Tmp suffix; those belong to its companions.";
+
+    private static ReportRosterEntry Tmp() => new("AxTable", "TmpTable", null, TmpNaming);
+    private static ReportRosterEntry Contract() => new("AxClass", "Contract", null, ContractNaming);
+    private static ReportRosterEntry Report() => new("AxReport", "Report", null, ReportNaming);
+    private static ReportRosterEntry MenuItem() => new("AxMenuItemOutput", "MenuItem", null,
+        "<Report> as an Output menu item — a report is opened through an Output item, never a Display one.");
+
+    private static ReportRosterEntry Dp(bool preProcess) => new(
+        "AxClass", "DP",
+        preProcess ? "SrsReportDataProviderPreProcessTempDB" : "SRSReportDataProviderBase",
+        "<Report>DP, decorated [SRSReportParameterAttribute(classStr(<Report>Contract))].");
+
+    private static ReportRosterEntry Controller(string extends) => new(
+        "AxClass", "Controller", extends,
+        extends == "SrsPrintMgmtFormLetterController"
+            ? "<Report>Controller — Print management resolves the design, so the controller does not name one."
+            : "<Report>Controller, with a static main() that constructs it and calls startOperation().");
+
+    private static readonly ReportRecipe[] All =
+    [
+        new(
+            Id: "simple-list",
+            Title: "Simple list",
+            WhenToUse: "One flat table of rows with no grouping and no totals. The default shape, and the right "
+                     + "one whenever the report is 'show me these records'.",
+            Roster: [Tmp(), Contract(), Dp(preProcess: false), Controller("SrsReportRunController"), Report(), MenuItem()],
+            ScaffoldCall: "d365fo generate report <Report> --tmp <Report>Tmp --field <F> [--field <F>…] --install-to <Model>",
+            MethodGuidance:
+            [
+                "processReport() fills the temp table: select the source, set the Tmp buffer's fields, insert().",
+                "The [SRSReportDataSetAttribute(tableStr(<Report>Tmp))] method returns the buffer the dataset binds to.",
+            ],
+            Checks:
+            [
+                "d365fo validate xpp on the DP — the select-inside-loop rules matter most here.",
+                "d365fo build, then run the menu item: an empty report almost always means an InMemory temp table.",
+            ],
+            ReferenceObjects: ["BankChequeStatisticsDP", "BankCodaDetailsDP"]),
+
+        new(
+            Id: "grouped-with-totals",
+            Title: "Grouped with totals",
+            WhenToUse: "Rows broken into groups with a subtotal per group. Same object stack as a simple list — "
+                     + "the grouping is a design concern, not a code one.",
+            Roster: [Tmp(), Contract(), Dp(preProcess: false), Controller("SrsReportRunController"), Report(), MenuItem()],
+            ScaffoldCall: "d365fo generate report <Report> --tmp <Report>Tmp --field <GroupKey> --field <F>… --install-to <Model>",
+            MethodGuidance:
+            [
+                "The group key is a field on the temp table like any other; the RDL groups on it.",
+                "Do NOT make the group key the temp table's unique index — the second row of a group then fails on "
+                + "a duplicate key. The scaffold used to do exactly this.",
+            ],
+            Checks:
+            [
+                "Run it with data that has at least two rows in one group. A unique-index mistake passes every "
+                + "single-row test there is.",
+            ],
+            ReferenceObjects: ["BankChequeStatisticsDP"]),
+
+        new(
+            Id: "header-detail",
+            Title: "Header / detail",
+            WhenToUse: "A document with a header and its lines — one dataset per level, joined by a shared key.",
+            Roster:
+            [
+                Tmp(), new("AxTable", "TmpTable (lines)", null, "<Report>LineTmp, also TempDB, carrying the header key."),
+                Contract(), Dp(preProcess: false), Controller("SrsReportRunController"), Report(), MenuItem(),
+            ],
+            ScaffoldCall: "d365fo generate report <Report> --tmp <Report>Tmp --field <F>… --extra-dataset <Report>LineTmp:<F>,<F> --install-to <Model>",
+            MethodGuidance:
+            [
+                "One [SRSReportDataSetAttribute] method per temp table — the RDL binds a dataset to each.",
+                "Fill both buffers in the same processReport(): the header key written into the line rows is what "
+                + "the design joins on.",
+            ],
+            Checks: ["d365fo get report <Report> — confirm both datasets are present before designing the RDL."],
+            ReferenceObjects: ["BankBillOfExchangeDP_FR"]),
+
+        new(
+            Id: "pre-process",
+            Title: "Pre-processed",
+            WhenToUse: "The data is expensive to compute, or the report must run in batch over a set the user "
+                     + "chose earlier. The DP runs FIRST and persists its rows; the design then reads them.",
+            Roster: [Tmp(), Contract(), Dp(preProcess: true), Controller("SrsReportRunController"), Report(), MenuItem()],
+            ScaffoldCall: "d365fo generate report <Report> --tmp <Report>Tmp --field <F>… --pre-process --install-to <Model>",
+            MethodGuidance:
+            [
+                "The DP extends SrsReportDataProviderPreProcessTempDB, NOT SRSReportDataProviderBase.",
+                "Rows are keyed by AX_RdpPreProcessedId — the framework sets it; do not invent a key of your own.",
+                "insertData() is where the rows go in, and it runs before the design is rendered rather than during.",
+            ],
+            Checks:
+            [
+                "Run it twice in the same session: rows keyed on the wrong id show up as a report that is correct "
+                + "the first time and empty or duplicated the second.",
+            ],
+            ReferenceObjects: ["AgreementFollowUpDP", "AssetAcceleratedDepreciationDP_JP"]),
+
+        new(
+            Id: "query-based",
+            Title: "Query-based",
+            WhenToUse: "The rows are a plain select over existing tables with no computation. No DP class at all — "
+                     + "the AOT query IS the data source, and the user gets filtering for free.",
+            Roster:
+            [
+                new("AxQuery", "Query", null, "<Report>Query — the report's DataSources point at it."),
+                Report(), MenuItem(),
+                new("AxClass", "Controller (optional)", "SrsReportRunController",
+                    "Only needed to pre-filter the query or pick a design at run time."),
+            ],
+            ScaffoldCall: "d365fo generate query <Report>Query --ds <Table> --install-to <Model>  # then bind the report to it",
+            MethodGuidance:
+            [
+                "No temp table, no contract, no DP. Adding them because the other recipes have them is the most "
+                + "common way a query-based report turns into three objects that do nothing.",
+                "Ranges on the query become user-editable filters; `d365fo modify add-query-range` sets a fixed one.",
+            ],
+            Checks: ["d365fo get query <Report>Query --output json — confirm the datasources are what you expect."],
+            ReferenceObjects: []),
+
+        new(
+            Id: "print-mgmt-form-letter",
+            Title: "Print management form letter",
+            WhenToUse: "A business document customers see — invoice, packing slip, confirmation — that must obey "
+                     + "Print management: per-customer copies, printer destinations, footer text.",
+            Roster:
+            [
+                Tmp(), Contract(), Dp(preProcess: false), Controller("SrsPrintMgmtFormLetterController"), Report(), MenuItem(),
+                new("AxClass", "PrintMgmt wiring", null,
+                    "A PrintMgmtDocType/PrintMgmtReportFormat extension linking the document type to this report's design."),
+            ],
+            ScaffoldCall: "d365fo generate report <Report> --tmp <Report>Tmp --field <F>… --controller-type print-mgmt --install-to <Model>",
+            MethodGuidance:
+            [
+                "The controller extends SrsPrintMgmtFormLetterController — only 6 shipped classes do, so read one "
+                + "before writing your own.",
+                "Print management picks the design, so the controller must NOT hard-code one.",
+                "Without the PrintMgmtReportFormat entry the report exists and is simply never selected — no error "
+                + "anywhere, which is what makes this the step people miss.",
+            ],
+            Checks:
+            [
+                "Print the document from its own journal form, not from the menu item — the menu item bypasses "
+                + "Print management and will look fine while the real path is unwired.",
+            ],
+            ReferenceObjects: ["CustDebitCreditNoteController", "CustVendAdvanceInvoiceController", "FiscalDocumentController_BR"]),
+
+        new(
+            Id: "ui-builder-dialog",
+            Title: "UI-builder dialog",
+            WhenToUse: "The parameter dialog needs behaviour the contract alone cannot express — a lookup, a field "
+                     + "that enables another, a default computed at open time.",
+            Roster:
+            [
+                Tmp(), Contract(), Dp(preProcess: false), Controller("SrsReportRunController"), Report(), MenuItem(),
+                new("AxClass", "UIBuilder", "SrsReportDataContractUIBuilder",
+                    "<Report>UIBuilder, named on the contract via [SysOperationContractProcessingAttribute]."),
+            ],
+            ScaffoldCall: "d365fo generate report <Report> --tmp <Report>Tmp --field <F>… --ui-builder --install-to <Model>",
+            MethodGuidance:
+            [
+                "build() is where controls are overridden; postBuild() is where they are wired to lookups and "
+                + "modified-handlers, because the controls do not exist until build() has run.",
+                "The UIBuilder is reached through the CONTRACT's attribute, not the controller — a UIBuilder that "
+                + "never runs is almost always one nothing points at.",
+            ],
+            Checks:
+            [
+                "Open the dialog from the menu item. A UIBuilder that is not wired shows the default dialog, which "
+                + "looks like a working report rather than a missing attribute.",
+            ],
+            ReferenceObjects: ["AgreementFollowUpUIBuilder", "AssetBasisUIBuilder"]),
+    ];
+
+    /// <summary>Every recipe.</summary>
+    public static IReadOnlyList<ReportRecipe> List() => All;
+
+    /// <summary>One recipe by id, case-insensitively; null when there is none.</summary>
+    public static ReportRecipe? Find(string id) =>
+        All.FirstOrDefault(r => string.Equals(r.Id, id?.Trim(), StringComparison.OrdinalIgnoreCase));
+
+    /// <summary>The ids, for an error message that lists what is available.</summary>
+    public static IReadOnlyList<string> Ids() => All.Select(r => r.Id).ToList();
+}

--- a/tests/D365FO.Core.Tests/ReportRecipesAotTests.cs
+++ b/tests/D365FO.Core.Tests/ReportRecipesAotTests.cs
@@ -1,0 +1,121 @@
+using D365FO.Core.Knowledge;
+using Xunit;
+
+namespace D365FO.Core.Tests;
+
+/// <summary>
+/// Ground-truth check for the report recipes against a real installation.
+/// </summary>
+/// <remarks>
+/// Inert unless <c>D365FO_PACKAGES_PATH</c> points at a <c>PackagesLocalDirectory</c> — CI has no
+/// AOS, and a test that silently passed on an empty directory would be exactly the confident lie
+/// this repo's triage rubric warns about.
+///
+/// What it pins is the pair of claims a recipe cannot make up: the base classes exist under those
+/// exact names, and each named reference object really extends the base its recipe puts it under.
+/// A recipe naming a class the platform does not have reads as authoritative and costs a build
+/// cycle to disprove.
+/// </remarks>
+public class ReportRecipesAotTests
+{
+    private static string? PackagesRoot()
+    {
+        var root = Environment.GetEnvironmentVariable("D365FO_PACKAGES_PATH");
+        return string.IsNullOrWhiteSpace(root) || !Directory.Exists(root) ? null : root;
+    }
+
+    /// <summary>The <c>&lt;Name&gt;</c> and declared base of one AxClass file, or null.</summary>
+    private static string? DeclaredBase(string classFile)
+    {
+        string text;
+        try { text = File.ReadAllText(classFile); }
+        catch { return null; }
+
+        var match = System.Text.RegularExpressions.Regex.Match(
+            text, @"\bclass\s+\w+\s+extends\s+(\w+)",
+            System.Text.RegularExpressions.RegexOptions.IgnoreCase);
+        return match.Success ? match.Groups[1].Value : null;
+    }
+
+    private static string? FindClassFile(string root, string className)
+    {
+        foreach (var package in SafeDirs(root))
+            foreach (var model in SafeDirs(package))
+            {
+                var candidate = Path.Combine(model, "AxClass", className + ".xml");
+                if (File.Exists(candidate)) return candidate;
+            }
+        return null;
+
+        static IEnumerable<string> SafeDirs(string d)
+        {
+            try { return Directory.EnumerateDirectories(d); }
+            catch { return Array.Empty<string>(); }
+        }
+    }
+
+    [Fact]
+    public void Every_reference_object_exists_and_extends_the_base_its_recipe_claims()
+    {
+        var root = PackagesRoot();
+        if (root is null) return;
+
+        var problems = new List<string>();
+
+        foreach (var recipe in ReportRecipes.List())
+        {
+            // The base a reference object of this recipe is expected to extend: the DP base for a
+            // *DP class, the controller base for a *Controller, the UI-builder base for a
+            // *UIBuilder. Anything else is not checked here.
+            foreach (var reference in recipe.ReferenceObjects)
+            {
+                var file = FindClassFile(root, reference);
+                if (file is null)
+                {
+                    problems.Add($"{recipe.Id}: reference class '{reference}' is not in this installation");
+                    continue;
+                }
+
+                var declared = DeclaredBase(file);
+                if (declared is null)
+                {
+                    problems.Add($"{recipe.Id}: '{reference}' declares no base class");
+                    continue;
+                }
+
+                var expected = recipe.Roster
+                    .Select(o => o.Extends)
+                    .Where(e => e is not null)
+                    .ToList();
+
+                if (!expected.Any(e => string.Equals(e, declared, StringComparison.OrdinalIgnoreCase)))
+                {
+                    problems.Add(
+                        $"{recipe.Id}: '{reference}' extends {declared}, which is not among the recipe's "
+                        + $"base classes ({string.Join(", ", expected)})");
+                }
+            }
+        }
+
+        Assert.True(problems.Count == 0, string.Join(Environment.NewLine, problems));
+    }
+
+    [Fact]
+    public void Every_base_class_a_recipe_names_exists_in_this_installation()
+    {
+        var root = PackagesRoot();
+        if (root is null) return;
+
+        var bases = ReportRecipes.List()
+            .SelectMany(r => r.Roster)
+            .Select(o => o.Extends)
+            .Where(e => !string.IsNullOrWhiteSpace(e))
+            .Distinct(StringComparer.OrdinalIgnoreCase)
+            .ToList();
+
+        var missing = bases.Where(b => FindClassFile(root, b!) is null).ToList();
+
+        Assert.True(missing.Count == 0,
+            "Recipes name base classes this installation does not have: " + string.Join(", ", missing));
+    }
+}

--- a/tests/D365FO.Core.Tests/ReportRecipesTests.cs
+++ b/tests/D365FO.Core.Tests/ReportRecipesTests.cs
@@ -1,0 +1,122 @@
+using D365FO.Core.Knowledge;
+using Xunit;
+
+namespace D365FO.Core.Tests;
+
+/// <summary>
+/// A recipe that names an object or a base class the platform does not have is worse than no
+/// recipe: it reads as authoritative and costs a build cycle to disprove.
+/// </summary>
+/// <remarks>
+/// The base-class names here were counted in a real ApplicationSuite/Foundation rather than
+/// recalled. These tests pin the shape of the catalog; <c>ReportRecipesAotTests</c> checks the
+/// names against an actual installation when one is present.
+/// </remarks>
+public class ReportRecipesTests
+{
+    [Fact]
+    public void There_are_seven_recipes_with_unique_ids()
+    {
+        var recipes = ReportRecipes.List();
+        Assert.Equal(7, recipes.Count);
+        Assert.Equal(recipes.Count, recipes.Select(r => r.Id).Distinct(StringComparer.OrdinalIgnoreCase).Count());
+    }
+
+    [Theory]
+    [InlineData("simple-list")]
+    [InlineData("grouped-with-totals")]
+    [InlineData("header-detail")]
+    [InlineData("pre-process")]
+    [InlineData("query-based")]
+    [InlineData("print-mgmt-form-letter")]
+    [InlineData("ui-builder-dialog")]
+    public void Every_recipe_is_findable_and_complete(string id)
+    {
+        var recipe = ReportRecipes.Find(id);
+
+        Assert.NotNull(recipe);
+        Assert.NotEmpty(recipe!.WhenToUse);
+        Assert.NotEmpty(recipe.Roster);
+        Assert.NotEmpty(recipe.ScaffoldCall);
+        Assert.NotEmpty(recipe.Checks);
+    }
+
+    [Fact]
+    public void Find_is_case_insensitive_and_tolerates_spacing()
+    {
+        Assert.NotNull(ReportRecipes.Find("PRE-PROCESS"));
+        Assert.NotNull(ReportRecipes.Find("  pre-process  "));
+        Assert.Null(ReportRecipes.Find("preprocess"));
+    }
+
+    [Fact]
+    public void The_pre_process_recipe_names_the_pre_process_base_and_the_others_do_not()
+    {
+        // Building a pre-processed requirement on SRSReportDataProviderBase behaves wrong in
+        // batch with nothing failing anywhere, so this is the distinction that matters most.
+        var pre = ReportRecipes.Find("pre-process")!;
+        Assert.Contains(pre.Roster, o => o.Extends == "SrsReportDataProviderPreProcessTempDB");
+
+        var simple = ReportRecipes.Find("simple-list")!;
+        Assert.Contains(simple.Roster, o => o.Extends == "SRSReportDataProviderBase");
+        Assert.DoesNotContain(simple.Roster, o => o.Extends == "SrsReportDataProviderPreProcessTempDB");
+    }
+
+    [Fact]
+    public void Only_the_print_management_recipe_uses_the_print_management_controller()
+    {
+        foreach (var recipe in ReportRecipes.List())
+        {
+            var usesPrintMgmt = recipe.Roster.Any(o => o.Extends == "SrsPrintMgmtFormLetterController");
+            Assert.Equal(recipe.Id == "print-mgmt-form-letter", usesPrintMgmt);
+        }
+    }
+
+    [Fact]
+    public void The_query_based_recipe_has_no_temp_table_contract_or_dp()
+    {
+        // Adding them because the other six have them is the common way a query-based report
+        // turns into three objects that do nothing.
+        var recipe = ReportRecipes.Find("query-based")!;
+
+        Assert.DoesNotContain(recipe.Roster, o => o.Role == "TmpTable");
+        Assert.DoesNotContain(recipe.Roster, o => o.Role == "Contract");
+        Assert.DoesNotContain(recipe.Roster, o => o.Role == "DP");
+        Assert.Contains(recipe.Roster, o => o.Kind == "AxQuery");
+    }
+
+    [Fact]
+    public void Every_scaffold_call_is_a_real_generate_invocation()
+    {
+        foreach (var recipe in ReportRecipes.List())
+        {
+            Assert.StartsWith("d365fo generate ", recipe.ScaffoldCall);
+            Assert.Contains("--install-to", recipe.ScaffoldCall);
+        }
+    }
+
+    [Fact]
+    public void Base_classes_are_spelled_the_way_the_AOT_spells_them()
+    {
+        // The DP base is SRS in capitals while every other class in the stack is Srs. X++
+        // resolves either, so this is consistency rather than compilation — but a scaffold that
+        // emits the shipped spelling produces files that diff cleanly against their neighbours.
+        var known = new[]
+        {
+            "SRSReportDataProviderBase",
+            "SrsReportDataProviderPreProcessTempDB",
+            "SrsReportRunController",
+            "SrsPrintMgmtFormLetterController",
+            "SrsReportDataContractUIBuilder",
+        };
+
+        var used = ReportRecipes.List()
+            .SelectMany(r => r.Roster)
+            .Select(o => o.Extends)
+            .Where(e => e is not null)
+            .Distinct()
+            .ToList();
+
+        Assert.All(used, e => Assert.Contains(e, known));
+    }
+}


### PR DESCRIPTION
`d365fo report-pattern list | spec` — the decision layer over `generate report`.

`generate report` could already build all seven of these. What was missing was the layer that says **which** to build, and getting that wrong is expensive in a way a form-pattern violation is not: there is no pattern XML to validate a report against, so a pre-processed requirement built on `SRSReportDataProviderBase` simply behaves wrong in batch **with nothing failing anywhere**.

A recipe is therefore not a spec. It is the object roster, the base classes, the one scaffold call that produces the stack, what still has to be written by hand, and the checks worth running afterwards.

## Nothing here was recalled

The base classes were **counted in this installation's own** `ApplicationSuite/Foundation`:

| base class | shipped subclasses |
|---|---:|
| `SrsReportRunController` | 152 |
| `SRSReportDataProviderBase` | 95 |
| `SrsReportDataProviderPreProcessTempDB` | 88 |
| `SrsReportDataContractUIBuilder` | 59 |
| `SrsPrintMgmtFormLetterController` | 6 |

The casing is reproduced exactly — the DP base is `SRS` in capitals while every other class in the stack is `Srs`. X++ resolves either, so this is consistency rather than compilation, but a scaffold emitting the shipped spelling produces files that diff cleanly against their neighbours.

Each recipe names shipped **reference objects to read** rather than working from prose.

## The tests are the point

`ReportRecipesAotTests` resolves all 11 reference objects against a real `PackagesLocalDirectory` and asserts each extends the base its recipe claims, plus that every base class named exists at all. It is **inert where there is no install** rather than passing vacuously — a test that silently passes on an empty directory is exactly the confident lie this repo's triage rubric warns about. Verified on a live D365FO VM:

```
simple-list              BankChequeStatisticsDP       extends SRSReportDataProviderBase
pre-process              AgreementFollowUpDP          extends SrsReportDataProviderPreProcessTempDB
print-mgmt-form-letter   CustDebitCreditNoteController extends SrsPrintMgmtFormLetterController
ui-builder-dialog        AgreementFollowUpUIBuilder   extends SrsReportDataContractUIBuilder
…11 reference objects, 5 base classes, all present
```

The offline tests pin the distinctions that cost a build cycle: only `pre-process` names the pre-process base; only `print-mgmt-form-letter` names `SrsPrintMgmtFormLetterController`; and `query-based` has **no temp table, contract or DP at all** — adding them because the other six have them is the common way a query-based report turns into three objects that do nothing.

## Verification

- 1 613 tests green (578 CLI + 1 035 Core)
- eval catalog 52/52 · knowledge audit clean · warning ratchet at baseline 117

## Still open in wave 03

Warehouse-app (mobile) recipes and five knowledge topics. Both are authored knowledge rather than extractable, so I want each claim through `xppc` before it ships — after this branch's experience I would rather that be a separate reviewable change than tacked on here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019D9AMJP7Ct2U4Q3xVeMn8B
