### PR TITLE
Wave 04 — Completing the surface

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,40 @@ was ported from.
 
 ## [Unreleased]
 
+### Added — wave 04: the rest of the surface
+The gap analysis's fourth wave: the MCP tools that had no CLI counterpart, plus the two write
+verbs whose absence forced a workaround.
+
+- **`analyze patterns` / `analyze implementations` / `analyze api-usage`** — learn from the
+  installation rather than from training data. `patterns` takes a scenario in the words the code
+  would use and returns the APIs that code reaches for, ranked by how many DISTINCT objects use
+  each (one verbose class must not make its own habits look like the codebase's); it reads whole
+  method bodies, because the line that mentions "number sequence" is a comment and the
+  `NumberSeqGlobal` call that answers the question is three lines below it. `implementations`
+  answers "who else declares this, and with what signature" — the question before writing an
+  override or a CoC wrapper. `api-usage` separates construction from static calls from
+  declarations, and says so when an API is never constructed, which means a `new` is the wrong
+  shape.
+  All three report **what they could actually read** in `coverage`: a search over method bodies
+  returns nothing when nothing matches, and also when the corpus was unreadable — no source
+  index, no source paths on this machine — and reporting the second as an empty result is how
+  "no callers" comes to mean "unused" for something used everywhere.
+- **`labels update` / `labels (action=update)`** — correct the text of a label that already
+  exists. Distinct from `create --overwrite` on purpose: create writes a new entry when the key
+  is absent, so a mistyped key in a correction produces a *second* label and reports success.
+  Correcting a typo used to mean delete plus create, which loses the entry's position in the file
+  and the comment block attached to it.
+- **`verify` / `verify_project`** — do the model on disk and its `.rnrproj` agree? An object the
+  project does not list is never compiled: the AOT does not see it and nothing anywhere reports
+  that. A project entry whose file is gone fails the build with a path rather than a reason.
+  A project with no explicit item list is not judged, because some project shapes glob and
+  calling every file unregistered there would be a wall of false findings.
+- `MetadataRepository.FindMethodDeclarations` — the inverse of `FindMethod`: every object that
+  declares a method of this name. Read through a raw reader, because for a literal column on an
+  EMPTY result set Dapper infers `byte[]` and refuses to materialise the record — the same trap
+  `SearchMethodSource` documents for the FTS columns, and one that fails only when there are no
+  rows.
+
 ### Fixed — the CLI and the MCP server had drifted apart
 - **`modify_object` reached four of the engine's twenty operations, and mis-applied the rest.**
   An unknown `action` fell back to `SetProperty`, so `action="add-index"` did not fail — it set a

--- a/docs/CAPABILITIES.md
+++ b/docs/CAPABILITIES.md
@@ -404,6 +404,21 @@ Runs integration-health checks against the index for a model: OData entities wit
 d365fo analyze integration [--model M] --output json
 ```
 
+### `analyze patterns` · `analyze implementations` · `analyze api-usage`
+
+Three readings of the X++ corpus, for grounding a change in what this installation actually does:
+
+| Command | Answers |
+|---|---|
+| `analyze patterns <SCENARIO>` | Which APIs the code around a scenario reaches for, ranked by how many distinct objects use each. Reads whole method bodies, not just the matching line. |
+| `analyze implementations <METHOD>` | Who else declares this method, with the signature each declared — before writing an override or a CoC wrapper. |
+| `analyze api-usage <API>` | Construction vs. static calls vs. declarations, with the lines that do it. Says so when an API is never constructed. |
+
+Each result carries a `coverage` block. A search over method bodies returns nothing when nothing
+matches — and also when the corpus could not be read at all, which is a different answer.
+`coverage.searched: false` means the second, and the result says so rather than letting an empty
+list read as "unused".
+
 ### `analyze impact`
 
 Change-impact graph for a named object: CoC wrappers, event handlers, object extensions, form datasources, data entities, and queries that reference it.
@@ -565,7 +580,7 @@ Returns `UNSUPPORTED_PLATFORM` on non-Windows.
 
 ## MCP server
 
-Exposes the same index and scaffolding surface as the CLI over the `ModelContextProtocol` C# SDK via stdio (default) or HTTP (`--http`, for a shared team deployment). The tool surface is **consolidated** into **31 discriminator-based tools** (`search`, `get_object_info`, `get_method`, `labels`, `security_info`, `extension_info`, `object_patterns`, `generate_object`, `modify_method`, `modify_object`, `get_knowledge`, `explain_build_error`, `analyze`, `models`, …) instead of one tool per object type — mirroring the upstream `d365fo-mcp-server` (which sits at 26). A single tool dispatches on a `type` / `objectType` / `mode` / `action` / `domain` / `include` field. See [MIGRATION_FROM_MCP.md](MIGRATION_FROM_MCP.md) for the full old→new mapping.
+Exposes the same index and scaffolding surface as the CLI over the `ModelContextProtocol` C# SDK via stdio (default) or HTTP (`--http`, for a shared team deployment). The tool surface is **consolidated** into **32 discriminator-based tools** (`search`, `get_object_info`, `get_method`, `labels`, `security_info`, `extension_info`, `object_patterns`, `generate_object`, `modify_method`, `modify_object`, `get_knowledge`, `explain_build_error`, `analyze`, `models`, …) instead of one tool per object type — mirroring the upstream `d365fo-mcp-server` (which sits at 26). A single tool dispatches on a `type` / `objectType` / `mode` / `action` / `domain` / `include` field. See [MIGRATION_FROM_MCP.md](MIGRATION_FROM_MCP.md) for the full old→new mapping.
 
 ### Keeping the two surfaces the same
 

--- a/src/D365FO.Cli/CliApp.cs
+++ b/src/D365FO.Cli/CliApp.cs
@@ -157,6 +157,7 @@ public static class CliApp
                 b.AddCommand<ResolveLabelCommand>("resolve").WithDescription("Resolve a @SYS12345-style label token to its text across languages.");
                 b.AddCommand<GetLabelCommand>("info").WithDescription("Fetch one label entry by (file, language, key).");
                 b.AddCommand<D365FO.Cli.Commands.Label.LabelCreateCommand>("create").WithDescription("Create or update a label entry.");
+                b.AddCommand<D365FO.Cli.Commands.Label.LabelUpdateCommand>("update").WithDescription("Correct the text of a label that already exists — never creates, so a mistyped key is refused rather than added.");
                 b.AddCommand<D365FO.Cli.Commands.Label.LabelRenameCommand>("rename").WithDescription("Rename a label key.");
                 b.AddCommand<D365FO.Cli.Commands.Label.LabelDeleteCommand>("delete").WithDescription("Delete a label entry.");
             });
@@ -197,6 +198,7 @@ public static class CliApp
             {
                 b.SetDescription("Edit *.label.txt resource files in-place.");
                 b.AddCommand<D365FO.Cli.Commands.Label.LabelCreateCommand>("create").WithDescription("Create or update a label entry.");
+                b.AddCommand<D365FO.Cli.Commands.Label.LabelUpdateCommand>("update").WithDescription("Correct the text of a label that already exists.");
                 b.AddCommand<D365FO.Cli.Commands.Label.LabelRenameCommand>("rename").WithDescription("Rename a label key.");
                 b.AddCommand<D365FO.Cli.Commands.Label.LabelDeleteCommand>("delete").WithDescription("Delete a label entry.");
             });
@@ -303,6 +305,9 @@ public static class CliApp
                 b.AddCommand<AnalyzeCompletenessCommand>("completeness").WithDescription("Report broken EDT, label, security-role references in a project folder.");
                 b.AddCommand<AnalyzeIntegrationCommand>("integration").WithDescription("Cross-check data entities for OData / DMF integration readiness.");
                 b.AddCommand<AnalyzeImpactCommand>("impact").WithDescription("Change-impact analysis: list all downstream consumers of an AOT object.");
+                b.AddCommand<AnalyzePatternsCommand>("patterns").WithDescription("How a scenario is usually done HERE: the APIs the code around it reaches for, ranked by how many objects use each.");
+                b.AddCommand<AnalyzeImplementationsCommand>("implementations").WithDescription("Who else implements this method, with the signature each declared — read before writing an override or a CoC wrapper.");
+                b.AddCommand<AnalyzeApiUsageCommand>("api-usage").WithDescription("How an API is actually reached: constructed, called statically, or declared — with the lines that do it.");
             });
 
             cfg.AddCommand<ReportIntegrationsCommand>("report-integrations").WithDescription("Aggregated report of OData entities, services, business events, workflow types, and batch jobs.");
@@ -404,6 +409,7 @@ public static class CliApp
             cfg.AddCommand<BuildCommand>("build").WithDescription("Invoke MSBuild (Windows VM).");
             cfg.AddCommand<SyncCommand>("sync").WithDescription("Run DB sync (Windows VM).");
             cfg.AddCommand<D365FO.Cli.Commands.Connect.ConnectCommand>("connect").WithDescription("Point an editor's MCP config at a deployed `d365fo-mcp --http` server (probes /health, merges rather than clobbers).");
+            cfg.AddCommand<VerifyCommand>("verify").WithDescription("Do the model on disk and its .rnrproj agree? An object the project does not list is never compiled, and nothing else reports it.");
             cfg.AddCommand<DoctorCommand>("doctor").WithDescription("Diagnose environment.");
             cfg.AddCommand<InitCommand>("init").WithDescription("Interactive quickstart: detects PackagesLocalDirectory and prepares the index.");
             cfg.AddCommand<StatsCommand>("stats").WithDescription("Aggregate counters over the index (top tables / classes / CoC targets).");

--- a/src/D365FO.Cli/Commands/Agent/SchemaCommand.cs
+++ b/src/D365FO.Cli/Commands/Agent/SchemaCommand.cs
@@ -143,6 +143,7 @@ public sealed class SchemaCommand : Command<SchemaCommand.Settings>
         C("labels resolve", "Resolve a @SYS12345-style label token across languages.", ["<TOKEN>"], ["--lang", "--raw-text", "--output"], ["labels (action=resolve)"], true),
         C("labels info", "Fetch one label entry by (file, language, key).", ["<FILE_OR_KEY>", "[KEY]"], ["--lang", "--raw-text", "--output"], ["labels (action=info)"], true),
         C("labels create", "Create or update a label entry.", ["<KEY>", "<VALUE>"], ["--file", "--overwrite", "--output"], ["labels (action=create)"], true),
+        C("labels update", "Correct the text of a label that already exists — never creates, so a mistyped key is refused rather than added.", ["<KEY>", "<VALUE>"], ["--file", "--install-to", "--lang", "--label-file", "--output"], ["labels (action=update)"], true),
         C("labels rename", "Rename a label key.", ["<OLD>", "<NEW>"], ["--file", "--overwrite", "--output"], ["labels (action=rename)"], true),
         C("labels delete", "Delete a label key.", ["<KEY>"], ["--file", "--output"], ["labels (action=delete)"], true),
         C("undo", "Revert the last N modification-journal entries (create removed, update/delete restored to their exact pre-image).", [], ["--steps", "--dry-run", "--db", "--output"], ["undo_last_modification"], true),
@@ -228,6 +229,9 @@ public sealed class SchemaCommand : Command<SchemaCommand.Settings>
         C("analyze completeness", "Cross-check a workspace folder's AOT XML against the index: broken EDT, label and security-role references.", ["<PATH>"], ["--skip-labels", "--skip-edts", "--skip-security", "--output"], ["analyze (mode=completeness)"]),
         C("analyze integration", "Cross-check data entities for OData/DMF readiness.", [], ["--model", "--output"], ["analyze (mode=integration)"]),
         C("analyze impact", "List downstream consumers of an AOT object.", ["<OBJECT>"], ["--output"], ["analyze (mode=impact)"]),
+        C("analyze patterns", "How a scenario is usually done HERE: the APIs that code reaches for, ranked by how many objects use each.", ["<SCENARIO>"], ["--model", "--limit", "--output"], ["analyze (mode=patterns)"]),
+        C("analyze implementations", "Who else implements this method, with the signature each declared.", ["<METHOD>"], ["--model", "--limit", "--output"], ["analyze (mode=implementations)"]),
+        C("analyze api-usage", "How an API is really reached: constructed, called statically, or declared.", ["<API>"], ["--model", "--limit", "--output"], ["analyze (mode=api-usage)"]),
         C("report-integrations", "Aggregated integration surface report.", [], ["--model", "--output"], ["analyze (mode=report)"]),
         C("review diff", "Inspect AOT changes vs. a git revision.", [], ["--base", "--head", "--repo", "--output"], ["get_workspace_info (changes=true)"]),
         C("build", "Invoke MSBuild on a D365FO project.", [], ["--msbuild", "--project", "--config", "--output"], ["sdlc (action=build)"]),
@@ -237,6 +241,7 @@ public sealed class SchemaCommand : Command<SchemaCommand.Settings>
         C("daemon start", "Start warm JSON-RPC daemon.", [], ["--db", "--packages", "--foreground", "--no-watch", "--watch-debounce"], []),
         C("daemon stop", "Stop daemon.", [], [], []),
         C("daemon status", "Report daemon status.", [], [], []),
+        C("verify", "Do the model on disk and its .rnrproj agree? An unlisted object is never compiled.", ["[MODEL]"], ["--path", "--expect", "--output"], ["verify_project"]),
         C("doctor", "Diagnose environment.", [], ["--output"], []),
         C("init", "Quickstart index/profile setup.", [], ["--packages", "--extra-packages", "--db", "--run-extract", "--dry-run", "--persist-profile"], []),
         C("version", "Print version information.", [], ["--output"], []),
@@ -262,6 +267,7 @@ public sealed class SchemaCommand : Command<SchemaCommand.Settings>
         C("resolve label", "Resolve @SYS12345-style label token to its text.", ["<TOKEN>"], ["--lang", "--output"], ["labels (action=resolve)"]),
 
         C("label create", "Create or update a label entry.", ["[KEY]", "[VALUE]"], ["--entry", "--file", "--install-to", "--lang", "--label-file", "--overwrite", "--allow-extension-label-file", "--output"], ["labels (action=create)"]),
+        C("label update", "Correct the text of a label that already exists.", ["<KEY>", "<VALUE>"], ["--file", "--install-to", "--lang", "--label-file", "--allow-extension-label-file", "--output"], ["labels (action=update)"]),
         C("label delete", "Delete a label entry.", ["<KEY>"], ["--file", "--output"], ["labels (action=delete)"]),
         C("label rename", "Rename a label key.", ["<OLD>", "<NEW>"], ["--file", "--overwrite", "--allow-extension-label-file", "--output"], ["labels (action=rename)"]),
 

--- a/src/D365FO.Cli/Commands/Analyze/AnalyzeCodeCommands.cs
+++ b/src/D365FO.Cli/Commands/Analyze/AnalyzeCodeCommands.cs
@@ -1,0 +1,73 @@
+using D365FO.Core.Analysis;
+using Spectre.Console.Cli;
+
+namespace D365FO.Cli.Commands.Analyze;
+
+// The three `analyze` modes the gap analysis lists as missing: learn from the installation
+// instead of from training data. All three read the same corpus of X++ method bodies and all
+// three report how much of it they could actually see — an empty answer from an unread corpus
+// is not the same answer as an empty one from a read corpus, and only one of them means "no".
+
+/// <summary><c>d365fo analyze patterns</c> — which APIs a scenario usually reaches for.</summary>
+public sealed class AnalyzePatternsCommand : Command<AnalyzePatternsCommand.Settings>
+{
+    public sealed class Settings : D365OutputSettings
+    {
+        [CommandArgument(0, "<SCENARIO>")]
+        [System.ComponentModel.Description("What you are about to do, in the words the code would use: \"number sequence\", \"posting\", \"batch job\".")]
+        public string Scenario { get; init; } = "";
+
+        [CommandOption("--model <NAME>")]
+        [System.ComponentModel.Description("Restrict to one model — e.g. your own, to see how THIS codebase does it.")]
+        public string? Model { get; init; }
+
+        [CommandOption("-l|--limit <N>")]
+        public int Limit { get; init; } = 20;
+    }
+
+    public override int Execute(CommandContext ctx, Settings settings) =>
+        RenderHelpers.Render(OutputMode.Resolve(settings.Output),
+            CodeAnalysis.Patterns(RepoFactory.Create(), settings.Scenario, settings.Model, settings.Limit));
+}
+
+/// <summary><c>d365fo analyze implementations</c> — who else implements this method.</summary>
+public sealed class AnalyzeImplementationsCommand : Command<AnalyzeImplementationsCommand.Settings>
+{
+    public sealed class Settings : D365OutputSettings
+    {
+        [CommandArgument(0, "<METHOD>")]
+        [System.ComponentModel.Description("Method name, e.g. validateWrite. Read before writing an override or a CoC wrapper.")]
+        public string Method { get; init; } = "";
+
+        [CommandOption("--model <NAME>")]
+        public string? Model { get; init; }
+
+        [CommandOption("-l|--limit <N>")]
+        public int Limit { get; init; } = 20;
+    }
+
+    public override int Execute(CommandContext ctx, Settings settings) =>
+        RenderHelpers.Render(OutputMode.Resolve(settings.Output),
+            CodeAnalysis.Implementations(RepoFactory.Create(), settings.Method, settings.Model, settings.Limit));
+}
+
+/// <summary><c>d365fo analyze api-usage</c> — how an API is constructed and called.</summary>
+public sealed class AnalyzeApiUsageCommand : Command<AnalyzeApiUsageCommand.Settings>
+{
+    public sealed class Settings : D365OutputSettings
+    {
+        [CommandArgument(0, "<API>")]
+        [System.ComponentModel.Description("Class or API name, e.g. NumberSeq, DocumentManagement, SysMailerFactory.")]
+        public string Api { get; init; } = "";
+
+        [CommandOption("--model <NAME>")]
+        public string? Model { get; init; }
+
+        [CommandOption("-l|--limit <N>")]
+        public int Limit { get; init; } = 25;
+    }
+
+    public override int Execute(CommandContext ctx, Settings settings) =>
+        RenderHelpers.Render(OutputMode.Resolve(settings.Output),
+            CodeAnalysis.ApiUsage(RepoFactory.Create(), settings.Api, settings.Model, settings.Limit));
+}

--- a/src/D365FO.Cli/Commands/Label/LabelWriteCommands.cs
+++ b/src/D365FO.Cli/Commands/Label/LabelWriteCommands.cs
@@ -1,4 +1,4 @@
-using D365FO.Core;
+﻿using D365FO.Core;
 using D365FO.Core.Journal;
 using D365FO.Core.Labels;
 using Spectre.Console.Cli;
@@ -95,45 +95,11 @@ public sealed class LabelCreateCommand : Command<LabelCreateCommand.Settings>
                 "--file <PATH> or --install-to <MODEL> is required.",
                 hint: "Use --file for an explicit absolute path, or --install-to <MODEL> to resolve the path automatically from D365FO_CUSTOM_PACKAGES_PATH or D365FO_PACKAGES_PATH."));
 
-        var resolvedFiles = new List<string>();
-        if (hasFile)
-        {
-            resolvedFiles.Add(settings.File!);
-        }
-        else
-        {
-            var cfg = D365FoSettings.FromEnvironment();
-            // Search custom paths first (write target for git repo models), then standard path.
-            var allRoots = cfg.CustomPackagesPaths.Concat(new[] { cfg.PackagesPath });
-            var root = allRoots
-                .FirstOrDefault(r => !string.IsNullOrEmpty(r) && Directory.Exists(Path.Combine(r!, settings.InstallTo!)))
-                ?? cfg.CustomPackagesPaths.FirstOrDefault()
-                ?? cfg.PackagesPath;
-            if (string.IsNullOrEmpty(root))
-                return RenderHelpers.Render(kind, ToolResult<object>.Fail("INSTALL_FAILED",
-                    $"Cannot resolve label file path for model '{settings.InstallTo}': neither D365FO_CUSTOM_PACKAGES_PATH nor D365FO_PACKAGES_PATH is set.",
-                    hint: "Set D365FO_CUSTOM_PACKAGES_PATH to your git repo PackagesLocalDirectory, or use --file with an absolute path."));
-
-            var langs = (string.IsNullOrWhiteSpace(settings.Lang) ? "en-us" : settings.Lang!)
-                .Split(',', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries);
-            var lf = string.IsNullOrWhiteSpace(settings.LabelFile) ? settings.InstallTo! : settings.LabelFile!;
-            var resourcesDir = System.IO.Path.Combine(root!, settings.InstallTo!, settings.InstallTo!, "AxLabelFile", "LabelResources");
-            foreach (var lang in langs)
-            {
-                var diskLang = ResolveOnDiskCasing(resourcesDir, lang);
-                resolvedFiles.Add(System.IO.Path.Combine(resourcesDir, diskLang, $"{lf}.{diskLang}.label.txt"));
-            }
-        }
-
-        if (!settings.AllowExtensionLabelFile)
-        {
-            var extFile = resolvedFiles.FirstOrDefault(LabelFileWriter.IsExtensionLabelFile);
-            if (extFile is not null)
-                return RenderHelpers.Render(kind, ToolResult<object>.Fail(
-                    "EXTENSION_LABEL_FILE",
-                    $"'{System.IO.Path.GetFileName(extFile)}' is a label file EXTENSION — it only extends a base label file owned by another model. New labels belong in the model's ORIGINAL label file.",
-                    hint: "Target the model's own label file (e.g. --label-file <MODEL>), or pass --allow-extension-label-file to override."));
-        }
+        var targets = LabelTargets.Resolve(
+            settings.File, settings.InstallTo, settings.Lang, settings.LabelFile,
+            settings.AllowExtensionLabelFile);
+        if (targets.Failure is not null) return RenderHelpers.Render(kind, targets.Failure);
+        var resolvedFiles = targets.Files;
 
         if (!batchMode)
         {
@@ -365,5 +331,170 @@ public sealed class LabelDeleteCommand : Command<LabelDeleteCommand.Settings>
         {
             return RenderHelpers.Render(kind, ToolResult<object>.Fail(D365FoErrorCodes.WriteFailed, ex.Message));
         }
+    }
+}
+
+/// <summary>
+/// Where a label write lands: an explicit file, or one file per language under a model.
+/// </summary>
+/// <remarks>
+/// Shared by <c>labels create</c> and <c>labels update</c>. The two differ in what they do to
+/// an entry, not in where they look for it, and a second copy of "which file is this label in"
+/// is a second place for the on-disk locale casing rule to be got wrong.
+/// </remarks>
+internal static class LabelTargets
+{
+    internal sealed record Resolution(IReadOnlyList<string> Files, ToolResult<object>? Failure);
+
+    internal static Resolution Resolve(
+        string? file, string? installTo, string? lang, string? labelFile, bool allowExtensionLabelFile)
+    {
+        var files = new List<string>();
+
+        if (!string.IsNullOrWhiteSpace(file))
+        {
+            files.Add(file!);
+        }
+        else
+        {
+            var cfg = D365FoSettings.FromEnvironment();
+            // Search custom paths first (write target for git repo models), then standard path.
+            var allRoots = cfg.CustomPackagesPaths.Concat(new[] { cfg.PackagesPath });
+            var root = allRoots
+                .FirstOrDefault(r => !string.IsNullOrEmpty(r) && Directory.Exists(Path.Combine(r!, installTo!)))
+                ?? cfg.CustomPackagesPaths.FirstOrDefault()
+                ?? cfg.PackagesPath;
+            if (string.IsNullOrEmpty(root))
+                return new Resolution([], ToolResult<object>.Fail("INSTALL_FAILED",
+                    $"Cannot resolve label file path for model '{installTo}': neither D365FO_CUSTOM_PACKAGES_PATH nor D365FO_PACKAGES_PATH is set.",
+                    hint: "Set D365FO_CUSTOM_PACKAGES_PATH to your git repo PackagesLocalDirectory, or use --file with an absolute path."));
+
+            var langs = (string.IsNullOrWhiteSpace(lang) ? "en-us" : lang!)
+                .Split(',', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries);
+            var lf = string.IsNullOrWhiteSpace(labelFile) ? installTo! : labelFile!;
+            var resourcesDir = Path.Combine(root!, installTo!, installTo!, "AxLabelFile", "LabelResources");
+            foreach (var l in langs)
+            {
+                var diskLang = LabelCreateCommand.ResolveOnDiskCasing(resourcesDir, l);
+                files.Add(Path.Combine(resourcesDir, diskLang, $"{lf}.{diskLang}.label.txt"));
+            }
+        }
+
+        if (!allowExtensionLabelFile)
+        {
+            var extFile = files.FirstOrDefault(LabelFileWriter.IsExtensionLabelFile);
+            if (extFile is not null)
+                return new Resolution([], ToolResult<object>.Fail(
+                    "EXTENSION_LABEL_FILE",
+                    $"'{Path.GetFileName(extFile)}' is a label file EXTENSION — it only extends a base label file owned by another model. New labels belong in the model's ORIGINAL label file.",
+                    hint: "Target the model's own label file (e.g. --label-file <MODEL>), or pass --allow-extension-label-file to override."));
+        }
+
+        return new Resolution(files, null);
+    }
+}
+
+/// <summary>
+/// <c>d365fo labels update</c> — correct the text of a label that already exists.
+/// </summary>
+/// <remarks>
+/// Distinct from <c>labels create --overwrite</c> on purpose: create writes a new entry when the
+/// key is absent, so a mistyped key in a correction produces a second label instead of fixing the
+/// first — and the caller is told "created", which reads as success. Fixing a typo in a
+/// translation used to mean delete plus create, which loses the entry's position in the file and
+/// its comment block on the way.
+/// </remarks>
+public sealed class LabelUpdateCommand : Command<LabelUpdateCommand.Settings>
+{
+    public sealed class Settings : D365OutputSettings
+    {
+        [CommandArgument(0, "<KEY>")]
+        [System.ComponentModel.Description("Label key to correct. Must already exist — this never creates.")]
+        public string Key { get; init; } = "";
+
+        [CommandArgument(1, "<VALUE>")]
+        [System.ComponentModel.Description("The corrected text.")]
+        public string Value { get; init; } = "";
+
+        [CommandOption("--file <PATH>")]
+        [System.ComponentModel.Description("Target <Name>.<lang>.label.txt file (absolute path). Required unless --install-to is used.")]
+        public string? File { get; init; }
+
+        [CommandOption("--install-to <MODEL>")]
+        [System.ComponentModel.Description("Model name; resolves the label file per language, as `labels create` does.")]
+        public string? InstallTo { get; init; }
+
+        [CommandOption("--lang <LANG>")]
+        [System.ComponentModel.Description("Language code(s), comma-separated (default: en-us). Each is updated independently.")]
+        public string? Lang { get; init; }
+
+        [CommandOption("--label-file <NAME>")]
+        [System.ComponentModel.Description("Label file name (without extension) used with --install-to (default: model name).")]
+        public string? LabelFile { get; init; }
+
+        [CommandOption("--allow-extension-label-file")]
+        [System.ComponentModel.Description("Permit writing into a label file EXTENSION (…_Extension…).")]
+        public bool AllowExtensionLabelFile { get; init; }
+    }
+
+    public override int Execute(CommandContext ctx, Settings settings)
+    {
+        var kind = OutputMode.Resolve(settings.Output);
+
+        if (string.IsNullOrWhiteSpace(settings.Key))
+            return RenderHelpers.Render(kind, ToolResult<object>.Fail(D365FoErrorCodes.BadInput, "Label key required."));
+        if (string.IsNullOrWhiteSpace(settings.File) && string.IsNullOrWhiteSpace(settings.InstallTo))
+            return RenderHelpers.Render(kind, ToolResult<object>.Fail(D365FoErrorCodes.BadInput,
+                "--file <PATH> or --install-to <MODEL> is required."));
+
+        var targets = LabelTargets.Resolve(
+            settings.File, settings.InstallTo, settings.Lang, settings.LabelFile,
+            settings.AllowExtensionLabelFile);
+        if (targets.Failure is not null) return RenderHelpers.Render(kind, targets.Failure);
+
+        var results = new List<object>();
+        var missing = new List<string>();
+        try
+        {
+            foreach (var file in targets.Files)
+            {
+                var res = LabelFileWriter.Update(file, settings.Key, settings.Value);
+                if (res.Outcome == WriteOutcome.KeyMissing)
+                {
+                    missing.Add(file);
+                    continue;
+                }
+                LabelJournalRecorder.RecordCreateOrUpdate(res, "labels update");
+                results.Add(new
+                {
+                    outcome = res.Outcome.ToString(),
+                    file = res.Path,
+                    key = res.Key,
+                    oldValue = res.OldValue,
+                    newValue = res.NewValue,
+                });
+            }
+        }
+        catch (Exception ex)
+        {
+            return RenderHelpers.Render(kind, ToolResult<object>.Fail(D365FoErrorCodes.WriteFailed, ex.Message));
+        }
+
+        // Nothing updated anywhere is a failure, not an empty success: the caller believes a
+        // correction landed.
+        if (results.Count == 0)
+            return RenderHelpers.Render(kind, ToolResult<object>.Fail("KEY_MISSING",
+                $"Label '{settings.Key}' is in none of the target files, so nothing was corrected.",
+                hint: $"Checked: {string.Join(", ", targets.Files)}. Use `labels create` to add it, or "
+                    + "`labels search` to find the key it was actually written under."));
+
+        return RenderHelpers.Render(kind, ToolResult<object>.Success(new
+        {
+            key = settings.Key,
+            updated = results.Count,
+            files = results,
+        }, missing.Count > 0
+            ? [$"{missing.Count} target file(s) do not carry this key and were left alone: {string.Join(", ", missing)}"]
+            : null));
     }
 }

--- a/src/D365FO.Cli/Commands/Ops/VerifyCommand.cs
+++ b/src/D365FO.Cli/Commands/Ops/VerifyCommand.cs
@@ -1,0 +1,80 @@
+using D365FO.Core;
+using D365FO.Core.Journal;
+using Spectre.Console.Cli;
+
+namespace D365FO.Cli.Commands.Ops;
+
+/// <summary>
+/// <c>d365fo verify</c> — does the model on disk and its Visual Studio project agree?
+/// </summary>
+/// <remarks>
+/// <c>generate --verify</c> answers a different question: it reads one freshly written artefact
+/// back through the metadata provider. This one asks about the model as a whole — every object
+/// file present, every project entry pointing at a file that exists. An object the project does
+/// not list is not compiled, and nothing anywhere says so.
+/// </remarks>
+public sealed class VerifyCommand : Command<VerifyCommand.Settings>
+{
+    public sealed class Settings : D365OutputSettings
+    {
+        [CommandArgument(0, "[MODEL]")]
+        [System.ComponentModel.Description("Model name (resolved under the configured packages paths), or a path to the inner <Model>/<Model> folder.")]
+        public string? Model { get; init; }
+
+        [CommandOption("--path <PATH>")]
+        [System.ComponentModel.Description("Model folder to check, when the name cannot be resolved.")]
+        public string? Path { get; init; }
+
+        [CommandOption("--expect <NAME>")]
+        [System.ComponentModel.Description("Repeatable: an object you believe you created — AxTable/ConFleetVehicle or plain ConFleetVehicle. Each is answered by name.")]
+        public string[] Expect { get; init; } = Array.Empty<string>();
+    }
+
+    public override int Execute(CommandContext ctx, Settings settings)
+    {
+        var kind = OutputMode.Resolve(settings.Output);
+
+        var folder = settings.Path;
+        if (string.IsNullOrWhiteSpace(folder))
+        {
+            if (string.IsNullOrWhiteSpace(settings.Model))
+                return RenderHelpers.Render(kind, ToolResult<object>.Fail(D365FoErrorCodes.BadInput,
+                    "A model name or --path is required."));
+
+            // A path given as the argument is used as one; otherwise the name is resolved the
+            // same way `index sync` resolves it, so both agree about where a model lives.
+            folder = Directory.Exists(settings.Model!)
+                ? settings.Model!
+                : ResolveModelFolder(settings.Model!);
+
+            if (folder is null)
+                return RenderHelpers.Render(kind, ToolResult<object>.Fail("MODEL_NOT_FOUND",
+                    $"No model directory called '{settings.Model}' under any configured packages path.",
+                    "Set D365FO_PACKAGES_PATH (and D365FO_CUSTOM_PACKAGES_PATH for custom-model roots), or pass --path."));
+        }
+
+        var result = ProjectVerifier.Verify(folder!, settings.Expect);
+        var rc = RenderHelpers.Render(kind, result);
+
+        // A disagreement is a finding, not a failure of the command — but it must not read as
+        // "all good" to a script.
+        if (rc != 0) return rc;
+        return result.Ok && result.Data is not null && HasIssues(result.Data) ? 2 : 0;
+    }
+
+    private static string? ResolveModelFolder(string model)
+    {
+        var cfg = D365FoSettings.FromEnvironment();
+        var roots = cfg.CustomPackagesPaths.Concat(new[] { cfg.PackagesPath });
+        return roots
+            .Where(r => !string.IsNullOrWhiteSpace(r) && Directory.Exists(r))
+            .SelectMany(r => D365FO.Core.Index.IndexSync.EnumerateModelDirs(r!, model))
+            .FirstOrDefault();
+    }
+
+    private static bool HasIssues(object data)
+    {
+        var prop = data.GetType().GetProperty("issueCount");
+        return prop?.GetValue(data) is int count && count > 0;
+    }
+}

--- a/src/D365FO.Core/Analysis/CodeAnalysis.cs
+++ b/src/D365FO.Core/Analysis/CodeAnalysis.cs
@@ -1,0 +1,286 @@
+using System.Text.RegularExpressions;
+using D365FO.Core.Index;
+
+namespace D365FO.Core.Analysis;
+
+/// <summary>
+/// "How is this done here?" answered from the installation rather than from training data:
+/// which APIs a scenario usually pulls in, who else has implemented this method, and how an
+/// API is actually constructed and called.
+/// </summary>
+/// <remarks>
+/// <para>
+/// The three modes the gap analysis lists as missing from <c>analyze</c>. Each is a reading of
+/// the same corpus — the X++ method bodies the index can reach — so they share one search and
+/// one honesty rule.
+/// </para>
+/// <para>
+/// The honesty rule is the point. A search over method bodies can return nothing because
+/// nothing matches, or because the corpus was not readable: no FTS index, no source paths on
+/// this machine, an index built somewhere else. Those are different answers, and reporting the
+/// second as an empty result is how "no callers" comes to mean "unused" for something that is
+/// used everywhere. Every result here carries how it was searched and how much it saw, and
+/// says so plainly when it saw nothing at all.
+/// </para>
+/// </remarks>
+public static class CodeAnalysis
+{
+    /// <summary>Corpus reachability, so an empty answer can be told apart from an unread one.</summary>
+    /// <param name="Via">fts | scan — which path served the search.</param>
+    /// <param name="FilesScanned">Source files opened; zero with a zero result means nothing was read.</param>
+    /// <param name="Searched">False when the corpus could not be read at all.</param>
+    /// <param name="Caveat">Why an empty answer is not evidence of absence, when it is not.</param>
+    public sealed record Coverage(string Via, int FilesScanned, bool Searched, string? Caveat);
+
+    private static Coverage CoverageOf(MetadataRepository repo, SourceRefResult result)
+    {
+        var ftsRows = repo.CountMethodSource();
+        var searched = ftsRows > 0 || result.FilesScanned > 0;
+        return new Coverage(
+            result.Via,
+            result.FilesScanned,
+            searched,
+            searched
+                ? null
+                : "Nothing was searched: the method-source index is empty and no source file could be opened. "
+                  + "This is not evidence of absence — run `d365fo index extract --index-source`, or point "
+                  + "D365FO_PACKAGES_PATH at the installation the index was built from.");
+    }
+
+    // ------------------------------------------------------------- patterns
+
+    /// <summary>
+    /// Which APIs the code around a scenario actually reaches for, ranked by how many distinct
+    /// objects use each.
+    /// </summary>
+    /// <param name="repo">Index to read the corpus through.</param>
+    /// <param name="scenario">Free text: "number sequence", "posting", "batch job".</param>
+    /// <param name="model">Restrict to one model — e.g. your own, to see how THIS codebase does it.</param>
+    /// <param name="limit">How many APIs and objects to return.</param>
+    public static ToolResult<object> Patterns(MetadataRepository repo, string scenario, string? model, int limit = 20)
+    {
+        ArgumentNullException.ThrowIfNull(repo);
+        if (string.IsNullOrWhiteSpace(scenario))
+            return ToolResult<object>.Fail(D365FoErrorCodes.BadInput, "A scenario is required.",
+                "Describe it in the words the code would use: \"number sequence\", \"posting\", \"batch job\".");
+
+        // Each word narrows the result; a scenario is a conjunction, not a bag.
+        var words = scenario.Split(' ', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries)
+            .Where(w => w.Length > 2)
+            .ToList();
+        if (words.Count == 0)
+            return ToolResult<object>.Fail(D365FoErrorCodes.BadInput,
+                "The scenario has no word longer than two characters to search on.");
+
+        var result = MethodSourceSearch.Find(repo, words[0], kind: null, model: model, limit: 400);
+        var hits = result.Hits
+            .Where(h => words.Skip(1).All(w =>
+                h.Matches.Any(m => m.Text.Contains(w, StringComparison.OrdinalIgnoreCase))
+                || h.Name.Contains(w, StringComparison.OrdinalIgnoreCase)
+                || h.Method.Contains(w, StringComparison.OrdinalIgnoreCase)))
+            .ToList();
+
+        // The APIs those methods reach for. Read from the WHOLE method body, not from the lines
+        // that matched: the line mentioning "number sequence" is a comment or a parameter name,
+        // and the NumberSeq call that answers the question is three lines below it. Counted by
+        // distinct owner so one verbose class cannot make its own habits look like the
+        // codebase's.
+        var byApi = new Dictionary<string, HashSet<string>>(StringComparer.Ordinal);
+        var bodiesRead = 0;
+        foreach (var hit in hits.Take(BodyReadCap))
+        {
+            var body = ReadBody(hit);
+            if (body is null) continue;
+            bodiesRead++;
+            foreach (Match m in ApiReference.Matches(body))
+            {
+                var api = m.Groups["api"].Value;
+                if (api.Length < 4 || Noise.Contains(api)) continue;
+                if (!byApi.TryGetValue(api, out var owners)) byApi[api] = owners = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+                owners.Add(hit.Name);
+            }
+        }
+
+        var apis = byApi
+            .OrderByDescending(kv => kv.Value.Count)
+            .ThenBy(kv => kv.Key, StringComparer.Ordinal)
+            .Take(limit)
+            .Select(kv => new { api = kv.Key, usedBy = kv.Value.Count, examples = kv.Value.Take(3).ToArray() })
+            .ToList();
+
+        var coverage = CoverageOf(repo, result);
+        return ToolResult<object>.Success(new
+        {
+            scenario,
+            coverage,
+            matchingMethods = hits.Count,
+            bodiesRead,
+            objects = hits.Select(h => h.Name).Distinct(StringComparer.OrdinalIgnoreCase).Take(limit).ToArray(),
+            apis,
+            note = "Ranked by how many DISTINCT objects use each API, not by how often it appears — one "
+                 + "verbose class should not make its own habits look like the codebase's.",
+        }, coverage.Caveat is null ? null : [coverage.Caveat]);
+    }
+
+    // ------------------------------------------------------ implementations
+
+    /// <summary>
+    /// Who else implements this method, with the signature each declared — the answer before
+    /// writing an override or a CoC wrapper.
+    /// </summary>
+    public static ToolResult<object> Implementations(
+        MetadataRepository repo, string methodName, string? model, int limit = 20)
+    {
+        ArgumentNullException.ThrowIfNull(repo);
+        if (string.IsNullOrWhiteSpace(methodName))
+            return ToolResult<object>.Fail(D365FoErrorCodes.BadInput, "A method name is required.");
+
+        var declared = repo.FindMethodDeclarations(methodName, model, limit);
+
+        // Bodies are a separate question from declarations: the index knows every declaration,
+        // and only the opt-in source index knows what is inside them.
+        var result = MethodSourceSearch.Find(repo, methodName, kind: null, model: model, limit: limit);
+        var bodies = result.Hits
+            .Where(h => string.Equals(h.Method, methodName, StringComparison.OrdinalIgnoreCase))
+            .ToList();
+
+        var coverage = CoverageOf(repo, result);
+        return ToolResult<object>.Success(new
+        {
+            method = methodName,
+            coverage,
+            count = declared.Count,
+            declarations = declared.Select(d => new
+            {
+                d.Owner,
+                d.OwnerKind,
+                d.Model,
+                d.Signature,
+            }),
+            bodies = bodies.Select(h => new
+            {
+                owner = h.Name,
+                ownerKind = h.Kind,
+                h.Model,
+                lines = h.Matches.Select(m => new { m.Line, m.Text }),
+                path = h.Path,
+            }),
+            note = declared.Count == 0
+                ? "No object in the index declares this method. It may be a kernel method, which has no AOT "
+                  + "declaration to find — `d365fo knowledge get system-objects` covers the ones that do not exist as files."
+                : "Read one in full with `d365fo read class <Owner> --method " + methodName + "`.",
+        }, coverage.Caveat is null ? null : [coverage.Caveat]);
+    }
+
+    // ----------------------------------------------------------- api-usage
+
+    /// <summary>
+    /// How an API is actually reached: constructed, called statically, declared as a type, or
+    /// taken as a parameter — with the lines that do it.
+    /// </summary>
+    public static ToolResult<object> ApiUsage(MetadataRepository repo, string api, string? model, int limit = 25)
+    {
+        ArgumentNullException.ThrowIfNull(repo);
+        if (string.IsNullOrWhiteSpace(api))
+            return ToolResult<object>.Fail(D365FoErrorCodes.BadInput, "An API name is required.");
+
+        var result = MethodSourceSearch.Find(repo, api, kind: null, model: model, limit: limit * 4);
+
+        var construction = new List<object>();
+        var staticCalls = new List<object>();
+        var declarations = new List<object>();
+        var other = new List<object>();
+
+        var newRx = new Regex($@"\bnew\s+{Regex.Escape(api)}\s*\(", RegexOptions.IgnoreCase);
+        var staticRx = new Regex($@"\b{Regex.Escape(api)}\s*::\s*(?<member>\w+)", RegexOptions.IgnoreCase);
+        var declRx = new Regex($@"^\s*{Regex.Escape(api)}\s+\w+\s*[;=]", RegexOptions.IgnoreCase | RegexOptions.Multiline);
+
+        foreach (var hit in result.Hits)
+        foreach (var line in hit.Matches)
+        {
+            var entry = new { owner = hit.Name, ownerKind = hit.Kind, hit.Model, method = hit.Method, line.Line, line.Text };
+            if (newRx.IsMatch(line.Text)) construction.Add(entry);
+            else if (staticRx.IsMatch(line.Text)) staticCalls.Add(entry);
+            else if (declRx.IsMatch(line.Text)) declarations.Add(entry);
+            else other.Add(entry);
+        }
+
+        // Which static members are reached, so the answer names the API's real entry points
+        // rather than only showing lines.
+        var members = result.Hits
+            .SelectMany(h => h.Matches)
+            .SelectMany(m => staticRx.Matches(m.Text).Select(x => x.Groups["member"].Value))
+            .Where(v => v.Length > 0)
+            .GroupBy(v => v, StringComparer.Ordinal)
+            .OrderByDescending(g => g.Count())
+            .Select(g => new { member = g.Key, uses = g.Count() })
+            .Take(limit)
+            .ToList();
+
+        var coverage = CoverageOf(repo, result);
+        return ToolResult<object>.Success(new
+        {
+            api,
+            coverage,
+            indexed = repo.SymbolKinds(api),
+            summary = new
+            {
+                construction = construction.Count,
+                staticCalls = staticCalls.Count,
+                declarations = declarations.Count,
+                other = other.Count,
+            },
+            staticMembers = members,
+            construction = construction.Take(limit),
+            staticCallSites = staticCalls.Take(limit),
+            declarations = declarations.Take(limit),
+            note = construction.Count == 0 && staticCalls.Count > 0
+                ? "Never constructed here — this API is reached statically, so a `new` is probably the wrong shape."
+                : null,
+        }, coverage.Caveat is null ? null : [coverage.Caveat]);
+    }
+
+    // ------------------------------------------------------------- helpers
+
+    /// <summary>
+    /// How many method bodies <see cref="Patterns"/> will open. Each is a file read, and the
+    /// ranking is stable long before the cap — a scenario answered by four hundred methods is
+    /// not a scenario.
+    /// </summary>
+    private const int BodyReadCap = 60;
+
+    /// <summary>The full X++ body behind a hit, or null when the source is not reachable.</summary>
+    private static string? ReadBody(SourceRefHit hit)
+    {
+        if (string.IsNullOrEmpty(hit.Path)) return null;
+        try
+        {
+            var src = Extract.XppSourceReader.Read(hit.Path);
+            return src is null ? null : Extract.XppSourceReader.FindMethod(src, hit.Method)?.Body;
+        }
+        catch { return null; }
+    }
+
+    /// <summary>PascalCase identifier used as a static call, a constructor, or a declared type.</summary>
+    private static readonly Regex ApiReference = new(
+        // Not preceded by '[': an attribute is a declaration ABOUT the method, not something the
+        // method reaches for, and [SubscribesTo(...)] would otherwise outrank the API being asked
+        // about.
+        @"(?<!\[)\b(?:new\s+)?(?<api>[A-Z][A-Za-z0-9_]{3,})\s*(?:::|\()",
+        RegexOptions.Compiled);
+
+    /// <summary>
+    /// Language and framework noise that appears in every method and says nothing about a
+    /// scenario.
+    /// </summary>
+    private static readonly HashSet<string> Noise = new(StringComparer.Ordinal)
+    {
+        "SysTest", "Debug", "Global", "Error", "Exception", "Types", "NoYes", "Info", "Warning",
+        "Throw", "Assert", "String", "Integer", "Container", "Query", "Args", "Common", "Object",
+        // Attributes and intrinsics: they name an object without being one the method reaches
+        // for, so they would rank above the API the caller actually asked about.
+        "SysObsolete", "SysEntryPointAttribute", "DataMemberAttribute", "SysTestMethodAttribute",
+        "SubscribesTo", "PostHandlerFor", "PreHandlerFor", "ExtensionOf", "DataEventHandler",
+        "FormEventHandler", "FormDataSourceEventHandler", "SysAttribute",
+    };
+}

--- a/src/D365FO.Core/Index/MetadataRepository.Validation.cs
+++ b/src/D365FO.Core/Index/MetadataRepository.Validation.cs
@@ -38,6 +38,61 @@ public sealed partial class MetadataRepository : IReferenceIndex, IPropertyStats
             new { name }) > 0;
     }
 
+    /// <summary>
+    /// Every object in the index that DECLARES a method of this name, with the signature it
+    /// declared — classes and tables alike.
+    /// </summary>
+    /// <remarks>
+    /// The inverse of <see cref="FindMethod"/>, which asks whether one owner has one method.
+    /// "Who else has implemented <c>validateWrite</c>, and with what signature" is the question
+    /// asked before writing an override, and it was not answerable from the index at all.
+    /// </remarks>
+    public IReadOnlyList<MethodDeclaration> FindMethodDeclarations(string methodName, string? model = null, int limit = 20)
+    {
+        if (string.IsNullOrWhiteSpace(methodName)) return Array.Empty<MethodDeclaration>();
+        limit = ClampLimit(limit, 20);
+
+        using var conn = OpenReadOnly();
+
+        // Read through a raw reader rather than Dapper's record materialiser: SQLite columns are
+        // typeless, and for a literal kind on an EMPTY result set Dapper infers byte[] and
+        // refuses to bind the record. It fails only when there are no rows — the case a test on
+        // an empty index hits first and a caller with data never sees. SearchMethodSource
+        // documents the same trap for the FTS columns.
+        using var cmd = conn.CreateCommand();
+        cmd.CommandText = @"
+            SELECT c.Name AS Owner, 'class' AS OwnerKind, mo.Name AS Model, m.Signature
+            FROM Methods m
+              JOIN Classes c ON m.ClassId = c.ClassId
+              JOIN Models  mo ON mo.ModelId = c.ModelId
+            WHERE m.Name = $method COLLATE NOCASE
+              AND ($model IS NULL OR mo.Name = $model COLLATE NOCASE)
+            UNION ALL
+            SELECT t.Name AS Owner, 'table' AS OwnerKind, mo.Name AS Model, tm.Signature
+            FROM TableMethods tm
+              JOIN Tables t  ON tm.TableId = t.TableId
+              JOIN Models mo ON mo.ModelId = t.ModelId
+            WHERE tm.Name = $method COLLATE NOCASE
+              AND ($model IS NULL OR mo.Name = $model COLLATE NOCASE)
+            ORDER BY Owner
+            LIMIT $limit";
+        cmd.Parameters.AddWithValue("$method", methodName);
+        cmd.Parameters.AddWithValue("$model", (object?)model ?? DBNull.Value);
+        cmd.Parameters.AddWithValue("$limit", limit);
+
+        using var reader = cmd.ExecuteReader();
+        var rows = new List<MethodDeclaration>();
+        while (reader.Read())
+        {
+            rows.Add(new MethodDeclaration(
+                reader.GetString(0),
+                reader.GetString(1),
+                reader.GetString(2),
+                reader.IsDBNull(3) ? null : reader.GetString(3)));
+        }
+        return rows;
+    }
+
     /// <inheritdoc />
     public MethodLookup? FindMethod(string ownerName, string methodName)
     {

--- a/src/D365FO.Core/Index/Models.cs
+++ b/src/D365FO.Core/Index/Models.cs
@@ -162,6 +162,13 @@ public sealed record EnumDetails(EnumInfo Enum, IReadOnlyList<EnumValueInfo> Val
 public sealed record LabelMatch(string File, string Language, string Key, string? Value);
 
 /// <summary>A method-body full-text hit from the opt-in <c>MethodSourceFts</c> index.</summary>
+/// <summary>One object's declaration of a method, from the index.</summary>
+/// <param name="Owner">Declaring object.</param>
+/// <param name="OwnerKind">class | table.</param>
+/// <param name="Model">Model the declaring object belongs to.</param>
+/// <param name="Signature">Signature as extracted, or null when the extractor captured none.</param>
+public sealed record MethodDeclaration(string Owner, string OwnerKind, string Model, string? Signature);
+
 public sealed record MethodSourceMatch(
     string Kind,
     string ObjectName,

--- a/src/D365FO.Core/Journal/ProjectVerifier.cs
+++ b/src/D365FO.Core/Journal/ProjectVerifier.cs
@@ -1,0 +1,160 @@
+using System.Xml.Linq;
+
+namespace D365FO.Core.Journal;
+
+/// <summary>
+/// Does the model on disk and its Visual Studio project agree about what exists?
+/// </summary>
+/// <remarks>
+/// <para>
+/// A generated object reaches the AOT only if the XML is in the model folder AND the
+/// <c>.rnrproj</c> references it. The two can disagree in both directions and neither one
+/// complains: an XML the project does not list builds nowhere, and a project entry whose file is
+/// gone fails the build with a path, not a reason. The write path registers objects as it
+/// creates them, so the usual cause of a disagreement is a hand edit, a merge, or a file copied
+/// in from elsewhere — exactly the cases nobody is watching.
+/// </para>
+/// <para>
+/// A project with no explicit item list is not judged: some project shapes glob their content,
+/// and calling every file "unregistered" there would be a wall of false findings.
+/// </para>
+/// </remarks>
+public static class ProjectVerifier
+{
+    /// <param name="Object">Object name, without the .xml.</param>
+    /// <param name="AxFolder">AOT subfolder it lives in, e.g. AxTable.</param>
+    /// <param name="Finding">MISSING_FILE | UNREGISTERED.</param>
+    /// <param name="Detail">What is wrong, and what it means for a build.</param>
+    public sealed record Issue(string Object, string AxFolder, string Finding, string Detail);
+
+    public sealed record Report(
+        string ModelFolder,
+        string? ProjectFile,
+        bool ProjectHasItemList,
+        int FilesOnDisk,
+        int RegisteredItems,
+        IReadOnlyList<Issue> Issues);
+
+    /// <summary>Cross-check a model folder against its <c>.rnrproj</c>.</summary>
+    /// <param name="modelFolder">
+    /// The inner model folder — the one holding the <c>Ax*</c> subdirectories.
+    /// </param>
+    /// <param name="expected">
+    /// Optional names the caller believes it created (<c>AxTable/ConFleetVehicle</c> or plain
+    /// <c>ConFleetVehicle</c>). Each is checked explicitly, so "I just generated these five" gets
+    /// an answer about those five rather than about the whole model.
+    /// </param>
+    public static ToolResult<object> Verify(string modelFolder, IReadOnlyList<string>? expected = null)
+    {
+        if (string.IsNullOrWhiteSpace(modelFolder) || !Directory.Exists(modelFolder))
+            return ToolResult<object>.Fail(D365FoErrorCodes.BadInput,
+                $"No such model folder: {modelFolder}",
+                "Point this at the inner <Model>/<Model> folder — the one holding the Ax* subdirectories.");
+
+        var onDisk = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase); // include -> full path
+        foreach (var axDir in Directory.EnumerateDirectories(modelFolder, "Ax*"))
+        {
+            var axName = Path.GetFileName(axDir);
+            foreach (var file in Directory.EnumerateFiles(axDir, "*.xml", SearchOption.TopDirectoryOnly))
+                onDisk[axName + "\\" + Path.GetFileNameWithoutExtension(file) + ".xml"] = file;
+        }
+
+        var projectFile = RnrProjRegistry.FindRnrProj(modelFolder);
+        var registered = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+        var hasItemList = false;
+
+        if (projectFile is not null)
+        {
+            try
+            {
+                var doc = XDocument.Load(projectFile);
+                var ns = doc.Root?.Name.Namespace ?? XNamespace.None;
+                foreach (var group in doc.Root?.Elements(ns + "ItemGroup") ?? [])
+                foreach (var item in group.Elements())
+                {
+                    var include = item.Attribute("Include")?.Value;
+                    if (string.IsNullOrWhiteSpace(include)) continue;
+                    hasItemList = true;
+                    registered.Add(include.Replace('/', '\\'));
+                }
+            }
+            catch (Exception ex)
+            {
+                return ToolResult<object>.Fail(D365FoErrorCodes.SourceUnreadable,
+                    $"Could not read {projectFile}: {ex.Message}");
+            }
+        }
+
+        var issues = new List<Issue>();
+
+        // Project entries whose file is gone.
+        foreach (var include in registered)
+        {
+            if (onDisk.ContainsKey(include)) continue;
+            var parts = include.Split('\\');
+            issues.Add(new Issue(
+                Path.GetFileNameWithoutExtension(parts[^1]),
+                parts.Length > 1 ? parts[0] : "",
+                "MISSING_FILE",
+                $"The project references {include}, and no such file is in the model. The build fails on the path, "
+                + "which does not say that the object was deleted or never arrived."));
+        }
+
+        // Files the project does not list — only meaningful when it lists anything at all.
+        if (hasItemList)
+        {
+            foreach (var (include, _) in onDisk)
+            {
+                if (registered.Contains(include)) continue;
+                var parts = include.Split('\\');
+                issues.Add(new Issue(
+                    Path.GetFileNameWithoutExtension(parts[^1]),
+                    parts[0],
+                    "UNREGISTERED",
+                    $"{include} is in the model folder but not in the project, so it is not compiled and the AOT "
+                    + "never sees it. Nothing reports this — the object simply does not exist as far as a build is concerned."));
+            }
+        }
+
+        // Explicitly expected objects, answered by name.
+        var expectedReport = new List<object>();
+        foreach (var name in expected ?? [])
+        {
+            var wanted = name.Replace('/', '\\');
+            if (!wanted.EndsWith(".xml", StringComparison.OrdinalIgnoreCase)) wanted += ".xml";
+            var match = wanted.Contains('\\')
+                ? (onDisk.ContainsKey(wanted) ? wanted : null)
+                : onDisk.Keys.FirstOrDefault(k => k.EndsWith("\\" + wanted, StringComparison.OrdinalIgnoreCase));
+
+            expectedReport.Add(new
+            {
+                name,
+                onDisk = match is not null,
+                registered = match is not null && registered.Contains(match),
+                include = match,
+            });
+        }
+
+        var warnings = new List<string>();
+        if (projectFile is null)
+            warnings.Add("No .rnrproj found beside this model, so only the on-disk side could be checked. "
+                       + "An object outside the project is not compiled, and nothing here can tell you which ones.");
+        else if (!hasItemList)
+            warnings.Add($"{Path.GetFileName(projectFile)} declares no explicit item list; unregistered files are "
+                       + "therefore not reported, because a globbing project legitimately lists nothing.");
+        if (issues.Count > 0)
+            warnings.Add($"{issues.Count} object(s) the model and the project disagree about.");
+
+        return ToolResult<object>.Success(new
+        {
+            modelFolder,
+            projectFile,
+            projectHasItemList = hasItemList,
+            filesOnDisk = onDisk.Count,
+            registeredItems = registered.Count,
+            issueCount = issues.Count,
+            issues,
+            expected = expectedReport.Count > 0 ? expectedReport : null,
+        }, warnings.Count > 0 ? warnings : null);
+    }
+}

--- a/src/D365FO.Core/Labels/LabelFileWriter.cs
+++ b/src/D365FO.Core/Labels/LabelFileWriter.cs
@@ -50,6 +50,35 @@ public static class LabelFileWriter
     }
 
     /// <summary>
+    /// Replace the text of an entry that must ALREADY exist.
+    /// </summary>
+    /// <remarks>
+    /// Not <see cref="CreateOrUpdate"/> with <c>overwrite</c>: that writes a new entry when the
+    /// key is absent, which turns a mistyped key in a correction into a second label rather than
+    /// a fix. Correcting a translation and creating one are different intents, and only one of
+    /// them should be able to invent a key.
+    /// </remarks>
+    public static WriteResult Update(string path, string key, string value)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(path);
+        ArgumentException.ThrowIfNullOrWhiteSpace(key);
+        if (key.Contains('=')) throw new ArgumentException("Label keys must not contain '='.", nameof(key));
+
+        if (!File.Exists(path))
+            return new WriteResult(path, WriteOutcome.KeyMissing, key, null, null);
+
+        var lines = File.ReadAllLines(path).ToList();
+        var existing = FindKey(lines, key);
+        if (existing.lineIdx < 0)
+            return new WriteResult(path, WriteOutcome.KeyMissing, key, null, null);
+
+        var prev = existing.existingValue;
+        lines[existing.lineIdx] = key + "=" + Sanitise(value);
+        AtomicWrite(path, lines);
+        return new WriteResult(path, WriteOutcome.Updated, key, prev, value);
+    }
+
+    /// <summary>
     /// Insert a new entry at its case-insensitive ORDINAL position among the
     /// existing key lines (upstream parity: culture-aware sorts put e.g.
     /// "Item_2" before "Item10" differently per OS locale, producing noisy

--- a/src/D365FO.Mcp/ToolCatalog.cs
+++ b/src/D365FO.Mcp/ToolCatalog.cs
@@ -176,7 +176,9 @@ public static class ToolCatalog
             "info (all translations of a token like @SYS12345, or one entry by file+language+key) · " +
             "resolve (alias of info) · create (write a key=value; needs file or installTo; " +
             "pass `labels:[{key,value}, …]` for a bulk create with shared top-level fields) · " +
-            "rename (rename a key in place) · delete (remove a key). Values are sanitised unless raw=true.",
+            "update (correct the text of a key that MUST already exist — unlike create, which writes a new entry "
+            + "when the key is absent, so a mistyped key in a correction becomes a second label and reports "
+            + "success) · rename (rename a key in place) · delete (remove a key). Values are sanitised unless raw=true.",
             Schema(("action", "string", true), ("query", "string", false), ("token", "string", false),
                    ("languages", "array", false), ("limit", "integer", false), ("raw", "boolean", false),
                    ("file", "string", false), ("language", "string", false), ("key", "string", false),
@@ -207,6 +209,10 @@ public static class ToolCatalog
                                 Bool(p, "overwrite"),
                                 StrAliasOrNull(p, "installTo", "model"), StrAliasOrNull(p, "lang", "language"),
                                 StrAliasOrNull(p, "labelFile", "labelFileId")),
+                "update" => h.UpdateLabel(StrOrNull(p, "file"), StrAlias(p, "key", "labelId"),
+                            StrAlias(p, "value", "text", "label"),
+                            StrAliasOrNull(p, "installTo", "model"), StrAliasOrNull(p, "lang", "language"),
+                            StrAliasOrNull(p, "labelFile", "labelFileId")),
                 "rename" => h.RenameLabel(Str(p, "file"), Str(p, "oldKey"), Str(p, "newKey"), Bool(p, "overwrite")),
                 "delete" => h.DeleteLabel(Str(p, "file"), Str(p, "key")),
                 _        => h.SearchLabels(Str(p, "query"), StrArray(p, "languages"), Int(p, "limit", 100), Bool(p, "raw")),
@@ -642,16 +648,32 @@ public static class ToolCatalog
             "folder, a PackagesLocalDirectory or one AOT XML file — and report references that resolve to nothing: " +
             "MISSING_DUTY, MISSING_PRIVILEGE, MISSING_EDT, MISSING_LABEL; narrow with `skipLabels`/`skipEdts`/" +
             "`skipSecurity`. This is the only mode that reads the working tree, so it needs a local path). " +
-            "`model` scopes integration/report.",
+            "`model` scopes integration/report.\n"
+            + "Three modes read the X++ corpus rather than the object graph, and each reports what it could "
+            + "actually see in `coverage` — an empty answer from an unread corpus is not the same answer as an "
+            + "empty one from a read corpus, and only one of them means no:\n"
+            + "• patterns (`scenario` in the words the code would use — \"number sequence\", \"posting\") — the "
+            + "APIs that code reaches for, ranked by how many DISTINCT objects use each\n"
+            + "• implementations (`method`) — who else declares it, with the signature each declared; read this "
+            + "before writing an override or a CoC wrapper\n"
+            + "• api-usage (`api`) — how it is really reached: constructed, called statically, declared as a "
+            + "type; says so when an API is never constructed, which means a `new` is the wrong shape",
             Schema(("mode", "string", true), ("object", "string", false), ("model", "string", false),
                    ("path", "string", false), ("skipLabels", "boolean", false),
-                   ("skipEdts", "boolean", false), ("skipSecurity", "boolean", false)),
+                   ("skipEdts", "boolean", false), ("skipSecurity", "boolean", false),
+                   ("scenario", "string", false), ("method", "string", false), ("api", "string", false),
+                   ("limit", "integer", false)),
             (h, p) => StrOr(p, "mode", "integration").ToLowerInvariant() switch
             {
                 "impact" => h.AnalyzeImpact(Str(p, "object")),
                 "report" => h.ReportIntegrations(StrOrNull(p, "model")),
                 "completeness" => h.AnalyzeCompleteness(Str(p, "path"), Bool(p, "skipLabels"),
                                     Bool(p, "skipEdts"), Bool(p, "skipSecurity")),
+                "patterns" => h.AnalyzePatterns(Str(p, "scenario"), StrOrNull(p, "model"), Int(p, "limit", 20)),
+                "implementations" => h.AnalyzeImplementations(StrOr(p, "method", Str(p, "object")),
+                                        StrOrNull(p, "model"), Int(p, "limit", 20)),
+                "api-usage" or "api" => h.AnalyzeApiUsage(StrOr(p, "api", Str(p, "object")),
+                                        StrOrNull(p, "model"), Int(p, "limit", 25)),
                 _        => h.AnalyzeIntegration(StrOrNull(p, "model")),
             }),
 
@@ -705,6 +727,17 @@ public static class ToolCatalog
             "Current row counts of every entity table.",
             Schema(),
             (h, _) => h.IndexStatus()),
+
+        new Descriptor("verify_project",
+            "Do the model on disk and its Visual Studio project agree? Every object XML present, every "
+            + "`.rnrproj` entry pointing at a file that exists. An object the project does not list is NOT "
+            + "compiled — the AOT never sees it and nothing anywhere reports that; a project entry whose file is "
+            + "gone fails the build with a path rather than a reason. Name the `model` or pass a `path` to the "
+            + "inner <Model>/<Model> folder; `expect` (array) answers by name for the objects you believe you "
+            + "just created. A project with no explicit item list is not judged — some project shapes glob, and "
+            + "calling every file unregistered there would be a wall of false findings.",
+            Schema(("model", "string", false), ("path", "string", false), ("expect", "array", false)),
+            (h, p) => h.VerifyProject(StrOrNull(p, "model"), StrOrNull(p, "path"), StrArray(p, "expect"))),
 
         new Descriptor("index_sync",
             "Re-index ONE model after an edit made outside this server — in Visual Studio, by a git pull, by "

--- a/src/D365FO.Mcp/ToolHandlers.cs
+++ b/src/D365FO.Mcp/ToolHandlers.cs
@@ -580,6 +580,68 @@ public sealed partial class ToolHandlers
         return ToolResult<object>.Success(new { total = entries.Count, created, failed, results });
     }
 
+    /// <summary>
+    /// Correct the text of a label that already exists, in every language file it resolves to.
+    /// </summary>
+    /// <remarks>
+    /// Deliberately not <c>CreateLabel</c> with overwrite: that writes a new entry when the key
+    /// is absent, so a mistyped key in a correction produces a second label and reports success.
+    /// Nothing updated anywhere is a failure, because the caller believes a correction landed.
+    /// </remarks>
+    public ToolResult<object> UpdateLabel(
+        string? file, string key, string value, string? installTo, string? lang, string? labelFile)
+    {
+        if (string.IsNullOrWhiteSpace(key))
+            return ToolResult<object>.Fail(D365FoErrorCodes.BadInput, "key is required.");
+
+        var targets = new List<string>();
+        if (!string.IsNullOrWhiteSpace(file))
+        {
+            targets.Add(file!);
+        }
+        else if (!string.IsNullOrWhiteSpace(installTo))
+        {
+            foreach (var l in (string.IsNullOrWhiteSpace(lang) ? "en-us" : lang!)
+                     .Split(',', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries))
+            {
+                var path = ResolveLabelPath(installTo!, l, labelFile);
+                if (path is not null) targets.Add(path);
+            }
+        }
+
+        if (targets.Count == 0)
+            return ToolResult<object>.Fail(D365FoErrorCodes.BadInput,
+                "file or installTo is required, and installTo must resolve to a packages path.");
+
+        var updated = new List<object>();
+        var missing = new List<string>();
+        try
+        {
+            foreach (var path in targets)
+            {
+                var res = D365FO.Core.Labels.LabelFileWriter.Update(path, key, value);
+                if (res.Outcome == D365FO.Core.Labels.WriteOutcome.KeyMissing) { missing.Add(path); continue; }
+                D365FO.Core.Journal.LabelJournalRecorder.RecordCreateOrUpdate(res, "labels update");
+                updated.Add(new { file = res.Path, key = res.Key, oldValue = res.OldValue, newValue = res.NewValue });
+            }
+        }
+        catch (Exception ex)
+        {
+            return ToolResult<object>.Fail(D365FoErrorCodes.WriteFailed, ex.Message);
+        }
+
+        if (updated.Count == 0)
+            return ToolResult<object>.Fail("KEY_MISSING",
+                $"Label '{key}' is in none of the target files, so nothing was corrected.",
+                $"Checked: {string.Join(", ", targets)}. Use action=create to add it, or action=search to find "
+                + "the key it was actually written under.");
+
+        return ToolResult<object>.Success(new { key, updated = updated.Count, files = updated },
+            missing.Count > 0
+                ? [$"{missing.Count} target file(s) do not carry this key and were left alone: {string.Join(", ", missing)}"]
+                : null);
+    }
+
     public ToolResult<object> RenameLabel(string file, string oldKey, string newKey, bool overwrite = false)
     {
         if (string.IsNullOrWhiteSpace(file)) return ToolResult<object>.Fail(D365FoErrorCodes.BadInput, "file required");
@@ -856,6 +918,46 @@ public sealed partial class ToolHandlers
             return ToolResult<object>.Fail("FORM_NOT_FOUND", ex.Message,
                 "Run `d365fo index extract` (or refresh) and retry, or check the spelling with search(type=form).");
         }
+    }
+
+    /// <summary>How a scenario is usually done in THIS installation.</summary>
+    public ToolResult<object> AnalyzePatterns(string scenario, string? model, int limit)
+        => D365FO.Core.Analysis.CodeAnalysis.Patterns(_repo, scenario, model, limit);
+
+    /// <summary>Who else declares this method, and with what signature.</summary>
+    public ToolResult<object> AnalyzeImplementations(string method, string? model, int limit)
+        => D365FO.Core.Analysis.CodeAnalysis.Implementations(_repo, method, model, limit);
+
+    /// <summary>How an API is constructed and called here.</summary>
+    public ToolResult<object> AnalyzeApiUsage(string api, string? model, int limit)
+        => D365FO.Core.Analysis.CodeAnalysis.ApiUsage(_repo, api, model, limit);
+
+    /// <summary>
+    /// Cross-check a model folder against its <c>.rnrproj</c>: present on disk, and listed by the
+    /// project that compiles it.
+    /// </summary>
+    public ToolResult<object> VerifyProject(string? model, string? path, string[]? expect)
+    {
+        var folder = path;
+        if (string.IsNullOrWhiteSpace(folder))
+        {
+            if (string.IsNullOrWhiteSpace(model))
+                return ToolResult<object>.Fail(D365FoErrorCodes.BadInput,
+                    "A model name or a path to the model folder is required.");
+
+            var cfg = D365FoSettings.FromEnvironment();
+            folder = cfg.CustomPackagesPaths.Concat(new[] { cfg.PackagesPath })
+                .Where(r => !string.IsNullOrWhiteSpace(r) && Directory.Exists(r))
+                .SelectMany(r => D365FO.Core.Index.IndexSync.EnumerateModelDirs(r!, model))
+                .FirstOrDefault();
+
+            if (folder is null)
+                return ToolResult<object>.Fail("MODEL_NOT_FOUND",
+                    $"No model directory called '{model}' under any configured packages path.",
+                    "Set D365FO_PACKAGES_PATH (and D365FO_CUSTOM_PACKAGES_PATH for custom-model roots), or pass a path.");
+        }
+
+        return D365FO.Core.Journal.ProjectVerifier.Verify(folder!, expect);
     }
 
     public ToolResult<object> AnalyzeIntegration(string? model)

--- a/tests/D365FO.Core.Tests/CodeAnalysisTests.cs
+++ b/tests/D365FO.Core.Tests/CodeAnalysisTests.cs
@@ -1,0 +1,111 @@
+using D365FO.Core.Analysis;
+using D365FO.Core.Index;
+using Xunit;
+
+namespace D365FO.Core.Tests;
+
+/// <summary>
+/// The three "learn from the installation" modes, and the one property that matters most about
+/// them: they never report an unread corpus as an empty one.
+/// </summary>
+/// <remarks>
+/// The index here is empty, which is exactly the condition under which a search over method
+/// bodies is tempted to answer "no callers" — and "no callers" reads as "unused", which is how a
+/// caller talks itself into deleting something that is used everywhere. Every mode has to say it
+/// searched nothing.
+/// </remarks>
+public class CodeAnalysisTests : IDisposable
+{
+    private readonly string _dbPath = Path.Combine(Path.GetTempPath(), $"d365fo-analysis-{Guid.NewGuid():N}.sqlite");
+    private readonly MetadataRepository _repo;
+
+    public CodeAnalysisTests()
+    {
+        _repo = new MetadataRepository(_dbPath);
+        _repo.EnsureSchema();
+    }
+
+    public void Dispose()
+    {
+        SqlitePool.ReleaseFor(_dbPath);
+        foreach (var ext in new[] { "", "-wal", "-shm" })
+        {
+            var p = _dbPath + ext;
+            if (File.Exists(p)) File.Delete(p);
+        }
+        GC.SuppressFinalize(this);
+    }
+
+    private static (bool Searched, string? Caveat) CoverageOf(ToolResult<object> result)
+    {
+        var coverage = result.Data!.GetType().GetProperty("coverage")!.GetValue(result.Data)!;
+        return (
+            (bool)coverage.GetType().GetProperty("Searched")!.GetValue(coverage)!,
+            (string?)coverage.GetType().GetProperty("Caveat")!.GetValue(coverage));
+    }
+
+    [Fact]
+    public void Patterns_over_an_unread_corpus_says_it_read_nothing()
+    {
+        var result = CodeAnalysis.Patterns(_repo, "number sequence", model: null);
+
+        Assert.True(result.Ok);
+        var (searched, caveat) = CoverageOf(result);
+        Assert.False(searched);
+        Assert.NotNull(caveat);
+        // The caveat has to be reachable as a warning too — a caller reading only the envelope
+        // must not take the empty list at face value.
+        Assert.NotNull(result.Warnings);
+        Assert.Contains("not evidence of absence", result.Warnings![0], StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void Implementations_over_an_unread_corpus_says_it_read_nothing()
+    {
+        var result = CodeAnalysis.Implementations(_repo, "validateWrite", model: null);
+
+        Assert.True(result.Ok);
+        Assert.False(CoverageOf(result).Searched);
+        Assert.NotNull(result.Warnings);
+    }
+
+    [Fact]
+    public void Api_usage_over_an_unread_corpus_says_it_read_nothing()
+    {
+        var result = CodeAnalysis.ApiUsage(_repo, "NumberSeq", model: null);
+
+        Assert.True(result.Ok);
+        Assert.False(CoverageOf(result).Searched);
+        Assert.NotNull(result.Warnings);
+    }
+
+    [Theory]
+    [InlineData("")]
+    [InlineData("   ")]
+    // Every word is too short to search on: a scenario of noise is refused rather than answered
+    // with whatever the corpus happens to contain.
+    [InlineData("a of to")]
+    public void A_scenario_with_nothing_to_search_on_is_refused(string scenario)
+    {
+        var result = CodeAnalysis.Patterns(_repo, scenario, model: null);
+        Assert.False(result.Ok);
+        Assert.Equal(D365FoErrorCodes.BadInput, result.Error!.Code);
+    }
+
+    [Fact]
+    public void An_unknown_method_says_where_kernel_methods_live_rather_than_just_zero()
+    {
+        var result = CodeAnalysis.Implementations(_repo, "insert", model: null);
+
+        Assert.True(result.Ok);
+        var note = (string?)result.Data!.GetType().GetProperty("note")!.GetValue(result.Data);
+        Assert.Contains("kernel", note, StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact]
+    public void Method_declarations_come_back_empty_rather_than_throwing_on_an_empty_index()
+    {
+        Assert.Empty(_repo.FindMethodDeclarations("validateWrite"));
+        Assert.Empty(_repo.FindMethodDeclarations(""));
+    }
+}

--- a/tests/D365FO.Core.Tests/LabelUpdateAndVerifyTests.cs
+++ b/tests/D365FO.Core.Tests/LabelUpdateAndVerifyTests.cs
@@ -1,0 +1,173 @@
+using D365FO.Core.Journal;
+using D365FO.Core.Labels;
+using Xunit;
+
+namespace D365FO.Core.Tests;
+
+/// <summary>
+/// Correcting a label, and asking whether a model and its project agree.
+/// </summary>
+public class LabelUpdateAndVerifyTests : IDisposable
+{
+    private readonly string _dir = Path.Combine(Path.GetTempPath(), $"d365fo-w4-{Guid.NewGuid():N}");
+
+    public LabelUpdateAndVerifyTests() => Directory.CreateDirectory(_dir);
+
+    public void Dispose()
+    {
+        if (Directory.Exists(_dir)) Directory.Delete(_dir, recursive: true);
+        GC.SuppressFinalize(this);
+    }
+
+    // ------------------------------------------------------------- labels
+
+    [Fact]
+    public void Update_corrects_an_existing_entry_in_place()
+    {
+        var path = Path.Combine(_dir, "ConFleet.en-us.label.txt");
+        LabelFileWriter.CreateOrUpdate(path, "ConVehicle", "Vehicel");
+
+        var result = LabelFileWriter.Update(path, "ConVehicle", "Vehicle");
+
+        Assert.Equal(WriteOutcome.Updated, result.Outcome);
+        Assert.Equal("Vehicel", result.OldValue);
+        Assert.Contains("ConVehicle=Vehicle", File.ReadAllText(path), StringComparison.Ordinal);
+    }
+
+    /// <summary>
+    /// The whole reason update exists as its own verb: a mistyped key in a correction must not
+    /// become a second label reported as success, which is what create-with-overwrite does.
+    /// </summary>
+    [Fact]
+    public void Update_refuses_a_key_that_does_not_exist_and_leaves_the_file_alone()
+    {
+        var path = Path.Combine(_dir, "ConFleet.en-us.label.txt");
+        LabelFileWriter.CreateOrUpdate(path, "ConVehicle", "Vehicle");
+        var before = File.ReadAllText(path);
+
+        var result = LabelFileWriter.Update(path, "ConVehcile", "Vehicle");
+
+        Assert.Equal(WriteOutcome.KeyMissing, result.Outcome);
+        Assert.Equal(before, File.ReadAllText(path));
+
+        // And the contrast that motivates it.
+        LabelFileWriter.CreateOrUpdate(path, "ConVehcile", "Vehicle", overwrite: true);
+        Assert.Contains("ConVehcile=", File.ReadAllText(path), StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void Update_on_a_file_that_does_not_exist_reports_the_key_as_missing()
+    {
+        var result = LabelFileWriter.Update(Path.Combine(_dir, "absent.en-us.label.txt"), "ConVehicle", "Vehicle");
+        Assert.Equal(WriteOutcome.KeyMissing, result.Outcome);
+    }
+
+    // ------------------------------------------------------------- verify
+
+    private string Model(params (string AxFolder, string Name)[] objects)
+    {
+        var model = Path.Combine(_dir, "ConFleet", "ConFleet");
+        foreach (var (axFolder, name) in objects)
+        {
+            var dir = Path.Combine(model, axFolder);
+            Directory.CreateDirectory(dir);
+            File.WriteAllText(Path.Combine(dir, name + ".xml"), $"<{axFolder}><Name>{name}</Name></{axFolder}>");
+        }
+        Directory.CreateDirectory(model);
+        return model;
+    }
+
+    private static void WriteProject(string modelFolder, params string[] includes)
+    {
+        var items = string.Join("\n", includes.Select(i => $"    <Compile Include=\"{i}\" />"));
+        File.WriteAllText(Path.Combine(modelFolder, "ConFleet.rnrproj"),
+            $"<Project><ItemGroup>\n{items}\n</ItemGroup></Project>");
+    }
+
+    private static (int IssueCount, string[] Findings) Issues(ToolResult<object> result)
+    {
+        var data = result.Data!;
+        var count = (int)data.GetType().GetProperty("issueCount")!.GetValue(data)!;
+        var issues = (IEnumerable<ProjectVerifier.Issue>)data.GetType().GetProperty("issues")!.GetValue(data)!;
+        return (count, issues.Select(i => i.Finding).ToArray());
+    }
+
+    [Fact]
+    public void An_object_the_project_does_not_list_is_reported_as_uncompiled()
+    {
+        var model = Model(("AxTable", "ConFleetVehicle"), ("AxClass", "ConFleetPosting"));
+        WriteProject(model, "AxTable\\ConFleetVehicle.xml");
+
+        var (count, findings) = Issues(ProjectVerifier.Verify(model));
+
+        Assert.Equal(1, count);
+        Assert.Equal("UNREGISTERED", findings[0]);
+    }
+
+    [Fact]
+    public void A_project_entry_whose_file_is_gone_is_reported_too()
+    {
+        var model = Model(("AxTable", "ConFleetVehicle"));
+        WriteProject(model, "AxTable\\ConFleetVehicle.xml", "AxClass\\ConFleetDeleted.xml");
+
+        var (count, findings) = Issues(ProjectVerifier.Verify(model));
+
+        Assert.Equal(1, count);
+        Assert.Equal("MISSING_FILE", findings[0]);
+    }
+
+    /// <summary>
+    /// A project that globs its content lists nothing, and calling every file unregistered there
+    /// would be a wall of findings that are all wrong.
+    /// </summary>
+    [Fact]
+    public void A_project_with_no_item_list_is_not_judged()
+    {
+        var model = Model(("AxTable", "ConFleetVehicle"));
+        File.WriteAllText(Path.Combine(model, "ConFleet.rnrproj"), "<Project><PropertyGroup /></Project>");
+
+        var result = ProjectVerifier.Verify(model);
+
+        Assert.Equal(0, Issues(result).IssueCount);
+        Assert.Contains(result.Warnings!, w => w.Contains("no explicit item list", StringComparison.Ordinal));
+    }
+
+    [Fact]
+    public void With_no_project_at_all_the_answer_says_only_disk_was_checked()
+    {
+        var model = Model(("AxTable", "ConFleetVehicle"));
+
+        var result = ProjectVerifier.Verify(model);
+
+        Assert.True(result.Ok);
+        Assert.Contains(result.Warnings!, w => w.Contains("No .rnrproj", StringComparison.Ordinal));
+    }
+
+    [Fact]
+    public void Expected_objects_are_answered_by_name_in_both_spellings()
+    {
+        var model = Model(("AxTable", "ConFleetVehicle"));
+        WriteProject(model, "AxTable\\ConFleetVehicle.xml");
+
+        var result = ProjectVerifier.Verify(model, ["ConFleetVehicle", "AxTable/ConFleetVehicle", "ConGone"]);
+
+        var expected = (System.Collections.IEnumerable)result.Data!.GetType().GetProperty("expected")!.GetValue(result.Data)!;
+        var rows = expected.Cast<object>().Select(o => new
+        {
+            OnDisk = (bool)o.GetType().GetProperty("onDisk")!.GetValue(o)!,
+            Registered = (bool)o.GetType().GetProperty("registered")!.GetValue(o)!,
+        }).ToList();
+
+        Assert.True(rows[0].OnDisk && rows[0].Registered);
+        Assert.True(rows[1].OnDisk && rows[1].Registered);
+        Assert.False(rows[2].OnDisk);
+    }
+
+    [Fact]
+    public void A_folder_that_is_not_there_is_refused_rather_than_reported_as_clean()
+    {
+        var result = ProjectVerifier.Verify(Path.Combine(_dir, "no-such-model"));
+        Assert.False(result.Ok);
+        Assert.Equal(D365FoErrorCodes.BadInput, result.Error!.Code);
+    }
+}


### PR DESCRIPTION
The fourth wave of the gap analysis *Parita CLI s MCP serverem*: "the rest of the MCP tools with no counterpart. Small pieces, quick parity."

> Stacked on [#194](https://github.com/dynamics365ninja/d365fo-cli/pull/194) (out of plan — surface parity), which is why that branch is the base. Waves 01–03 are in `main`.

| Wave 04 item | Status |
|---|---|
| `analyze patterns`, `analyze implementations`, `analyze api-usage` | ✅ |
| `labels update` | ✅ |
| `verify` as a standalone command | ✅ |
| Port the 12 fixes from the 1.16.0 table | ⏭ remaining — needs a diff against upstream, its own PR |

## `analyze` — learn from the installation, not from training data

| Mode | Answers |
|---|---|
| `patterns <SCENARIO>` | Which APIs the code around a scenario actually reaches for, ranked by how many **distinct** objects use each — one verbose class must not make its own habits look like the codebase's |
| `implementations <METHOD>` | Who else declares it, and with what signature — the question before writing an override or a CoC wrapper |
| `api-usage <API>` | Construction vs. static calls vs. declarations, with the lines that do it |

`patterns` reads **whole method bodies**, not the matching lines: the line that mentions "number sequence" is a comment, and the `NumberSeqGlobal` call that answers the question is three lines below it. Verified against `ApplicationCommon` on this host — the query now returns exactly that one API.

**Every mode reports what it could actually read.** A search over method bodies returns nothing when nothing matches — and also when the corpus was unreadable (no source index, no source paths on this machine). Reporting the second as an empty result is how "no callers" comes to mean "unused" for something that is used everywhere. `coverage.searched` tells them apart.

## `labels update`

Deliberately not `create --overwrite`: create writes a **new entry** when the key is absent, so a mistyped key in a correction produces a second label — and reports success. Fixing a typo previously meant delete plus create, which loses the entry's position in the file and the comment block above it.

## `verify`

Do the model on disk and its `.rnrproj` agree? An object the project does not list is **not compiled** — the AOT never sees it and nothing anywhere reports that; a project entry whose file is gone fails the build with a path rather than a reason. A project with no explicit item list is not judged, because globbing project shapes exist and calling every file unregistered there would be a wall of false findings.

## Verification

1 733 tests green, warning ratchet at its 117 baseline, `knowledge audit --verify` clean, `eval coverage --check` and `eval run --all` (52/52) pass. Against the installation on this host:

- `analyze patterns "number sequence"` → `NumberSeqGlobal` (3 methods matched, 3 bodies read);
- `verify ApplicationCommon` → 1 337 files, no `.rnrproj`, and it says so rather than implying a check it did not make;
- `verify --expect <object>` answers by name in both spellings (`AgentFeed` and `AxTable/AgentFeed`);
- `labels update` corrects an existing key and **refuses** a missing one without touching the file.

> **CI note.** The workflow only triggers on pull requests into `main`, so this stacked PR reports no checks until #194 merges and GitHub retargets it. Everything above was run locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HoeL3ZT1QLerLfjgQHGSB4