### PR TITLE
Wave 03: warehouse scanner screens, and the framework choice they start with

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,6 +37,20 @@ was ported from.
   `D365FO_BP_CATALOG_PATH` points at a snapshot matching an instance's own D365FO version.
   The resources are read through `PEReader` rather than by loading the assemblies — loading a
   D365FO rule assembly drags in its dependency graph for the sake of a string table.
+- **`d365fo mobile-pattern list|spec`** — warehouse scanner screens, seven recipes across the two
+  frameworks. The list leads with the framework DECISION rather than the recipes, because it is
+  the one choice that cannot be taken back cheaply: the same screens are built by ProcessGuide
+  (controller, step, page builder, data processor, navigation agent, action — each behind an
+  abstract factory, each an extension point) and by the legacy `WhsWorkExecuteDisplay` hierarchy
+  (all of it in one class with a `displayForm()` per mode). Picking wrong is a rewrite.
+  Counted here rather than recalled: the `ProcessGuide` package holds 382 classes, of which
+  `ProcessGuidePageBuilder` has 75 subclasses, `ProcessGuideStep` 74,
+  `ProcessGuideNavigationAgent` 40, `ProcessGuideController` 25, `ProcessGuideAction` 23; the
+  abstract `WhsWorkExecuteDisplay` has 64 subclasses in ApplicationSuite/Foundation alone.
+  Two recipes deliberately ask for **no code at all** — a screen's title, icon and menu placement
+  are warehouse configuration, and GS1 barcode splitting is barcode configuration. Writing a class
+  for the first or a `parseBarcode()` for the second is the mistake those recipes exist to prevent.
+  `MobileAppRecipesAotTests` resolves every named class against a real installation.
 - **`d365fo report-pattern list|spec`** — the seven SSRS shapes as implementation recipes:
   object roster, base classes, the one `generate report` call that produces the stack, what still
   has to be written by hand, and the checks worth running. `generate report` could already build

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
 [![.NET](https://img.shields.io/badge/.NET-10-purple.svg)](https://dotnet.microsoft.com/)
 [![Platform](https://img.shields.io/badge/platform-Windows%20%7C%20macOS%20%7C%20Linux-lightgrey.svg)]()
-[![Tests](https://img.shields.io/badge/tests-1613-brightgreen.svg)]()
+[![Tests](https://img.shields.io/badge/tests-1630-brightgreen.svg)]()
 [![Successor to d365fo-mcp-server](https://img.shields.io/badge/successor%20to-d365fo--mcp--server-orange.svg)](https://github.com/dynamics365ninja/d365fo-mcp-server)
 
 *Grounded AI development for Dynamics 365 Finance & Operations — works with GitHub Copilot, Claude Code, Codex, Gemini CLI, and any agent with a shell*
@@ -292,7 +292,7 @@ See [docs/TOKEN_ECONOMICS.md](docs/TOKEN_ECONOMICS.md) for the full analysis and
 | **Labels** | `labels search\|resolve\|info\|create\|rename\|delete` — search/resolve plus in-place `*.label.txt` edits, multi-language via `--lang` (mirrors the MCP `labels` tool) |
 | **Journal / undo** | `undo [--steps N] [--dry-run]`, `journal list`, `delete` (kind/name, bridge or on-disk) — deterministic single-command rollback for every write path (mirrors the MCP `undo_last_modification` tool) |
 | **Modify** | `modify property\|method`, `modify add-field\|add-enum-value\|add-control`, `modify add-index\|add-relation\|add-field-group\|add-delete-action`, `modify rename-field`, `modify add-query-range\|remove-query-range`, `modify add-entry-point\|remove-entry-point`, seven `modify remove-*` forms, and `modify batch` (several changes in one read-edit-write) — 22 operations over all 41 bridge-writable kinds, extension-aware and journalled for `undo` |
-| **Patterns & rules** | `report-pattern list\|spec` — the seven SSRS shapes as recipes · `table-pattern list\|spec` — table shapes and what each presets · `bp-moniker validate\|search\|suppress\|extract` — Best-Practice rule monikers from names a real installation declares, never a guess |
+| **Patterns & rules** | `mobile-pattern list\|spec` — warehouse scanner screens, and which of the two frameworks owns the flow · `report-pattern list\|spec` — the seven SSRS shapes as recipes · `table-pattern list\|spec` — table shapes and what each presets · `bp-moniker validate\|search\|suppress\|extract` — Best-Practice rule monikers from names a real installation declares, never a guess |
 | **Analyze** | `analyze completeness`, `analyze integration`, `analyze impact`, `lint`, `suggest edt`, `suggest extension`, `report-integrations` |
 | **Review** | `review diff` |
 | **Models** | `models list`, `models deps`, `models coupling` |

--- a/src/D365FO.Cli/CliApp.cs
+++ b/src/D365FO.Cli/CliApp.cs
@@ -359,6 +359,13 @@ public static class CliApp
             // The CLI's `get_knowledge` equivalent: the verified skills/_source corpus,
             // embedded in the binary and served per-topic / per-section so an agent
             // without skill-file support can still ground itself.
+            cfg.AddBranch("mobile-pattern", b =>
+            {
+                b.SetDescription("Warehouse scanner screens: which of the two frameworks owns the flow, then how to change it.");
+                b.AddCommand<MobilePatternListCommand>("list").WithDescription("The framework decision, then the seven recipes.");
+                b.AddCommand<MobilePatternSpecCommand>("spec").WithDescription("One recipe in full, with shipped reference classes to read.");
+            });
+
             cfg.AddBranch("report-pattern", b =>
             {
                 b.SetDescription("SSRS report shapes as implementation recipes: object roster, base classes, one scaffold call.");

--- a/src/D365FO.Cli/Commands/Knowledge/MobilePatternCommands.cs
+++ b/src/D365FO.Cli/Commands/Knowledge/MobilePatternCommands.cs
@@ -1,0 +1,97 @@
+using D365FO.Core;
+using D365FO.Core.Knowledge;
+using Spectre.Console.Cli;
+
+namespace D365FO.Cli.Commands.Knowledge;
+
+// `d365fo mobile-pattern` — warehouse scanner screens.
+//
+// The list deliberately leads with the framework decision rather than the recipes, because that
+// is the one choice the platform will not let you take back cheaply: the same screens are built
+// by two frameworks, and building on the wrong one is a rewrite.
+
+/// <summary><c>d365fo mobile-pattern list</c> — the framework decision, then the recipes.</summary>
+public sealed class MobilePatternListCommand : Command<MobilePatternListCommand.Settings>
+{
+    public sealed class Settings : D365OutputSettings
+    {
+        [CommandOption("--framework <NAME>")]
+        [System.ComponentModel.Description("Show only one framework's recipes: process-guide | work-execute-display | configuration.")]
+        public string? Framework { get; init; }
+    }
+
+    public override int Execute(CommandContext ctx, Settings settings)
+    {
+        var kind = OutputMode.Resolve(settings.Output);
+
+        var recipes = MobileAppRecipes.List().AsEnumerable();
+        if (!string.IsNullOrWhiteSpace(settings.Framework))
+        {
+            var wanted = settings.Framework!.Replace("-", "", StringComparison.Ordinal);
+            if (!Enum.TryParse<MobileFramework>(wanted, ignoreCase: true, out var framework))
+            {
+                return RenderHelpers.Render(kind, ToolResult<object>.Fail(D365FoErrorCodes.BadInput,
+                    $"Unknown framework '{settings.Framework}'.",
+                    "Use process-guide, work-execute-display or configuration."));
+            }
+            recipes = recipes.Where(r => r.Framework == framework);
+        }
+
+        var items = recipes.ToList();
+        return RenderHelpers.Render(kind, ToolResult<object>.Success(new
+        {
+            decideFirst = MobileAppRecipes.FrameworkDecision,
+            count = items.Count,
+            items = items.Select(r => new
+            {
+                r.Id,
+                r.Title,
+                framework = r.Framework.ToString(),
+                r.WhenToUse,
+                classes = r.Roster.Count,
+            }),
+        }));
+    }
+}
+
+/// <summary><c>d365fo mobile-pattern spec</c> — one recipe in full.</summary>
+public sealed class MobilePatternSpecCommand : Command<MobilePatternSpecCommand.Settings>
+{
+    public sealed class Settings : D365OutputSettings
+    {
+        [CommandArgument(0, "<RECIPE>")]
+        [System.ComponentModel.Description("Recipe id: processguide-flow | processguide-page-control | processguide-page-replace | processguide-step-insert | app-step-identity | legacy-workexecutedisplay | gs1-scan-input")]
+        public string Recipe { get; init; } = "";
+    }
+
+    public override int Execute(CommandContext ctx, Settings settings)
+    {
+        var kind = OutputMode.Resolve(settings.Output);
+
+        var recipe = MobileAppRecipes.Find(settings.Recipe);
+        if (recipe is null)
+        {
+            return RenderHelpers.Render(kind, ToolResult<object>.Fail(D365FoErrorCodes.TopicNotFound,
+                $"No warehouse-app recipe called '{settings.Recipe}'.",
+                $"Available: {string.Join(", ", MobileAppRecipes.Ids())}."));
+        }
+
+        return RenderHelpers.Render(kind, ToolResult<object>.Success(new
+        {
+            recipe.Id,
+            recipe.Title,
+            framework = recipe.Framework.ToString(),
+            recipe.WhenToUse,
+            roster = recipe.Roster.Select(o => new { o.Role, o.Extends, o.Naming, o.Required }),
+            guidance = recipe.Guidance,
+            checks = recipe.Checks,
+            referenceObjects = recipe.ReferenceObjects.Count > 0 ? recipe.ReferenceObjects : null,
+            readTheReference = recipe.ReferenceObjects.Count > 0
+                ? $"Shipped classes of this exact shape — read one with `d365fo read class {recipe.ReferenceObjects[0]}`."
+                : null,
+            note = recipe.Framework == MobileFramework.Configuration
+                ? "This one is CONFIGURATION, not code. Writing a class here is the mistake the recipe exists to prevent."
+                : null,
+        }));
+    }
+}

--- a/src/D365FO.Core/Knowledge/MobileAppRecipes.cs
+++ b/src/D365FO.Core/Knowledge/MobileAppRecipes.cs
@@ -1,0 +1,268 @@
+// <copyright file="MobileAppRecipes.cs" company="d365fo-cli contributors">
+// MIT
+// </copyright>
+
+namespace D365FO.Core.Knowledge;
+
+/// <summary>Which of the two warehouse-app frameworks a recipe belongs to.</summary>
+public enum MobileFramework
+{
+    /// <summary>The current one: controller → step → page builder → data processor → navigation agent → action.</summary>
+    ProcessGuide,
+
+    /// <summary>The legacy one: a <c>WhsWorkExecuteDisplay</c> subclass with one <c>displayForm()</c> per mode.</summary>
+    WorkExecuteDisplay,
+
+    /// <summary>Neither — the answer is configuration rather than code.</summary>
+    Configuration,
+}
+
+/// <summary>One class a warehouse-app recipe needs.</summary>
+/// <param name="Role">Its job in the flow.</param>
+/// <param name="Extends">Base class, spelled as the AOT spells it.</param>
+/// <param name="Naming">The convention shipped classes follow.</param>
+/// <param name="Required">False for the parts a flow only sometimes needs.</param>
+public sealed record MobileRosterEntry(string Role, string? Extends, string Naming, bool Required = true);
+
+/// <summary>An implementation recipe for one warehouse-app change.</summary>
+public sealed record MobileAppRecipe(
+    string Id,
+    string Title,
+    MobileFramework Framework,
+    string WhenToUse,
+    IReadOnlyList<MobileRosterEntry> Roster,
+    IReadOnlyList<string> Guidance,
+    IReadOnlyList<string> Checks,
+    IReadOnlyList<string> ReferenceObjects);
+
+/// <summary>
+/// Warehouse mobile-app (scanner) screen recipes.
+/// </summary>
+/// <remarks>
+/// <para>
+/// The list leads with the decision the platform forces on you, because it is the one that cannot
+/// be undone cheaply: the SAME screens are built by TWO frameworks. <b>ProcessGuide</b> is the
+/// current one — controller, step, page builder, data processor, navigation agent and action are
+/// each their own class with an abstract factory in front of it, so each is an extension point.
+/// The legacy <b>WhsWorkExecuteDisplay</b> hierarchy puts all of it in one class with a
+/// <c>displayForm()</c> per mode. Picking the wrong one is a rewrite, not a refactor.
+/// </para>
+/// <para>
+/// Counted in this installation rather than recalled. The <c>ProcessGuide</c> package holds 382
+/// classes; within it <c>ProcessGuidePageBuilder</c> has 75 subclasses, <c>ProcessGuideStep</c>
+/// 74, <c>ProcessGuideNavigationAgent</c> 40, <c>ProcessGuideController</c> 25,
+/// <c>ProcessGuideAction</c> 23, and <c>ProcessGuideStepWithoutPrompt</c> 18. The legacy
+/// <c>WhsWorkExecuteDisplay</c> is abstract with 64 subclasses in ApplicationSuite/Foundation
+/// alone.
+/// </para>
+/// <para>
+/// A casing note worth having, because it looks like a typo in review and is not: the AOT itself
+/// is inconsistent here — both <c>WHSWorkExecuteDisplay</c> and <c>WhsWorkExecuteDisplay</c>
+/// appear as the declared base among shipped subclasses. X++ resolves either.
+/// </para>
+/// </remarks>
+public static class MobileAppRecipes
+{
+    private static readonly MobileAppRecipe[] All =
+    [
+        new(
+            Id: "processguide-flow",
+            Title: "New ProcessGuide flow",
+            Framework: MobileFramework.ProcessGuide,
+            WhenToUse: "A new scanner process of your own — the operator walks through a sequence of screens. "
+                     + "This is the default answer for new work; reach for the legacy hierarchy only when "
+                     + "extending something already built on it.",
+            Roster:
+            [
+                new("Controller", "ProcessGuideController",
+                    "<Prefix>ProcessGuide<Flow>Controller — owns the flow and the order of its steps."),
+                new("Step", "ProcessGuideStep",
+                    "<Prefix>ProcessGuide<Screen>Step — one screen. Use ProcessGuideStepWithoutPrompt for a step "
+                    + "that does work and shows no prompt."),
+                new("Page builder", "ProcessGuidePageBuilder",
+                    "<Prefix>ProcessGuide<Screen>PageBuilder — builds the controls the step shows."),
+                new("Navigation agent", "ProcessGuideNavigationAgent",
+                    "<Prefix>ProcessGuide<Flow>NavigationAgent — decides which step comes next.", Required: false),
+                new("Data processor", "ProcessGuideDataProcessor",
+                    "<Prefix>ProcessGuide<Flow>DataProcessor — turns what the operator entered into a business "
+                    + "action. ProcessGuideDataProcessorDefault covers the simple case.", Required: false),
+            ],
+            Guidance:
+            [
+                "Every part is reached through an abstract factory (ProcessGuide*AbstractFactory), which is what "
+                + "makes each one an extension point. Register your class with the matching factory — a step that "
+                + "no factory returns is a class the app never constructs.",
+                "The step is the unit of navigation, the page builder the unit of layout. Putting layout in the "
+                + "step is what makes a flow impossible to extend later.",
+            ],
+            Checks:
+            [
+                "d365fo build, then walk the flow on a device or the emulator — a missing factory registration "
+                + "shows up as the flow ending early, not as an error.",
+            ],
+            ReferenceObjects: ["InventProcessGuideAdjustInController", "InventProcessGuideCaptureCatchWeightTagAdjustInStep"]),
+
+        new(
+            Id: "processguide-page-control",
+            Title: "Add a control to a standard screen",
+            Framework: MobileFramework.ProcessGuide,
+            WhenToUse: "A shipped screen needs one more field shown or captured, and everything else about it "
+                     + "stays as it is.",
+            Roster:
+            [
+                new("Page builder extension", null,
+                    "A Chain of Command extension of the standard <Screen>PageBuilder, wrapping the method that "
+                    + "adds controls."),
+            ],
+            Guidance:
+            [
+                "Extend the page builder, NOT the step: the step decides navigation, and wrapping it to add a "
+                + "control couples your change to a sequence that may be reordered.",
+                "`d365fo find coc <PageBuilder>::<method>` first — a standard page builder often already has a "
+                + "wrapper, and two wrappers adding the same control produce it twice.",
+            ],
+            Checks: ["d365fo validate xpp on the CoC class — the next-must-be-reached rules apply."],
+            ReferenceObjects: ["InventProcessGuideDisplayInquiryItemDetailsPageBuilder"]),
+
+        new(
+            Id: "processguide-page-replace",
+            Title: "Replace a standard page",
+            Framework: MobileFramework.ProcessGuide,
+            WhenToUse: "The shipped screen is wrong for your process rather than merely incomplete — different "
+                     + "controls, different layout.",
+            Roster:
+            [
+                new("Page builder", "ProcessGuidePageBuilder",
+                    "Your own builder for the screen."),
+                new("Page builder factory", "ProcessGuidePageBuilderAbstractFactory",
+                    "Returns your builder instead of the standard one for this step."),
+            ],
+            Guidance:
+            [
+                "This is a substitution, not an extension: the factory is what decides, so the standard builder "
+                + "stays untouched and yours is returned in its place.",
+                "Prefer processguide-page-control when the difference is additive — a replaced page stops "
+                + "receiving Microsoft's changes to that screen.",
+                "Extend the nearest intermediate base, not always ProcessGuidePageBuilder itself. Modules ship "
+                + "their own layer — WHSProcessGuideCycleCountPageBuilder extends ProcessGuidePageBuilder and has "
+                + "five subclasses of its own — and starting from the framework type loses whatever that layer "
+                + "already does for the flow.",
+            ],
+            Checks: ["Confirm the standard builder is no longer being constructed; two builders for one step is a "
+                   + "factory that returns the wrong one under some condition."],
+            ReferenceObjects: ["WHSProcessGuidePromptCycleCountItemBuilder"]),
+
+        new(
+            Id: "processguide-step-insert",
+            Title: "Insert a step into a standard flow",
+            Framework: MobileFramework.ProcessGuide,
+            WhenToUse: "The operator must do or confirm something extra part-way through a shipped process.",
+            Roster:
+            [
+                new("Step", "ProcessGuideStep",
+                    "The new screen. ProcessGuideStepWithoutPrompt when it only does work."),
+                new("Page builder", "ProcessGuidePageBuilder", "Its layout.", Required: false),
+                new("Navigation agent", "ProcessGuideNavigationAgent",
+                    "Your agent, returning the new step at the right point."),
+                new("Navigation agent factory", "ProcessGuideNavigationAgentAbstractFactory",
+                    "Returns your agent for the flow you are changing."),
+            ],
+            Guidance:
+            [
+                "The navigation agent is the ONLY thing that decides order. Inserting a step means replacing the "
+                + "agent, not editing the controller.",
+                "Handle the back path as well as the forward one — an inserted step that cannot be reversed strands "
+                + "the operator mid-process.",
+            ],
+            Checks: ["Walk the flow forwards and backwards. Skipping the reverse direction is the usual defect."],
+            ReferenceObjects: ["InventProcessGuideInquiryItemPromptNavigationAgent", "WHSProcessGuideBackEnabledNavigationAgentFactory"]),
+
+        new(
+            Id: "app-step-identity",
+            Title: "The step's identity in the app",
+            Framework: MobileFramework.Configuration,
+            WhenToUse: "The screen works but shows the wrong title, the wrong icon, or does not appear on the "
+                     + "menu the operator uses.",
+            Roster:
+            [
+                new("Menu item (warehouse)", null,
+                    "A warehouse mobile device menu item — configured in the app's own menu, not the AOT menu tree.",
+                    Required: false),
+            ],
+            Guidance:
+            [
+                "This is configuration, not code: title, icon and menu placement come from the warehouse mobile "
+                + "device menu setup, and a code change will not move them.",
+                "Writing a class to change a caption is the mistake this recipe exists to prevent.",
+            ],
+            Checks: ["Change it in the setup form and re-open the app — no build is involved."],
+            ReferenceObjects: ["WHSMobileAppActionIconSelector"]),
+
+        new(
+            Id: "legacy-workexecutedisplay",
+            Title: "Extend a legacy WorkExecuteDisplay screen",
+            Framework: MobileFramework.WorkExecuteDisplay,
+            WhenToUse: "You are changing a process that is ALREADY built on the legacy hierarchy. Do not start "
+                     + "new work here — but do not port an existing flow to ProcessGuide as a side effect of a "
+                     + "small change either.",
+            Roster:
+            [
+                new("Display class extension", null,
+                    "A Chain of Command extension of the relevant WhsWorkExecuteDisplay subclass, wrapping its "
+                    + "displayForm() (or the mode-specific method)."),
+            ],
+            Guidance:
+            [
+                "The base is abstract and has 64 subclasses in ApplicationSuite/Foundation alone — find the one "
+                + "that owns the mode you are changing with `d365fo search class WHSWorkExecuteDisplay`.",
+                "The AOT is inconsistent about the casing: both WHSWorkExecuteDisplay and WhsWorkExecuteDisplay "
+                + "appear as the declared base among shipped subclasses. X++ resolves either; it is not a typo.",
+                "One class does navigation, layout and business logic together, which is exactly why new work "
+                + "belongs in ProcessGuide.",
+            ],
+            Checks: ["d365fo find coc <DisplayClass>::displayForm before writing — these classes are heavily wrapped already."],
+            ReferenceObjects: ["WhsWorkExecuteDisplayAdjustIn", "WHSWorkExecuteDisplayCancelWork"]),
+
+        new(
+            Id: "gs1-scan-input",
+            Title: "Accept a GS1 barcode",
+            Framework: MobileFramework.Configuration,
+            WhenToUse: "A scanned barcode carries several values — item, batch, quantity, expiry — and the screen "
+                     + "must take them apart.",
+            Roster: [],
+            Guidance:
+            [
+                "Scanning is CONFIGURATION, not a hand-written parser. The GS1 application identifiers and the "
+                + "fields they map to are set up in the warehouse barcode configuration; the app splits the scan "
+                + "before any of your code sees it.",
+                "Writing a parseBarcode() is the failure mode this recipe exists to prevent: it works for the "
+                + "sample barcode and breaks on the first variable-length identifier.",
+            ],
+            Checks:
+            [
+                "Scan a barcode carrying two identifiers and confirm both fields populate. A parser that appears "
+                + "to work on one identifier proves nothing.",
+            ],
+            ReferenceObjects: []),
+    ];
+
+    /// <summary>Every recipe.</summary>
+    public static IReadOnlyList<MobileAppRecipe> List() => All;
+
+    /// <summary>One recipe by id, case-insensitively; null when there is none.</summary>
+    public static MobileAppRecipe? Find(string id) =>
+        All.FirstOrDefault(r => string.Equals(r.Id, id?.Trim(), StringComparison.OrdinalIgnoreCase));
+
+    /// <summary>The ids, for an error message that lists what is available.</summary>
+    public static IReadOnlyList<string> Ids() => All.Select(r => r.Id).ToList();
+
+    /// <summary>
+    /// The choice to make before any of the recipes apply.
+    /// </summary>
+    public static string FrameworkDecision =>
+        "The SAME screens are built by TWO frameworks, and picking the wrong one is a rewrite. "
+        + "ProcessGuide is the current one: controller, step, page builder, data processor, navigation agent and "
+        + "action are separate classes, each behind an abstract factory, so each is an extension point. The legacy "
+        + "WhsWorkExecuteDisplay hierarchy does all of it in one class with a displayForm() per mode. "
+        + "New work goes in ProcessGuide; a change to a process already built on the legacy hierarchy stays there.";
+}

--- a/tests/D365FO.Core.Tests/MobileAppRecipesAotTests.cs
+++ b/tests/D365FO.Core.Tests/MobileAppRecipesAotTests.cs
@@ -1,0 +1,126 @@
+using D365FO.Core.Knowledge;
+using Xunit;
+
+namespace D365FO.Core.Tests;
+
+/// <summary>
+/// Ground-truth check for the warehouse-app recipes against a real installation.
+/// </summary>
+/// <remarks>
+/// Inert unless <c>D365FO_PACKAGES_PATH</c> points at a <c>PackagesLocalDirectory</c>. These
+/// recipes are AUTHORED knowledge rather than extracted, which is exactly why the class names in
+/// them need checking: a recipe naming a base class the platform does not have reads as
+/// authoritative and costs a build cycle to disprove.
+/// </remarks>
+public class MobileAppRecipesAotTests
+{
+    private static string? PackagesRoot()
+    {
+        var root = Environment.GetEnvironmentVariable("D365FO_PACKAGES_PATH");
+        return string.IsNullOrWhiteSpace(root) || !Directory.Exists(root) ? null : root;
+    }
+
+    private static string? FindClassFile(string root, string className)
+    {
+        foreach (var package in SafeDirs(root))
+            foreach (var model in SafeDirs(package))
+            {
+                var candidate = Path.Combine(model, "AxClass", className + ".xml");
+                if (File.Exists(candidate)) return candidate;
+            }
+        return null;
+
+        static IEnumerable<string> SafeDirs(string d)
+        {
+            try { return Directory.EnumerateDirectories(d); }
+            catch { return Array.Empty<string>(); }
+        }
+    }
+
+    private static string? DeclaredBase(string classFile)
+    {
+        string text;
+        try { text = File.ReadAllText(classFile); }
+        catch { return null; }
+
+        var match = System.Text.RegularExpressions.Regex.Match(
+            text, @"\bclass\s+\w+\s+extends\s+(\w+)",
+            System.Text.RegularExpressions.RegexOptions.IgnoreCase);
+        return match.Success ? match.Groups[1].Value : null;
+    }
+
+    [Fact]
+    public void Every_base_class_a_recipe_names_exists_in_this_installation()
+    {
+        var root = PackagesRoot();
+        if (root is null) return;
+
+        var bases = MobileAppRecipes.List()
+            .SelectMany(r => r.Roster)
+            .Select(o => o.Extends)
+            .Where(e => !string.IsNullOrWhiteSpace(e))
+            .Distinct(StringComparer.OrdinalIgnoreCase)
+            .ToList();
+
+        var missing = bases.Where(b => FindClassFile(root, b!) is null).ToList();
+
+        Assert.True(missing.Count == 0,
+            "Recipes name base classes this installation does not have: " + string.Join(", ", missing));
+    }
+
+    [Fact]
+    public void Every_reference_class_exists_and_sits_under_the_framework_its_recipe_claims()
+    {
+        var root = PackagesRoot();
+        if (root is null) return;
+
+        var problems = new List<string>();
+
+        foreach (var recipe in MobileAppRecipes.List())
+        {
+            foreach (var reference in recipe.ReferenceObjects)
+            {
+                var file = FindClassFile(root, reference);
+                if (file is null)
+                {
+                    problems.Add($"{recipe.Id}: reference class '{reference}' is not in this installation");
+                    continue;
+                }
+
+                // The framework a class belongs to is visible in its declared base. CONTAINS, not
+                // starts-with: a concrete class often extends a module-prefixed intermediate base
+                // rather than the framework type directly — WHSProcessGuidePromptCycleCountItemBuilder
+                // extends WHSProcessGuideCycleCountPageBuilder, which extends ProcessGuidePageBuilder.
+                // Measured in the ProcessGuide package: 287 classes extend a ProcessGuide* type
+                // directly and a further ~17 go through such an intermediate. A starts-with rule
+                // called those legacy, which is the opposite of the truth.
+                var declared = DeclaredBase(file) ?? "";
+                var isProcessGuide = declared.Contains("ProcessGuide", StringComparison.OrdinalIgnoreCase);
+                var isLegacy = declared.Contains("WorkExecuteDisplay", StringComparison.OrdinalIgnoreCase);
+
+                if (recipe.Framework == MobileFramework.ProcessGuide && !isProcessGuide)
+                    problems.Add($"{recipe.Id} is a ProcessGuide recipe but '{reference}' extends {declared}");
+
+                if (recipe.Framework == MobileFramework.WorkExecuteDisplay && !isLegacy)
+                    problems.Add($"{recipe.Id} is a legacy recipe but '{reference}' extends {declared}");
+            }
+        }
+
+        Assert.True(problems.Count == 0, string.Join(Environment.NewLine, problems));
+    }
+
+    [Fact]
+    public void The_process_guide_framework_is_a_package_of_its_own()
+    {
+        // The recipes tell a reader ProcessGuide is a separate, current framework rather than a
+        // handful of helper classes. If that stops being true the advice needs revisiting.
+        var root = PackagesRoot();
+        if (root is null) return;
+
+        var classDir = Path.Combine(root, "ProcessGuide", "ProcessGuide", "AxClass");
+        if (!Directory.Exists(classDir)) return;
+
+        Assert.True(Directory.GetFiles(classDir, "*.xml").Length > 100,
+            "the ProcessGuide package holds far fewer classes than a framework would");
+    }
+}

--- a/tests/D365FO.Core.Tests/MobileAppRecipesTests.cs
+++ b/tests/D365FO.Core.Tests/MobileAppRecipesTests.cs
@@ -1,0 +1,77 @@
+using D365FO.Core.Knowledge;
+using Xunit;
+
+namespace D365FO.Core.Tests;
+
+/// <summary>Shape of the warehouse-app recipe catalog, independent of any installation.</summary>
+public class MobileAppRecipesTests
+{
+    [Fact]
+    public void There_are_seven_recipes_with_unique_ids()
+    {
+        var recipes = MobileAppRecipes.List();
+        Assert.Equal(7, recipes.Count);
+        Assert.Equal(recipes.Count, recipes.Select(r => r.Id).Distinct(StringComparer.OrdinalIgnoreCase).Count());
+    }
+
+    [Theory]
+    [InlineData("processguide-flow")]
+    [InlineData("processguide-page-control")]
+    [InlineData("processguide-page-replace")]
+    [InlineData("processguide-step-insert")]
+    [InlineData("app-step-identity")]
+    [InlineData("legacy-workexecutedisplay")]
+    [InlineData("gs1-scan-input")]
+    public void Every_recipe_is_findable_and_says_when_it_applies(string id)
+    {
+        var recipe = MobileAppRecipes.Find(id);
+
+        Assert.NotNull(recipe);
+        Assert.NotEmpty(recipe!.WhenToUse);
+        Assert.NotEmpty(recipe.Guidance);
+        Assert.NotEmpty(recipe.Checks);
+    }
+
+    [Fact]
+    public void Both_frameworks_are_represented_and_the_decision_is_stated()
+    {
+        // The list exists to make the framework choice first, so a catalog covering only one of
+        // them would quietly answer "use ProcessGuide" to a question about a legacy flow.
+        var frameworks = MobileAppRecipes.List().Select(r => r.Framework).Distinct().ToList();
+
+        Assert.Contains(MobileFramework.ProcessGuide, frameworks);
+        Assert.Contains(MobileFramework.WorkExecuteDisplay, frameworks);
+        Assert.Contains(MobileFramework.Configuration, frameworks);
+
+        Assert.Contains("rewrite", MobileAppRecipes.FrameworkDecision, StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact]
+    public void The_configuration_recipes_ask_for_no_classes_at_all()
+    {
+        // Writing a class to change a caption, or a parser to split a barcode, is the mistake
+        // these two exist to prevent — so neither may carry a required class in its roster.
+        foreach (var recipe in MobileAppRecipes.List().Where(r => r.Framework == MobileFramework.Configuration))
+        {
+            Assert.DoesNotContain(recipe.Roster, o => o.Required && o.Extends is not null);
+        }
+    }
+
+    [Fact]
+    public void Only_the_legacy_recipe_belongs_to_the_legacy_framework()
+    {
+        foreach (var recipe in MobileAppRecipes.List())
+        {
+            var legacy = recipe.Framework == MobileFramework.WorkExecuteDisplay;
+            Assert.Equal(recipe.Id == "legacy-workexecutedisplay", legacy);
+        }
+    }
+
+    [Fact]
+    public void Find_is_case_insensitive_and_trims()
+    {
+        Assert.NotNull(MobileAppRecipes.Find("PROCESSGUIDE-FLOW"));
+        Assert.NotNull(MobileAppRecipes.Find("  gs1-scan-input "));
+        Assert.Null(MobileAppRecipes.Find("processguide flow"));
+    }
+}


### PR DESCRIPTION
`d365fo mobile-pattern list | spec` — seven warehouse-app recipes across the two frameworks.

## The list leads with the decision, not the recipes

Because it is the one choice the platform will not let you take back cheaply. **The same screens are built by two frameworks:**

- **ProcessGuide** — controller, step, page builder, data processor, navigation agent and action are separate classes, each behind an abstract factory, so each is an extension point.
- the legacy **`WhsWorkExecuteDisplay`** hierarchy — all of it in one class with a `displayForm()` per mode.

Picking wrong is a rewrite, not a refactor. New work goes in ProcessGuide; a change to a process already built on the legacy hierarchy stays there.

## Counted, not recalled

| | |
|---|---:|
| classes in the `ProcessGuide` package | 382 |
| `ProcessGuidePageBuilder` subclasses | 75 |
| `ProcessGuideStep` | 74 |
| `ProcessGuideNavigationAgent` | 40 |
| `ProcessGuideController` | 25 |
| `ProcessGuideAction` | 23 |
| `WhsWorkExecuteDisplay` subclasses (ApplicationSuite/Foundation alone) | 64 |

## Two recipes deliberately ask for no code

A screen's title, icon and menu placement are **warehouse configuration**; GS1 barcode splitting is **barcode configuration**, and the app does it before any X++ sees the scan. Writing a class for the first, or a `parseBarcode()` for the second, is precisely the mistake those recipes exist to prevent — the hand-written parser works on the sample barcode and breaks on the first variable-length identifier.

## Two facts the AOT taught during verification

Both recorded because they look like typos in review:

1. **The casing is inconsistent in Microsoft's own code** — both `WHSWorkExecuteDisplay` and `WhsWorkExecuteDisplay` appear as the declared base among shipped subclasses. X++ resolves either.
2. **A concrete class often extends a module-prefixed *intermediate* base** rather than the framework type: `WHSProcessGuidePromptCycleCountItemBuilder` → `WHSProcessGuideCycleCountPageBuilder` → `ProcessGuidePageBuilder`. The AOT test caught this — my first rule was starts-with, which classified those as *legacy*, the opposite of the truth. The recipe now says to extend the nearest intermediate base, since starting from the framework type loses whatever the module layer already does.

That second one is the argument for these tests existing: this is authored knowledge, so the class names are exactly what needs checking against a real install. `MobileAppRecipesAotTests` resolves every named base and reference class against a real `PackagesLocalDirectory`, and is **inert where there is no install** rather than passing vacuously.

## Verification

- 1 630 tests green (580 CLI + 1 050 Core)
- eval catalog 52/52 · knowledge audit clean · warning ratchet at baseline 117

## Remaining in wave 03

Five knowledge topics (`global-class-statics`, `system-objects`, `report-print-destinations`, `document-attachments`, `rdl-design-expressions`) — next.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019D9AMJP7Ct2U4Q3xVeMn8B
