### PR TITLE
perf(index): the extract's time went to checkpointing, not to the work

### DIFF
--- a/docs/CAPABILITIES.md
+++ b/docs/CAPABILITIES.md
@@ -25,7 +25,7 @@ By default the index stores object/method *metadata* only — method bodies (the
 | `index export` | Dump the index to a portable archive |
 | `index import` | Restore from an archive |
 | `index cross-check` | Report where this tool's catalogs are narrower than the installation |
-| `index optimize` | Run `VACUUM` + `ANALYZE` to compact and re-plan |
+| `index optimize` | Checkpoint the WAL, then `VACUUM` + `ANALYZE` to compact and re-plan |
 | `doctor` | End-to-end health check: paths, schema version, object counts |
 
 ### `index cross-check`

--- a/docs/SETUP.md
+++ b/docs/SETUP.md
@@ -158,6 +158,10 @@ d365fo index extract --model MyCustomModel       # seconds
 d365fo index extract --model ApplicationSuite    # minutes — parallelised per file
 ```
 
+`--model` is also how you benchmark extraction: with `--output json` it reports `parseMs` and
+`writeMs` per model, which is enough to tell a slow model from a slow database. See
+[Extraction is slow](TROUBLESHOOTING.md#extraction-is-slow).
+
 | When to refresh | Command |
 |---|---|
 | You edited XML in a custom model | `d365fo index refresh --model <Model>` |

--- a/docs/TROUBLESHOOTING.md
+++ b/docs/TROUBLESHOOTING.md
@@ -125,6 +125,89 @@ This is expected behaviour — the index still serves `search`, `get`, `find`, a
 
 ---
 
+## Extraction is slow
+
+`index extract` spends far more time writing than parsing, so "slow" almost always means the
+database rather than the AOT XML. Measure before changing anything — and measure against a
+**copy** of the index, so a benchmark run cannot disturb the one your agent is using.
+
+### Benchmark a single model
+
+`--model` limits the run to one model folder and `--output json` reports where its time went:
+
+```powershell
+Copy-Item "$env:LOCALAPPDATA\d365fo-cli\d365fo-index.sqlite" "$env:TEMP\bench.sqlite"
+d365fo index extract --model RentalManagement --db "$env:TEMP\bench.sqlite" --output json
+```
+
+```json
+"perModel": [
+  { "model": "RentalManagement", "classes": 906, "elapsedMs": 13283, "parseMs": 1326, "writeMs": 11957 }
+]
+```
+
+| Field | What it covers | What it scales with |
+|---|---|---|
+| `parseMs` | Walking and parsing the model's AOT XML | The model. A 906-class model parses in ~1.3 s |
+| `writeMs` | `ApplyExtract` — clearing the model's rows and re-inserting them | The **database**, not the model |
+
+Run the same model two or three times: the first run pays for a cold page cache. A model that is
+cheap on its own but expensive inside a full run is the signature of a cost that grows with
+database size — that is `writeMs`, and it is where every extraction slowdown found so far has
+lived.
+
+### Benchmark a handful of models
+
+A single model will not show costs that only appear across models (WAL growth, checkpointing).
+For that, build a packages root of junctions to the few packages you want and point `--packages`
+at it — the extractor treats it as a normal `PackagesLocalDirectory`:
+
+```powershell
+$root = "$env:TEMP\bench-packages"
+New-Item -ItemType Directory -Force $root | Out-Null
+'RentalManagement','TaxEngine','GeneralLedger' | ForEach-Object {
+    cmd /c mklink /J "$root\$_" "$env:D365FO_PACKAGES_PATH\$_"
+}
+d365fo index extract --packages $root --db "$env:TEMP\bench.sqlite" --output json
+```
+
+Junctions need no admin rights, and removing one must be done with `cmd /c rmdir` (or
+`Remove-Item` without `-Recurse`) so the delete does not follow the link into the real
+`PackagesLocalDirectory`.
+
+### Reference numbers
+
+Measured on a 751 MB index (203 models, 60k classes, 525k methods, 1.4M labels) on the schema
+these numbers were taken at:
+
+| Sample | Time |
+|---|---|
+| 76-class model, write phase | ~1.4 s |
+| 906-class model, write phase | ~12 s |
+| Ten mid-size models, end to end | ~60 s |
+
+If your `writeMs` is several times these for a comparable model, something is scanning.
+
+### When `writeMs` is out of proportion to the model
+
+Almost always a missing index — the per-model re-extract filters by `ModelId` and by parent keys,
+and foreign keys are enforced, so an unindexed column turns a delete into a full table scan (for
+foreign keys, one scan *per deleted parent row*). Check the plan for the delete you suspect:
+
+```sql
+EXPLAIN QUERY PLAN DELETE FROM Forms WHERE ModelId = 161;
+```
+
+`SEARCH ... USING INDEX` is fine. `SCAN <table>` is the bug — including a `SCAN` of a *child*
+table, which is the foreign-key check rather than anything in the statement itself.
+
+`SchemaIndexCoverageTests` guards this: it derives from the live schema, via `pragma_table_info`
+and `pragma_foreign_key_list`, that every `ModelId`, every parent key the re-extract deletes by,
+and every foreign-key child column is indexed. A new table or foreign key that misses one fails
+the test suite rather than quietly slowing extraction down.
+
+---
+
 ## SQLite WAL-mode locking
 
 The index uses WAL (Write-Ahead Logging) mode for concurrent reads. You may see these files alongside the main database:
@@ -151,7 +234,7 @@ d365fo-index.sqlite-shm      ← shared memory for WAL
    ```
 4. Re-run extraction, then optimise: `d365fo index optimize`
 
-`index optimize` runs `PRAGMA wal_checkpoint(FULL)` + `PRAGMA optimize` which compacts the WAL and reclaims space. Schedule it periodically in CI.
+`index optimize` runs `PRAGMA wal_checkpoint(TRUNCATE)` + `VACUUM` + `ANALYZE`: it compacts the WAL, reclaims the space that the delete-and-reinsert extract cycle frees, and refreshes the query planner's statistics. Schedule it periodically in CI.
 
 ---
 

--- a/src/D365FO.Cli/Commands/Index/IndexCommands.cs
+++ b/src/D365FO.Cli/Commands/Index/IndexCommands.cs
@@ -336,6 +336,11 @@ public sealed class IndexExtractCommand : Command<IndexExtractCommand.Settings>
                         coc = batch.CocExtensions.Count,
                         labels = batch.Labels.Count,
                         elapsedMs,
+                        // Split out so a slow extract can be attributed without a profiler:
+                        // parse is XML off the packages folder, write is ApplyExtract's
+                        // delete-and-reinsert against SQLite.
+                        parseMs,
+                        writeMs = writeSw.ElapsedMilliseconds,
                     });
                     onDone?.Invoke(batch.Model, batch, elapsedMs);
                 }
