### PR TITLE
Wave 04 follow-up — the audit findings and the remaining 1.16.0 ports

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,33 @@ was ported from.
 
 ## [Unreleased]
 
+### Fixed — what the wave-04 audit found
+Auditing the wave against the gap analysis turned up four defects, one of them in the wave's own
+new code.
+
+- **`labels update` wrote one language's text into every language file.** Targeting `en-us,cs`
+  with a single value replaced the Czech translation with the English string and reported
+  success — data loss dressed as a correction. A correction *is* a translation, so several
+  languages now need one `--text <LANG>=<VALUE>` each, and a single text for several languages is
+  refused with the arguments to pass instead.
+- **A search that read nothing reported a clean zero.** `find refs` on an index built elsewhere
+  (no source index, no source paths on this machine) answered `count: 0` — indistinguishable from
+  a codebase where the symbol is genuinely unused, which is how "no callers" becomes "safe to
+  delete". `SourceRefResult` now carries `searched` and a caveat, so `find refs`, the
+  `find_references` tool and the three `analyze` modes all say the same thing.
+- **`validate name` called the only extension-name shape Microsoft ships illegal.** The character
+  rule rejected the dot in `CustTable.FleetExtension` as an invalid character while the kind rule
+  in the same run recommended exactly that form. Counted on this host: of the **1 093**
+  `AxTableExtension` objects in the installation, **1 093** use `Base.Suffix` and none uses
+  `Base_Extension`. Extension kinds now accept one dot separating base from suffix; a second dot,
+  a space, or a dot on a non-extension kind still fail.
+- **A label file could be created under an id nothing can reference.** `--label-file "Con Fleet"`
+  wrote `Con Fleet.en-us.label.txt` and reported success, but no `@File:Id` token can name it, so
+  every use of the label resolves to nothing. Both surfaces now refuse an id that is not a
+  referenceable identifier.
+- Documentation the wave had left behind: `labels update` and `verify` were absent from
+  CAPABILITIES, and none of the five new commands had an entry in EXAMPLES.
+
 ### Added — wave 04: the rest of the surface
 The gap analysis's fourth wave: the MCP tools that had no CLI counterpart, plus the two write
 verbs whose absence forced a workaround.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,43 @@ was ported from.
 
 ## [Unreleased]
 
+### Fixed — the rest of the 1.16.0 ports
+The remainder of the upstream fixes the gap analysis lists under wave 04, each checked against
+this codebase before being ported: a fix for a defect we do not have is a change with no reason.
+
+- **A rule could read the document's root out of a comment.** The XML rules asked whether the
+  TEXT contained `<AxTable`, so `<!-- this was an <AxTable> before it was rewritten -->` above an
+  `AxClass` made every table rule fire on it — a finding naming a rule the document cannot break.
+  `XmlScan` reads the root by scanning tokens, skipping the prolog, comments, CDATA and
+  processing instructions; the six rules that guessed from text now ask it. Deleting the comments
+  first and re-scanning is the other tempting shape and is worse: it mutates the document being
+  judged, and a `-->` inside CDATA takes the deletion with it.
+- **`prepare create` on an extension asked about the wrong object.** Preparing
+  `CustTable.FleetExtension` reported "no collision, nothing similar" — true of a name that by
+  definition does not exist yet, and useless. It now grounds in the object being extended: does
+  it exist, which model owns it, what already extends it. A base that is not in the index is a
+  note rather than a veto — the index is a mirror of what was extracted, and the metadata
+  provider may well see the object.
+- **`get form` says when the file holds members the reader drops.** The reading half of the
+  silent-drop defect class: a form that reads as missing a datasource is indistinguishable from
+  one that never had it, and the caller goes looking for the wrong bug.
+
+### Not ported, and why
+- **Multi-line attribute blocks dropped on create** — this repository has no path that splits a
+  supplied X++ class body into methods, and `ExtractSignatureLine` already tracks bracket depth.
+- **Member list printing the signature instead of the name** — names and signatures are separate
+  columns here; verified against a real class, not assumed.
+- **The scaffold writing controls the platform cannot see** — the write path canonicalises member
+  order before writing; checked by generating all five form patterns and validating each.
+- **A form-order validation rule** was written and then **withdrawn**. Run against the
+  installation it flagged files Microsoft ships: an `AxEnum` with `ConfigurationKey` after
+  `UseEnumValue`, an `AccessGrant` with `Create` after `Update`, an `AxTableFieldString` with
+  `Label` after `StringSize` — all shipped, all loading. The contract's member list is
+  declaration order and the deserializer is more tolerant than that, so ordering what we write
+  stays and calling a document broken for its order does not. `MetadataContractsAotTests`, the
+  repository's own census over 10 028 shipped files, is what caught it; the reasoning is recorded
+  on `ContractOrderCanonicalizer` so the rule is not rediscovered and re-added.
+
 ### Fixed — what the wave-04 audit found
 Auditing the wave against the gap analysis turned up four defects, one of them in the wave's own
 new code.

--- a/docs/CAPABILITIES.md
+++ b/docs/CAPABILITIES.md
@@ -459,6 +459,48 @@ d365fo labels delete Key           --file path/Foo.en-us.label.txt
 
 ---
 
+### `verify` — does the model on disk match its project?
+
+```sh
+d365fo verify ConFleet --output json
+d365fo verify --path /repo/PackagesLocalDirectory/ConFleet/ConFleet --expect ConFleetVehicle
+```
+
+Two findings, both invisible otherwise:
+
+| Finding | What it means |
+|---|---|
+| `UNREGISTERED` | The XML is in the model folder and the `.rnrproj` does not list it, so it is **not compiled** — the AOT never sees the object and nothing anywhere reports that. |
+| `MISSING_FILE` | The project references a file that is gone; the build fails on a path rather than a reason. |
+
+`--expect <NAME>` answers by name (`ConFleetVehicle` or `AxTable/ConFleetVehicle`) for the objects
+you believe you just created. A project with **no explicit item list** is not judged: some project
+shapes glob their content, and calling every file unregistered there would be a wall of findings
+that are all wrong — the result says so instead.
+
+MCP parity: `verify_project` (`model` / `path`, `expect[]`).
+
+### `labels update` — correct a label that already exists
+
+```sh
+# One language: the corrected text is positional
+d365fo labels update ConVehicle "Vehicle" --install-to ConFleet --lang en-us
+
+# Several languages: one --text per language, because a translation is not the same string twice
+d365fo labels update ConVehicle --install-to ConFleet --lang en-us,cs \
+  --text en-us=Vehicle --text cs=Vozidlo
+```
+
+Deliberately **not** `labels create --overwrite`: create writes a *new* entry when the key is
+absent, so a mistyped key in a correction produces a second label and reports success. `update`
+refuses a key that is not there and leaves the file untouched.
+
+Targeting several languages with a single text is refused rather than applied — writing one
+language's string into every file silently replaces the other translations. The refusal names the
+`--text` arguments to pass instead.
+
+MCP parity: `labels (action=update)`.
+
 ## Modification journal & undo
 
 Every metadata write — `generate *`, `labels create\|rename\|delete`, and `delete` — appends

--- a/docs/EXAMPLES.md
+++ b/docs/EXAMPLES.md
@@ -628,6 +628,42 @@ d365fo suggest extension CustTable  --kind Form   --output json
 
 Ranks extension strategies (`CoC`, `EventHandler`, `Extension`) by confidence based on what already exists in the codebase. Use before scaffolding.
 