@@ -374,6 +379,10 @@ public sealed class IndexExtractCommand : Command<IndexExtractCommand.Settings>
         {
             ProcessAll(null, null);
         }
+
+        // ApplyExtract only checkpoints once the WAL crosses its threshold, so flush what the
+        // last models left behind rather than leaving it for whichever process opens next.
+        repo.CheckpointWal();
 
         runSw.Stop();
         var totals = repo.CountAll();

--- a/src/D365FO.Core/Index/MetadataRepository.cs
+++ b/src/D365FO.Core/Index/MetadataRepository.cs
@@ -14,8 +14,15 @@ namespace D365FO.Core.Index;
 public sealed partial class MetadataRepository
 {
     /// <summary>Current schema version tracked in PRAGMA user_version.</summary>
-    /// <remarks>v17: LabelFiles table (per-label-file source paths for the disk check).</remarks>
-    public const int CurrentSchemaVersion = 17;
+    /// <remarks>
+    /// v19: index on FormDataSources(FormId) — the one foreign key whose child column was
+    /// unindexed, so enforcing it rescanned the child table once per deleted form.
+    /// &lt;para&gt;v18: indexes on every ModelId and on the parent keys the per-model re-extract
+    /// deletes filter by. Pure additions — an existing database picks them up on the next
+    /// EnsureSchema, with no re-extract.&lt;/para&gt;
+    /// &lt;para&gt;v17: LabelFiles table (per-label-file source paths for the disk check).&lt;/para&gt;
+    /// </remarks>
+    public const int CurrentSchemaVersion = 19;
 
     private static readonly Lazy<string> SchemaSql = new(LoadEmbeddedSchema);
 
@@ -2911,10 +2918,8 @@ public sealed partial class MetadataRepository
 
         tx.Commit();
 
-        // Flush and truncate WAL after each model commit. wal_autocheckpoint=0
-        // prevents mid-transaction checkpoint stalls on large models; we do it
-        // manually here so the WAL never grows unboundedly across models.
-        conn.Execute("PRAGMA wal_checkpoint(TRUNCATE)");
+        // Keep the WAL bounded across models without paying a checkpoint per model.
+        MaybeCheckpointWal(conn);
 
         // Rebuild the flattened SecurityMap (Role x Duty x Privilege x
         // EntryPoint) for this model's roles/duties. We do this in a short
@@ -3045,6 +3050,51 @@ public sealed partial class MetadataRepository
             .Select(r => new TopCocStat((string)r.Target, (long)r.ExtensionCount)).ToList();
 
         return new IndexStats(perModel, topTables, topClasses, topCoc);
+    }
+
+    /// <summary>
+    /// How much WAL we tolerate between checkpoints during a bulk extract.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// A checkpoint copies the WAL back into the database file and fsyncs it, and it was run
+    /// after every model. That charged even a trivial model the full latency — a model with 76
+    /// classes and no forms spent 982 ms of its 1.2 s write on the checkpoint — and it wrote a
+    /// page once per model that dirtied it instead of once per run. Over a ten-model sample it
+    /// was 60 s of an 83 s extract; batching brought that to 26 s and the run to 60 s.
+    /// </para>
+    /// <para>
+    /// Bounding the WAL is the only thing the per-model checkpoint was there for, so a size
+    /// threshold does the same job. The file peaks at the threshold plus one model's
+    /// transaction (88 MB on that sample) — the same worst case the old code had while a large
+    /// model was still uncommitted.
+    /// </para>
+    /// </remarks>
+    private const long WalCheckpointThresholdBytes = 64L * 1024 * 1024;
+
+    /// <summary>
+    /// Checkpoint the WAL back into the database, but only once it has grown past
+    /// <see cref="WalCheckpointThresholdBytes"/>. Call <see cref="CheckpointWal"/> at the end
+    /// of a bulk run to flush whatever is left.
+    /// </summary>
+    private void MaybeCheckpointWal(SqliteConnection conn)
+    {
+        // Reading the file length does not touch the database, so a below-threshold model
+        // pays a stat() rather than a checkpoint.
+        var wal = new FileInfo(_databasePath + "-wal");
+        if (!wal.Exists || wal.Length < WalCheckpointThresholdBytes) return;
+        conn.Execute("PRAGMA wal_checkpoint(TRUNCATE)");
+    }
+
+    /// <summary>
+    /// Flush the WAL back into the database file and truncate it. Bulk callers
+    /// (<c>index extract</c> / <c>index refresh</c>) run this once when they are done, so the
+    /// database on disk is complete and the WAL does not outlive the run.
+    /// </summary>
+    public void CheckpointWal()
+    {
+        using var conn = Open();
+        conn.Execute("PRAGMA wal_checkpoint(TRUNCATE)");
     }
 
     internal SqliteConnection Open()

--- a/src/D365FO.Core/Index/Schema.sql
+++ b/src/D365FO.Core/Index/Schema.sql
@@ -710,3 +710,70 @@ CREATE VIRTUAL TABLE IF NOT EXISTS MethodSourceFts USING fts5(
     tokenize = 'unicode61'
 );
 
+
+-- ---------------------------------------------------------------------------
+-- v18: indexes for the per-model re-extract path.
+--
+-- ApplyExtract clears a model's rows before re-inserting them, which is ~40
+-- statements of the shape `DELETE FROM X WHERE ModelId=@m` plus a dozen nested
+-- `DELETE FROM Child WHERE ParentId IN (SELECT ParentId FROM Parent WHERE
+-- ModelId=@m)`. Of the 28 tables carrying ModelId, exactly one was indexed on
+-- it, so every one of those statements was a full table scan — over 60k
+-- classes, 525k methods and 1.4M labels, repeated for each of ~200 models.
+--
+-- Measured before this: one model (241 classes, no tables, no labels) took
+-- 4.8s extracted on its own and 57s inside a full run. The model had not
+-- changed; the database had grown. The cost was O(models x database size),
+-- which is why a full extract took about an hour and got slower as it went.
+--
+-- These are pure additions: no table shape changes, so an existing database
+-- picks them up on the next EnsureSchema without a re-extract.
+-- ---------------------------------------------------------------------------
+CREATE INDEX IF NOT EXISTS IX_Tables_ModelId             ON Tables(ModelId);
+CREATE INDEX IF NOT EXISTS IX_Classes_ModelId            ON Classes(ModelId);
+CREATE INDEX IF NOT EXISTS IX_CocExtensions_ModelId      ON CocExtensions(ModelId);
+CREATE INDEX IF NOT EXISTS IX_Edts_ModelId               ON Edts(ModelId);
+CREATE INDEX IF NOT EXISTS IX_Enums_ModelId              ON Enums(ModelId);
+CREATE INDEX IF NOT EXISTS IX_MenuItems_ModelId          ON MenuItems(ModelId);
+CREATE INDEX IF NOT EXISTS IX_SecurityRoles_ModelId      ON SecurityRoles(ModelId);
+CREATE INDEX IF NOT EXISTS IX_Forms_ModelId              ON Forms(ModelId);
+CREATE INDEX IF NOT EXISTS IX_ObjectExtensions_ModelId   ON ObjectExtensions(ModelId);
+CREATE INDEX IF NOT EXISTS IX_EventSubscribers_ModelId   ON EventSubscribers(ModelId);
+CREATE INDEX IF NOT EXISTS IX_SecurityDuties_ModelId     ON SecurityDuties(ModelId);
+CREATE INDEX IF NOT EXISTS IX_SecurityPrivileges_ModelId ON SecurityPrivileges(ModelId);
+CREATE INDEX IF NOT EXISTS IX_Queries_ModelId            ON Queries(ModelId);
+CREATE INDEX IF NOT EXISTS IX_Views_ModelId              ON Views(ModelId);
+CREATE INDEX IF NOT EXISTS IX_DataEntities_ModelId       ON DataEntities(ModelId);
+CREATE INDEX IF NOT EXISTS IX_Reports_ModelId            ON Reports(ModelId);
+CREATE INDEX IF NOT EXISTS IX_Services_ModelId           ON Services(ModelId);
+CREATE INDEX IF NOT EXISTS IX_ServiceGroups_ModelId      ON ServiceGroups(ModelId);
+CREATE INDEX IF NOT EXISTS IX_WorkflowTypes_ModelId      ON WorkflowTypes(ModelId);
+CREATE INDEX IF NOT EXISTS IX_Maps_ModelId               ON Maps(ModelId);
+CREATE INDEX IF NOT EXISTS IX_BusinessEvents_ModelId     ON BusinessEvents(ModelId);
+CREATE INDEX IF NOT EXISTS IX_SecurityPolicies_ModelId   ON SecurityPolicies(ModelId);
+CREATE INDEX IF NOT EXISTS IX_ConfigurationKeys_ModelId  ON ConfigurationKeys(ModelId);
+CREATE INDEX IF NOT EXISTS IX_Tiles_ModelId              ON Tiles(ModelId);
+CREATE INDEX IF NOT EXISTS IX_Workspaces_ModelId         ON Workspaces(ModelId);
+CREATE INDEX IF NOT EXISTS IX_ExtensionFields_ModelId    ON ExtensionFields(ModelId);
+
+-- The nested deletes scan the CHILD table too, so the parent key needs covering
+-- on both sides of the IN.
+CREATE INDEX IF NOT EXISTS IX_ClassAttributes_ClassId    ON ClassAttributes(ClassId);
+CREATE INDEX IF NOT EXISTS IX_TableIndexes_TableId       ON TableIndexes(TableId);
+CREATE INDEX IF NOT EXISTS IX_TableDeleteActions_TableId ON TableDeleteActions(TableId);
+CREATE INDEX IF NOT EXISTS IX_ViewFields_ViewId          ON ViewFields(ViewId);
+CREATE INDEX IF NOT EXISTS IX_DataEntityFields_EntityId  ON DataEntityFields(EntityId);
+CREATE INDEX IF NOT EXISTS IX_ReportDataSets_ReportId    ON ReportDataSets(ReportId);
+CREATE INDEX IF NOT EXISTS IX_ServiceOperations_SvcId    ON ServiceOperations(ServiceId);
+CREATE INDEX IF NOT EXISTS IX_ServiceGroupMembers_GrpId  ON ServiceGroupMembers(GroupId);
+CREATE INDEX IF NOT EXISTS IX_MapFields_MapId            ON MapFields(MapId);
+CREATE INDEX IF NOT EXISTS IX_MapTables_MapId            ON MapTables(MapId);
+CREATE INDEX IF NOT EXISTS IX_SecurityMap_Role           ON SecurityMap(Role);
+
+-- Foreign keys are enforced (PRAGMA foreign_keys = ON), and SQLite checks a parent
+-- DELETE by looking for referencing child rows. Without an index on the child's FK
+-- column that check is a full scan of the child table *per parent row deleted*:
+-- `DELETE FROM Forms WHERE ModelId=?` for a 222-form model spent 1.27s scanning
+-- FormDataSources 222 times over. Every other FK column in this schema is already
+-- covered by an index; this was the only one that was not.
+CREATE INDEX IF NOT EXISTS IX_FormDataSources_FormId     ON FormDataSources(FormId);