+### `analyze patterns` — how a scenario is usually done here
+
+```sh
+# Which APIs does the code around this scenario reach for?
+d365fo analyze patterns "number sequence" --output json
+
+# Restrict to your own model to see how THIS codebase does it
+d365fo analyze patterns "posting" --model ConFleet --output json
+```
+
+Ranked by how many **distinct** objects use each API, so one verbose class cannot make its own
+habits look like the codebase's. Reads whole method bodies, not just the matching line — the line
+that mentions "number sequence" is usually a comment, and the call that answers the question is
+below it.
+
+Check `coverage.searched`: `false` means the corpus could not be read at all, which is a different
+answer from "nothing matches".
+
+### `analyze implementations` — who else implements this method
+
+```sh
+# Before writing an override or a CoC wrapper
+d365fo analyze implementations validateWrite --output json
+d365fo analyze implementations initValue --model ApplicationSuite --output json
+```
+
+### `analyze api-usage` — how an API is really reached
+
+```sh
+d365fo analyze api-usage NumberSeq --output json
+d365fo analyze api-usage DocumentManagement --limit 10 --output json
+```
+
+Separates construction from static calls from declarations. When an API is never constructed, it
+says so — a `new` is then the wrong shape.
+
 ### `analyze completeness` — cross-check project against index
 
 ```sh
@@ -667,6 +703,20 @@ d365fo label delete RenamedKey         --file path/Foo.en-us.label.txt
 `search label --fts` requires FTS5 (falls back to `LIKE` if unavailable). Write commands keep a `.bak` of the previous file.
 
 ---
+
+### `labels update` — correct an existing label
+
+```sh
+# One language
+d365fo labels update ConVehicle "Vehicle" --install-to ConFleet --lang en-us
+
+# Several: one --text per language
+d365fo labels update ConVehicle --install-to ConFleet --lang en-us,cs \
+  --text en-us=Vehicle --text cs=Vozidlo
+```
+
+Refuses a key that does not exist (that is `labels create`), and refuses one text for several
+languages — which would replace every other translation with this one's string.
 
 ## Journal / undo
 
@@ -709,6 +759,24 @@ Compare two revs with `--base main --head feature/my-branch`. Rules shipped toda
 - `DYNAMIC_QUERY` — dynamic `Query` construction (flag for security review).
 
 ---
+
+## Verify the project
+
+### `verify` — objects on disk, and in the `.rnrproj`
+
+```sh
+# The whole model
+d365fo verify ConFleet --output json
+
+# Just the objects you believe you created
+d365fo verify ConFleet --expect ConFleetVehicle --expect AxClass/ConFleetPosting --output json
+
+# A folder that is not under a configured packages path
+d365fo verify --path /repo/PackagesLocalDirectory/ConFleet/ConFleet --output json
+```
+
+`UNREGISTERED` means the file is there and the project does not list it, so it is never compiled —
+the failure mode nothing else reports. Exit code 2 when the model and the project disagree.
 
 ## Windows-only ops (D365FO VM)
 

--- a/src/D365FO.Cli/Commands/Label/LabelWriteCommands.cs
+++ b/src/D365FO.Cli/Commands/Label/LabelWriteCommands.cs
@@ -380,6 +380,18 @@ internal static class LabelTargets
             }
         }
 
+        // An id no @File:Id token can name produces a label nothing can reference — the write
+        // succeeds and every use of it resolves to nothing.
+        var unreferenceable = files
+            .Select(LabelFileWriter.LabelFileIdOf)
+            .FirstOrDefault(id => !LabelFileWriter.IsReferenceableLabelFileId(id));
+        if (unreferenceable is not null)
+            return new Resolution([], ToolResult<object>.Fail(
+                "LABEL_FILE_UNREFERENCEABLE",
+                $"'{unreferenceable}' cannot be named by an @File:Id token, so a label written there could never be referenced.",
+                "A label file id is letters, digits and underscore, starting with a letter — no spaces, dots or dashes. "
+                + "Rename the target (e.g. --label-file ConFleet)."));
+
         if (!allowExtensionLabelFile)
         {
             var extFile = files.FirstOrDefault(LabelFileWriter.IsExtensionLabelFile);
@@ -412,9 +424,13 @@ public sealed class LabelUpdateCommand : Command<LabelUpdateCommand.Settings>
         [System.ComponentModel.Description("Label key to correct. Must already exist — this never creates.")]
         public string Key { get; init; } = "";
 
-        [CommandArgument(1, "<VALUE>")]
-        [System.ComponentModel.Description("The corrected text.")]
+        [CommandArgument(1, "[VALUE]")]
+        [System.ComponentModel.Description("The corrected text. Only for a SINGLE language — with several, give one --text per language.")]
         public string Value { get; init; } = "";
+
+        [CommandOption("--text <LANG=VALUE>")]
+        [System.ComponentModel.Description("Repeatable: the corrected text for one language, e.g. --text en-us=Vehicle --text cs=Vozidlo. Required when more than one language is targeted, because a translation is not the same string in every language.")]
+        public string[] Text { get; init; } = Array.Empty<string>();
 
         [CommandOption("--file <PATH>")]
         [System.ComponentModel.Description("Target <Name>.<lang>.label.txt file (absolute path). Required unless --install-to is used.")]
@@ -447,6 +463,42 @@ public sealed class LabelUpdateCommand : Command<LabelUpdateCommand.Settings>
             return RenderHelpers.Render(kind, ToolResult<object>.Fail(D365FoErrorCodes.BadInput,
                 "--file <PATH> or --install-to <MODEL> is required."));
 
+        // Per-language texts. A correction is a translation, and a translation is not the same
+        // string in every language — writing one value into every resolved file silently
+        // replaces every other language with this one's text and reports it as success.
+        var byLang = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
+        foreach (var raw in settings.Text)
+        {
+            var eq = raw.IndexOf('=');
+            if (eq <= 0)
+                return RenderHelpers.Render(kind, ToolResult<object>.Fail(D365FoErrorCodes.BadInput,
+                    $"Malformed --text '{raw}'.", "Expected <LANG>=<VALUE>, e.g. --text cs=Vozidlo."));
+            byLang[raw[..eq].Trim()] = raw[(eq + 1)..];
+        }
+
+        var langs = (string.IsNullOrWhiteSpace(settings.Lang) ? "en-us" : settings.Lang!)
+            .Split(',', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries);
+        var multiLingual = string.IsNullOrWhiteSpace(settings.File) && langs.Length > 1;
+
+        if (multiLingual && byLang.Count == 0)
+            return RenderHelpers.Render(kind, ToolResult<object>.Fail(D365FoErrorCodes.BadInput,
+                $"{langs.Length} languages were targeted but only one text was given.",
+                "A correction is a translation: pass one --text per language "
+                + $"(e.g. {string.Join(" ", langs.Select(l => $"--text {l}=<VALUE>"))}), or correct one language at a time. "
+                + "Writing the same string into every language would silently replace the other translations."));
+
+        if (byLang.Count == 0 && string.IsNullOrWhiteSpace(settings.Value))
+            return RenderHelpers.Render(kind, ToolResult<object>.Fail(D365FoErrorCodes.BadInput,
+                "The corrected text is required.", "Pass it as <VALUE>, or as --text <LANG>=<VALUE>."));
+
+        var untargeted = byLang.Keys
+            .Where(l => !langs.Contains(l, StringComparer.OrdinalIgnoreCase))
+            .ToList();
+        if (untargeted.Count > 0 && !string.IsNullOrWhiteSpace(settings.InstallTo))
+            return RenderHelpers.Render(kind, ToolResult<object>.Fail(D365FoErrorCodes.BadInput,
+                $"--text was given for {string.Join(", ", untargeted)}, which --lang does not target.",
+                $"--lang covers: {string.Join(", ", langs)}. Add the language there, or drop the --text."));
+
         var targets = LabelTargets.Resolve(
             settings.File, settings.InstallTo, settings.Lang, settings.LabelFile,
             settings.AllowExtensionLabelFile);
@@ -456,9 +508,18 @@ public sealed class LabelUpdateCommand : Command<LabelUpdateCommand.Settings>
         var missing = new List<string>();
         try
         {
-            foreach (var file in targets.Files)
+            for (var i = 0; i < targets.Files.Count; i++)
             {
-                var res = LabelFileWriter.Update(file, settings.Key, settings.Value);
+                var file = targets.Files[i];
+                // Files come back in --lang order, so the language a file carries is known
+                // without re-parsing its name.
+                var lang = string.IsNullOrWhiteSpace(settings.File) && i < langs.Length ? langs[i] : null;
+                var value = lang is not null && byLang.TryGetValue(lang, out var perLang)
+                    ? perLang
+                    : byLang.Count == 1 && langs.Length == 1 ? byLang.Values.First()
+                    : settings.Value;
+
+                var res = LabelFileWriter.Update(file, settings.Key, value);
                 if (res.Outcome == WriteOutcome.KeyMissing)
                 {
                     missing.Add(file);

--- a/src/D365FO.Core/Analysis/CodeAnalysis.cs
+++ b/src/D365FO.Core/Analysis/CodeAnalysis.cs
@@ -32,20 +32,12 @@ public static class CodeAnalysis
     /// <param name="Caveat">Why an empty answer is not evidence of absence, when it is not.</param>
     public sealed record Coverage(string Via, int FilesScanned, bool Searched, string? Caveat);
 
-    private static Coverage CoverageOf(MetadataRepository repo, SourceRefResult result)
-    {
-        var ftsRows = repo.CountMethodSource();
-        var searched = ftsRows > 0 || result.FilesScanned > 0;
-        return new Coverage(
-            result.Via,
-            result.FilesScanned,
-            searched,
-            searched
-                ? null
-                : "Nothing was searched: the method-source index is empty and no source file could be opened. "
-                  + "This is not evidence of absence — run `d365fo index extract --index-source`, or point "
-                  + "D365FO_PACKAGES_PATH at the installation the index was built from.");
-    }
+    /// <remarks>
+    /// The verdict comes from the search itself rather than being recomputed here, so
+    /// <c>find refs</c> and these three modes cannot disagree about whether the corpus was read.
+    /// </remarks>
+    private static Coverage CoverageOf(MetadataRepository repo, SourceRefResult result) =>
+        new(result.Via, result.FilesScanned, result.Searched, result.Caveat);
 
     // ------------------------------------------------------------- patterns
 

--- a/src/D365FO.Core/Index/MetadataRepository.cs
+++ b/src/D365FO.Core/Index/MetadataRepository.cs
@@ -1674,10 +1674,12 @@ public sealed partial class MetadataRepository
             return FindUsages(needle, limit);
 
         using var conn = OpenReadOnly();
-        var like = $"%{EscapeLike(needle)}%";
+        var tokens = QueryTokens(needle);
+        var like = $"%{EscapeLike(tokens.Length > 0 ? tokens[0] : needle)}%";
+        var sqlLimit = tokens.Length > 1 ? Math.Min(limit * 20, 5000) : limit;
         var sql = string.Join("\nUNION ALL\n", fragments) + "\nORDER BY Name\nLIMIT @limit";
-        var rows = conn.Query<UsageRow>(sql, new { like, limit });
-        return rows.Select(r => (r.Kind, r.Name, r.Model)).ToList();
+        var rows = conn.Query<UsageRow>(sql, new { like, limit = sqlLimit });
+        return KeepRowsCarryingEveryToken(rows, tokens, limit);
     }
 
     /// <summary>
@@ -2166,11 +2168,44 @@ public sealed partial class MetadataRepository
     /// `d365fo find usages` to approximate a cross-object search without
     /// loading X++ source itself.
     /// </summary>
+    /// <summary>
+    /// The words a free-text query is made of. An object name has no spaces, so a multi-word
+    /// query matched as one literal matches nothing at all — "agent feed" found none of the
+    /// three <c>AgentFeed*</c> tables. Every token has to appear, in any order.
+    /// </summary>
+    private static string[] QueryTokens(string needle) =>
+        (needle ?? "").Split(new[] { ' ', '\t' }, StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries);
+
+    /// <summary>Keep the rows whose name carries every token after the first.</summary>
+    /// <remarks>
+    /// The first token narrows in SQL, where the index can help; the rest filter here. The SQL
+    /// limit is widened for a multi-token query so a row that only the later tokens disqualify
+    /// cannot push a real match past the cap.
+    /// </remarks>
+    private static IReadOnlyList<(string Kind, string Name, string Model)> KeepRowsCarryingEveryToken(
+        IEnumerable<UsageRow> rows, string[] tokens, int limit)
+    {
+        var result = new List<(string, string, string)>();
+        foreach (var r in rows)
+        {
+            if (tokens.Length > 1 && !tokens.Skip(1).All(t =>
+                    r.Name.Contains(t, StringComparison.OrdinalIgnoreCase)))
+                continue;
+            result.Add((r.Kind, r.Name, r.Model));
+            if (result.Count >= limit) break;
+        }
+        return result;
+    }
+
     public IReadOnlyList<(string Kind, string Name, string Model)> FindUsages(string needle, int limit = 100)
     {
         limit = ClampLimit(limit, 100);
         using var conn = OpenReadOnly();
-        var like = $"%{EscapeLike(needle)}%";
+        var tokens = QueryTokens(needle);
+        var like = $"%{EscapeLike(tokens.Length > 0 ? tokens[0] : needle)}%";
+        // Widened only when there is a second token to filter on; a single-token query keeps
+        // exactly the cap the caller asked for.
+        var sqlLimit = tokens.Length > 1 ? Math.Min(limit * 20, 5000) : limit;
         var rows = conn.Query<UsageRow>(@"
             SELECT 'Table' AS Kind, t.Name AS Name, m.Name AS Model FROM Tables t JOIN Models m ON m.ModelId=t.ModelId WHERE t.Name LIKE @like ESCAPE '!'
             UNION ALL
@@ -2198,8 +2233,8 @@ public sealed partial class MetadataRepository
             UNION ALL
             SELECT 'Map', mp.Name, m.Name FROM Maps mp JOIN Models m ON m.ModelId=mp.ModelId WHERE mp.Name LIKE @like ESCAPE '!'
             ORDER BY Name
-            LIMIT @limit", new { like, limit });
-        return rows.Select(r => (r.Kind, r.Name, r.Model)).ToList();
+            LIMIT @limit", new { like, limit = sqlLimit });
+        return KeepRowsCarryingEveryToken(rows, tokens, limit);
     }
 
     /// <summary>

--- a/src/D365FO.Core/Index/MethodSourceSearch.cs
+++ b/src/D365FO.Core/Index/MethodSourceSearch.cs
@@ -16,12 +16,50 @@ public sealed record SourceRefHit(
     IReadOnlyList<SourceRefMatchLine> Matches);
 
 /// <summary>Result of a reverse-reference search over X++ method bodies.</summary>
+/// <param name="Needle">The symbol that was searched for.</param>
+/// <param name="Via">"fts" when served from MethodSourceFts, else "scan".</param>
+/// <param name="FilesScanned">Source files opened. Zero with no hits means nothing was read.</param>
+/// <param name="Truncated">The limit was reached, so there may be more.</param>
+/// <param name="Hits">The methods that reference the symbol.</param>
+/// <param name="Searched">
+/// False when the corpus could not be read at all — no FTS rows and no source file opened.
+/// </param>
+/// <param name="Caveat">
+/// Why an empty result is not evidence of absence, when it is not. Null when the search really
+/// did look.
+/// </param>
 public sealed record SourceRefResult(
     string Needle,
-    string Via,           // "fts" when served from MethodSourceFts, else "scan"
+    string Via,
     int FilesScanned,
     bool Truncated,
-    IReadOnlyList<SourceRefHit> Hits);
+    IReadOnlyList<SourceRefHit> Hits,
+    bool Searched = true,
+    string? Caveat = null)
+{
+    /// <summary>
+    /// The reachability verdict for a finished search.
+    /// </summary>
+    /// <remarks>
+    /// A search over method bodies returns nothing when nothing matches, and also when there was
+    /// nothing to search: no opt-in source index, and no source path on this machine — an index
+    /// built elsewhere looks exactly like a codebase where the symbol is unused. Reporting the
+    /// second as a clean zero is how "no callers" becomes "safe to delete".
+    /// </remarks>
+    public static SourceRefResult Finish(
+        string needle, string via, int filesScanned, bool truncated,
+        IReadOnlyList<SourceRefHit> hits, long ftsRows)
+    {
+        var searched = ftsRows > 0 || filesScanned > 0;
+        return new SourceRefResult(needle, via, filesScanned, truncated, hits, searched,
+            searched
+                ? null
+                : "Nothing was searched: the method-source index is empty and no source file could be opened. "
+                  + "An empty result here is not evidence that the symbol is unused — run "
+                  + "`d365fo index extract --index-source`, or point D365FO_PACKAGES_PATH at the installation "
+                  + "the index was built from.");
+    }
+}
 
 /// <summary>
 /// Shared reverse-reference search over X++ method bodies, used by both
@@ -76,7 +114,7 @@ public static class MethodSourceSearch
                 ScanSources(repo.EnumerateSourcePaths(model).Where(s => s.Kind == "Form"),
                             rx, limit, sampleLinesPerHit, hits, ref scanned, ref truncated);
 
-            return new SourceRefResult(needle, "fts", scanned, truncated, hits);
+            return SourceRefResult.Finish(needle, "fts", scanned, truncated, hits, repo.CountMethodSource());
         }
 
         // No FTS index: scan the whole corpus on disk.
@@ -84,7 +122,7 @@ public static class MethodSourceSearch
         if (normKind is not null)
             sources = sources.Where(s => string.Equals(s.Kind, normKind, StringComparison.OrdinalIgnoreCase)).ToList();
         ScanSources(sources, rx, limit, sampleLinesPerHit, hits, ref scanned, ref truncated);
-        return new SourceRefResult(needle, "scan", scanned, truncated, hits);
+        return SourceRefResult.Finish(needle, "scan", scanned, truncated, hits, ftsRows: 0);
     }
 
     private static void ScanSources(

--- a/src/D365FO.Core/Labels/LabelFileWriter.cs
+++ b/src/D365FO.Core/Labels/LabelFileWriter.cs
@@ -156,6 +156,33 @@ public static class LabelFileWriter
     /// extends a base file owned by another model, and writing there is what
     /// leads clients to wrongly prefix label IDs.
     /// </summary>
+    /// <summary>
+    /// Can an <c>@File:Id</c> token name this label file? Letters, digits and underscore only,
+    /// starting with a letter.
+    /// </summary>
+    /// <remarks>
+    /// The token grammar has no room for a space, a dot or a dash, so a file created under such
+    /// a name is a file nothing can reference: the write succeeds, the label exists on disk, and
+    /// every attempt to use it resolves to nothing. Refusing at write time is the only point
+    /// where the mistake is still cheap.
+    /// </remarks>
+    public static bool IsReferenceableLabelFileId(string? labelFileId)
+    {
+        if (string.IsNullOrWhiteSpace(labelFileId)) return false;
+        if (!char.IsLetter(labelFileId[0])) return false;
+        foreach (var ch in labelFileId)
+            if (!char.IsLetterOrDigit(ch) && ch != '_') return false;
+        return true;
+    }
+
+    /// <summary>The label file id a path names, i.e. the part before the first dot.</summary>
+    public static string LabelFileIdOf(string pathOrId)
+    {
+        var name = Path.GetFileName(pathOrId ?? "");
+        var dot = name.IndexOf('.');
+        return dot > 0 ? name[..dot] : name;
+    }
+
     public static bool IsExtensionLabelFile(string labelFileIdOrPath)
     {
         if (string.IsNullOrWhiteSpace(labelFileIdOrPath)) return false;

--- a/src/D365FO.Core/ObjectNamingRules.cs
+++ b/src/D365FO.Core/ObjectNamingRules.cs
@@ -46,6 +46,21 @@ public static class ObjectNamingRules
         return effective;
     }
 
+    /// <summary>
+    /// Kinds whose objects are named <c>&lt;Base&gt;.&lt;Suffix&gt;</c> — the element extensions.
+    /// </summary>
+    private static bool IsElementExtensionKind(string? kind) =>
+        // Case-insensitively: callers pass the kind as the user typed it, and
+        // `validate name tableextension` is how it arrives from the shell.
+        (kind ?? "").Trim().ToLowerInvariant() switch
+        {
+            "tableextension" or "formextension" or "edtextension" or "enumextension"
+                or "viewextension" or "mapextension" or "queryextension"
+                or "dataentityviewextension" or "menuextension" or "securityroleextension"
+                or "securitydutyextension" or "securityprivilegeextension" => true,
+            _ => false,
+        };
+
     public static IReadOnlyList<Violation> Validate(string kind, string name, string? prefix = null)
     {
         var v = new List<Violation>();
@@ -59,14 +74,27 @@ public static class ObjectNamingRules
             v.Add(new("NAME_TOO_LONG", "warn",
                 $"Name is {name.Length} chars (soft limit 80, metadata XML filename hits FS limits above 160)."));
 
-        foreach (var ch in name)
+        // An element extension is named <Base>.<Suffix>, and the dot is not a typo: of the 1 093
+        // AxTableExtension objects in a stock installation, 1 093 carry it and none use the
+        // underscore form. The character rule used to reject that dot outright, so the validator
+        // called the only shape Microsoft ships illegal — while the kind rule below recommended
+        // it in the same breath.
+        var extensionKind = IsElementExtensionKind(kind);
+        var dotAt = extensionKind ? name.IndexOf('.') : -1;
+        var dotIsSuffixSeparator = dotAt > 0 && dotAt < name.Length - 1
+                                   && name.IndexOf('.', dotAt + 1) < 0;
+
+        for (var i = 0; i < name.Length; i++)
         {
-            if (!(char.IsLetterOrDigit(ch) || ch == '_'))
-            {
-                v.Add(new("INVALID_CHARS", "error",
-                    $"Character '{ch}' is not allowed. Only letters, digits and underscore are legal."));
-                break;
-            }
+            var ch = name[i];
+            if (char.IsLetterOrDigit(ch) || ch == '_') continue;
+            if (ch == '.' && dotIsSuffixSeparator && i == dotAt) continue;
+
+            v.Add(new("INVALID_CHARS", "error", ch == '.' && extensionKind
+                ? "An extension name carries at most one '.', separating the base object from the suffix "
+                  + "(e.g. CustTable.FleetExtension)."
+                : $"Character '{ch}' is not allowed. Only letters, digits and underscore are legal."));
+            break;
         }
 
         if (char.IsDigit(name[0]))
@@ -85,7 +113,8 @@ public static class ObjectNamingRules
                 if (!name.Contains(".", StringComparison.Ordinal) &&
                     !name.EndsWith("_Extension", StringComparison.Ordinal))
                     v.Add(new("EXTENSION_SUFFIX", "warn",
-                        "Extension objects should either contain '.' (target.Suffix) or end with '_Extension'."));
+                        "Extension objects are named <Base>.<Suffix> — the form every shipped extension uses. "
+                        + "Base_Extension is also accepted, but nothing in a stock installation is named that way."));
                 break;
             case "Coc":
             case "CocClass":

--- a/src/D365FO.Core/Scaffolding/ContractOrderCanonicalizer.cs
+++ b/src/D365FO.Core/Scaffolding/ContractOrderCanonicalizer.cs
@@ -23,6 +23,24 @@ namespace D365FO.Core.Scaffolding;
 /// collection, which is data rather than contract.
 /// </para>
 /// </remarks>
+/// <remarks>
+/// <para>
+/// A note on the rule that is deliberately NOT here. Canonicalising order on write is cheap and
+/// safe, so this class does it. Turning the same knowledge into a validation rule — "this member
+/// arrives after one the contract declares later, so the reader will drop it" — was tried and
+/// withdrawn: run against the installation, it flagged files Microsoft ships. An
+/// <c>AxEnum</c> with <c>ConfigurationKey</c> after <c>UseEnumValue</c>, an <c>AccessGrant</c>
+/// with <c>Create</c> after <c>Update</c>, an <c>AxTableFieldString</c> with <c>Label</c> after
+/// <c>StringSize</c> — all shipped, all loading.
+/// </para>
+/// <para>
+/// So the member list this canonicaliser follows is a contract's declaration order, and the
+/// deserializer is evidently more tolerant of order than that list implies. Ordering the members
+/// we write remains worth doing; calling a document broken because its order differs is not
+/// something the evidence on this machine supports, and a rule that fails on Microsoft's own
+/// files is worse than no rule. <c>MetadataContractsAotTests</c> is what caught it.
+/// </para>
+/// </remarks>
 public static class ContractOrderCanonicalizer
 {
     private static readonly XNamespace Xsi = "http://www.w3.org/2001/XMLSchema-instance";

--- a/src/D365FO.Core/Validation/ContractShapeRules.cs
+++ b/src/D365FO.Core/Validation/ContractShapeRules.cs
@@ -42,6 +42,7 @@ public static class ContractShapeRules
     /// <summary>A value outside its enum — the whole document fails to deserialize.</summary>
     public const string RuleInvalidEnumValue = "XML008";
 
+
     /// <summary>Appends any contract-shape violations found in <paramref name="xml"/>.</summary>
     public static void Check(string xml, List<XppViolation> violations)
     {

--- a/src/D365FO.Core/Validation/XmlScan.cs
+++ b/src/D365FO.Core/Validation/XmlScan.cs
@@ -1,0 +1,139 @@
+namespace D365FO.Core.Validation;
+
+/// <summary>
+/// Reads the shape of an AOT document by scanning tokens, without parsing it and without
+/// rewriting it first.
+/// </summary>
+/// <remarks>
+/// <para>
+/// The rules that decide whether a document is a table, a report or an extension used to ask
+/// whether the TEXT contained <c>&lt;AxTable</c>. Text is not structure: a comment above the
+/// root — <c>&lt;!-- this was an &lt;AxTable&gt; before it was rewritten --&gt;</c> — made an
+/// <c>AxClass</c> answer to every table rule, and so does the same name inside a CDATA X++
+/// block or a string literal. The finding then names a rule the document cannot break.
+/// </para>
+/// <para>
+/// Deleting the comments first and re-scanning is the other tempting shape, and it is worse: it
+/// mutates the document being judged, and a <c>--&gt;</c> inside a CDATA section takes the
+/// deletion with it. Scanning forward and skipping what cannot contain markup costs one pass and
+/// changes nothing.
+/// </para>
+/// </remarks>
+public static class XmlScan
+{
+    /// <summary>
+    /// The name of the root element, or null when the text has no element outside a prolog,
+    /// a comment or a processing instruction.
+    /// </summary>
+    public static string? RootElementName(string? xml)
+    {
+        if (string.IsNullOrEmpty(xml)) return null;
+
+        var i = 0;
+        while (i < xml.Length)
+        {
+            var lt = xml.IndexOf('<', i);
+            if (lt < 0) return null;
+
+            // <!-- comment -->, <![CDATA[ … ]]>, <!DOCTYPE …>
+            if (Starts(xml, lt, "<!--"))
+            {
+                var end = xml.IndexOf("-->", lt + 4, StringComparison.Ordinal);
+                if (end < 0) return null;
+                i = end + 3;
+                continue;
+            }
+            if (Starts(xml, lt, "<![CDATA["))
+            {
+                var end = xml.IndexOf("]]>", lt + 9, StringComparison.Ordinal);
+                if (end < 0) return null;
+                i = end + 3;
+                continue;
+            }
+            if (Starts(xml, lt, "<!"))
+            {
+                var end = xml.IndexOf('>', lt + 2);
+                if (end < 0) return null;
+                i = end + 1;
+                continue;
+            }
+            // <?xml … ?>
+            if (Starts(xml, lt, "<?"))
+            {
+                var end = xml.IndexOf("?>", lt + 2, StringComparison.Ordinal);
+                if (end < 0) return null;
+                i = end + 2;
+                continue;
+            }
+            // </close> is not a root opening; malformed input, but do not answer with the name.
+            if (Starts(xml, lt, "</")) return null;
+
+            var start = lt + 1;
+            var j = start;
+            while (j < xml.Length && (char.IsLetterOrDigit(xml[j]) || xml[j] is '_' or '-' or '.' or ':')) j++;
+            return j > start ? xml[start..j] : null;
+        }
+        return null;
+    }
+
+    /// <summary>Is the document's ROOT this element — not merely a text that mentions it?</summary>
+    public static bool RootIs(string? xml, string elementName) =>
+        string.Equals(RootElementName(xml), elementName, StringComparison.OrdinalIgnoreCase);
+
+    /// <summary>
+    /// Does an element with this name appear as real markup anywhere outside comments, CDATA
+    /// and the prolog?
+    /// </summary>
+    /// <remarks>
+    /// For the rules that ask about a CHILD (does this table declare an index?) rather than
+    /// about the root. Same reason: an <c>&lt;AxTableIndex&gt;</c> written inside a comment is
+    /// not an index.
+    /// </remarks>
+    public static bool ContainsElement(string? xml, string elementName)
+    {
+        if (string.IsNullOrEmpty(xml) || string.IsNullOrEmpty(elementName)) return false;
+
+        var i = 0;
+        while (i < xml.Length)
+        {
+            var lt = xml.IndexOf('<', i);
+            if (lt < 0) return false;
+
+            if (Starts(xml, lt, "<!--"))
+            {
+                var end = xml.IndexOf("-->", lt + 4, StringComparison.Ordinal);
+                if (end < 0) return false;
+                i = end + 3;
+                continue;
+            }
+            if (Starts(xml, lt, "<![CDATA["))
+            {
+                var end = xml.IndexOf("]]>", lt + 9, StringComparison.Ordinal);
+                if (end < 0) return false;
+                i = end + 3;
+                continue;
+            }
+            if (Starts(xml, lt, "<!") || Starts(xml, lt, "<?"))
+            {
+                var end = xml.IndexOf('>', lt + 1);
+                if (end < 0) return false;
+                i = end + 1;
+                continue;
+            }
+
+            var start = Starts(xml, lt, "</") ? lt + 2 : lt + 1;
+            var j = start;
+            while (j < xml.Length && (char.IsLetterOrDigit(xml[j]) || xml[j] is '_' or '-' or '.' or ':')) j++;
+
+            if (j - start == elementName.Length
+                && string.Compare(xml, start, elementName, 0, elementName.Length, StringComparison.OrdinalIgnoreCase) == 0)
+                return true;
+
+            i = j;
+        }
+        return false;
+    }
+
+    private static bool Starts(string s, int at, string token) =>
+        at + token.Length <= s.Length && string.CompareOrdinal(s, at, token, 0, token.Length) == 0;
+}

--- a/src/D365FO.Core/Validation/XppValidator.cs
+++ b/src/D365FO.Core/Validation/XppValidator.cs
@@ -1545,8 +1545,8 @@ public static class XppValidator
     /// <summary>RPT101 — AxReport without a design node.</summary>
     private static void CheckReportHasDesign(string code, List<XppViolation> v)
     {
-        if (!Regex.IsMatch(code, @"<AxReport[\s>]", RegexOptions.IgnoreCase)) return;
-        if (Regex.IsMatch(code, @"<AxReportDesign\b", RegexOptions.IgnoreCase)) return;
+        if (!XmlScan.RootIs(code, "AxReport")) return;
+        if (XmlScan.ContainsElement(code, "AxReportDesign")) return;
         v.Add(new XppViolation("RPT101", "error", null, "<AxReport> — no <AxReportDesign>",
             "The report declares no design — ssrsReportStr(report, design) can never reference it and the report cannot run. " +
             "`d365fo generate report` scaffolds one auto design named \"AutoDesign\"."));
@@ -1555,7 +1555,7 @@ public static class XppValidator
     /// <summary>RPT102 — report dataset without a Query.</summary>
     private static void CheckReportDatasetShape(string code, List<XppViolation> v)
     {
-        if (!Regex.IsMatch(code, @"<AxReport[\s>]", RegexOptions.IgnoreCase)) return;
+        if (!XmlScan.RootIs(code, "AxReport")) return;
         foreach (Match m in Regex.Matches(code, @"<AxReportDataSet\b[\s\S]*?</AxReportDataSet>", RegexOptions.IgnoreCase))
         {
             if (Regex.IsMatch(m.Value, "<Query>", RegexOptions.IgnoreCase)) continue;
@@ -1570,8 +1570,8 @@ public static class XppValidator
 
     private static void CheckMissingAlternateKey(string code, List<XppViolation> v)
     {
-        var isExtension = Regex.IsMatch(code, @"<AxTableExtension[\s>]", RegexOptions.IgnoreCase);
-        var isBaseTable = Regex.IsMatch(code, @"<AxTable[\s>]", RegexOptions.IgnoreCase);
+        var isExtension = XmlScan.RootIs(code, "AxTableExtension");
+        var isBaseTable = XmlScan.RootIs(code, "AxTable");
         if (!isExtension && !isBaseTable) return;
 
         // A table extension merges into the base table it targets — it does not
@@ -1584,7 +1584,7 @@ public static class XppValidator
         // precondition (Microsoft Learn's Customization Analysis Report reference)
         // is "tables that have a unique index" — only hold the extension to this
         // rule once it actually introduces an index of its own.
-        if (isExtension && !Regex.IsMatch(code, @"<AxTableIndex[\s>]", RegexOptions.IgnoreCase)) return;
+        if (isExtension && !XmlScan.ContainsElement(code, "AxTableIndex")) return;
 
         if (!Regex.IsMatch(code, @"<AlternateKey>\s*Yes\s*</AlternateKey>", RegexOptions.IgnoreCase))
         {
@@ -1627,7 +1627,7 @@ public static class XppValidator
 
     private static void CheckTableProperties(string code, IPropertyStatsProvider? stats, List<XppViolation> v)
     {
-        if (!Regex.IsMatch(code, @"<AxTable[\s>]", RegexOptions.IgnoreCase)) return;
+        if (!XmlScan.RootIs(code, "AxTable")) return;
         var header = TableHeaderSegment(code);
 
         var label = PropertyRuleApplies(stats, "AxTable", "Label");
@@ -1668,7 +1668,7 @@ public static class XppValidator
 
     private static void CheckFieldEdt(string code, IPropertyStatsProvider? stats, List<XppViolation> v)
     {
-        if (!Regex.IsMatch(code, @"<AxTableField[\s>]", RegexOptions.IgnoreCase)) return;
+        if (!XmlScan.ContainsElement(code, "AxTableField")) return;
         var rule = PropertyRuleApplies(stats, "AxTableField", "ExtendedDataType");
         if (!rule.Applies) return;
 

--- a/src/D365FO.Mcp/ToolHandlers.cs
+++ b/src/D365FO.Mcp/ToolHandlers.cs
@@ -1212,10 +1212,15 @@ public sealed partial class ToolHandlers
     /// Searches <c>D365FO_CUSTOM_PACKAGES_PATH</c> first (write target), then
     /// <c>D365FO_PACKAGES_PATH</c>. Returns <c>null</c> when neither is set.
     /// </summary>
+    /// <summary>
+    /// Resolve the label file for a model and language, or null when the id is one no
+    /// <c>@File:Id</c> token could name — a label written there could never be referenced.
+    /// </summary>
     private static string? ResolveLabelPath(string model, string lang, string? labelFile)
     {
         var cfg = D365FoSettings.FromEnvironment();
         var lf = string.IsNullOrWhiteSpace(labelFile) ? model : labelFile!;
+        if (!D365FO.Core.Labels.LabelFileWriter.IsReferenceableLabelFileId(lf)) return null;
         var candidates = cfg.CustomPackagesPaths.Concat(new[] { cfg.PackagesPath });
         foreach (var root in candidates)
         {
@@ -2574,10 +2579,11 @@ public sealed partial class ToolHandlers
             needle = result.Needle,
             via = result.Via,
             filesScanned = result.FilesScanned,
+            searched = result.Searched,
             count = items.Count,
             truncated = result.Truncated,
             items,
-        });
+        }, result.Caveat is null ? null : [result.Caveat]);
     }
 
     /// <summary>

--- a/src/D365FO.Mcp/ToolHandlers.cs
+++ b/src/D365FO.Mcp/ToolHandlers.cs
@@ -162,12 +162,60 @@ public sealed partial class ToolHandlers
 
     // ---- Parity tools (forms / queries / views / entities / reports / services / workflows) ----
 
+    /// <summary>
+    /// A form's metadata, with a warning when the file on disk holds members the platform
+    /// cannot see.
+    /// </summary>
+    /// <remarks>
+    /// The reading half of the out-of-order defect. A member that appears after one the contract
+    /// declares later is dropped by the deserializer without a word, so a form that reads as
+    /// missing a datasource or a design is indistinguishable from a form that never had one —
+    /// and the caller goes looking for the wrong bug. The check costs one parse and only runs
+    /// when the source file is reachable.
+    /// </remarks>
     public ToolResult<object> GetForm(string name)
     {
         var f = _repo.GetForm(name);
-        return f is null
-            ? ToolResult<object>.Fail("FORM_NOT_FOUND", $"Form '{name}' not found.")
-            : ToolResult<object>.Success(f);
+        if (f is null) return ToolResult<object>.Fail("FORM_NOT_FOUND", $"Form '{name}' not found.");
+
+        return ToolResult<object>.Success(f, InvisibleMemberWarnings(f.Form.SourcePath));
+    }
+
+    /// <summary>
+    /// The order violations in a document on disk, phrased for someone reading the object rather
+    /// than writing it. Null when the file is unreachable or clean — an unreadable file is not a
+    /// finding.
+    /// </summary>
+    private static List<string>? InvisibleMemberWarnings(string? sourcePath)
+    {
+        if (string.IsNullOrWhiteSpace(sourcePath) || !File.Exists(sourcePath)) return null;
+
+        try
+        {
+            var violations = new List<D365FO.Core.Validation.XppViolation>();
+            D365FO.Core.Validation.ContractShapeRules.Check(File.ReadAllText(sourcePath), violations);
+
+            var dropped = violations
+                .Where(v => v.Rule == D365FO.Core.Validation.ContractShapeRules.RuleUnknownMember)
+                .Select(v => v.Excerpt)
+                .Distinct(StringComparer.Ordinal)
+                .Take(10)
+                .ToList();
+
+            if (dropped.Count == 0) return null;
+
+            return
+            [
+                $"The file on disk holds {dropped.Count} member(s) the metadata reader DROPS, so what is "
+                + $"reported here is not all of what the file contains: {string.Join(", ", dropped)}. "
+                + "Run `d365fo validate xpp <path> --code-type xml-any` for the detail — this is a defect in "
+                + "the file, not in the object it describes.",
+            ];
+        }
+        catch
+        {
+            return null; // the file is not readable as XML; other paths report that
+        }
     }
 
     public ToolResult<object> SearchQueries(string query, int limit = 50)
@@ -2134,6 +2182,25 @@ public sealed partial class ToolHandlers
     /// grounding token. Backs the unified <c>prepare</c> MCP tool
     /// (<c>mode=create</c>) and the CLI <c>prepare create</c> command.
     /// </summary>
+    /// <summary>
+    /// The object an extension extends, or null when this is not an extension.
+    /// </summary>
+    /// <remarks>
+    /// Both shapes the platform accepts: <c>Base.Suffix</c>, which every shipped extension uses,
+    /// and <c>Base_Extension</c>. The type alone is not enough to tell — a caller naming
+    /// <c>CustTable.Fleet</c> without a type is still creating an extension.
+    /// </remarks>
+    private static string? ExtensionBaseOf(string objectType, string name)
+    {
+        var looksLikeExtension = objectType.Contains("extension", StringComparison.OrdinalIgnoreCase)
+                                 || name.Contains('.')
+                                 || name.EndsWith("_Extension", StringComparison.OrdinalIgnoreCase);
+        if (!looksLikeExtension) return null;
+
+        var normalized = ObjectNamingRules.NormalizeExtensionTarget(name, out _);
+        return string.Equals(normalized, name, StringComparison.Ordinal) ? null : normalized;
+    }
+
     public ToolResult<object> PrepareCreate(string name, string type, string? goal, string[]? fields, string? prefix)
     {
         if (string.IsNullOrWhiteSpace(name))
@@ -2162,7 +2229,40 @@ public sealed partial class ToolHandlers
         };
         var violations = ObjectNamingRules.Validate(namingKind, finalName, prefix);
 
-        var similar = _repo.FindSimilarObjects(objectType, LastToken(baseName))
+        // An extension is created against an object that already exists, and everything worth
+        // knowing before writing one is about THAT object: does it exist, what model owns it,
+        // and who is already extending it. Grounding on the extension's own name asks about a
+        // name that by definition is not there yet, and answers "no collision, nothing similar"
+        // — true, and useless.
+        var extendedObject = ExtensionBaseOf(objectType, baseName);
+        object? extensionBase = null;
+        if (extendedObject is not null)
+        {
+            var kinds = _repo.SymbolKinds(extendedObject);
+            var existing = _repo.FindExtensions(extendedObject)
+                .Select(e => new { name = e.ExtensionName, e.Model, e.Kind })
+                .ToList();
+
+            extensionBase = new
+            {
+                name = extendedObject,
+                indexed = kinds.Count > 0,
+                existsAs = kinds.Count > 0 ? kinds : null,
+                existingExtensions = existing.Count,
+                extensions = existing.Take(10),
+                // Not being in the index is not a veto: the index is a mirror, and the bridge
+                // reads the live provider. Refusing here would block a legitimate write on a
+                // model that has simply not been extracted.
+                note = kinds.Count > 0
+                    ? "Extend this object rather than copying it — an extension merges into the base at build time."
+                    : $"\"{extendedObject}\" is not in the index. That is not proof it does not exist: the index is "
+                      + "a mirror of what was extracted, and the metadata provider may still see it. Run "
+                      + "`d365fo index sync <model>` if it should be there.",
+            };
+        }
+
+        // Similar objects: the peers of the BASE for an extension, of the name itself otherwise.
+        var similar = _repo.FindSimilarObjects(objectType, LastToken(extendedObject ?? baseName))
             .Select(s => new { s.Name, s.Model })
             .ToList();
 
@@ -2225,7 +2325,10 @@ public sealed partial class ToolHandlers
             collisions = collisions.Count > 0 ? collisions : null,
             collisionVerdict = collisions.Count > 0
                 ? "Name already exists — pick a different name or extend the existing object instead."
-                : $"No collision — neither \"{finalName}\" nor \"{baseName}\" exists in the index.",
+                : string.Equals(finalName, baseName, StringComparison.Ordinal)
+                    ? $"No collision — \"{finalName}\" does not exist in the index."
+                    : $"No collision — neither \"{finalName}\" nor \"{baseName}\" exists in the index.",
+            extensionBase,
             namingViolations = violations.Select(v => new { code = v.Code, severity = v.Severity, message = v.Message }),
             similarObjects = similar,
             fieldEdtSuggestions = fieldSuggestions.Count > 0 ? fieldSuggestions : null,

--- a/tests/D365FO.Core.Tests/CodeAnalysisTests.cs
+++ b/tests/D365FO.Core.Tests/CodeAnalysisTests.cs
@@ -54,9 +54,10 @@ public class CodeAnalysisTests : IDisposable
         Assert.False(searched);
         Assert.NotNull(caveat);
         // The caveat has to be reachable as a warning too — a caller reading only the envelope
-        // must not take the empty list at face value.
+        // must not take the empty list at face value. The wording comes from the search itself,
+        // so `find refs` and these modes say the same thing.
         Assert.NotNull(result.Warnings);
-        Assert.Contains("not evidence of absence", result.Warnings![0], StringComparison.Ordinal);
+        Assert.Contains("not evidence", result.Warnings![0], StringComparison.OrdinalIgnoreCase);
     }
 
     [Fact]

--- a/tests/D365FO.Core.Tests/Wave04AuditFixTests.cs
+++ b/tests/D365FO.Core.Tests/Wave04AuditFixTests.cs
@@ -1,0 +1,171 @@
+using D365FO.Core.Index;
+using D365FO.Core.Labels;
+using Xunit;
+
+namespace D365FO.Core.Tests;
+
+/// <summary>
+/// The defects the wave-04 audit found, each locked by the case that exposed it.
+/// </summary>
+/// <remarks>
+/// Three of these are the upstream 1.16.0 fixes the gap analysis lists under this wave; one is a
+/// defect in the wave's own new code, found by running it against two languages instead of one.
+/// </remarks>
+public class Wave04AuditFixTests : IDisposable
+{
+    private readonly string _dir = Path.Combine(Path.GetTempPath(), $"d365fo-w4a-{Guid.NewGuid():N}");
+    private readonly string _dbPath;
+    private readonly MetadataRepository _repo;
+
+    public Wave04AuditFixTests()
+    {
+        Directory.CreateDirectory(_dir);
+        _dbPath = Path.Combine(_dir, "index.sqlite");
+        _repo = new MetadataRepository(_dbPath);
+        _repo.EnsureSchema();
+    }
+
+    public void Dispose()
+    {
+        SqlitePool.ReleaseFor(_dbPath);
+        if (Directory.Exists(_dir)) Directory.Delete(_dir, recursive: true);
+        GC.SuppressFinalize(this);
+    }
+
+    // ── a degraded zero is not "unused" ────────────────────────────────────
+
+    /// <summary>
+    /// An empty index and no readable source is not a codebase where the symbol is unused, and
+    /// the difference decides whether someone deletes it.
+    /// </summary>
+    [Fact]
+    public void A_search_that_read_nothing_says_so_instead_of_returning_a_clean_zero()
+    {
+        var result = MethodSourceSearch.Find(_repo, "NumberSeq", kind: null, model: null, limit: 50);
+
+        Assert.Empty(result.Hits);
+        Assert.Equal(0, result.FilesScanned);
+        Assert.False(result.Searched);
+        Assert.NotNull(result.Caveat);
+        Assert.Contains("not evidence", result.Caveat!, StringComparison.OrdinalIgnoreCase);
+    }
+
+    // ── the extension suffix the platform actually ships ───────────────────
+
+    /// <summary>
+    /// Every one of the 1 093 AxTableExtension objects in a stock installation is named
+    /// <c>Base.Suffix</c>; none uses the underscore form. The validator used to call that dot an
+    /// illegal character while the same run recommended the shape it appears in.
+    /// </summary>
+    [Theory]
+    [InlineData("VendInvoiceInfoTable.Extension")]
+    [InlineData("BOM.AdvancedQualityManagement")]
+    [InlineData("CustTable_Extension")]
+    public void Both_element_extension_suffix_forms_are_legal(string name)
+    {
+        var errors = ObjectNamingRules.Validate("tableextension", name)
+            .Where(v => v.Severity == "error")
+            .ToList();
+
+        Assert.Empty(errors);
+    }
+
+    [Theory]
+    // Two dots is not a suffix, it is a second one.
+    [InlineData("tableextension", "Cust.Table.Bad")]
+    [InlineData("tableextension", "Cust Table")]
+    // And the dot stays illegal for a kind that is not an extension.
+    [InlineData("table", "Cust.Table")]
+    [InlineData("class", "Cust.Class")]
+    public void A_dot_is_still_refused_where_the_platform_does_not_use_one(string kind, string name)
+    {
+        var errors = ObjectNamingRules.Validate(kind, name)
+            .Where(v => v.Severity == "error")
+            .ToList();
+
+        Assert.Contains(errors, e => e.Code == "INVALID_CHARS");
+    }
+
+    // ── a label file nothing can reference ─────────────────────────────────
+
+    [Theory]
+    [InlineData("ConFleet", true)]
+    [InlineData("Con_Fleet2", true)]
+    [InlineData("Con Fleet", false)]   // the @File:Id grammar has no space
+    [InlineData("Con.Fleet", false)]   // nor a dot — that separates file from id
+    [InlineData("Con-Fleet", false)]
+    [InlineData("2ConFleet", false)]   // an identifier does not start with a digit
+    [InlineData("", false)]
+    public void A_label_file_id_must_be_one_an_at_token_can_name(string id, bool referenceable)
+        => Assert.Equal(referenceable, LabelFileWriter.IsReferenceableLabelFileId(id));
+
+    [Theory]
+    [InlineData("ConFleet.en-us.label.txt", "ConFleet")]
+    [InlineData("/a/b/Con Fleet.cs.label.txt", "Con Fleet")]
+    public void The_label_file_id_is_the_part_before_the_first_dot(string path, string expected)
+        => Assert.Equal(expected, LabelFileWriter.LabelFileIdOf(path));
+
+    // ── one text is not a translation ──────────────────────────────────────
+
+    /// <summary>
+    /// <c>Update</c> writes exactly the value it is given, so the guard against writing one
+    /// language's text into every file belongs to the caller — this locks the writer's half:
+    /// each file keeps whatever was written to it.
+    /// </summary>
+    [Fact]
+    public void Each_language_file_keeps_its_own_text()
+    {
+        var en = Path.Combine(_dir, "ConFleet.en-us.label.txt");
+        var cs = Path.Combine(_dir, "ConFleet.cs.label.txt");
+        LabelFileWriter.CreateOrUpdate(en, "ConVehicle", "Vehicel");
+        LabelFileWriter.CreateOrUpdate(cs, "ConVehicle", "Vozidlo");
+
+        LabelFileWriter.Update(en, "ConVehicle", "Vehicle");
+        LabelFileWriter.Update(cs, "ConVehicle", "Vozidlo");
+
+        Assert.Contains("ConVehicle=Vehicle", File.ReadAllText(en), StringComparison.Ordinal);
+        Assert.Contains("ConVehicle=Vozidlo", File.ReadAllText(cs), StringComparison.Ordinal);
+    }
+
+    // ── a multi-word query ─────────────────────────────────────────────────
+
+    /// <summary>
+    /// An object name has no spaces, so a multi-word query matched as one literal matches
+    /// nothing: "agent feed" found none of the three AgentFeed* tables in a real index.
+    /// </summary>
+    [Fact]
+    public void A_multi_word_query_matches_names_carrying_every_token()
+    {
+        Seed("AgentFeed", "AgentFeedItemSourceRecord", "AgentFeedMenuItem", "SalesTable");
+
+        var both = _repo.FindUsages("agent feed").Select(r => r.Name).ToList();
+        Assert.Equal(3, both.Count);
+        Assert.DoesNotContain("SalesTable", both);
+
+        // Narrower still — and "item" is carried by AgentFeedMenuItem too, which is the point:
+        // a token matches anywhere in the name, not only at a word boundary the name does not have.
+        var items = _repo.FindUsages("agent feed item").Select(r => r.Name).OrderBy(n => n).ToList();
+        Assert.Equal(["AgentFeedItemSourceRecord", "AgentFeedMenuItem"], items);
+
+        // Order does not matter.
+        Assert.Equal(items, _repo.FindUsages("item feed").Select(r => r.Name).OrderBy(n => n).ToList());
+
+        // A token only one name carries narrows to that one.
+        Assert.Equal(["AgentFeedItemSourceRecord"], _repo.FindUsages("feed source").Select(r => r.Name).ToList());
+
+        // A token nothing carries takes the result to nothing.
+        Assert.Empty(_repo.FindUsages("agent nosuchtoken"));
+
+        // The single-token behaviour is untouched.
+        Assert.Equal(3, _repo.FindUsages("AgentFeed").Count);
+    }
+
+    private void Seed(params string[] tableNames)
+    {
+        var batch = ExtractBatch.Empty("ConFleet") with
+        {
+            Tables = tableNames.Select(n => new ExtractedTable(n, null, null, [])).ToList(),
+        };
+        _repo.ApplyExtract(batch);
+    }
+}

--- a/tests/D365FO.Core.Tests/XmlScanAndOrderTests.cs
+++ b/tests/D365FO.Core.Tests/XmlScanAndOrderTests.cs
@@ -1,0 +1,87 @@
+using D365FO.Core.Validation;
+using Xunit;
+
+namespace D365FO.Core.Tests;
+
+/// <summary>
+/// Reading a document's shape by tokens rather than by text, and the members the reader drops.
+/// </summary>
+/// <remarks>
+/// The two remaining defect classes from the upstream 1.16.0 table: a rule that decided what a
+/// document was by searching its TEXT, and an out-of-order member that the metadata
+/// deserializer discards without a word.
+/// </remarks>
+public class XmlScanAndOrderTests
+{
+    // ── the root is the root, not a mention of one ─────────────────────────
+
+    [Theory]
+    [InlineData("<AxClass><Name>X</Name></AxClass>", "AxClass")]
+    [InlineData("<?xml version=\"1.0\"?>\n<AxTable/>", "AxTable")]
+    // The name in a comment above the root is not the root.
+    [InlineData("<!-- was an <AxTable> once -->\n<AxClass/>", "AxClass")]
+    [InlineData("<?xml version=\"1.0\"?>\n<!-- <AxTable> -->\n<!DOCTYPE x>\n<AxForm/>", "AxForm")]
+    [InlineData("   \n\n<AxEnum />", "AxEnum")]
+    [InlineData("", null)]
+    [InlineData("<!-- only a comment -->", null)]
+    [InlineData("no markup at all", null)]
+    public void The_root_element_is_read_past_the_prolog_and_the_comments(string xml, string? expected)
+        => Assert.Equal(expected, XmlScan.RootElementName(xml));
+
+    [Fact]
+    public void A_name_inside_a_comment_is_not_the_root()
+    {
+        const string xml = "<!-- This was an <AxTable> before it was rewritten -->\n<AxClass><Name>C</Name></AxClass>";
+
+        Assert.True(XmlScan.RootIs(xml, "AxClass"));
+        Assert.False(XmlScan.RootIs(xml, "AxTable"));
+    }
+
+    [Fact]
+    public void An_element_named_only_in_a_comment_or_cdata_is_not_present()
+    {
+        const string xml = """
+            <AxClass>
+              <!-- <AxTableIndex> would go here -->
+              <SourceCode><Declaration><![CDATA[// see <AxTableIndex> on the base table
+            class C {}]]></Declaration></SourceCode>
+            </AxClass>
+            """;
+
+        Assert.False(XmlScan.ContainsElement(xml, "AxTableIndex"));
+        Assert.True(XmlScan.ContainsElement(xml, "SourceCode"));
+        Assert.True(XmlScan.ContainsElement(xml, "Declaration"));
+    }
+
+    // ── a member the reader would drop ─────────────────────────────────────
+    //
+    // There is no order rule here on purpose. One was written, and the census over the
+    // installation (MetadataContractsAotTests) showed it flagging files Microsoft ships — an
+    // AxEnum with ConfigurationKey after UseEnumValue, an AccessGrant with Create after Update.
+    // The contract's member list is declaration order; the deserializer is more tolerant than
+    // that. Ordering what we write stays; calling a document broken for its order does not.
+
+    private static List<XppViolation> Check(string xml)
+    {
+        var v = new List<XppViolation>();
+        ContractShapeRules.Check(xml, v);
+        return v;
+    }
+
+    /// <summary>
+    /// The unknown-member rule still owns what it always owned, and did not change when the
+    /// order rule was withdrawn.
+    /// </summary>
+    [Fact]
+    public void An_unknown_member_is_still_reported()
+    {
+        const string xml = """
+            <AxTable>
+              <Name>ConT</Name>
+              <NoSuchMember>x</NoSuchMember>
+            </AxTable>
+            """;
+
+        Assert.Contains(Check(xml), x => x.Rule == ContractShapeRules.RuleUnknownMember);
+    }
+}


### PR DESCRIPTION
Wave 04 landed in [#195](https://github.com/dynamics365ninja/d365fo-cli/pull/195) before these two commits were pushed, so they need their own PR. Both belong to wave 04 of the gap analysis: the audit of what that wave actually delivered, and the ports it had left open.

| Wave 04 item | Status |
|---|---|
| `analyze patterns` / `implementations` / `api-usage` | ✅ #195 |
| `labels update` | ✅ #195, **corrected here** |
| `verify` as a standalone command | ✅ #195 |
| Port the 12 fixes from the 1.16.0 table | ✅ **completed here** — 7 ported, 3 verified not applicable, 1 withdrawn |

## The audit found four defects, one in the wave's own new code

| Defect | How it looked |
|---|---|
| **`labels update` destroyed translations** | `--lang en-us,cs` with one value wrote the English string into the Czech file (`Vozidlo` → `Vehicle`) and reported success. A correction *is* a translation, so several languages now need one `--text <LANG>=<VALUE>` each; one text for many is refused, and the refusal names the arguments to pass. |
| **A degraded zero read as "unused"** | `find refs` against an index built elsewhere answered `count: 0` — indistinguishable from a symbol nothing calls, which is how "no callers" becomes "safe to delete". The verdict now lives on `SourceRefResult`, so `find refs`, `find_references` and the three `analyze` modes cannot disagree about whether the corpus was read. |
| **`validate name` refused the only shape the platform ships** | The character rule rejected the dot in `CustTable.FleetExtension` while the kind rule in the same run recommended that very form. Counted on the dev host: **1 093 of 1 093** `AxTableExtension` objects use `Base.Suffix`; none uses the underscore form. |
| **A label file under an unreferenceable id** | `--label-file "Con Fleet"` succeeded, and no `@File:Id` token can name the file — the label existed on disk and resolved to nothing everywhere it was used. |

Plus the documentation the wave had skipped: `labels update` and `verify` were missing from CAPABILITIES, and none of the five new commands had an EXAMPLES entry.

## The remaining ports, each checked before porting

A fix for a defect we do not have is a change with no reason, so every item was verified against this codebase first.

**Ported:** the root element could be read out of an XML comment (`<!-- was an <AxTable> -->` above an `AxClass` fired every table rule) — `XmlScan` now reads the root by token scan past the prolog, comments and CDATA, and the six rules that guessed from text ask it; `prepare create` on an extension asked about the extension's own name, and now grounds in the object being extended, with a base missing from the index treated as a note rather than a veto; `get form` says when the file holds members the reader drops.

**Not applicable, verified rather than assumed:** no path here splits a supplied class body into methods (the attribute-block defect); names and signatures are separate columns (the member-list defect); the write path canonicalises order, checked by generating all five form patterns and validating each (the scaffold defect).

## One rule written, then withdrawn

A form member-order validation rule (XML014) passed a 150-file sample — and then the repository's own census over **10 028 shipped files** showed it flagging what Microsoft ships: an `AxEnum` with `ConfigurationKey` after `UseEnumValue`, an `AccessGrant` with `Create` after `Update`, an `AxTableFieldString` with `Label` after `StringSize`. All shipped, all loading.

So the contract's member list is declaration order and the deserializer is more tolerant than that. Ordering what we write stays; calling someone else's document broken for its order does not — a rule that fails on Microsoft's own files is worse than no rule. `MetadataContractsAotTests` caught it, and the reasoning is recorded on `ContractOrderCanonicalizer` so the rule is not rediscovered and re-added.

## Verification

1 763 tests green, warning ratchet at its 117 baseline, `knowledge audit --verify` clean, `eval coverage --check` and `eval run --all` (52/52) pass. Against the installation on this host: the extension-name evidence above, 0 false positives from the token scan across 150 sampled AOT files, and `labels update` refusing a cross-language overwrite without touching either file.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HoeL3ZT1QLerLfjgQHGSB4