--- a/tests/D365FO.Core.Tests/SchemaIndexCoverageTests.cs
+++ b/tests/D365FO.Core.Tests/SchemaIndexCoverageTests.cs
@@ -1,0 +1,212 @@
+using D365FO.Core.Index;
+using Microsoft.Data.Sqlite;
+using Xunit;
+
+namespace D365FO.Core.Tests;
+
+/// <summary>
+/// Every column the per-model re-extract filters by must be indexed.
+/// </summary>
+/// <remarks>
+/// <para>
+/// <c>ApplyExtract</c> clears a model's rows before re-inserting them: roughly forty statements
+/// of the shape <c>DELETE FROM X WHERE ModelId=@m</c>, plus a dozen nested
+/// <c>DELETE FROM Child WHERE ParentId IN (SELECT ParentId FROM Parent WHERE ModelId=@m)</c>.
+/// Of the 28 tables carrying <c>ModelId</c>, exactly one was indexed on it — so each of those
+/// statements scanned the whole table, over 60k classes and 525k methods, once per model for
+/// about 200 models.
+/// </para>
+/// <para>
+/// Measured on a 751 MB index, re-applying one model: RentalManagement (906 classes) spent
+/// <b>50.5 s writing before, 12.0 s after</b>; a 76-class model, <b>4.9 s before, 1.4 s after</b>.
+/// The cost was O(models x database size), which is why a full extract got slower as it went.
+/// </para>
+/// <para>
+/// A new table with a <c>ModelId</c> and no index would silently reintroduce it, and the symptom
+/// (a slow extract) is far away from the cause. So the check is derived: it reads the columns out
+/// of the schema rather than from a list somebody has to remember to extend.
+/// </para>
+/// </remarks>
+public sealed class SchemaIndexCoverageTests : IDisposable
+{
+    private readonly string _dbPath = Path.Combine(Path.GetTempPath(), $"schema-idx-{Guid.NewGuid():N}.sqlite");
+
+    public void Dispose()
+    {
+        SqlitePool.ReleaseFor(_dbPath);
+        foreach (var ext in new[] { "", "-wal", "-shm" })
+        {
+            var p = _dbPath + ext;
+            if (File.Exists(p)) { try { File.Delete(p); } catch { } }
+        }
+    }
+
+    private SqliteConnection OpenFreshSchema()
+    {
+        new MetadataRepository(_dbPath).EnsureSchema();
+        var connection = new SqliteConnection($"Data Source={_dbPath}");
+        connection.Open();
+        return connection;
+    }
+
+    /// <summary>Tables that declare a column, from the live schema rather than a hand-kept list.</summary>
+    private static List<string> TablesWithColumn(SqliteConnection connection, string column)
+    {
+        var tables = new List<string>();
+        using (var cmd = connection.CreateCommand())
+        {
+            cmd.CommandText = "SELECT name FROM sqlite_master WHERE type='table' AND name NOT LIKE 'sqlite_%'";
+            using var reader = cmd.ExecuteReader();
+            while (reader.Read()) tables.Add(reader.GetString(0));
+        }
+
+        var hits = new List<string>();
+        foreach (var table in tables)
+        {
+            using var cmd = connection.CreateCommand();
+            cmd.CommandText = $"PRAGMA table_info({table})";
+            using var reader = cmd.ExecuteReader();
+            while (reader.Read())
+            {
+                if (!string.Equals(reader.GetString(1), column, StringComparison.OrdinalIgnoreCase)) continue;
+
+                // An INTEGER PRIMARY KEY is an alias for the rowid, so a lookup on it is
+                // already a B-tree seek and PRAGMA index_list shows nothing. Models.ModelId is
+                // exactly that; demanding an index there would add a second copy of the rowid.
+                var isRowidAlias = reader.GetInt32(5) == 1
+                    && string.Equals(reader.GetString(2), "INTEGER", StringComparison.OrdinalIgnoreCase);
+                if (!isRowidAlias) hits.Add(table);
+                break;
+            }
+        }
+        return hits;
+    }
+
+    /// <summary>Is <paramref name="column"/> the FIRST column of some index on the table?</summary>
+    /// <remarks>
+    /// First column, because SQLite can only use an index for a lookup on a prefix of its
+    /// columns — an index on <c>(Name, ModelId)</c> does nothing for <c>WHERE ModelId=?</c>.
+    /// </remarks>
+    private static bool HasLeadingIndexOn(SqliteConnection connection, string table, string column)
+    {
+        var indexes = new List<string>();
+        using (var cmd = connection.CreateCommand())
+        {
+            cmd.CommandText = $"PRAGMA index_list({table})";
+            using var reader = cmd.ExecuteReader();
+            while (reader.Read()) indexes.Add(reader.GetString(1));
+        }
+
+        foreach (var index in indexes)
+        {
+            using var cmd = connection.CreateCommand();
+            cmd.CommandText = $"PRAGMA index_info({index})";
+            using var reader = cmd.ExecuteReader();
+            while (reader.Read())
+            {
+                // seqno 0 is the leading column.
+                if (reader.GetInt32(0) != 0) continue;
+                if (!reader.IsDBNull(2) && string.Equals(reader.GetString(2), column, StringComparison.OrdinalIgnoreCase))
+                    return true;
+            }
+        }
+        return false;
+    }
+
+    /// <summary>Foreign keys declared by <paramref name="table"/>, as (child column, parent).</summary>
+    private static List<(string Column, string Parent)> ForeignKeysOf(SqliteConnection connection, string table)
+    {
+        var keys = new List<(string, string)>();
+        using var cmd = connection.CreateCommand();
+        cmd.CommandText = $"PRAGMA foreign_key_list({table})";
+        using var reader = cmd.ExecuteReader();
+        var parentOrdinal = reader.GetOrdinal("table");
+        var fromOrdinal = reader.GetOrdinal("from");
+        while (reader.Read()) keys.Add((reader.GetString(fromOrdinal), reader.GetString(parentOrdinal)));
+        return keys;
+    }
+
+    /// <summary>
+    /// Foreign keys are enforced (<c>PRAGMA foreign_keys = ON</c>), so deleting a parent row
+    /// makes SQLite look for children referencing it. With no index on the child's FK column
+    /// that is a full scan of the child table for <em>every</em> parent row deleted — a cost
+    /// that appears nowhere in the SQL the extractor writes, which is what made it hard to
+    /// spot: <c>DELETE FROM Forms WHERE ModelId=?</c> spent 1.27s scanning FormDataSources
+    /// once per form.
+    /// </summary>
+    [Fact]
+    public void Every_foreign_key_child_column_is_indexed()
+    {
+        using var connection = OpenFreshSchema();
+
+        var tables = new List<string>();
+        using (var cmd = connection.CreateCommand())
+        {
+            cmd.CommandText = "SELECT name FROM sqlite_master WHERE type='table' AND name NOT LIKE 'sqlite_%'";
+            using var reader = cmd.ExecuteReader();
+            while (reader.Read()) tables.Add(reader.GetString(0));
+        }
+
+        var uncovered = new List<string>();
+        var seen = 0;
+        foreach (var table in tables)
+        {
+            foreach (var (column, parent) in ForeignKeysOf(connection, table))
+            {
+                seen++;
+                if (!HasLeadingIndexOn(connection, table, column))
+                    uncovered.Add($"{table}({column}) -> {parent}");
+            }
+        }
+
+        Assert.True(seen > 10, $"only {seen} foreign keys found — the schema query is wrong");
+        Assert.True(uncovered.Count == 0,
+            "These foreign key columns have no index leading on them, so enforcing the key "
+            + "scans the whole child table once per deleted parent row:\n  "
+            + string.Join("\n  ", uncovered));
+    }
+
+    [Fact]
+    public void Every_table_with_a_ModelId_is_indexed_on_it()
+    {
+        using var connection = OpenFreshSchema();
+
+        var tables = TablesWithColumn(connection, "ModelId");
+        Assert.True(tables.Count > 20, $"only {tables.Count} tables carry ModelId — the schema query is wrong");
+
+        var unindexed = tables.Where(t => !HasLeadingIndexOn(connection, t, "ModelId")).ToList();
+
+        Assert.True(unindexed.Count == 0,
+            "These tables carry ModelId with no index leading on it, so the per-model DELETE in "
+            + "ApplyExtract scans them whole, once per model:\n  " + string.Join("\n  ", unindexed));
+    }
+
+    [Theory]
+    // The parent keys the nested per-model deletes filter the CHILD table by.
+    [InlineData("Methods", "ClassId")]
+    [InlineData("ClassAttributes", "ClassId")]
+    [InlineData("TableFields", "TableId")]
+    [InlineData("TableMethods", "TableId")]
+    [InlineData("TableIndexes", "TableId")]
+    [InlineData("TableDeleteActions", "TableId")]
+    [InlineData("EnumValues", "EnumId")]
+    [InlineData("QueryDataSources", "QueryId")]
+    [InlineData("ViewFields", "ViewId")]
+    [InlineData("DataEntityFields", "EntityId")]
+    [InlineData("ReportDataSets", "ReportId")]
+    [InlineData("ServiceOperations", "ServiceId")]
+    [InlineData("ServiceGroupMembers", "GroupId")]
+    [InlineData("MapFields", "MapId")]
+    [InlineData("MapTables", "MapId")]
+    [InlineData("SecurityMap", "Role")]
+    [InlineData("Relations", "FromTable")]
+    [InlineData("Labels", "LabelFile")]
+    public void Every_child_key_the_reextract_deletes_by_is_indexed(string table, string column)
+    {
+        using var connection = OpenFreshSchema();
+
+        Assert.True(HasLeadingIndexOn(connection, table, column),
+            $"{table}({column}) has no index leading on it — the nested DELETE in ApplyExtract "
+            + "scans the whole child table once per model.");
+    }
+}


### PR DESCRIPTION
Index extraction had got slow and nobody had pinned down why. Measured against a copy of a real 751 MB index — one model at a time via `--model`, and a ten-model sample through a packages root of junctions — the time was in three places, none of them parsing.

## What was slow

**Missing `ModelId` indexes.** Of the 28 tables carrying `ModelId`, exactly one was indexed on it, so every `DELETE FROM X WHERE ModelId=?` in `ApplyExtract` scanned the whole table — 60k classes, 525k methods — once per model, for ~200 models. O(models × database size), which is why the run got slower as it went.

| | before | after |
|---|---|---|
| RentalManagement (906 classes) write | 50.5 s | 12.0 s |
| 76-class model write | 4.9 s | 1.4 s |

**`FormDataSources(FormId)`, the one unindexed foreign key.** Foreign keys are enforced (`PRAGMA foreign_keys = ON`), so deleting a parent row makes SQLite look for children referencing it — without an index that is a full scan of the child table *per deleted parent row*. `DELETE FROM Forms WHERE ModelId=?` spent **1271 ms** on a 222-form model; `EXPLAIN QUERY PLAN` showed `SCAN FormDataSources`. This cost appears nowhere in the SQL the extractor writes, which is what made it hard to see. Over ten models the delete phase went **3.1 s → 1.2 s**.

**`PRAGMA wal_checkpoint(TRUNCATE)` after every model** — the largest remaining cost, **60.3 s of an 83.3 s ten-model run**. It charged even a trivial model the full latency (982 ms of a 76-class model's 1.2 s write) and re-wrote a page once per model that dirtied it, instead of once per run. Bounding the WAL was the only thing it was there for, so a 64 MB size threshold does the same job, plus one `CheckpointWal()` when the run ends. The WAL peaked at 88 MB on the sample — threshold plus one model's transaction, the same worst case the old code had while a large model was still uncommitted.

**Ten-model sample end to end: 83.3 s → 60.0 s**, on top of what the `ModelId` indexes already recovered.

## Migration

Both index gaps are pure additions — no table shape changes — so an existing database picks them up on the next `EnsureSchema` (schema v19) with **no re-extract**.

## Tests

`SchemaIndexCoverageTests` derives what must be indexed from the live schema, via `pragma_table_info` and `pragma_foreign_key_list`, rather than from a list somebody has to remember to extend — a hand-kept list would not have caught the foreign key. A new table with a `ModelId`, or a new FK, now fails the build instead of quietly making the extract slow again.

`index extract --output json` now reports `parseMs` and `writeMs` per model. Parsing was never the problem (1.3 s for a 906-class model); the split is what localised this, and it means the next regression can be attributed without a profiler.

Full suite green: 1070 + 580 tests, 0 failures.

## Not covered

- A full 203-model run was not timed; the numbers above are the one- and ten-model samples.
- Moving the index off `C:` was tried and is **slower** (76.8 s vs 60.0 s with the DB on `K:`), so the default location stands.
- Re-extraction of the live index is deliberately left for later.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Rmijn8Y66xKYHAgfCw6uQT
