### PR TITLE
Wave 05 — Oracles, and what the first one found

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -59,7 +59,7 @@ jobs:
           dotnet-version: 10.0.x
       - name: Warning count must not rise
         shell: pwsh
-        run: ./scripts/check-build-warnings.ps1 -Baseline 117
+        run: ./scripts/check-build-warnings.ps1 -Baseline 114
 
   # What `dotnet test` builds is not what anybody installs. install.ps1/install.sh publish
   # self-contained, single-file and TRIMMED, and issue #182 showed that shape failing on
@@ -115,6 +115,13 @@ jobs:
         run: dotnet run --project src/D365FO.Cli -c Release -- eval run --all --output json
       - name: Check the K/E/T coverage report
         run: dotnet run --project src/D365FO.Cli -c Release --no-build -- eval coverage --check --output json
+      # The oracle's bar without an installation: every rule over the checked-in fixtures,
+      # zero errors. It cannot catch what a sweep of a real PackagesLocalDirectory catches
+      # — that needs 242 858 shipped files and a VM — but it does catch a rule that starts
+      # firing on the corpus's own reference material, which is the same failure in
+      # miniature and the reason the fixtures are XML the tool itself would accept.
+      - name: Sweep the fixtures with every rule
+        run: dotnet run --project src/D365FO.Cli -c Release --no-build -- oracle sweep --dry --output json
 
   skills:
     runs-on: ubuntu-latest

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,94 @@ was ported from.
 
 ## [Unreleased]
 
+### Added — wave 05: oracles, and what the first one found
+
+Five `oracle` commands that measure this tool against the installation it claims to understand,
+plus the corpus work that the measurement made possible. None is published over MCP: they are a
+measurement of `d365fo-cli`, not an operation on anyone's X++.
+
+- **`oracle sweep`** — every rule over every AOT file in a PackagesLocalDirectory. The bar is
+  **zero errors on Microsoft's own X++**, not "few": a rule that fires on shipped code teaches a
+  caller to ignore findings. `--dry` sweeps the checked-in fixtures so CI without an installation
+  can still run it; findings are tallied per rule with a few samples each, because an
+  installation is a quarter of a million files and keeping every finding to group at the end
+  costs gigabytes and says nothing the counters do not.
+- **`oracle census` / `oracle members`** — what shipped XML actually carries, member by member,
+  against what the metadata contract declares. This is where compiler and metadata facts come
+  from instead of from guessing.
+- **`oracle probe`** — compiles one artefact (or a handful) with the real `xppc.exe` in a
+  throwaway model. An xppc that rejects its argument list prints usage, which parses as "no
+  diagnostics", so that case is reported as a failure of the probe rather than as a pass.
+- **`oracle runtime`** — whether `SysTestConsole.exe` is wired to a database (its keys are in the
+  AOS `web.config`, so the answer is derivable rather than guessable, and `--configure` copies
+  only the missing ones, keeping a `.bak`), and `--negative-control`, a test class whose three
+  methods pass, fail and throw on purpose. "All tests passed" is also what a runner prints when
+  it ran nothing.
+
+### Fixed — every rule that fired on Microsoft's own code
+
+The first full sweep of a live installation (242 858 files, 107 241 X++ blocks) reported
+**4 674 errors**. Every one was the validator being wrong. `SweepFalsePositiveTests` pins each
+with the count it accounted for, alongside the code the rule exists for — so a "fix" that
+silences a rule fails there rather than passing quietly.
+
+- **XML007, 4 574 findings.** A member name that is also a type name was read as the type. The
+  catalog has exactly two such collisions; one of them is `DataSource`, declared by
+  `AxQueryExtensionEmbeddedDataSource` as an `AxQuerySimpleEmbeddedDataSource` while an unrelated
+  three-member type of that name exists — so every real data-source property under it was
+  reported as unknown. What the parent declares now beats what the name coincides with.
+- **XML007 again, 1 463 in one model.** The rule descended into documents whose root it did not
+  recognise, which is how the BP suppression list every model ships got judged against the
+  metadata contracts. It now stops at an unknown root, as its own documentation always claimed,
+  and skips `IgnoreDiagnostics` explicitly: those entries really do carry members
+  `AxIgnoreDiagnosticItem` does not declare (reflected off the assembly — it has seven), and the
+  file is read by the best-practice tooling rather than by the metadata serializer.
+- **XML002 / XML003, 229 in one model, downgraded to warnings.** Both are majority conventions
+  mined from standard models, and the minority is Microsoft's own. A convention most artefacts
+  follow is not a defect in the ones that do not.
+- **ATTR001, 72 findings.** Masking blanks a comment's content *and* its closing delimiter, so
+  `[SysSetupConfig(true /*ContinueOnError*/, 600)]` reached the literal test as the argument
+  `true /*`.
+- **SEL010, 15 findings.** `validTimeState` is also a method on the query classes and a parameter
+  name on their declarations; the rule is about the select clause and now only looks there.
+- **FN001, 7 findings.** `new Info()` constructs the class of that name — a predefined function
+  is never reached through `new`.
+- **CS001, 3 findings.** A file may alias a CLR type into scope (`using string = System.String;`),
+  which is what the platform's Commerce pricing classes do; `string groupKey` is then a
+  declaration of that alias, not the C# keyword.
+- **SEL008, 1 finding.** A select inside a `#localmacro` has no terminating semicolon, so the
+  statement scan ran into the next macro and paired one macro's `where` with the next one's
+  `order by`.
+- **COC003, 1 finding.** The `_Extension` suffix is now matched case-insensitively, as X++
+  identifiers are — the platform ships `JournalCheckPostIV_extension`.
+
+### Added — the eval corpus reaches the artefacts nothing was checking
+
+- **Companions are scored.** A report is a report plus a TempDB table, a DP, a controller and an
+  output menu item; only the main artefact used to be diffed, so companions were captured once
+  and never checked again. Turning it on immediately found ten companions across the two report
+  cases that no golden had pinned. A companion the golden names and the run did not produce is
+  missing; one the run produced and the golden does not name is extra.
+- **Cases can start from an artefact.** `generate table-relation` and `generate find-methods`
+  augment a table that already exists and refuse `--out` outright, so neither was reachable by a
+  replay. A case may now name an `apply_to_seed` under `eval/seeds/`, which the replay copies in
+  as its output file and merges into.
+- **Eight new cases**, goldens captured on this VM through the real CLI, taking the corpus from
+  52 to 60: the workflow approval/task elements, the service group, the deprecated `simple-list`
+  alias, a report dataset extension, view/query/data-entity extensions, and the two table
+  augmenters above.
+- **Three families gained the command that builds them.** `AxViewExtension`,
+  `AxQuerySimpleExtension` and `AxDataEntityViewExtension` were reported as having no generator
+  while `generate extension` was building all three.
+- **Knowledge for twelve leaves the corpus taught nothing about**: the remaining extension kinds
+  and their root elements, security duty/role extensions, `AxView` and `AxMap` with the commands
+  that build them, the plain `generate class`, the two form-method scaffolders and `form-clone`.
+
+Coverage: **64 of 74 leaves** are now K ∧ E ∧ T, up from 42. The remaining ten
+(`AxAggregateDataEntity`, `AxCompositeDataEntityView`, `AxConfigurationKey`, `AxFormPart`,
+`AxLabelFile`, `AxMapExtension`, `AxMenu`, `AxResource`, `AxTile`, `AxWorkflowCategory`) are
+blocked on a `generate` subcommand that does not exist yet — surface work, not corpus work.
+
 ### Fixed — the rest of the 1.16.0 ports
 The remainder of the upstream fixes the gap analysis lists under wave 04, each checked against
 this codebase before being ported: a fix for a defect we do not have is a change with no reason.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -79,6 +79,17 @@ silences a rule fails there rather than passing quietly.
   `order by`.
 - **COC003, 1 finding.** The `_Extension` suffix is now matched case-insensitively, as X++
   identifiers are — the platform ships `JournalCheckPostIV_extension`.
+- **FN001 again, 2 findings.** X++ allows a function to be declared inside a method body, and it
+  takes precedence over the predefined name of the same spelling — which the compiler's own
+  message says ("nor a previously defined local function"). `BatchRun.runJob` declares
+  `void info()` and calls it twice.
+- **RPT001, 1 finding.** An abstract data provider is a base for concrete ones and carries no
+  contract of its own; `CustVendAdvanceInvoiceDP` reads `parmDataContract()` and declares none,
+  because `CustAdvanceInvoiceDP` and `VendAdvanceInvoiceDP` each declare their own.
+
+Re-swept after each fix: the four rules above were the last errors on the installation. The
+warnings (41 475) are counted and left alone — they are style rules that shipped code
+legitimately breaks, and the bar was never about them.
 
 ### Added — the eval corpus reaches the artefacts nothing was checking
 

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
 [![.NET](https://img.shields.io/badge/.NET-10-purple.svg)](https://dotnet.microsoft.com/)
 [![Platform](https://img.shields.io/badge/platform-Windows%20%7C%20macOS%20%7C%20Linux-lightgrey.svg)]()
-[![Tests](https://img.shields.io/badge/tests-1630-brightgreen.svg)]()
+[![Tests](https://img.shields.io/badge/tests-1810-brightgreen.svg)]()
 [![Successor to d365fo-mcp-server](https://img.shields.io/badge/successor%20to-d365fo--mcp--server-orange.svg)](https://github.com/dynamics365ninja/d365fo-mcp-server)
 
 *Grounded AI development for Dynamics 365 Finance & Operations — works with GitHub Copilot, Claude Code, Codex, Gemini CLI, and any agent with a shell*

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
 [![.NET](https://img.shields.io/badge/.NET-10-purple.svg)](https://dotnet.microsoft.com/)
 [![Platform](https://img.shields.io/badge/platform-Windows%20%7C%20macOS%20%7C%20Linux-lightgrey.svg)]()
-[![Tests](https://img.shields.io/badge/tests-1810-brightgreen.svg)]()
+[![Tests](https://img.shields.io/badge/tests-1813-brightgreen.svg)]()
 [![Successor to d365fo-mcp-server](https://img.shields.io/badge/successor%20to-d365fo--mcp--server-orange.svg)](https://github.com/dynamics365ninja/d365fo-mcp-server)
 
 *Grounded AI development for Dynamics 365 Finance & Operations — works with GitHub Copilot, Claude Code, Codex, Gemini CLI, and any agent with a shell*

--- a/docs/AGENT_EVAL_LOOP.md
+++ b/docs/AGENT_EVAL_LOOP.md
@@ -245,16 +245,28 @@ report a verdict nobody collected*:
 - a diagnostic naming an object no case provisioned is reported as *unattributed*
   rather than spread across every case.
 
-**Companions.** A case scores exactly one artifact — `EvalScorer` rejects a golden
-directory holding more, and rightly so. But one generate command usually ships
+**Companions.** A case's golden directory holds exactly one artifact — `EvalScorer`
+rejects one holding more, and rightly so. But one generate command usually ships
 several: `generate custom-service` writes the `AxService` *and* the class it names;
 `generate business-event` writes the event and its contract. Compiling the scored
 file alone left those siblings dangling and reported five cases red for objects the
-tool does in fact generate. Sibling artifacts now live in a `_companions` subfolder
-of the case's golden directory — invisible to the scorer, which enumerates the case
-directory non-recursively, and compiled by the oracle. They are captured from the
-same command run as the golden, so a companion that drifts fails the build exactly
-like the golden does.
+tool does in fact generate. Sibling artifacts live in a `_companions` subfolder of
+the case's golden directory — outside the single-golden rule, which enumerates the
+case directory non-recursively — and are captured from the same command run as the
+golden.
+
+They are **also diffed**, which they were not at first. Being merely captured meant
+they were reviewed once and then never checked again: any later drift in them was
+invisible to the whole corpus, and a case's `target_artifact_types` was half true,
+because the families it named were the companions' families and nothing compared
+them to anything. The scorer now matches each golden companion to the file of the
+same name in the run's own work directory, prefixes every diff line with the
+companion's name, reports a companion the golden names and the run did not produce
+as **missing**, and one the run produced that no golden names as **extra** — a new
+file appearing unannounced being exactly the drift worth failing on. Turning this on
+found ten unpinned companions across the two report cases on the first run. The
+extras half needs a directory the caller owns, so it applies to the replay and not
+to scoring a file an agent left somewhere.
 
 Its first runs found seven shipping defects the offline loop had no way to see —
 every generated `AxQuery` crashed the metadata reader; a generated event handler
@@ -283,7 +295,21 @@ convention is `NumberSeqModule<Module>`, and the wrapped `loadModule` is
 `protected`, not `public`. Four cases were also mis-authored: they extended a
 `NoYes` that is not extensible, added a privilege a duty already had, named a
 policy query nothing generates, and hung a number sequence off a module that does
-not exist. The catalog is now 51 of 51 clean.
+not exist. The catalog is now 60 of 60 clean.
+
+The eighth came from the same oracle, on a case authored later: a workflow type
+generated with its own approval AND task elements reported "Workflow approval
+'<task>' does not exist" — a kind the file never mentions. `AxWorkflowElementReference`
+carries the kind in `<Type>`, and only for the kinds that are not the default (across a
+live installation: `Task` 49 times, `AutomatedTask` 28, absent 117, absent meaning
+approval). Written without it, the task reference was read as an approval. No offline
+rule can know that, and the document is otherwise perfectly well-formed.
+
+The reference list moved with it: a golden that EXTENDS a standard object drags in what
+that object references, which does not stay inside ApplicationSuite/Foundation/Platform —
+a view extension over `CustAccountName` needs `DirPartyTable` from `Directory`. The
+throwaway model now references every package in the installation, read off the disk
+rather than guessed at per case.
 
 **Attribution is the load-bearing part.** Every diagnostic must land on the case
 whose golden produced the object it names, and the parser must recognise the shapes
@@ -319,6 +345,18 @@ library is used anywhere else in this repo):
   "golden_pending": false
 }
 ```
+
+`apply_to_seed` is the one field not shown above. A few commands augment an artifact
+that already exists — `generate table-relation` and `generate find-methods` merge into
+a table's XML and refuse `--out`/`--install-to` outright, because accepting a
+scaffold-output option and quietly dropping it would be worse than refusing it. A case
+for either therefore starts *from* an artifact instead of producing one: it names a
+bare file name under `eval/seeds/`, which the replay copies into its work directory as
+the run's output file and points `--apply-to` at, so the golden is the merged artifact
+and the seed is never mutated in place. A seed whose name matches an `AxTable` in the
+MiniAot fixture has to stay byte-identical to it — the index the replay builds comes
+from that fixture, and a drifted seed would be a case merging into a table the tool
+never saw.
 
 `canonical_args` is optional — cases meant only for the eval-runner agent
 (not yet reproducible deterministically, or deliberately testing whether an

--- a/docs/CAPABILITIES.md
+++ b/docs/CAPABILITIES.md
@@ -620,6 +620,40 @@ Returns `UNSUPPORTED_PLATFORM` on non-Windows.
 
 ---
 
+## Oracles (`oracle`) — measuring the tool against the platform
+
+A green test suite proves the code does what its author expected. These five commands ask a
+different question: does what this tool believes match what the installation actually contains,
+compiles and runs? They are maintainer tools — a measurement of `d365fo-cli`, not an operation
+on your X++ — and none of them is published over MCP.
+
+```powershell
+d365fo oracle sweep                       # every rule over every AOT file in the installation
+d365fo oracle sweep --model ApplicationFoundation --warnings
+d365fo oracle sweep --dry                 # the checked-in fixtures, for CI with no installation
+d365fo oracle census AxTable              # what shipped XML actually carries, member by member
+d365fo oracle members AxTable             # declared-but-never-seen and seen-but-not-declared
+d365fo oracle probe MyClass.xml           # compile one artefact with the real xppc.exe
+d365fo oracle runtime                     # is SysTestConsole wired to a database, and does it discriminate?
+d365fo oracle runtime --negative-control  # a test class that passes, fails and throws on purpose
+```
+
+**The bar for `sweep` is zero errors on Microsoft's own X++.** Not "few": a rule that fires on
+shipped code teaches a caller to ignore findings, which costs more than the rule ever earned.
+Warnings are counted separately and do not fail the bar — several are style rules that shipped
+code legitimately breaks. The first full run (242 858 files) reported 4 674 errors, every one of
+them the validator being wrong; `SweepFalsePositiveTests` pins each with the count it accounted
+for.
+
+`probe` compiles into a throwaway model built around the artefact, so a clean result means the
+compiler ran and said nothing — an xppc that rejects its own argument list prints usage, which
+parses as "no diagnostics", and that case is reported as a failure of the probe rather than a
+pass. `runtime` answers the question nobody asks about a green suite: "all tests passed" is also
+what a runner prints when it ran nothing, so the negative control has to fail before any pass
+means anything.
+
+---
+
 ## MCP server
 
 Exposes the same index and scaffolding surface as the CLI over the `ModelContextProtocol` C# SDK via stdio (default) or HTTP (`--http`, for a shared team deployment). The tool surface is **consolidated** into **32 discriminator-based tools** (`search`, `get_object_info`, `get_method`, `labels`, `security_info`, `extension_info`, `object_patterns`, `generate_object`, `modify_method`, `modify_object`, `get_knowledge`, `explain_build_error`, `analyze`, `models`, …) instead of one tool per object type — mirroring the upstream `d365fo-mcp-server` (which sits at 26). A single tool dispatches on a `type` / `objectType` / `mode` / `action` / `domain` / `include` field. See [MIGRATION_FROM_MCP.md](MIGRATION_FROM_MCP.md) for the full old→new mapping.

--- a/eval/COVERAGE.md
+++ b/eval/COVERAGE.md
@@ -14,53 +14,53 @@ Every column is derived — families from `ObjectTypeRegistry`, capabilities fro
 file cannot claim coverage that no longer exists. Regenerate with
 `d365fo eval coverage --write`; CI runs `--check`.
 
-**42 of 74 leaves complete.**
+**64 of 74 leaves complete.**
 
 ## AOT families
 
 | Root element | Kind | K | E | T | Topics | Cases | Built by |
 |---|---|:-:|:-:|:-:|---|---|---|
 | `AxAggregateDataEntity` | aggregatedataentity | — | — | — | — | — | — |
-| `AxClass` | class | ✅ | ✅ | ✅ | `analytics-and-er`, `business-events-authoring`, `coc-extension-authoring`, `custom-service-authoring`, `data-entity-scaffolding`, `event-handler-authoring`, `form-pattern-scaffolding`, `global-class-statics`, `integration-patterns`, `label-translation`, `model-dependency-and-coupling`, `object-extension-authoring`, `report-print-destinations`, `review-and-checkpoint-workflow`, `security-hierarchy-trace`, `ssrs-report-authoring`, `system-objects`, `table-scaffolding`, `testing-and-quality`, `x++-class-authoring`, `xpp-best-practice-rules`, `xpp-class-and-method-rules`, `xpp-database-queries`, `xpp-statement-and-type-rules` | `L1-business-event-basic`, `L1-class-basic`, `L1-migration-script-basic`, `L1-runbase-basic`, `L1-sysoperation-basic`, `L1-systest-basic`, `L2-coc-extension`, `L2-event-handler-basic`, `L2-numberseq-basic` | generate class |
+| `AxClass` | class | ✅ | ✅ | ✅ | `analytics-and-er`, `business-events-authoring`, `coc-extension-authoring`, `custom-service-authoring`, `data-entity-scaffolding`, `event-handler-authoring`, `form-pattern-scaffolding`, `global-class-statics`, `integration-patterns`, `label-translation`, `model-dependency-and-coupling`, `object-extension-authoring`, `report-print-destinations`, `review-and-checkpoint-workflow`, `security-hierarchy-trace`, `ssrs-report-authoring`, `system-objects`, `table-scaffolding`, `testing-and-quality`, `x++-class-authoring`, `xpp-best-practice-rules`, `xpp-class-and-method-rules`, `xpp-database-queries`, `xpp-statement-and-type-rules` | `L1-business-event-basic`, `L1-class-basic`, `L1-custom-service-basic`, `L1-migration-script-basic`, `L1-runbase-basic`, `L1-sysoperation-basic`, `L1-systest-basic`, `L2-coc-extension`, `L2-event-handler-basic`, `L2-numberseq-basic`, `L2-report-extension-dataset` | generate class |
 | `AxCompositeDataEntityView` | compositedataentityview | — | — | — | — | — | — |
 | `AxConfigurationKey` | configurationkey | — | — | — | — | — | — |
 | `AxDataEntityView` | dataentityview | ✅ | ✅ | ✅ | `data-entity-scaffolding`, `integration-dmf-dualwrite`, `integration-patterns` | `L2-virtual-entity-basic` | generate entity |
-| `AxDataEntityViewExtension` | dataentityviewextension | — | — | — | — | — | — |
+| `AxDataEntityViewExtension` | dataentityviewextension | ✅ | ✅ | ✅ | `object-extension-authoring` | `L2-data-entity-extension` | generate extension |
 | `AxEdt` | edt | ✅ | ✅ | ✅ | `object-extension-authoring`, `system-objects`, `table-scaffolding` | `L0-edt-basic`, `L0-edt-extends` | generate edt |
-| `AxEdtExtension` | edtextension | — | ✅ | ✅ | — | `L2-edt-extension` | generate extension |
+| `AxEdtExtension` | edtextension | ✅ | ✅ | ✅ | `object-extension-authoring` | `L2-edt-extension` | generate extension |
 | `AxEnum` | enum | ✅ | ✅ | ✅ | `event-handler-authoring`, `object-extension-authoring`, `report-print-destinations`, `system-objects` | `L0-enum-basic`, `L0-enum-non-extensible` | generate enum |
-| `AxEnumExtension` | enumextension | — | ✅ | ✅ | — | `L2-enum-extension` | generate extension |
-| `AxForm` | form | ✅ | ✅ | ✅ | `coc-extension-authoring`, `data-entity-scaffolding`, `event-handler-authoring`, `form-pattern-scaffolding`, `label-translation`, `model-dependency-and-coupling`, `object-extension-authoring`, `review-and-checkpoint-workflow`, `security-hierarchy-trace`, `table-scaffolding`, `x++-class-authoring`, `xpp-best-practice-rules`, `xpp-class-and-method-rules`, `xpp-database-queries`, `xpp-statement-and-type-rules` | `L1-form-basic`, `L1-form-details-master`, `L1-form-details-transaction`, `L1-form-dialog`, `L1-form-list-page`, `L1-form-lookup`, `L1-form-simplelist-details`, `L1-form-table-of-contents`, `L1-form-workspace`, `L2-control-method-basic`, `L2-datasource-method-basic`, `L2-form-clone-basic` | generate form |
-| `AxFormExtension` | formextension | ✅ | ✅ | ✅ | `form-pattern-scaffolding`, `review-and-checkpoint-workflow` | `L2-form-extension-basic` | generate extension |
+| `AxEnumExtension` | enumextension | ✅ | ✅ | ✅ | `object-extension-authoring` | `L2-enum-extension` | generate extension |
+| `AxForm` | form | ✅ | ✅ | ✅ | `coc-extension-authoring`, `data-entity-scaffolding`, `event-handler-authoring`, `form-pattern-scaffolding`, `forms-and-navigation`, `label-translation`, `model-dependency-and-coupling`, `object-extension-authoring`, `review-and-checkpoint-workflow`, `security-hierarchy-trace`, `table-scaffolding`, `x++-class-authoring`, `xpp-best-practice-rules`, `xpp-class-and-method-rules`, `xpp-database-queries`, `xpp-statement-and-type-rules` | `L1-form-basic`, `L1-form-details-master`, `L1-form-details-transaction`, `L1-form-dialog`, `L1-form-list-page`, `L1-form-lookup`, `L1-form-simplelist-details`, `L1-form-table-of-contents`, `L1-form-workspace`, `L1-simple-list-alias`, `L2-control-method-basic`, `L2-datasource-method-basic`, `L2-form-clone-basic` | generate form |
+| `AxFormExtension` | formextension | ✅ | ✅ | ✅ | `form-pattern-scaffolding`, `object-extension-authoring`, `review-and-checkpoint-workflow` | `L2-form-extension-basic` | generate extension |
 | `AxFormPart` | formpart | — | — | — | — | — | — |
 | `AxLabelFile` | labelfile | ✅ | — | — | `label-translation` | — | — |
-| `AxMap` | map | — | ✅ | ✅ | — | `L1-map-basic`, `L1-map-multi-table` | generate map |
-| `AxMapExtension` | mapextension | — | — | — | — | — | — |
+| `AxMap` | map | ✅ | ✅ | ✅ | `table-scaffolding` | `L1-map-basic`, `L1-map-multi-table` | generate map |
+| `AxMapExtension` | mapextension | ✅ | — | — | `object-extension-authoring` | — | — |
 | `AxMenu` | menu | ✅ | — | — | `forms-and-navigation` | — | — |
 | `AxMenuItemAction` | menuitemaction | ✅ | ✅ | ✅ | `form-pattern-scaffolding` | `L1-menu-item-action` | generate menu-item |
 | `AxMenuItemDisplay` | menuitemdisplay | ✅ | ✅ | ✅ | `form-pattern-scaffolding` | `L1-menu-item-basic` | generate menu-item |
 | `AxMenuItemOutput` | menuitemoutput | ✅ | ✅ | ✅ | `form-pattern-scaffolding` | `L1-menu-item-output` | generate menu-item |
 | `AxQuery` | query | ✅ | ✅ | ✅ | `object-extension-authoring`, `table-scaffolding` | `L1-query-basic`, `L1-query-join` | generate query |
-| `AxQuerySimpleExtension` | queryextension | — | — | — | — | — | — |
+| `AxQuerySimpleExtension` | queryextension | ✅ | ✅ | ✅ | `object-extension-authoring` | `L2-query-extension` | generate extension |
 | `AxReport` | report | ✅ | ✅ | ✅ | `rdl-design-expressions`, `ssrs-report-authoring` | `L1-report-basic`, `L1-report-parameters` | generate report |
 | `AxResource` | resource | — | — | — | — | — | — |
 | `AxSecurityDuty` | securityduty | ✅ | ✅ | ✅ | `security-modeling` | `L1-duty-basic` | generate duty |
-| `AxSecurityDutyExtension` | securitydutyextension | — | ✅ | ✅ | — | `L2-security-duty-extension` | generate extension |
+| `AxSecurityDutyExtension` | securitydutyextension | ✅ | ✅ | ✅ | `object-extension-authoring`, `security-modeling` | `L2-security-duty-extension` | generate extension |
 | `AxSecurityPolicy` | securitypolicy | ✅ | ✅ | ✅ | `object-extension-authoring`, `security-modeling` | `L2-security-policy-basic` | generate security-policy |
 | `AxSecurityPrivilege` | securityprivilege | ✅ | ✅ | ✅ | `security-hierarchy-trace`, `security-modeling` | `L1-privilege-basic`, `L1-privilege-data-entity` | generate privilege |
 | `AxSecurityRole` | securityrole | ✅ | ✅ | ✅ | `security-hierarchy-trace`, `security-modeling` | `L1-role-basic` | generate role |
-| `AxSecurityRoleExtension` | securityroleextension | — | ✅ | ✅ | — | `L2-security-role-extension` | generate extension |
+| `AxSecurityRoleExtension` | securityroleextension | ✅ | ✅ | ✅ | `object-extension-authoring`, `security-modeling` | `L2-security-role-extension` | generate extension |
 | `AxService` | service | ✅ | ✅ | ✅ | `custom-service-authoring`, `integration-patterns` | `L1-custom-service-basic` | generate custom-service |
-| `AxServiceGroup` | servicegroup | ✅ | — | ✅ | `custom-service-authoring`, `integration-patterns` | — | generate custom-service |
-| `AxTable` | table | ✅ | ✅ | ✅ | `coc-extension-authoring`, `data-entity-scaffolding`, `event-handler-authoring`, `form-pattern-scaffolding`, `integration-dmf-dualwrite`, `label-translation`, `model-dependency-and-coupling`, `object-extension-authoring`, `review-and-checkpoint-workflow`, `security-hierarchy-trace`, `ssrs-report-authoring`, `system-objects`, `table-scaffolding`, `x++-class-authoring`, `xpp-best-practice-rules`, `xpp-class-and-method-rules`, `xpp-database-queries`, `xpp-statement-and-type-rules` | `L1-table-basic`, `L1-table-tempdb` | generate table |
-| `AxTableExtension` | tableextension | ✅ | ✅ | ✅ | `review-and-checkpoint-workflow` | `L2-table-extension` | generate extension |
+| `AxServiceGroup` | servicegroup | ✅ | ✅ | ✅ | `custom-service-authoring`, `integration-patterns` | `L1-custom-service-basic` | generate custom-service |
+| `AxTable` | table | ✅ | ✅ | ✅ | `coc-extension-authoring`, `data-entity-scaffolding`, `event-handler-authoring`, `form-pattern-scaffolding`, `integration-dmf-dualwrite`, `label-translation`, `model-dependency-and-coupling`, `object-extension-authoring`, `review-and-checkpoint-workflow`, `security-hierarchy-trace`, `ssrs-report-authoring`, `system-objects`, `table-scaffolding`, `x++-class-authoring`, `xpp-best-practice-rules`, `xpp-class-and-method-rules`, `xpp-database-queries`, `xpp-statement-and-type-rules` | `L1-table-basic`, `L1-table-tempdb`, `L2-find-methods-basic`, `L2-table-relation-migrated` | generate table |
+| `AxTableExtension` | tableextension | ✅ | ✅ | ✅ | `object-extension-authoring`, `review-and-checkpoint-workflow` | `L2-table-extension` | generate extension |
 | `AxTile` | tile | ✅ | — | — | `analytics-and-er` | — | — |
-| `AxView` | view | — | ✅ | ✅ | — | `L1-view-basic`, `L1-view-computed` | generate view |
-| `AxViewExtension` | viewextension | — | — | — | — | — | — |
-| `AxWorkflowApproval` | workflowapproval | ✅ | — | ✅ | `workflow-authoring` | — | generate workflow |
+| `AxView` | view | ✅ | ✅ | ✅ | `table-scaffolding` | `L1-view-basic`, `L1-view-computed` | generate view |
+| `AxViewExtension` | viewextension | ✅ | ✅ | ✅ | `object-extension-authoring` | `L2-view-extension` | generate extension |
+| `AxWorkflowApproval` | workflowapproval | ✅ | ✅ | ✅ | `workflow-authoring` | `L1-workflow-approval-task` | generate workflow |
 | `AxWorkflowCategory` | workflowcategory | — | — | — | — | — | — |
-| `AxWorkflowTask` | workflowtask | ✅ | — | ✅ | `workflow-authoring` | — | generate workflow |
-| `AxWorkflowTemplate` | workflowtemplate | ✅ | ✅ | ✅ | `workflow-authoring` | `L1-workflow-basic` | generate workflow |
+| `AxWorkflowTask` | workflowtask | ✅ | ✅ | ✅ | `workflow-authoring` | `L1-workflow-approval-task` | generate workflow |
+| `AxWorkflowTemplate` | workflowtemplate | ✅ | ✅ | ✅ | `workflow-authoring` | `L1-workflow-approval-task`, `L1-workflow-basic` | generate workflow |
 
 ## `generate` capabilities
 
@@ -70,32 +70,32 @@ whether it is taught and proven.
 | Subcommand | Emits | K | E | Topics | Cases |
 |---|---|:-:|:-:|---|---|
 | `generate table` | AxTable | ✅ | ✅ | `label-translation`, `performance-and-caching`, `table-scaffolding`, `xpp-best-practice-rules` | `L1-table-basic`, `L1-table-tempdb` |
-| `generate table-relation` | AxTable | ✅ | — | `table-scaffolding` | — |
-| `generate find-methods` | AxTable | ✅ | — | `table-scaffolding` | — |
-| `generate class` | AxClass | — | ✅ | — | `L1-class-basic` |
-| `generate coc` | AxClass | ✅ | ✅ | `coc-extension-authoring`, `object-extension-authoring` | `L2-coc-extension` |
-| `generate form` | AxForm | ✅ | ✅ | `form-pattern-scaffolding` | `L1-form-basic`, `L1-form-details-master`, `L1-form-details-transaction`, `L1-form-dialog`, `L1-form-list-page`, `L1-form-lookup`, `L1-form-simplelist-details`, `L1-form-table-of-contents`, `L1-form-workspace` |
-| `generate datasource-method` | AxForm | — | ✅ | — | `L2-datasource-method-basic` |
-| `generate control-method` | AxForm | — | ✅ | — | `L2-control-method-basic` |
-| `generate form-clone` | AxForm | — | ✅ | — | `L2-form-clone-basic` |
-| `generate simple-list` | deprecated alias | — | — | — | — |
+| `generate table-relation` | AxTable | ✅ | ✅ | `table-scaffolding` | `L2-table-relation-migrated` |
+| `generate find-methods` | AxTable | ✅ | ✅ | `table-scaffolding` | `L2-find-methods-basic` |
+| `generate class` | AxClass | ✅ | ✅ | `x++-class-authoring` | `L1-class-basic` |
+| `generate coc` | AxClass | ✅ | ✅ | `coc-extension-authoring`, `object-extension-authoring`, `x++-class-authoring` | `L2-coc-extension` |
+| `generate form` | AxForm | ✅ | ✅ | `form-pattern-scaffolding`, `forms-and-navigation` | `L1-form-basic`, `L1-form-details-master`, `L1-form-details-transaction`, `L1-form-dialog`, `L1-form-list-page`, `L1-form-lookup`, `L1-form-simplelist-details`, `L1-form-table-of-contents`, `L1-form-workspace` |
+| `generate datasource-method` | AxForm | ✅ | ✅ | `forms-and-navigation` | `L2-datasource-method-basic` |
+| `generate control-method` | AxForm | ✅ | ✅ | `forms-and-navigation` | `L2-control-method-basic` |
+| `generate form-clone` | AxForm | ✅ | ✅ | `forms-and-navigation` | `L2-form-clone-basic` |
+| `generate simple-list` | deprecated alias | ✅ | ✅ | `form-pattern-scaffolding` | `L1-simple-list-alias` |
 | `generate entity` | AxDataEntityView | ✅ | ✅ | `data-entity-scaffolding`, `integration-dmf-dualwrite`, `integration-patterns` | `L2-virtual-entity-basic` |
-| `generate extension` | AxTableExtension, AxFormExtension, AxEdtExtension, AxEnumExtension, AxViewExtension, AxQuerySimpleExtension, AxDataEntityViewExtension, AxSecurityDutyExtension, AxSecurityRoleExtension | ✅ | ✅ | `forms-and-navigation`, `object-extension-authoring`, `xpp-best-practice-rules` | `L2-edt-extension`, `L2-enum-extension`, `L2-form-extension-basic`, `L2-security-duty-extension`, `L2-security-role-extension`, `L2-table-extension` |
-| `generate event-handler` | AxClass | ✅ | ✅ | `event-handler-authoring`, `forms-and-navigation` | `L2-event-handler-basic` |
+| `generate extension` | AxTableExtension, AxFormExtension, AxEdtExtension, AxEnumExtension, AxViewExtension, AxQuerySimpleExtension, AxDataEntityViewExtension, AxSecurityDutyExtension, AxSecurityRoleExtension | ✅ | ✅ | `forms-and-navigation`, `object-extension-authoring`, `security-modeling`, `xpp-best-practice-rules` | `L2-data-entity-extension`, `L2-edt-extension`, `L2-enum-extension`, `L2-form-extension-basic`, `L2-query-extension`, `L2-security-duty-extension`, `L2-security-role-extension`, `L2-table-extension`, `L2-view-extension` |
+| `generate event-handler` | AxClass | ✅ | ✅ | `event-handler-authoring`, `forms-and-navigation`, `x++-class-authoring` | `L2-event-handler-basic` |
 | `generate privilege` | AxSecurityPrivilege | ✅ | ✅ | `security-hierarchy-trace`, `security-modeling` | `L1-privilege-basic`, `L1-privilege-data-entity` |
 | `generate duty` | AxSecurityDuty | ✅ | ✅ | `security-hierarchy-trace`, `security-modeling` | `L1-duty-basic` |
 | `generate role` | AxSecurityRole | ✅ | ✅ | `security-hierarchy-trace`, `security-modeling` | `L1-role-basic` |
 | `generate report` | AxReport, AxTable, AxClass, AxMenuItemOutput | ✅ | ✅ | `ssrs-report-authoring` | `L1-report-basic`, `L1-report-parameters` |
-| `generate report-extension` | AxClass | ✅ | — | `ssrs-report-authoring` | — |
+| `generate report-extension` | AxClass | ✅ | ✅ | `ssrs-report-authoring` | `L2-report-extension-dataset` |
 | `generate sysoperation` | AxClass | ✅ | ✅ | `sysoperation-batch-patterns`, `x++-class-authoring` | `L1-sysoperation-basic` |
 | `generate number-sequence` | AxClass, AxEdt | ✅ | ✅ | `number-sequence-patterns`, `table-scaffolding` | `L2-numberseq-basic` |
-| `generate workflow` | AxWorkflowTemplate, AxWorkflowApproval, AxWorkflowTask, AxClass | ✅ | ✅ | `workflow-authoring` | `L1-workflow-basic` |
+| `generate workflow` | AxWorkflowTemplate, AxWorkflowApproval, AxWorkflowTask, AxClass | ✅ | ✅ | `workflow-authoring` | `L1-workflow-approval-task`, `L1-workflow-basic` |
 | `generate menu-item` | AxMenuItemDisplay, AxMenuItemAction, AxMenuItemOutput | ✅ | ✅ | `form-pattern-scaffolding`, `forms-and-navigation` | `L1-menu-item-action`, `L1-menu-item-basic`, `L1-menu-item-output` |
 | `generate edt` | AxEdt | ✅ | ✅ | `object-extension-authoring`, `xpp-best-practice-rules` | `L0-edt-basic`, `L0-edt-extends` |
 | `generate enum` | AxEnum | ✅ | ✅ | `object-extension-authoring` | `L0-enum-basic`, `L0-enum-non-extensible` |
 | `generate query` | AxQuery | ✅ | ✅ | `object-extension-authoring`, `table-scaffolding`, `xpp-database-queries` | `L1-query-basic`, `L1-query-join` |
-| `generate view` | AxView | — | ✅ | — | `L1-view-basic`, `L1-view-computed` |
-| `generate map` | AxMap | — | ✅ | — | `L1-map-basic`, `L1-map-multi-table` |
+| `generate view` | AxView | ✅ | ✅ | `table-scaffolding` | `L1-view-basic`, `L1-view-computed` |
+| `generate map` | AxMap | ✅ | ✅ | `table-scaffolding` | `L1-map-basic`, `L1-map-multi-table` |
 | `generate business-event` | AxClass | ✅ | ✅ | `business-events-authoring`, `integration-patterns` | `L1-business-event-basic` |
 | `generate custom-service` | AxService, AxServiceGroup, AxClass | ✅ | ✅ | `custom-service-authoring`, `integration-patterns` | `L1-custom-service-basic` |
 | `generate migration-script` | AxClass | ✅ | ✅ | `sysoperation-batch-patterns` | `L1-migration-script-basic` |
@@ -105,25 +105,4 @@ whether it is taught and proven.
 
 ## Open gaps
 
-Leaves the tool builds but knowledge or evals do not yet cover. Families the tool
-cannot build at all are omitted — they are a generation gap, not a coverage gap.
-
-- **class** (capability) — no topic names it
-- **control-method** (capability) — no topic names it
-- **datasource-method** (capability) — no topic names it
-- **find-methods** (capability) — no case with a reviewed golden
-- **form-clone** (capability) — no topic names it
-- **map** (capability) — no topic names it
-- **report-extension** (capability) — no case with a reviewed golden
-- **simple-list** (capability) — no topic names it; no case with a reviewed golden
-- **table-relation** (capability) — no case with a reviewed golden
-- **view** (capability) — no topic names it
-- **AxEdtExtension** (family) — no topic names it
-- **AxEnumExtension** (family) — no topic names it
-- **AxMap** (family) — no topic names it
-- **AxSecurityDutyExtension** (family) — no topic names it
-- **AxSecurityRoleExtension** (family) — no topic names it
-- **AxServiceGroup** (family) — no case with a reviewed golden
-- **AxView** (family) — no topic names it
-- **AxWorkflowApproval** (family) — no case with a reviewed golden
-- **AxWorkflowTask** (family) — no case with a reviewed golden
+None: every leaf the tool can build is both taught and proven.

--- a/eval/README.md
+++ b/eval/README.md
@@ -44,7 +44,16 @@ This builds a throwaway temp SQLite index (plus fixture data from
 scores the produced XML against `eval/goldens/<id>/` — `validate xpp` and
 `validate references` are called directly against the Core APIs
 (`D365FO.Core.Validation.XppValidator` / `ReferenceResolver`), not via a
-subprocess. `--write` appends a record to `eval/corpus/runs/`.
+subprocess. The artifacts the command writes *beside* its main one are scored
+too, against `eval/goldens/<id>/_companions/`: one the golden names and the run
+did not produce is missing, one the run produced that no golden names is extra.
+`--write` appends a record to `eval/corpus/runs/`.
+
+A case that AUGMENTS an existing artifact rather than producing one — `generate
+table-relation`, `generate find-methods`, both of which refuse `--out` — names an
+`apply_to_seed` instead. The replay copies that file out of `eval/seeds/` into its
+work directory as the run's output file and points `--apply-to` at it, so the
+golden is the merged artifact and the seed itself is never touched.
 
 Agent-driven run (what actually tests "can an agent use this tool
 correctly" — the loop's real purpose): the **eval-runner** agent
@@ -87,7 +96,7 @@ returns `EVAL_BUILD_INVOCATION` and writes **no** verdicts — an argument mista
 must never be recorded as a broken golden. `EvalScoreCard.BuildClean` is `null`
 wherever no compiler ran; it is never `false` by default.
 
-Current baseline: **51 of 51 goldens compile clean**, with **zero unattributed
+Current baseline: **60 of 60 goldens compile clean**, with **zero unattributed
 diagnostics** — every complaint the compiler makes is blamed on the case that
 produced the object it names.
 

--- a/eval/cases/L1-custom-service-basic.json
+++ b/eval/cases/L1-custom-service-basic.json
@@ -4,7 +4,7 @@
   "tier": 1,
   "instruction": "Create a custom AOT service named ConFmVehicleQueryService with a single operation 'lookup' returning str. Use only the d365fo CLI (search/get/generate/validate) — do not hand-write XML.",
   "canonical_args": ["generate", "custom-service", "ConFmVehicleQueryService", "--operation", "lookup:str"],
-  "target_artifact_types": ["AxService"],
+  "target_artifact_types": ["AxService", "AxServiceGroup", "AxClass"],
   "golden_path": "L1-custom-service-basic",
   "tags": ["custom-service", "metadata"],
   "ignore": [],

--- a/eval/cases/L1-simple-list-alias.json
+++ b/eval/cases/L1-simple-list-alias.json
@@ -1,0 +1,25 @@
+{
+  "id": "L1-simple-list-alias",
+  "title": "The simple-list alias produces the SimpleList form pattern",
+  "tier": 1,
+  "instruction": "Create a SimpleList form named ConFmVehicleSimpleList over the FmVehicle table using the simple-list command. Confirm the table exists with `d365fo get table FmVehicle` first. Use only the d365fo CLI — do not hand-write XML.",
+  "canonical_args": [
+    "generate",
+    "simple-list",
+    "ConFmVehicleSimpleList",
+    "--table",
+    "FmVehicle"
+  ],
+  "target_artifact_types": [
+    "AxForm"
+  ],
+  "golden_path": "L1-simple-list-alias",
+  "tags": [
+    "simple-list",
+    "form",
+    "deprecated-alias"
+  ],
+  "ignore": [],
+  "requires_fixture_index": true,
+  "golden_pending": false
+}

--- a/eval/cases/L1-workflow-approval-task.json
+++ b/eval/cases/L1-workflow-approval-task.json
@@ -1,0 +1,33 @@
+{
+  "id": "L1-workflow-approval-task",
+  "title": "Workflow type with its own approval and task elements",
+  "tier": 1,
+  "instruction": "Create an approval workflow type named ConFmVehicleServiceWorkflow driven by the FmVehicle table in the existing FixedAssets workflow category, and give it its own approval element ConFmVehicleServiceApproval and task element ConFmVehicleServiceTask. Confirm the table with `d365fo get table FmVehicle` before generating. AxWorkflowTemplate.Category is required — a workflow type without one does not build, and the approval and task elements have to be referenced by the template, not merely created. Use only the d365fo CLI — do not hand-write XML.",
+  "canonical_args": [
+    "generate",
+    "workflow",
+    "ConFmVehicleServiceWorkflow",
+    "--table",
+    "FmVehicle",
+    "--category",
+    "FixedAssets",
+    "--approval-name",
+    "ConFmVehicleServiceApproval",
+    "--task-name",
+    "ConFmVehicleServiceTask"
+  ],
+  "target_artifact_types": [
+    "AxWorkflowTemplate",
+    "AxWorkflowApproval",
+    "AxWorkflowTask"
+  ],
+  "golden_path": "L1-workflow-approval-task",
+  "tags": [
+    "workflow",
+    "metadata",
+    "companions"
+  ],
+  "ignore": [],
+  "requires_fixture_index": true,
+  "golden_pending": false
+}

--- a/eval/cases/L2-data-entity-extension.json
+++ b/eval/cases/L2-data-entity-extension.json
@@ -1,0 +1,26 @@
+{
+  "id": "L2-data-entity-extension",
+  "title": "AxDataEntityViewExtension over a shipped data entity",
+  "tier": 2,
+  "instruction": "A field this model added to the customer master has to be exposed through the standard CustCustomerV3Entity data entity, which must not be over-layered. Scaffold the data entity extension with the ConFleet suffix. Use only the d365fo CLI — do not hand-write the XML.",
+  "canonical_args": [
+    "generate",
+    "extension",
+    "DataEntityView",
+    "CustCustomerV3Entity",
+    "--suffix",
+    "ConFleet"
+  ],
+  "target_artifact_types": [
+    "AxDataEntityViewExtension"
+  ],
+  "golden_path": "L2-data-entity-extension",
+  "tags": [
+    "extension",
+    "data-entity",
+    "metadata"
+  ],
+  "ignore": [],
+  "requires_fixture_index": false,
+  "golden_pending": false
+}

--- a/eval/cases/L2-find-methods-basic.json
+++ b/eval/cases/L2-find-methods-basic.json
@@ -1,0 +1,24 @@
+{
+  "id": "L2-find-methods-basic",
+  "title": "Standard find()/exists()/findRecId() keyed on the table's alternate key",
+  "tier": 2,
+  "instruction": "Add the standard static find(), exists() and findRecId() methods to the FmServiceOrder table, keyed on its alternate-key index, and merge them into the table's source code. Do not invent the key — read it off the table with `d365fo get table FmServiceOrder`. Use only the d365fo CLI — do not hand-write the X++.",
+  "canonical_args": [
+    "generate",
+    "find-methods",
+    "FmServiceOrder"
+  ],
+  "target_artifact_types": [
+    "AxTable"
+  ],
+  "golden_path": "L2-find-methods-basic",
+  "tags": [
+    "find-methods",
+    "xpp",
+    "apply-to"
+  ],
+  "ignore": [],
+  "requires_fixture_index": true,
+  "apply_to_seed": "FmServiceOrder.xml",
+  "golden_pending": false
+}

--- a/eval/cases/L2-query-extension.json
+++ b/eval/cases/L2-query-extension.json
@@ -1,0 +1,26 @@
+{
+  "id": "L2-query-extension",
+  "title": "AxQuerySimpleExtension over an existing query",
+  "tier": 2,
+  "instruction": "Extend the FmVehicleQuery query with a range this model needs, without over-layering it. Scaffold the query extension with the ConFleet suffix. Note that a query extension's root element and AOT folder are both AxQuerySimpleExtension — there is no AxQueryExtension type. Use only the d365fo CLI — do not hand-write the XML.",
+  "canonical_args": [
+    "generate",
+    "extension",
+    "Query",
+    "FmVehicleQuery",
+    "--suffix",
+    "ConFleet"
+  ],
+  "target_artifact_types": [
+    "AxQuerySimpleExtension"
+  ],
+  "golden_path": "L2-query-extension",
+  "tags": [
+    "extension",
+    "query",
+    "metadata"
+  ],
+  "ignore": [],
+  "requires_fixture_index": true,
+  "golden_pending": false
+}

--- a/eval/cases/L2-report-extension-dataset.json
+++ b/eval/cases/L2-report-extension-dataset.json
@@ -1,0 +1,31 @@
+{
+  "id": "L2-report-extension-dataset",
+  "title": "Dataset post-handler extending a shipped report's data provider",
+  "tier": 2,
+  "instruction": "A table extension has added fields to the AssetBarCodeTmp temp table, and the shipped AssetBarCodeDP data provider has to populate them without the report being over-layered. Generate the dataset extension for it. Read the dataset accessor off the DP with `d365fo get class AssetBarCodeDP` rather than deriving it from the temp-table name: the platform ships it misspelled as geAssetBarCodeTmp, and a handler that calls the name you would expect does not compile. Use only the d365fo CLI — do not hand-write the class.",
+  "canonical_args": [
+    "generate",
+    "report-extension",
+    "dataset",
+    "--dp",
+    "AssetBarCodeDP",
+    "--tmp-table",
+    "AssetBarCodeTmp",
+    "--dataset-accessor",
+    "geAssetBarCodeTmp",
+    "--suffix",
+    "ConFleet"
+  ],
+  "target_artifact_types": [
+    "AxClass"
+  ],
+  "golden_path": "L2-report-extension-dataset",
+  "tags": [
+    "report-extension",
+    "report",
+    "xpp"
+  ],
+  "ignore": [],
+  "requires_fixture_index": false,
+  "golden_pending": false
+}

--- a/eval/cases/L2-table-relation-migrated.json
+++ b/eval/cases/L2-table-relation-migrated.json
@@ -1,0 +1,26 @@
+{
+  "id": "L2-table-relation-migrated",
+  "title": "Explicit AxTableRelation derived from an un-migrated EDT reference",
+  "tier": 2,
+  "instruction": "The FmServiceOrder table has a VIN field whose EDT still carries the reference to FmVehicle instead of an explicit table relation, which D365FO rejects as BPErrorEDTNotMigrated. Derive the relation and merge it into the table. Use `d365fo get table FmServiceOrder` and `d365fo get edt VIN` first to confirm what the reference actually points at. Use only the d365fo CLI — do not hand-write the relation XML.",
+  "canonical_args": [
+    "generate",
+    "table-relation",
+    "FmServiceOrder",
+    "--field",
+    "VIN"
+  ],
+  "target_artifact_types": [
+    "AxTable"
+  ],
+  "golden_path": "L2-table-relation-migrated",
+  "tags": [
+    "table-relation",
+    "metadata",
+    "apply-to"
+  ],
+  "ignore": [],
+  "requires_fixture_index": true,
+  "apply_to_seed": "FmServiceOrder.xml",
+  "golden_pending": false
+}

--- a/eval/cases/L2-view-extension.json
+++ b/eval/cases/L2-view-extension.json
@@ -1,0 +1,26 @@
+{
+  "id": "L2-view-extension",
+  "title": "AxViewExtension over a shipped view",
+  "tier": 2,
+  "instruction": "The standard CustAccountName view has to carry an extra field for this model without being over-layered. Scaffold the view extension for it with the ConFleet suffix. Confirm what already extends it with `d365fo find extensions CustAccountName` before scaffolding, so a second extension with the same suffix is not created. Use only the d365fo CLI — do not hand-write the XML.",
+  "canonical_args": [
+    "generate",
+    "extension",
+    "View",
+    "CustAccountName",
+    "--suffix",
+    "ConFleet"
+  ],
+  "target_artifact_types": [
+    "AxViewExtension"
+  ],
+  "golden_path": "L2-view-extension",
+  "tags": [
+    "extension",
+    "view",
+    "metadata"
+  ],
+  "ignore": [],
+  "requires_fixture_index": false,
+  "golden_pending": false
+}

--- a/eval/cases/schema.json
+++ b/eval/cases/schema.json
@@ -25,7 +25,7 @@
     "canonical_args": {
       "type": ["array", "null"],
       "items": { "type": "string" },
-      "description": "Optional. Full `d365fo` args (e.g. [\"generate\", \"edt\", \"Name\", \"--base-type\", \"String\"]) for the deterministic `eval run` replay path. Must NOT include --out/--overwrite/--install-to/--output — `eval run` supplies those (the last forced to json, so the replay never touches Spectre's AnsiConsole). Omit for instruction-only cases (agent-driven via `eval score` only)."
+      "description": "Optional. Full `d365fo` args (e.g. [\"generate\", \"edt\", \"Name\", \"--base-type\", \"String\"]) for the deterministic `eval run` replay path. Must NOT include --out/--overwrite/--install-to/--output/--apply-to — `eval run` supplies those (the last forced to json, so the replay never touches Spectre's AnsiConsole). Omit for instruction-only cases (agent-driven via `eval score` only)."
     },
     "target_artifact_types": {
       "type": "array",
@@ -47,6 +47,10 @@
       "type": "boolean",
       "default": false,
       "description": "True when the case extends/references an object from tests/Samples/MiniAot (e.g. a CoC wrapper). `eval run` builds a disposable temp index from that fixture before replaying."
+    },
+    "apply_to_seed": {
+      "type": "string",
+      "description": "Bare file name under eval/seeds/. For commands that AUGMENT an existing artifact (generate table-relation, generate find-methods) and therefore refuse --out: `eval run` copies the seed into its work directory as the run's output file and passes --apply-to at it, so the golden is the merged artifact. A seed named after a MiniAot AxTable must stay byte-identical to it."
     },
     "golden_pending": {
       "type": "boolean",

--- a/eval/corpus/runs/20260902T062209693Z__L0-edt-basic__a60c56867767492da9c77cadeec6aefc.json
+++ b/eval/corpus/runs/20260902T062209693Z__L0-edt-basic__a60c56867767492da9c77cadeec6aefc.json
@@ -1,0 +1,21 @@
+{
+  "runId": "20260902T062209693Z__L0-edt-basic__a60c56867767492da9c77cadeec6aefc",
+  "caseId": "L0-edt-basic",
+  "tier": 0,
+  "timestampUtc": "2026-09-02T06:22:09.6955033+00:00",
+  "source": "build-oracle",
+  "score": {
+    "xppErrors": 0,
+    "referenceErrors": 0,
+    "goldenMatch": true,
+    "goldenDiff": {
+      "missing": [],
+      "extra": [],
+      "changed": [],
+      "isMatch": true
+    },
+    "buildClean": true,
+    "buildErrors": 0,
+    "runtimeFailures": 0
+  }
+}

--- a/eval/corpus/runs/20260902T062209716Z__L0-edt-extends__d0f36f3569a94c529b9aa6cc0093a3cb.json
+++ b/eval/corpus/runs/20260902T062209716Z__L0-edt-extends__d0f36f3569a94c529b9aa6cc0093a3cb.json
@@ -1,0 +1,21 @@
+{
+  "runId": "20260902T062209716Z__L0-edt-extends__d0f36f3569a94c529b9aa6cc0093a3cb",
+  "caseId": "L0-edt-extends",
+  "tier": 0,
+  "timestampUtc": "2026-09-02T06:22:09.7161429+00:00",
+  "source": "build-oracle",
+  "score": {
+    "xppErrors": 0,
+    "referenceErrors": 0,
+    "goldenMatch": true,
+    "goldenDiff": {
+      "missing": [],
+      "extra": [],
+      "changed": [],
+      "isMatch": true
+    },
+    "buildClean": true,
+    "buildErrors": 0,
+    "runtimeFailures": 0
+  }
+}

--- a/eval/corpus/runs/20260902T062209716Z__L0-enum-basic__3d5665c865ab4d55adf87d808c2f6d40.json
+++ b/eval/corpus/runs/20260902T062209716Z__L0-enum-basic__3d5665c865ab4d55adf87d808c2f6d40.json
@@ -1,0 +1,21 @@
+{
+  "runId": "20260902T062209716Z__L0-enum-basic__3d5665c865ab4d55adf87d808c2f6d40",
+  "caseId": "L0-enum-basic",
+  "tier": 0,
+  "timestampUtc": "2026-09-02T06:22:09.7167688+00:00",
+  "source": "build-oracle",
+  "score": {
+    "xppErrors": 0,
+    "referenceErrors": 0,
+    "goldenMatch": true,
+    "goldenDiff": {
+      "missing": [],
+      "extra": [],
+      "changed": [],
+      "isMatch": true
+    },
+    "buildClean": true,
+    "buildErrors": 0,
+    "runtimeFailures": 0
+  }
+}

--- a/eval/corpus/runs/20260902T062209717Z__L0-enum-non-extensible__ec83d334d3bd443487030bdc0d0e6343.json
+++ b/eval/corpus/runs/20260902T062209717Z__L0-enum-non-extensible__ec83d334d3bd443487030bdc0d0e6343.json
@@ -1,0 +1,21 @@
+{
+  "runId": "20260902T062209717Z__L0-enum-non-extensible__ec83d334d3bd443487030bdc0d0e6343",
+  "caseId": "L0-enum-non-extensible",
+  "tier": 0,
+  "timestampUtc": "2026-09-02T06:22:09.7172365+00:00",
+  "source": "build-oracle",
+  "score": {
+    "xppErrors": 0,
+    "referenceErrors": 0,
+    "goldenMatch": true,
+    "goldenDiff": {
+      "missing": [],
+      "extra": [],
+      "changed": [],
+      "isMatch": true
+    },
+    "buildClean": true,
+    "buildErrors": 0,
+    "runtimeFailures": 0
+  }
+}

--- a/eval/corpus/runs/20260902T062209717Z__L1-business-event-basic__aa78aa1fbe214b9eae269652621f957d.json
+++ b/eval/corpus/runs/20260902T062209717Z__L1-business-event-basic__aa78aa1fbe214b9eae269652621f957d.json
@@ -1,0 +1,21 @@
+{
+  "runId": "20260902T062209717Z__L1-business-event-basic__aa78aa1fbe214b9eae269652621f957d",
+  "caseId": "L1-business-event-basic",
+  "tier": 1,
+  "timestampUtc": "2026-09-02T06:22:09.7177105+00:00",
+  "source": "build-oracle",
+  "score": {
+    "xppErrors": 0,
+    "referenceErrors": 0,
+    "goldenMatch": true,
+    "goldenDiff": {
+      "missing": [],
+      "extra": [],
+      "changed": [],
+      "isMatch": true
+    },
+    "buildClean": true,
+    "buildErrors": 0,
+    "runtimeFailures": 0
+  }
+}

--- a/eval/corpus/runs/20260902T062209718Z__L1-class-basic__c18acc74ebe142c5a38deec971517c15.json
+++ b/eval/corpus/runs/20260902T062209718Z__L1-class-basic__c18acc74ebe142c5a38deec971517c15.json
@@ -1,0 +1,21 @@
+{
+  "runId": "20260902T062209718Z__L1-class-basic__c18acc74ebe142c5a38deec971517c15",
+  "caseId": "L1-class-basic",
+  "tier": 1,
+  "timestampUtc": "2026-09-02T06:22:09.7182784+00:00",
+  "source": "build-oracle",
+  "score": {
+    "xppErrors": 0,
+    "referenceErrors": 0,
+    "goldenMatch": true,
+    "goldenDiff": {
+      "missing": [],
+      "extra": [],
+      "changed": [],
+      "isMatch": true
+    },
+    "buildClean": true,
+    "buildErrors": 0,
+    "runtimeFailures": 0
+  }
+}

--- a/eval/corpus/runs/20260902T062209718Z__L1-custom-service-basic__8d1e94eb5ad84680923d4f321d5a2784.json
+++ b/eval/corpus/runs/20260902T062209718Z__L1-custom-service-basic__8d1e94eb5ad84680923d4f321d5a2784.json
@@ -1,0 +1,21 @@
+{
+  "runId": "20260902T062209718Z__L1-custom-service-basic__8d1e94eb5ad84680923d4f321d5a2784",
+  "caseId": "L1-custom-service-basic",
+  "tier": 1,
+  "timestampUtc": "2026-09-02T06:22:09.7187765+00:00",
+  "source": "build-oracle",
+  "score": {
+    "xppErrors": 0,
+    "referenceErrors": 0,
+    "goldenMatch": true,
+    "goldenDiff": {
+      "missing": [],
+      "extra": [],
+      "changed": [],
+      "isMatch": true
+    },
+    "buildClean": true,
+    "buildErrors": 0,
+    "runtimeFailures": 0
+  }
+}

--- a/eval/corpus/runs/20260902T062209719Z__L1-duty-basic__6005ebdb5ac54c72bbc5a40bb65d5511.json
+++ b/eval/corpus/runs/20260902T062209719Z__L1-duty-basic__6005ebdb5ac54c72bbc5a40bb65d5511.json
@@ -1,0 +1,21 @@
+{
+  "runId": "20260902T062209719Z__L1-duty-basic__6005ebdb5ac54c72bbc5a40bb65d5511",
+  "caseId": "L1-duty-basic",
+  "tier": 1,
+  "timestampUtc": "2026-09-02T06:22:09.7192258+00:00",
+  "source": "build-oracle",
+  "score": {
+    "xppErrors": 0,
+    "referenceErrors": 0,
+    "goldenMatch": true,
+    "goldenDiff": {
+      "missing": [],
+      "extra": [],
+      "changed": [],
+      "isMatch": true
+    },
+    "buildClean": true,
+    "buildErrors": 0,
+    "runtimeFailures": 0
+  }
+}

--- a/eval/corpus/runs/20260902T062209719Z__L1-form-basic__1bc488109fd549e291e32bb2d51c9262.json
+++ b/eval/corpus/runs/20260902T062209719Z__L1-form-basic__1bc488109fd549e291e32bb2d51c9262.json
@@ -1,0 +1,21 @@
+{
+  "runId": "20260902T062209719Z__L1-form-basic__1bc488109fd549e291e32bb2d51c9262",
+  "caseId": "L1-form-basic",
+  "tier": 1,
+  "timestampUtc": "2026-09-02T06:22:09.7197084+00:00",
+  "source": "build-oracle",
+  "score": {
+    "xppErrors": 0,
+    "referenceErrors": 0,
+    "goldenMatch": true,
+    "goldenDiff": {
+      "missing": [],
+      "extra": [],
+      "changed": [],
+      "isMatch": true
+    },
+    "buildClean": true,
+    "buildErrors": 0,
+    "runtimeFailures": 0
+  }
+}

--- a/eval/corpus/runs/20260902T062209720Z__L1-form-details-master__7de897d76fba460484ee543993aee638.json
+++ b/eval/corpus/runs/20260902T062209720Z__L1-form-details-master__7de897d76fba460484ee543993aee638.json
@@ -1,0 +1,21 @@
+{
+  "runId": "20260902T062209720Z__L1-form-details-master__7de897d76fba460484ee543993aee638",
+  "caseId": "L1-form-details-master",
+  "tier": 1,
+  "timestampUtc": "2026-09-02T06:22:09.7201542+00:00",
+  "source": "build-oracle",
+  "score": {
+    "xppErrors": 0,
+    "referenceErrors": 0,
+    "goldenMatch": true,
+    "goldenDiff": {
+      "missing": [],
+      "extra": [],
+      "changed": [],
+      "isMatch": true
+    },
+    "buildClean": true,
+    "buildErrors": 0,
+    "runtimeFailures": 0
+  }
+}

--- a/eval/corpus/runs/20260902T062209720Z__L1-form-details-transaction__0021b6d0ef8e41c49c20a391d9c88573.json
+++ b/eval/corpus/runs/20260902T062209720Z__L1-form-details-transaction__0021b6d0ef8e41c49c20a391d9c88573.json
@@ -1,0 +1,21 @@
+{
+  "runId": "20260902T062209720Z__L1-form-details-transaction__0021b6d0ef8e41c49c20a391d9c88573",
+  "caseId": "L1-form-details-transaction",
+  "tier": 1,
+  "timestampUtc": "2026-09-02T06:22:09.7206182+00:00",
+  "source": "build-oracle",
+  "score": {
+    "xppErrors": 0,
+    "referenceErrors": 0,
+    "goldenMatch": true,
+    "goldenDiff": {
+      "missing": [],
+      "extra": [],
+      "changed": [],
+      "isMatch": true
+    },
+    "buildClean": true,
+    "buildErrors": 0,
+    "runtimeFailures": 0
+  }
+}

--- a/eval/corpus/runs/20260902T062209721Z__L1-form-dialog__e41c7297b48f4812ad7529c3478e2f65.json
+++ b/eval/corpus/runs/20260902T062209721Z__L1-form-dialog__e41c7297b48f4812ad7529c3478e2f65.json
@@ -1,0 +1,21 @@
+{
+  "runId": "20260902T062209721Z__L1-form-dialog__e41c7297b48f4812ad7529c3478e2f65",
+  "caseId": "L1-form-dialog",
+  "tier": 1,
+  "timestampUtc": "2026-09-02T06:22:09.7211515+00:00",
+  "source": "build-oracle",
+  "score": {
+    "xppErrors": 0,
+    "referenceErrors": 0,
+    "goldenMatch": true,
+    "goldenDiff": {
+      "missing": [],
+      "extra": [],
+      "changed": [],
+      "isMatch": true
+    },
+    "buildClean": true,
+    "buildErrors": 0,
+    "runtimeFailures": 0
+  }
+}

--- a/eval/corpus/runs/20260902T062209721Z__L1-form-list-page__18de82d4b13e498e9ac5ebc1e5790968.json
+++ b/eval/corpus/runs/20260902T062209721Z__L1-form-list-page__18de82d4b13e498e9ac5ebc1e5790968.json
@@ -1,0 +1,21 @@
+{
+  "runId": "20260902T062209721Z__L1-form-list-page__18de82d4b13e498e9ac5ebc1e5790968",
+  "caseId": "L1-form-list-page",
+  "tier": 1,
+  "timestampUtc": "2026-09-02T06:22:09.7216698+00:00",
+  "source": "build-oracle",
+  "score": {
+    "xppErrors": 0,
+    "referenceErrors": 0,
+    "goldenMatch": true,
+    "goldenDiff": {
+      "missing": [],
+      "extra": [],
+      "changed": [],
+      "isMatch": true
+    },
+    "buildClean": true,
+    "buildErrors": 0,
+    "runtimeFailures": 0
+  }
+}

--- a/eval/corpus/runs/20260902T062209722Z__L1-form-lookup__11896c1875dc407baad1fc4e5d6a422b.json
+++ b/eval/corpus/runs/20260902T062209722Z__L1-form-lookup__11896c1875dc407baad1fc4e5d6a422b.json
@@ -1,0 +1,21 @@
+{
+  "runId": "20260902T062209722Z__L1-form-lookup__11896c1875dc407baad1fc4e5d6a422b",
+  "caseId": "L1-form-lookup",
+  "tier": 1,
+  "timestampUtc": "2026-09-02T06:22:09.7223297+00:00",
+  "source": "build-oracle",
+  "score": {
+    "xppErrors": 0,
+    "referenceErrors": 0,
+    "goldenMatch": true,
+    "goldenDiff": {
+      "missing": [],
+      "extra": [],
+      "changed": [],
+      "isMatch": true
+    },
+    "buildClean": true,
+    "buildErrors": 0,
+    "runtimeFailures": 0
+  }
+}

--- a/eval/corpus/runs/20260902T062209722Z__L1-form-simplelist-details__18108972ecd441638eb25c9803b0d6a5.json
+++ b/eval/corpus/runs/20260902T062209722Z__L1-form-simplelist-details__18108972ecd441638eb25c9803b0d6a5.json
@@ -1,0 +1,21 @@
+{
+  "runId": "20260902T062209722Z__L1-form-simplelist-details__18108972ecd441638eb25c9803b0d6a5",
+  "caseId": "L1-form-simplelist-details",
+  "tier": 1,
+  "timestampUtc": "2026-09-02T06:22:09.722801+00:00",
+  "source": "build-oracle",
+  "score": {
+    "xppErrors": 0,
+    "referenceErrors": 0,
+    "goldenMatch": true,
+    "goldenDiff": {
+      "missing": [],
+      "extra": [],
+      "changed": [],
+      "isMatch": true
+    },
+    "buildClean": true,
+    "buildErrors": 0,
+    "runtimeFailures": 0
+  }
+}

--- a/eval/corpus/runs/20260902T062209723Z__L1-form-table-of-contents__650c88d997d6416f8c3f8055a47f7124.json
+++ b/eval/corpus/runs/20260902T062209723Z__L1-form-table-of-contents__650c88d997d6416f8c3f8055a47f7124.json
@@ -1,0 +1,21 @@
+{
+  "runId": "20260902T062209723Z__L1-form-table-of-contents__650c88d997d6416f8c3f8055a47f7124",
+  "caseId": "L1-form-table-of-contents",
+  "tier": 1,
+  "timestampUtc": "2026-09-02T06:22:09.7232458+00:00",
+  "source": "build-oracle",
+  "score": {
+    "xppErrors": 0,
+    "referenceErrors": 0,
+    "goldenMatch": true,
+    "goldenDiff": {
+      "missing": [],
+      "extra": [],
+      "changed": [],
+      "isMatch": true
+    },
+    "buildClean": true,
+    "buildErrors": 0,
+    "runtimeFailures": 0
+  }
+}

--- a/eval/corpus/runs/20260902T062209723Z__L1-form-workspace__7a9c15a5e72144c5900a0274a7374864.json
+++ b/eval/corpus/runs/20260902T062209723Z__L1-form-workspace__7a9c15a5e72144c5900a0274a7374864.json
@@ -1,0 +1,21 @@
+{
+  "runId": "20260902T062209723Z__L1-form-workspace__7a9c15a5e72144c5900a0274a7374864",
+  "caseId": "L1-form-workspace",
+  "tier": 1,
+  "timestampUtc": "2026-09-02T06:22:09.7236898+00:00",
+  "source": "build-oracle",
+  "score": {
+    "xppErrors": 0,
+    "referenceErrors": 0,
+    "goldenMatch": true,
+    "goldenDiff": {
+      "missing": [],
+      "extra": [],
+      "changed": [],
+      "isMatch": true
+    },
+    "buildClean": true,
+    "buildErrors": 0,
+    "runtimeFailures": 0
+  }
+}

--- a/eval/corpus/runs/20260902T062209724Z__L1-map-basic__dac8269fac2041e6b8003fca6d6f62d6.json
+++ b/eval/corpus/runs/20260902T062209724Z__L1-map-basic__dac8269fac2041e6b8003fca6d6f62d6.json
@@ -1,0 +1,21 @@
+{
+  "runId": "20260902T062209724Z__L1-map-basic__dac8269fac2041e6b8003fca6d6f62d6",
+  "caseId": "L1-map-basic",
+  "tier": 1,
+  "timestampUtc": "2026-09-02T06:22:09.7241582+00:00",
+  "source": "build-oracle",
+  "score": {
+    "xppErrors": 0,
+    "referenceErrors": 0,
+    "goldenMatch": true,
+    "goldenDiff": {
+      "missing": [],
+      "extra": [],
+      "changed": [],
+      "isMatch": true
+    },
+    "buildClean": true,
+    "buildErrors": 0,
+    "runtimeFailures": 0
+  }
+}

--- a/eval/corpus/runs/20260902T062209724Z__L1-map-multi-table__24c94548ab0c4feead0c01493149d1c1.json
+++ b/eval/corpus/runs/20260902T062209724Z__L1-map-multi-table__24c94548ab0c4feead0c01493149d1c1.json
@@ -1,0 +1,21 @@
+{
+  "runId": "20260902T062209724Z__L1-map-multi-table__24c94548ab0c4feead0c01493149d1c1",
+  "caseId": "L1-map-multi-table",
+  "tier": 1,
+  "timestampUtc": "2026-09-02T06:22:09.724757+00:00",
+  "source": "build-oracle",
+  "score": {
+    "xppErrors": 0,
+    "referenceErrors": 0,
+    "goldenMatch": true,
+    "goldenDiff": {
+      "missing": [],
+      "extra": [],
+      "changed": [],
+      "isMatch": true
+    },
+    "buildClean": true,
+    "buildErrors": 0,
+    "runtimeFailures": 0
+  }
+}

--- a/eval/corpus/runs/20260902T062209725Z__L1-menu-item-action__92b00179227d4adfbaeb5d11a6ac8ead.json
+++ b/eval/corpus/runs/20260902T062209725Z__L1-menu-item-action__92b00179227d4adfbaeb5d11a6ac8ead.json
@@ -1,0 +1,21 @@
+{
+  "runId": "20260902T062209725Z__L1-menu-item-action__92b00179227d4adfbaeb5d11a6ac8ead",
+  "caseId": "L1-menu-item-action",
+  "tier": 1,
+  "timestampUtc": "2026-09-02T06:22:09.7252153+00:00",
+  "source": "build-oracle",
+  "score": {
+    "xppErrors": 0,
+    "referenceErrors": 0,
+    "goldenMatch": true,
+    "goldenDiff": {
+      "missing": [],
+      "extra": [],
+      "changed": [],
+      "isMatch": true
+    },
+    "buildClean": true,
+    "buildErrors": 0,
+    "runtimeFailures": 0
+  }
+}

--- a/eval/corpus/runs/20260902T062209725Z__L1-menu-item-basic__1c4714609f2b4e6c9fdc56ca00ee7c52.json
+++ b/eval/corpus/runs/20260902T062209725Z__L1-menu-item-basic__1c4714609f2b4e6c9fdc56ca00ee7c52.json
@@ -1,0 +1,21 @@
+{
+  "runId": "20260902T062209725Z__L1-menu-item-basic__1c4714609f2b4e6c9fdc56ca00ee7c52",
+  "caseId": "L1-menu-item-basic",
+  "tier": 1,
+  "timestampUtc": "2026-09-02T06:22:09.725663+00:00",
+  "source": "build-oracle",
+  "score": {
+    "xppErrors": 0,
+    "referenceErrors": 0,
+    "goldenMatch": true,
+    "goldenDiff": {
+      "missing": [],
+      "extra": [],
+      "changed": [],
+      "isMatch": true
+    },
+    "buildClean": true,
+    "buildErrors": 0,
+    "runtimeFailures": 0
+  }
+}

--- a/eval/corpus/runs/20260902T062209726Z__L1-menu-item-output__148bd36f679d47cd87890b0e466f5c16.json
+++ b/eval/corpus/runs/20260902T062209726Z__L1-menu-item-output__148bd36f679d47cd87890b0e466f5c16.json
@@ -1,0 +1,21 @@
+{
+  "runId": "20260902T062209726Z__L1-menu-item-output__148bd36f679d47cd87890b0e466f5c16",
+  "caseId": "L1-menu-item-output",
+  "tier": 1,
+  "timestampUtc": "2026-09-02T06:22:09.7261115+00:00",
+  "source": "build-oracle",
+  "score": {
+    "xppErrors": 0,
+    "referenceErrors": 0,
+    "goldenMatch": true,
+    "goldenDiff": {
+      "missing": [],
+      "extra": [],
+      "changed": [],
+      "isMatch": true
+    },
+    "buildClean": true,
+    "buildErrors": 0,
+    "runtimeFailures": 0
+  }
+}

--- a/eval/corpus/runs/20260902T062209726Z__L1-migration-script-basic__0d21928e2cc44897b182d6520794ad0a.json
+++ b/eval/corpus/runs/20260902T062209726Z__L1-migration-script-basic__0d21928e2cc44897b182d6520794ad0a.json
@@ -1,0 +1,21 @@
+{
+  "runId": "20260902T062209726Z__L1-migration-script-basic__0d21928e2cc44897b182d6520794ad0a",
+  "caseId": "L1-migration-script-basic",
+  "tier": 1,
+  "timestampUtc": "2026-09-02T06:22:09.7265418+00:00",
+  "source": "build-oracle",
+  "score": {
+    "xppErrors": 0,
+    "referenceErrors": 0,
+    "goldenMatch": true,
+    "goldenDiff": {
+      "missing": [],
+      "extra": [],
+      "changed": [],
+      "isMatch": true
+    },
+    "buildClean": true,
+    "buildErrors": 0,
+    "runtimeFailures": 0
+  }
+}

--- a/eval/corpus/runs/20260902T062209726Z__L1-privilege-basic__a8b962883ad54ddda4b2361d88c4dbdd.json
+++ b/eval/corpus/runs/20260902T062209726Z__L1-privilege-basic__a8b962883ad54ddda4b2361d88c4dbdd.json
@@ -1,0 +1,21 @@
+{
+  "runId": "20260902T062209726Z__L1-privilege-basic__a8b962883ad54ddda4b2361d88c4dbdd",
+  "caseId": "L1-privilege-basic",
+  "tier": 1,
+  "timestampUtc": "2026-09-02T06:22:09.726978+00:00",
+  "source": "build-oracle",
+  "score": {
+    "xppErrors": 0,
+    "referenceErrors": 0,
+    "goldenMatch": true,
+    "goldenDiff": {
+      "missing": [],
+      "extra": [],
+      "changed": [],
+      "isMatch": true
+    },
+    "buildClean": true,
+    "buildErrors": 0,
+    "runtimeFailures": 0
+  }
+}

--- a/eval/corpus/runs/20260902T062209727Z__L1-privilege-data-entity__3e120f1c34bf48beab512b4d6ee7906e.json
+++ b/eval/corpus/runs/20260902T062209727Z__L1-privilege-data-entity__3e120f1c34bf48beab512b4d6ee7906e.json
@@ -1,0 +1,21 @@
+{
+  "runId": "20260902T062209727Z__L1-privilege-data-entity__3e120f1c34bf48beab512b4d6ee7906e",
+  "caseId": "L1-privilege-data-entity",
+  "tier": 1,
+  "timestampUtc": "2026-09-02T06:22:09.7274344+00:00",
+  "source": "build-oracle",
+  "score": {
+    "xppErrors": 0,
+    "referenceErrors": 0,
+    "goldenMatch": true,
+    "goldenDiff": {
+      "missing": [],
+      "extra": [],
+      "changed": [],
+      "isMatch": true
+    },
+    "buildClean": true,
+    "buildErrors": 0,
+    "runtimeFailures": 0
+  }
+}

--- a/eval/corpus/runs/20260902T062209727Z__L1-query-basic__e2c287d18ef145babf657a01e8f4c44b.json
+++ b/eval/corpus/runs/20260902T062209727Z__L1-query-basic__e2c287d18ef145babf657a01e8f4c44b.json
@@ -1,0 +1,21 @@
+{
+  "runId": "20260902T062209727Z__L1-query-basic__e2c287d18ef145babf657a01e8f4c44b",
+  "caseId": "L1-query-basic",
+  "tier": 1,
+  "timestampUtc": "2026-09-02T06:22:09.7279078+00:00",
+  "source": "build-oracle",
+  "score": {
+    "xppErrors": 0,
+    "referenceErrors": 0,
+    "goldenMatch": true,
+    "goldenDiff": {
+      "missing": [],
+      "extra": [],
+      "changed": [],
+      "isMatch": true
+    },
+    "buildClean": true,
+    "buildErrors": 0,
+    "runtimeFailures": 0
+  }
+}

--- a/eval/corpus/runs/20260902T062209728Z__L1-query-join__ebf58bdfe3f749a3b8bcc9529afd3d02.json
+++ b/eval/corpus/runs/20260902T062209728Z__L1-query-join__ebf58bdfe3f749a3b8bcc9529afd3d02.json
@@ -1,0 +1,21 @@
+{
+  "runId": "20260902T062209728Z__L1-query-join__ebf58bdfe3f749a3b8bcc9529afd3d02",
+  "caseId": "L1-query-join",
+  "tier": 1,
+  "timestampUtc": "2026-09-02T06:22:09.7283532+00:00",
+  "source": "build-oracle",
+  "score": {
+    "xppErrors": 0,
+    "referenceErrors": 0,
+    "goldenMatch": true,
+    "goldenDiff": {
+      "missing": [],
+      "extra": [],
+      "changed": [],
+      "isMatch": true
+    },
+    "buildClean": true,
+    "buildErrors": 0,
+    "runtimeFailures": 0
+  }
+}

--- a/eval/corpus/runs/20260902T062209728Z__L1-report-basic__051c2358a192408593b278e5c7806823.json
+++ b/eval/corpus/runs/20260902T062209728Z__L1-report-basic__051c2358a192408593b278e5c7806823.json
@@ -1,0 +1,21 @@
+{
+  "runId": "20260902T062209728Z__L1-report-basic__051c2358a192408593b278e5c7806823",
+  "caseId": "L1-report-basic",
+  "tier": 1,
+  "timestampUtc": "2026-09-02T06:22:09.728864+00:00",
+  "source": "build-oracle",
+  "score": {
+    "xppErrors": 0,
+    "referenceErrors": 0,
+    "goldenMatch": true,
+    "goldenDiff": {
+      "missing": [],
+      "extra": [],
+      "changed": [],
+      "isMatch": true
+    },
+    "buildClean": true,
+    "buildErrors": 0,
+    "runtimeFailures": 0
+  }
+}

--- a/eval/corpus/runs/20260902T062209729Z__L1-report-parameters__c79cd46b8cc24726b087932e92466133.json
+++ b/eval/corpus/runs/20260902T062209729Z__L1-report-parameters__c79cd46b8cc24726b087932e92466133.json
@@ -1,0 +1,21 @@
+{
+  "runId": "20260902T062209729Z__L1-report-parameters__c79cd46b8cc24726b087932e92466133",
+  "caseId": "L1-report-parameters",
+  "tier": 1,
+  "timestampUtc": "2026-09-02T06:22:09.7293444+00:00",
+  "source": "build-oracle",
+  "score": {
+    "xppErrors": 0,
+    "referenceErrors": 0,
+    "goldenMatch": true,
+    "goldenDiff": {
+      "missing": [],
+      "extra": [],
+      "changed": [],
+      "isMatch": true
+    },
+    "buildClean": true,
+    "buildErrors": 0,
+    "runtimeFailures": 0
+  }
+}

--- a/eval/corpus/runs/20260902T062209729Z__L1-role-basic__0e967039b72f4d58b55934cb33a3d2ee.json
+++ b/eval/corpus/runs/20260902T062209729Z__L1-role-basic__0e967039b72f4d58b55934cb33a3d2ee.json
@@ -1,0 +1,21 @@
+{
+  "runId": "20260902T062209729Z__L1-role-basic__0e967039b72f4d58b55934cb33a3d2ee",
+  "caseId": "L1-role-basic",
+  "tier": 1,
+  "timestampUtc": "2026-09-02T06:22:09.7297997+00:00",
+  "source": "build-oracle",
+  "score": {
+    "xppErrors": 0,
+    "referenceErrors": 0,
+    "goldenMatch": true,
+    "goldenDiff": {
+      "missing": [],
+      "extra": [],
+      "changed": [],
+      "isMatch": true
+    },
+    "buildClean": true,
+    "buildErrors": 0,
+    "runtimeFailures": 0
+  }
+}

--- a/eval/corpus/runs/20260902T062209730Z__L1-runbase-basic__ada2557f0d414b8d925a9bbab4e52d42.json
+++ b/eval/corpus/runs/20260902T062209730Z__L1-runbase-basic__ada2557f0d414b8d925a9bbab4e52d42.json
@@ -1,0 +1,21 @@
+{
+  "runId": "20260902T062209730Z__L1-runbase-basic__ada2557f0d414b8d925a9bbab4e52d42",
+  "caseId": "L1-runbase-basic",
+  "tier": 1,
+  "timestampUtc": "2026-09-02T06:22:09.7302598+00:00",
+  "source": "build-oracle",
+  "score": {
+    "xppErrors": 0,
+    "referenceErrors": 0,
+    "goldenMatch": true,
+    "goldenDiff": {
+      "missing": [],
+      "extra": [],
+      "changed": [],
+      "isMatch": true
+    },
+    "buildClean": true,
+    "buildErrors": 0,
+    "runtimeFailures": 0
+  }
+}

--- a/eval/corpus/runs/20260902T062209730Z__L1-simple-list-alias__f54361635462485fb5b61f9fcaaf46e2.json
+++ b/eval/corpus/runs/20260902T062209730Z__L1-simple-list-alias__f54361635462485fb5b61f9fcaaf46e2.json
@@ -1,0 +1,21 @@
+{
+  "runId": "20260902T062209730Z__L1-simple-list-alias__f54361635462485fb5b61f9fcaaf46e2",
+  "caseId": "L1-simple-list-alias",
+  "tier": 1,
+  "timestampUtc": "2026-09-02T06:22:09.7307823+00:00",
+  "source": "build-oracle",
+  "score": {
+    "xppErrors": 0,
+    "referenceErrors": 0,
+    "goldenMatch": true,
+    "goldenDiff": {
+      "missing": [],
+      "extra": [],
+      "changed": [],
+      "isMatch": true
+    },
+    "buildClean": true,
+    "buildErrors": 0,
+    "runtimeFailures": 0
+  }
+}

--- a/eval/corpus/runs/20260902T062209733Z__L1-sysoperation-basic__3faa2ca1e5914ecf94927a0cf0923ec3.json
+++ b/eval/corpus/runs/20260902T062209733Z__L1-sysoperation-basic__3faa2ca1e5914ecf94927a0cf0923ec3.json
@@ -1,0 +1,21 @@
+{
+  "runId": "20260902T062209733Z__L1-sysoperation-basic__3faa2ca1e5914ecf94927a0cf0923ec3",
+  "caseId": "L1-sysoperation-basic",
+  "tier": 1,
+  "timestampUtc": "2026-09-02T06:22:09.733294+00:00",
+  "source": "build-oracle",
+  "score": {
+    "xppErrors": 0,
+    "referenceErrors": 0,
+    "goldenMatch": true,
+    "goldenDiff": {
+      "missing": [],
+      "extra": [],
+      "changed": [],
+      "isMatch": true
+    },
+    "buildClean": true,
+    "buildErrors": 0,
+    "runtimeFailures": 0
+  }
+}

--- a/eval/corpus/runs/20260902T062209733Z__L1-systest-basic__35d94d38c4f84b66b79442bd77ab0b70.json
+++ b/eval/corpus/runs/20260902T062209733Z__L1-systest-basic__35d94d38c4f84b66b79442bd77ab0b70.json
@@ -1,0 +1,21 @@
+{
+  "runId": "20260902T062209733Z__L1-systest-basic__35d94d38c4f84b66b79442bd77ab0b70",
+  "caseId": "L1-systest-basic",
+  "tier": 1,
+  "timestampUtc": "2026-09-02T06:22:09.7337495+00:00",
+  "source": "build-oracle",
+  "score": {
+    "xppErrors": 0,
+    "referenceErrors": 0,
+    "goldenMatch": true,
+    "goldenDiff": {
+      "missing": [],
+      "extra": [],
+      "changed": [],
+      "isMatch": true
+    },
+    "buildClean": true,
+    "buildErrors": 0,
+    "runtimeFailures": 0
+  }
+}

--- a/eval/corpus/runs/20260902T062209734Z__L1-table-basic__0da1caef93ce439d958541e5a911f509.json
+++ b/eval/corpus/runs/20260902T062209734Z__L1-table-basic__0da1caef93ce439d958541e5a911f509.json
@@ -1,0 +1,21 @@
+{
+  "runId": "20260902T062209734Z__L1-table-basic__0da1caef93ce439d958541e5a911f509",
+  "caseId": "L1-table-basic",
+  "tier": 1,
+  "timestampUtc": "2026-09-02T06:22:09.7343025+00:00",
+  "source": "build-oracle",
+  "score": {
+    "xppErrors": 0,
+    "referenceErrors": 0,
+    "goldenMatch": true,
+    "goldenDiff": {
+      "missing": [],
+      "extra": [],
+      "changed": [],
+      "isMatch": true
+    },
+    "buildClean": true,
+    "buildErrors": 0,
+    "runtimeFailures": 0
+  }
+}

--- a/eval/corpus/runs/20260902T062209734Z__L1-table-tempdb__7a4175cda4e242ff825492000bd8fb45.json
+++ b/eval/corpus/runs/20260902T062209734Z__L1-table-tempdb__7a4175cda4e242ff825492000bd8fb45.json
@@ -1,0 +1,21 @@
+{
+  "runId": "20260902T062209734Z__L1-table-tempdb__7a4175cda4e242ff825492000bd8fb45",
+  "caseId": "L1-table-tempdb",
+  "tier": 1,
+  "timestampUtc": "2026-09-02T06:22:09.734758+00:00",
+  "source": "build-oracle",
+  "score": {
+    "xppErrors": 0,
+    "referenceErrors": 0,
+    "goldenMatch": true,
+    "goldenDiff": {
+      "missing": [],
+      "extra": [],
+      "changed": [],
+      "isMatch": true
+    },
+    "buildClean": true,
+    "buildErrors": 0,
+    "runtimeFailures": 0
+  }
+}

--- a/eval/corpus/runs/20260902T062209735Z__L1-view-basic__11c0df2c0d404bfc82476d1e42431306.json
+++ b/eval/corpus/runs/20260902T062209735Z__L1-view-basic__11c0df2c0d404bfc82476d1e42431306.json
@@ -1,0 +1,21 @@
+{
+  "runId": "20260902T062209735Z__L1-view-basic__11c0df2c0d404bfc82476d1e42431306",
+  "caseId": "L1-view-basic",
+  "tier": 1,
+  "timestampUtc": "2026-09-02T06:22:09.735227+00:00",
+  "source": "build-oracle",
+  "score": {
+    "xppErrors": 0,
+    "referenceErrors": 0,
+    "goldenMatch": true,
+    "goldenDiff": {
+      "missing": [],
+      "extra": [],
+      "changed": [],
+      "isMatch": true
+    },
+    "buildClean": true,
+    "buildErrors": 0,
+    "runtimeFailures": 0
+  }
+}

--- a/eval/corpus/runs/20260902T062209735Z__L1-view-computed__7560a11513bf4a0b9ff36b5d977dda46.json
+++ b/eval/corpus/runs/20260902T062209735Z__L1-view-computed__7560a11513bf4a0b9ff36b5d977dda46.json
@@ -1,0 +1,21 @@
+{
+  "runId": "20260902T062209735Z__L1-view-computed__7560a11513bf4a0b9ff36b5d977dda46",
+  "caseId": "L1-view-computed",
+  "tier": 1,
+  "timestampUtc": "2026-09-02T06:22:09.7357594+00:00",
+  "source": "build-oracle",
+  "score": {
+    "xppErrors": 0,
+    "referenceErrors": 0,
+    "goldenMatch": true,
+    "goldenDiff": {
+      "missing": [],
+      "extra": [],
+      "changed": [],
+      "isMatch": true
+    },
+    "buildClean": true,
+    "buildErrors": 0,
+    "runtimeFailures": 0
+  }
+}

--- a/eval/corpus/runs/20260902T062209736Z__L1-workflow-approval-task__be850174c5004df6b2bf1b72581beec3.json
+++ b/eval/corpus/runs/20260902T062209736Z__L1-workflow-approval-task__be850174c5004df6b2bf1b72581beec3.json
@@ -1,0 +1,21 @@
+{
+  "runId": "20260902T062209736Z__L1-workflow-approval-task__be850174c5004df6b2bf1b72581beec3",
+  "caseId": "L1-workflow-approval-task",
+  "tier": 1,
+  "timestampUtc": "2026-09-02T06:22:09.7362697+00:00",
+  "source": "build-oracle",
+  "score": {
+    "xppErrors": 0,
+    "referenceErrors": 0,
+    "goldenMatch": true,
+    "goldenDiff": {
+      "missing": [],
+      "extra": [],
+      "changed": [],
+      "isMatch": true
+    },
+    "buildClean": true,
+    "buildErrors": 0,
+    "runtimeFailures": 0
+  }
+}

--- a/eval/corpus/runs/20260902T062209736Z__L1-workflow-basic__cd430b20d72c4b0bb5bd20decebef996.json
+++ b/eval/corpus/runs/20260902T062209736Z__L1-workflow-basic__cd430b20d72c4b0bb5bd20decebef996.json
@@ -1,0 +1,21 @@
+{
+  "runId": "20260902T062209736Z__L1-workflow-basic__cd430b20d72c4b0bb5bd20decebef996",
+  "caseId": "L1-workflow-basic",
+  "tier": 1,
+  "timestampUtc": "2026-09-02T06:22:09.7367021+00:00",
+  "source": "build-oracle",
+  "score": {
+    "xppErrors": 0,
+    "referenceErrors": 0,
+    "goldenMatch": true,
+    "goldenDiff": {
+      "missing": [],
+      "extra": [],
+      "changed": [],
+      "isMatch": true
+    },
+    "buildClean": true,
+    "buildErrors": 0,
+    "runtimeFailures": 0
+  }
+}

--- a/eval/corpus/runs/20260902T062209737Z__L2-coc-extension__18087a56c66a470aa1bc907a3686862f.json
+++ b/eval/corpus/runs/20260902T062209737Z__L2-coc-extension__18087a56c66a470aa1bc907a3686862f.json
@@ -1,0 +1,21 @@
+{
+  "runId": "20260902T062209737Z__L2-coc-extension__18087a56c66a470aa1bc907a3686862f",
+  "caseId": "L2-coc-extension",
+  "tier": 2,
+  "timestampUtc": "2026-09-02T06:22:09.7371132+00:00",
+  "source": "build-oracle",
+  "score": {
+    "xppErrors": 0,
+    "referenceErrors": 0,
+    "goldenMatch": true,
+    "goldenDiff": {
+      "missing": [],
+      "extra": [],
+      "changed": [],
+      "isMatch": true
+    },
+    "buildClean": true,
+    "buildErrors": 0,
+    "runtimeFailures": 0
+  }
+}

--- a/eval/corpus/runs/20260902T062209737Z__L2-control-method-basic__3c751686de054e009324e312de862a58.json
+++ b/eval/corpus/runs/20260902T062209737Z__L2-control-method-basic__3c751686de054e009324e312de862a58.json
@@ -1,0 +1,21 @@
+{
+  "runId": "20260902T062209737Z__L2-control-method-basic__3c751686de054e009324e312de862a58",
+  "caseId": "L2-control-method-basic",
+  "tier": 2,
+  "timestampUtc": "2026-09-02T06:22:09.7375021+00:00",
+  "source": "build-oracle",
+  "score": {
+    "xppErrors": 0,
+    "referenceErrors": 0,
+    "goldenMatch": true,
+    "goldenDiff": {
+      "missing": [],
+      "extra": [],
+      "changed": [],
+      "isMatch": true
+    },
+    "buildClean": true,
+    "buildErrors": 0,
+    "runtimeFailures": 0
+  }
+}

--- a/eval/corpus/runs/20260902T062209738Z__L2-data-entity-extension__ba71ece4c06e4792a1eb1a79cddaec65.json
+++ b/eval/corpus/runs/20260902T062209738Z__L2-data-entity-extension__ba71ece4c06e4792a1eb1a79cddaec65.json
@@ -1,0 +1,21 @@
+{
+  "runId": "20260902T062209738Z__L2-data-entity-extension__ba71ece4c06e4792a1eb1a79cddaec65",
+  "caseId": "L2-data-entity-extension",
+  "tier": 2,
+  "timestampUtc": "2026-09-02T06:22:09.738042+00:00",
+  "source": "build-oracle",
+  "score": {
+    "xppErrors": 0,
+    "referenceErrors": 0,
+    "goldenMatch": true,
+    "goldenDiff": {
+      "missing": [],
+      "extra": [],
+      "changed": [],
+      "isMatch": true
+    },
+    "buildClean": true,
+    "buildErrors": 0,
+    "runtimeFailures": 0
+  }
+}

--- a/eval/corpus/runs/20260902T062209738Z__L2-datasource-method-basic__50320dbb87944eff9476864340b52104.json
+++ b/eval/corpus/runs/20260902T062209738Z__L2-datasource-method-basic__50320dbb87944eff9476864340b52104.json
@@ -1,0 +1,21 @@
+{
+  "runId": "20260902T062209738Z__L2-datasource-method-basic__50320dbb87944eff9476864340b52104",
+  "caseId": "L2-datasource-method-basic",
+  "tier": 2,
+  "timestampUtc": "2026-09-02T06:22:09.7385602+00:00",
+  "source": "build-oracle",
+  "score": {
+    "xppErrors": 0,
+    "referenceErrors": 0,
+    "goldenMatch": true,
+    "goldenDiff": {
+      "missing": [],
+      "extra": [],
+      "changed": [],
+      "isMatch": true
+    },
+    "buildClean": true,
+    "buildErrors": 0,
+    "runtimeFailures": 0
+  }
+}

--- a/eval/corpus/runs/20260902T062209738Z__L2-edt-extension__57fa3b951926492cb0bdd154a7b1cc6d.json
+++ b/eval/corpus/runs/20260902T062209738Z__L2-edt-extension__57fa3b951926492cb0bdd154a7b1cc6d.json
@@ -1,0 +1,21 @@
+{
+  "runId": "20260902T062209738Z__L2-edt-extension__57fa3b951926492cb0bdd154a7b1cc6d",
+  "caseId": "L2-edt-extension",
+  "tier": 2,
+  "timestampUtc": "2026-09-02T06:22:09.7389626+00:00",
+  "source": "build-oracle",
+  "score": {
+    "xppErrors": 0,
+    "referenceErrors": 0,
+    "goldenMatch": true,
+    "goldenDiff": {
+      "missing": [],
+      "extra": [],
+      "changed": [],
+      "isMatch": true
+    },
+    "buildClean": true,
+    "buildErrors": 0,
+    "runtimeFailures": 0
+  }
+}

--- a/eval/corpus/runs/20260902T062209739Z__L2-enum-extension__f37d855080c8433c814108c85fe5dfa7.json
+++ b/eval/corpus/runs/20260902T062209739Z__L2-enum-extension__f37d855080c8433c814108c85fe5dfa7.json
@@ -1,0 +1,21 @@
+{
+  "runId": "20260902T062209739Z__L2-enum-extension__f37d855080c8433c814108c85fe5dfa7",
+  "caseId": "L2-enum-extension",
+  "tier": 2,
+  "timestampUtc": "2026-09-02T06:22:09.7393636+00:00",
+  "source": "build-oracle",
+  "score": {
+    "xppErrors": 0,
+    "referenceErrors": 0,
+    "goldenMatch": true,
+    "goldenDiff": {
+      "missing": [],
+      "extra": [],
+      "changed": [],
+      "isMatch": true
+    },
+    "buildClean": true,
+    "buildErrors": 0,
+    "runtimeFailures": 0
+  }
+}

--- a/eval/corpus/runs/20260902T062209739Z__L2-event-handler-basic__725fe2588dbc454dbd7d541d1e48072c.json
+++ b/eval/corpus/runs/20260902T062209739Z__L2-event-handler-basic__725fe2588dbc454dbd7d541d1e48072c.json
@@ -1,0 +1,21 @@
+{
+  "runId": "20260902T062209739Z__L2-event-handler-basic__725fe2588dbc454dbd7d541d1e48072c",
+  "caseId": "L2-event-handler-basic",
+  "tier": 2,
+  "timestampUtc": "2026-09-02T06:22:09.7397451+00:00",
+  "source": "build-oracle",
+  "score": {
+    "xppErrors": 0,
+    "referenceErrors": 0,
+    "goldenMatch": true,
+    "goldenDiff": {
+      "missing": [],
+      "extra": [],
+      "changed": [],
+      "isMatch": true
+    },
+    "buildClean": true,
+    "buildErrors": 0,
+    "runtimeFailures": 0
+  }
+}

--- a/eval/corpus/runs/20260902T062209740Z__L2-find-methods-basic__fff77112db12410cb56e406273397ed9.json
+++ b/eval/corpus/runs/20260902T062209740Z__L2-find-methods-basic__fff77112db12410cb56e406273397ed9.json
@@ -1,0 +1,21 @@
+{
+  "runId": "20260902T062209740Z__L2-find-methods-basic__fff77112db12410cb56e406273397ed9",
+  "caseId": "L2-find-methods-basic",
+  "tier": 2,
+  "timestampUtc": "2026-09-02T06:22:09.7402381+00:00",
+  "source": "build-oracle",
+  "score": {
+    "xppErrors": 0,
+    "referenceErrors": 0,
+    "goldenMatch": true,
+    "goldenDiff": {
+      "missing": [],
+      "extra": [],
+      "changed": [],
+      "isMatch": true
+    },
+    "buildClean": true,
+    "buildErrors": 0,
+    "runtimeFailures": 0
+  }
+}

--- a/eval/corpus/runs/20260902T062209740Z__L2-form-clone-basic__0d0cf21c745243b289f7a7ef51c025b4.json
+++ b/eval/corpus/runs/20260902T062209740Z__L2-form-clone-basic__0d0cf21c745243b289f7a7ef51c025b4.json
@@ -1,0 +1,21 @@
+{
+  "runId": "20260902T062209740Z__L2-form-clone-basic__0d0cf21c745243b289f7a7ef51c025b4",
+  "caseId": "L2-form-clone-basic",
+  "tier": 2,
+  "timestampUtc": "2026-09-02T06:22:09.7406608+00:00",
+  "source": "build-oracle",
+  "score": {
+    "xppErrors": 0,
+    "referenceErrors": 0,
+    "goldenMatch": true,
+    "goldenDiff": {
+      "missing": [],
+      "extra": [],
+      "changed": [],
+      "isMatch": true
+    },
+    "buildClean": true,
+    "buildErrors": 0,
+    "runtimeFailures": 0
+  }
+}

--- a/eval/corpus/runs/20260902T062209741Z__L2-form-extension-basic__6a4c24ddd3294142a5e9911fde67985f.json
+++ b/eval/corpus/runs/20260902T062209741Z__L2-form-extension-basic__6a4c24ddd3294142a5e9911fde67985f.json
@@ -1,0 +1,21 @@
+{
+  "runId": "20260902T062209741Z__L2-form-extension-basic__6a4c24ddd3294142a5e9911fde67985f",
+  "caseId": "L2-form-extension-basic",
+  "tier": 2,
+  "timestampUtc": "2026-09-02T06:22:09.7410488+00:00",
+  "source": "build-oracle",
+  "score": {
+    "xppErrors": 0,
+    "referenceErrors": 0,
+    "goldenMatch": true,
+    "goldenDiff": {
+      "missing": [],
+      "extra": [],
+      "changed": [],
+      "isMatch": true
+    },
+    "buildClean": true,
+    "buildErrors": 0,
+    "runtimeFailures": 0
+  }
+}

--- a/eval/corpus/runs/20260902T062209741Z__L2-numberseq-basic__d27b4dedb2d848b89fec2840815a87bc.json
+++ b/eval/corpus/runs/20260902T062209741Z__L2-numberseq-basic__d27b4dedb2d848b89fec2840815a87bc.json
@@ -1,0 +1,21 @@
+{
+  "runId": "20260902T062209741Z__L2-numberseq-basic__d27b4dedb2d848b89fec2840815a87bc",
+  "caseId": "L2-numberseq-basic",
+  "tier": 2,
+  "timestampUtc": "2026-09-02T06:22:09.7414218+00:00",
+  "source": "build-oracle",
+  "score": {
+    "xppErrors": 0,
+    "referenceErrors": 0,
+    "goldenMatch": true,
+    "goldenDiff": {
+      "missing": [],
+      "extra": [],
+      "changed": [],
+      "isMatch": true
+    },
+    "buildClean": true,
+    "buildErrors": 0,
+    "runtimeFailures": 0
+  }
+}

--- a/eval/corpus/runs/20260902T062209741Z__L2-query-extension__f61a8030b8a9401ba120b2542038dd2c.json
+++ b/eval/corpus/runs/20260902T062209741Z__L2-query-extension__f61a8030b8a9401ba120b2542038dd2c.json
@@ -1,0 +1,21 @@
+{
+  "runId": "20260902T062209741Z__L2-query-extension__f61a8030b8a9401ba120b2542038dd2c",
+  "caseId": "L2-query-extension",
+  "tier": 2,
+  "timestampUtc": "2026-09-02T06:22:09.7418676+00:00",
+  "source": "build-oracle",
+  "score": {
+    "xppErrors": 0,
+    "referenceErrors": 0,
+    "goldenMatch": true,
+    "goldenDiff": {
+      "missing": [],
+      "extra": [],
+      "changed": [],
+      "isMatch": true
+    },
+    "buildClean": true,
+    "buildErrors": 0,
+    "runtimeFailures": 0
+  }
+}

--- a/eval/corpus/runs/20260902T062209742Z__L2-report-extension-dataset__21640f74d0d74268b95e65d94365bfd8.json
+++ b/eval/corpus/runs/20260902T062209742Z__L2-report-extension-dataset__21640f74d0d74268b95e65d94365bfd8.json
@@ -1,0 +1,21 @@
+{
+  "runId": "20260902T062209742Z__L2-report-extension-dataset__21640f74d0d74268b95e65d94365bfd8",
+  "caseId": "L2-report-extension-dataset",
+  "tier": 2,
+  "timestampUtc": "2026-09-02T06:22:09.7422778+00:00",
+  "source": "build-oracle",
+  "score": {
+    "xppErrors": 0,
+    "referenceErrors": 0,
+    "goldenMatch": true,
+    "goldenDiff": {
+      "missing": [],
+      "extra": [],
+      "changed": [],
+      "isMatch": true
+    },
+    "buildClean": true,
+    "buildErrors": 0,
+    "runtimeFailures": 0
+  }
+}

--- a/eval/corpus/runs/20260902T062209742Z__L2-security-duty-extension__55ac9268756841d9be38beee5c76efe4.json
+++ b/eval/corpus/runs/20260902T062209742Z__L2-security-duty-extension__55ac9268756841d9be38beee5c76efe4.json
@@ -1,0 +1,21 @@
+{
+  "runId": "20260902T062209742Z__L2-security-duty-extension__55ac9268756841d9be38beee5c76efe4",
+  "caseId": "L2-security-duty-extension",
+  "tier": 2,
+  "timestampUtc": "2026-09-02T06:22:09.7427598+00:00",
+  "source": "build-oracle",
+  "score": {
+    "xppErrors": 0,
+    "referenceErrors": 0,
+    "goldenMatch": true,
+    "goldenDiff": {
+      "missing": [],
+      "extra": [],
+      "changed": [],
+      "isMatch": true
+    },
+    "buildClean": true,
+    "buildErrors": 0,
+    "runtimeFailures": 0
+  }
+}

--- a/eval/corpus/runs/20260902T062209743Z__L2-security-policy-basic__2d1c00945cd245d0891ebebaa1a43846.json
+++ b/eval/corpus/runs/20260902T062209743Z__L2-security-policy-basic__2d1c00945cd245d0891ebebaa1a43846.json
@@ -1,0 +1,21 @@
+{
+  "runId": "20260902T062209743Z__L2-security-policy-basic__2d1c00945cd245d0891ebebaa1a43846",
+  "caseId": "L2-security-policy-basic",
+  "tier": 2,
+  "timestampUtc": "2026-09-02T06:22:09.7432912+00:00",
+  "source": "build-oracle",
+  "score": {
+    "xppErrors": 0,
+    "referenceErrors": 0,
+    "goldenMatch": true,
+    "goldenDiff": {
+      "missing": [],
+      "extra": [],
+      "changed": [],
+      "isMatch": true
+    },
+    "buildClean": true,
+    "buildErrors": 0,
+    "runtimeFailures": 0
+  }
+}

--- a/eval/corpus/runs/20260902T062209743Z__L2-security-role-extension__3ee6c9967aa142e59db92b118b9dd85c.json
+++ b/eval/corpus/runs/20260902T062209743Z__L2-security-role-extension__3ee6c9967aa142e59db92b118b9dd85c.json
@@ -1,0 +1,21 @@
+{
+  "runId": "20260902T062209743Z__L2-security-role-extension__3ee6c9967aa142e59db92b118b9dd85c",
+  "caseId": "L2-security-role-extension",
+  "tier": 2,
+  "timestampUtc": "2026-09-02T06:22:09.7437609+00:00",
+  "source": "build-oracle",
+  "score": {
+    "xppErrors": 0,
+    "referenceErrors": 0,
+    "goldenMatch": true,
+    "goldenDiff": {
+      "missing": [],
+      "extra": [],
+      "changed": [],
+      "isMatch": true
+    },
+    "buildClean": true,
+    "buildErrors": 0,
+    "runtimeFailures": 0
+  }
+}

--- a/eval/corpus/runs/20260902T062209744Z__L2-table-extension__c32b652105794c1ca4ce0950c52d8b80.json
+++ b/eval/corpus/runs/20260902T062209744Z__L2-table-extension__c32b652105794c1ca4ce0950c52d8b80.json
@@ -1,0 +1,21 @@
+{
+  "runId": "20260902T062209744Z__L2-table-extension__c32b652105794c1ca4ce0950c52d8b80",
+  "caseId": "L2-table-extension",
+  "tier": 2,
+  "timestampUtc": "2026-09-02T06:22:09.7442128+00:00",
+  "source": "build-oracle",
+  "score": {
+    "xppErrors": 0,
+    "referenceErrors": 0,
+    "goldenMatch": true,
+    "goldenDiff": {
+      "missing": [],
+      "extra": [],
+      "changed": [],
+      "isMatch": true
+    },
+    "buildClean": true,
+    "buildErrors": 0,
+    "runtimeFailures": 0
+  }
+}

--- a/eval/corpus/runs/20260902T062209744Z__L2-table-relation-migrated__754822d3809c4cc2ba25f51a1df41b02.json
+++ b/eval/corpus/runs/20260902T062209744Z__L2-table-relation-migrated__754822d3809c4cc2ba25f51a1df41b02.json
@@ -1,0 +1,21 @@
+{
+  "runId": "20260902T062209744Z__L2-table-relation-migrated__754822d3809c4cc2ba25f51a1df41b02",
+  "caseId": "L2-table-relation-migrated",
+  "tier": 2,
+  "timestampUtc": "2026-09-02T06:22:09.7446997+00:00",
+  "source": "build-oracle",
+  "score": {
+    "xppErrors": 0,
+    "referenceErrors": 0,
+    "goldenMatch": true,
+    "goldenDiff": {
+      "missing": [],
+      "extra": [],
+      "changed": [],
+      "isMatch": true
+    },
+    "buildClean": true,
+    "buildErrors": 0,
+    "runtimeFailures": 0
+  }
+}

--- a/eval/corpus/runs/20260902T062209745Z__L2-view-extension__442c80fe16484a2b80c1e85dc7f4de52.json
+++ b/eval/corpus/runs/20260902T062209745Z__L2-view-extension__442c80fe16484a2b80c1e85dc7f4de52.json
@@ -1,0 +1,21 @@
+{
+  "runId": "20260902T062209745Z__L2-view-extension__442c80fe16484a2b80c1e85dc7f4de52",
+  "caseId": "L2-view-extension",
+  "tier": 2,
+  "timestampUtc": "2026-09-02T06:22:09.7451254+00:00",
+  "source": "build-oracle",
+  "score": {
+    "xppErrors": 0,
+    "referenceErrors": 0,
+    "goldenMatch": true,
+    "goldenDiff": {
+      "missing": [],
+      "extra": [],
+      "changed": [],
+      "isMatch": true
+    },
+    "buildClean": true,
+    "buildErrors": 0,
+    "runtimeFailures": 0
+  }
+}

--- a/eval/corpus/runs/20260902T062209745Z__L2-virtual-entity-basic__bde3e323f59f40f0b482063c6318de75.json
+++ b/eval/corpus/runs/20260902T062209745Z__L2-virtual-entity-basic__bde3e323f59f40f0b482063c6318de75.json
@@ -1,0 +1,21 @@
+{
+  "runId": "20260902T062209745Z__L2-virtual-entity-basic__bde3e323f59f40f0b482063c6318de75",
+  "caseId": "L2-virtual-entity-basic",
+  "tier": 2,
+  "timestampUtc": "2026-09-02T06:22:09.7455344+00:00",
+  "source": "build-oracle",
+  "score": {
+    "xppErrors": 0,
+    "referenceErrors": 0,
+    "goldenMatch": true,
+    "goldenDiff": {
+      "missing": [],
+      "extra": [],
+      "changed": [],
+      "isMatch": true
+    },
+    "buildClean": true,
+    "buildErrors": 0,
+    "runtimeFailures": 0
+  }
+}

--- a/eval/golden-build-verification.json
+++ b/eval/golden-build-verification.json
@@ -1,12 +1,12 @@
 {
-  "capturedUtc": "2026-08-31T19:54:06.5940508+00:00",
+  "capturedUtc": "2026-09-02T06:22:09.6575032+00:00",
   "host": "D365ASLDEV2-1",
   "packagesRoot": "K:\\AosService\\PackagesLocalDirectory",
   "compiler": "K:\\AosService\\PackagesLocalDirectory\\Bin\\xppc.exe",
-  "compilerArgs": "-metadata=C:\\Users\\Admin7e00859cee\\AppData\\Local\\Temp\\2\\d365fo-l3-39cc692c101e4d1ba6b900d6996e43e5 -modelmodule=D365FoCliEvalGoldens -output=C:\\Users\\Admin7e00859cee\\AppData\\Local\\Temp\\2\\d365fo-l3-39cc692c101e4d1ba6b900d6996e43e5\\bin -referencefolder=K:\\AosService\\PackagesLocalDirectory -refPath=C:\\Users\\Admin7e00859cee\\AppData\\Local\\Temp\\2\\d365fo-l3-39cc692c101e4d1ba6b900d6996e43e5\\bin -log=C:\\Users\\Admin7e00859cee\\AppData\\Local\\Temp\\2\\d365fo-l3-39cc692c101e4d1ba6b900d6996e43e5\\Dynamics.AX.D365FoCliEvalGoldens.xppc.log",
+  "compilerArgs": "-metadata=C:\\Users\\Admin7e00859cee\\AppData\\Local\\Temp\\2\\d365fo-l3-47c7a7f066514250a1b5fff46193659e -modelmodule=D365FoCliEvalGoldens -output=C:\\Users\\Admin7e00859cee\\AppData\\Local\\Temp\\2\\d365fo-l3-47c7a7f066514250a1b5fff46193659e\\bin -referencefolder=K:\\AosService\\PackagesLocalDirectory -refPath=C:\\Users\\Admin7e00859cee\\AppData\\Local\\Temp\\2\\d365fo-l3-47c7a7f066514250a1b5fff46193659e\\bin -log=C:\\Users\\Admin7e00859cee\\AppData\\Local\\Temp\\2\\d365fo-l3-47c7a7f066514250a1b5fff46193659e\\Dynamics.AX.D365FoCliEvalGoldens.xppc.log",
   "modelName": "D365FoCliEvalGoldens",
-  "total": 52,
-  "clean": 52,
+  "total": 60,
+  "clean": 60,
   "failed": 0,
   "skipped": 0,
   "cases": [
@@ -259,6 +259,14 @@
       "messages": []
     },
     {
+      "caseId": "L1-simple-list-alias",
+      "verdict": "clean",
+      "errors": 0,
+      "warnings": 0,
+      "ruleIds": [],
+      "messages": []
+    },
+    {
       "caseId": "L1-sysoperation-basic",
       "verdict": "clean",
       "errors": 0,
@@ -307,6 +315,14 @@
       "messages": []
     },
     {
+      "caseId": "L1-workflow-approval-task",
+      "verdict": "clean",
+      "errors": 0,
+      "warnings": 13,
+      "ruleIds": [],
+      "messages": []
+    },
+    {
       "caseId": "L1-workflow-basic",
       "verdict": "clean",
       "errors": 0,
@@ -324,6 +340,14 @@
     },
     {
       "caseId": "L2-control-method-basic",
+      "verdict": "clean",
+      "errors": 0,
+      "warnings": 0,
+      "ruleIds": [],
+      "messages": []
+    },
+    {
+      "caseId": "L2-data-entity-extension",
       "verdict": "clean",
       "errors": 0,
       "warnings": 0,
@@ -363,6 +387,14 @@
       "messages": []
     },
     {
+      "caseId": "L2-find-methods-basic",
+      "verdict": "clean",
+      "errors": 0,
+      "warnings": 0,
+      "ruleIds": [],
+      "messages": []
+    },
+    {
       "caseId": "L2-form-clone-basic",
       "verdict": "clean",
       "errors": 0,
@@ -380,6 +412,22 @@
     },
     {
       "caseId": "L2-numberseq-basic",
+      "verdict": "clean",
+      "errors": 0,
+      "warnings": 0,
+      "ruleIds": [],
+      "messages": []
+    },
+    {
+      "caseId": "L2-query-extension",
+      "verdict": "clean",
+      "errors": 0,
+      "warnings": 0,
+      "ruleIds": [],
+      "messages": []
+    },
+    {
+      "caseId": "L2-report-extension-dataset",
       "verdict": "clean",
       "errors": 0,
       "warnings": 0,
@@ -412,6 +460,22 @@
     },
     {
       "caseId": "L2-table-extension",
+      "verdict": "clean",
+      "errors": 0,
+      "warnings": 0,
+      "ruleIds": [],
+      "messages": []
+    },
+    {
+      "caseId": "L2-table-relation-migrated",
+      "verdict": "clean",
+      "errors": 0,
+      "warnings": 0,
+      "ruleIds": [],
+      "messages": []
+    },
+    {
+      "caseId": "L2-view-extension",
       "verdict": "clean",
       "errors": 0,
       "warnings": 0,

--- a/eval/goldens/L1-report-basic/_companions/ConFmVehicleReportController.xml
+++ b/eval/goldens/L1-report-basic/_companions/ConFmVehicleReportController.xml
@@ -1,0 +1,24 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<AxClass>
+  <Name>ConFmVehicleReportController</Name>
+  <SourceCode>
+    <Declaration><![CDATA[public class ConFmVehicleReportController extends SrsReportRunController
+{
+}
+]]></Declaration>
+    <Methods>
+      <Method>
+        <Name>main</Name>
+        <Source><![CDATA[public static void main(Args _args)
+{
+    ConFmVehicleReportController controller = new ConFmVehicleReportController();
+
+    controller.parmReportName(ssrsReportStr(ConFmVehicleReport, AutoDesign));
+    controller.parmArgs(_args);
+    controller.startOperation();
+}
+]]></Source>
+      </Method>
+    </Methods>
+  </SourceCode>
+</AxClass>

--- a/eval/goldens/L1-report-basic/_companions/ConFmVehicleReportDP.xml
+++ b/eval/goldens/L1-report-basic/_companions/ConFmVehicleReportDP.xml
@@ -1,0 +1,44 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<AxClass>
+  <Name>ConFmVehicleReportDP</Name>
+  <SourceCode>
+    <Declaration><![CDATA[class ConFmVehicleReportDP extends SrsReportDataProviderBase
+{
+    ConFmVehicleReportDPTmp conFmVehicleReportDPTmp;
+}
+]]></Declaration>
+    <Methods>
+      <Method>
+        <Name>getConFmVehicleReportDPTmp</Name>
+        <Source><![CDATA[[SRSReportDataSet("ConFmVehicleReportDS")]
+public ConFmVehicleReportDPTmp getConFmVehicleReportDPTmp()
+{
+    select conFmVehicleReportDPTmp;
+    return conFmVehicleReportDPTmp;
+}
+]]></Source>
+      </Method>
+      <Method>
+        <Name>processReport</Name>
+        <Source><![CDATA[public void processReport()
+{
+
+    QueryRun qr = new QueryRun(this.parmQuery());
+
+    ttsbegin;
+    while (qr.next())
+    {
+        // Retrieve the primary source buffer:
+        // MyTable src = qr.get(tableNum(MyTable));
+
+        // Populate the staging table and insert:
+        // conFmVehicleReportDPTmp.Field1 = src.Field1;
+        // conFmVehicleReportDPTmp.insert();
+    }
+    ttscommit;
+}
+]]></Source>
+      </Method>
+    </Methods>
+  </SourceCode>
+</AxClass>

--- a/eval/goldens/L1-report-basic/_companions/ConFmVehicleReportDPTmp.xml
+++ b/eval/goldens/L1-report-basic/_companions/ConFmVehicleReportDPTmp.xml
@@ -1,0 +1,73 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<AxTable xmlns:i="http://www.w3.org/2001/XMLSchema-instance">
+  <Name>ConFmVehicleReportDPTmp</Name>
+  <ClusteredIndex>PrimaryIdx</ClusteredIndex>
+  <TableType>TempDB</TableType>
+  <FieldGroups>
+    <AxTableFieldGroup>
+      <Name>AutoReport</Name>
+      <Fields />
+    </AxTableFieldGroup>
+    <AxTableFieldGroup>
+      <Name>AutoLookup</Name>
+      <Fields />
+    </AxTableFieldGroup>
+    <AxTableFieldGroup>
+      <Name>AutoIdentification</Name>
+      <AutoPopulate>Yes</AutoPopulate>
+      <Fields />
+    </AxTableFieldGroup>
+    <AxTableFieldGroup>
+      <Name>AutoSummary</Name>
+      <Fields />
+    </AxTableFieldGroup>
+    <AxTableFieldGroup>
+      <Name>AutoBrowse</Name>
+      <Fields />
+    </AxTableFieldGroup>
+    <AxTableFieldGroup>
+      <Name>Overview</Name>
+      <Fields>
+        <AxTableFieldGroupField>
+          <DataField>VIN</DataField>
+        </AxTableFieldGroupField>
+        <AxTableFieldGroupField>
+          <DataField>Make</DataField>
+        </AxTableFieldGroupField>
+      </Fields>
+    </AxTableFieldGroup>
+    <AxTableFieldGroup>
+      <Name>General</Name>
+      <Fields>
+        <AxTableFieldGroupField>
+          <DataField>VIN</DataField>
+        </AxTableFieldGroupField>
+        <AxTableFieldGroupField>
+          <DataField>Make</DataField>
+        </AxTableFieldGroupField>
+      </Fields>
+    </AxTableFieldGroup>
+  </FieldGroups>
+  <Fields>
+    <AxTableField i:type="AxTableFieldString">
+      <Name>VIN</Name>
+      <ExtendedDataType>Description255</ExtendedDataType>
+    </AxTableField>
+    <AxTableField i:type="AxTableFieldString">
+      <Name>Make</Name>
+      <ExtendedDataType>Description255</ExtendedDataType>
+    </AxTableField>
+  </Fields>
+  <Indexes>
+    <AxTableIndex>
+      <Name>PrimaryIdx</Name>
+      <AllowDuplicates>No</AllowDuplicates>
+      <AlternateKey>Yes</AlternateKey>
+      <Fields>
+        <AxTableIndexField>
+          <DataField>VIN</DataField>
+        </AxTableIndexField>
+      </Fields>
+    </AxTableIndex>
+  </Indexes>
+</AxTable>

--- a/eval/goldens/L1-report-basic/_companions/ConFmVehicleReportMenuItem.xml
+++ b/eval/goldens/L1-report-basic/_companions/ConFmVehicleReportMenuItem.xml
@@ -1,0 +1,7 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<AxMenuItemOutput xmlns="Microsoft.Dynamics.AX.Metadata.V1">
+  <Name>ConFmVehicleReportMenuItem</Name>
+  <Label>Fleet vehicle report</Label>
+  <Object>ConFmVehicleReportController</Object>
+  <ObjectType>Class</ObjectType>
+</AxMenuItemOutput>

--- a/eval/goldens/L1-report-parameters/_companions/ConFmVehicleParamReportController.xml
+++ b/eval/goldens/L1-report-parameters/_companions/ConFmVehicleParamReportController.xml
@@ -1,0 +1,24 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<AxClass>
+  <Name>ConFmVehicleParamReportController</Name>
+  <SourceCode>
+    <Declaration><![CDATA[public class ConFmVehicleParamReportController extends SrsReportRunController
+{
+}
+]]></Declaration>
+    <Methods>
+      <Method>
+        <Name>main</Name>
+        <Source><![CDATA[public static void main(Args _args)
+{
+    ConFmVehicleParamReportController controller = new ConFmVehicleParamReportController();
+
+    controller.parmReportName(ssrsReportStr(ConFmVehicleParamReport, AutoDesign));
+    controller.parmArgs(_args);
+    controller.startOperation();
+}
+]]></Source>
+      </Method>
+    </Methods>
+  </SourceCode>
+</AxClass>

--- a/eval/goldens/L1-report-parameters/_companions/ConFmVehicleParamReportDP.xml
+++ b/eval/goldens/L1-report-parameters/_companions/ConFmVehicleParamReportDP.xml
@@ -1,0 +1,57 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<AxClass>
+  <Name>ConFmVehicleParamReportDP</Name>
+  <SourceCode>
+    <Declaration><![CDATA[[SRSReportParameterAttribute(classStr(ConFmVehicleParamReportDPContract))]
+class ConFmVehicleParamReportDP extends SrsReportDataProviderBase
+{
+    ConFmVehicleParamReportDPTmp conFmVehicleParamReportDPTmp;
+    ConFmVehicleSummaryDPTmp conFmVehicleSummaryDPTmp;
+}
+]]></Declaration>
+    <Methods>
+      <Method>
+        <Name>getConFmVehicleParamReportDPTmp</Name>
+        <Source><![CDATA[[SRSReportDataSet("ConFmVehicleParamReportDS")]
+public ConFmVehicleParamReportDPTmp getConFmVehicleParamReportDPTmp()
+{
+    select conFmVehicleParamReportDPTmp;
+    return conFmVehicleParamReportDPTmp;
+}
+]]></Source>
+      </Method>
+      <Method>
+        <Name>getConFmVehicleSummaryDPTmp</Name>
+        <Source><![CDATA[[SRSReportDataSet("ConFmVehicleSummaryDS")]
+public ConFmVehicleSummaryDPTmp getConFmVehicleSummaryDPTmp()
+{
+    select conFmVehicleSummaryDPTmp;
+    return conFmVehicleSummaryDPTmp;
+}
+]]></Source>
+      </Method>
+      <Method>
+        <Name>processReport</Name>
+        <Source><![CDATA[public void processReport()
+{
+
+    ConFmVehicleParamReportDPContract contract = this.parmDataContract() as ConFmVehicleParamReportDPContract;
+    QueryRun qr = new QueryRun(this.parmQuery());
+
+    ttsbegin;
+    while (qr.next())
+    {
+        // Retrieve the primary source buffer:
+        // MyTable src = qr.get(tableNum(MyTable));
+
+        // Populate the staging table and insert:
+        // conFmVehicleParamReportDPTmp.Field1 = src.Field1;
+        // conFmVehicleParamReportDPTmp.insert();
+    }
+    ttscommit;
+}
+]]></Source>
+      </Method>
+    </Methods>
+  </SourceCode>
+</AxClass>

--- a/eval/goldens/L1-report-parameters/_companions/ConFmVehicleParamReportDPContract.xml
+++ b/eval/goldens/L1-report-parameters/_companions/ConFmVehicleParamReportDPContract.xml
@@ -1,0 +1,24 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<AxClass>
+  <Name>ConFmVehicleParamReportDPContract</Name>
+  <SourceCode>
+    <Declaration><![CDATA[[DataContractAttribute]
+public class ConFmVehicleParamReportDPContract
+{
+    utcDateTime fromDate;
+}
+]]></Declaration>
+    <Methods>
+      <Method>
+        <Name>parmFromDate</Name>
+        <Source><![CDATA[[DataMemberAttribute('FromDate')]
+public utcDateTime parmFromDate(utcDateTime _fromDate = fromDate)
+{
+    fromDate = _fromDate;
+    return fromDate;
+}
+]]></Source>
+      </Method>
+    </Methods>
+  </SourceCode>
+</AxClass>

--- a/eval/goldens/L1-report-parameters/_companions/ConFmVehicleParamReportDPTmp.xml
+++ b/eval/goldens/L1-report-parameters/_companions/ConFmVehicleParamReportDPTmp.xml
@@ -1,0 +1,73 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<AxTable xmlns:i="http://www.w3.org/2001/XMLSchema-instance">
+  <Name>ConFmVehicleParamReportDPTmp</Name>
+  <ClusteredIndex>PrimaryIdx</ClusteredIndex>
+  <TableType>TempDB</TableType>
+  <FieldGroups>
+    <AxTableFieldGroup>
+      <Name>AutoReport</Name>
+      <Fields />
+    </AxTableFieldGroup>
+    <AxTableFieldGroup>
+      <Name>AutoLookup</Name>
+      <Fields />
+    </AxTableFieldGroup>
+    <AxTableFieldGroup>
+      <Name>AutoIdentification</Name>
+      <AutoPopulate>Yes</AutoPopulate>
+      <Fields />
+    </AxTableFieldGroup>
+    <AxTableFieldGroup>
+      <Name>AutoSummary</Name>
+      <Fields />
+    </AxTableFieldGroup>
+    <AxTableFieldGroup>
+      <Name>AutoBrowse</Name>
+      <Fields />
+    </AxTableFieldGroup>
+    <AxTableFieldGroup>
+      <Name>Overview</Name>
+      <Fields>
+        <AxTableFieldGroupField>
+          <DataField>VIN</DataField>
+        </AxTableFieldGroupField>
+        <AxTableFieldGroupField>
+          <DataField>Make</DataField>
+        </AxTableFieldGroupField>
+      </Fields>
+    </AxTableFieldGroup>
+    <AxTableFieldGroup>
+      <Name>General</Name>
+      <Fields>
+        <AxTableFieldGroupField>
+          <DataField>VIN</DataField>
+        </AxTableFieldGroupField>
+        <AxTableFieldGroupField>
+          <DataField>Make</DataField>
+        </AxTableFieldGroupField>
+      </Fields>
+    </AxTableFieldGroup>
+  </FieldGroups>
+  <Fields>
+    <AxTableField i:type="AxTableFieldString">
+      <Name>VIN</Name>
+      <ExtendedDataType>Description255</ExtendedDataType>
+    </AxTableField>
+    <AxTableField i:type="AxTableFieldString">
+      <Name>Make</Name>
+      <ExtendedDataType>Description255</ExtendedDataType>
+    </AxTableField>
+  </Fields>
+  <Indexes>
+    <AxTableIndex>
+      <Name>PrimaryIdx</Name>
+      <AllowDuplicates>No</AllowDuplicates>
+      <AlternateKey>Yes</AlternateKey>
+      <Fields>
+        <AxTableIndexField>
+          <DataField>VIN</DataField>
+        </AxTableIndexField>
+      </Fields>
+    </AxTableIndex>
+  </Indexes>
+</AxTable>

--- a/eval/goldens/L1-report-parameters/_companions/ConFmVehicleParamReportMenuItem.xml
+++ b/eval/goldens/L1-report-parameters/_companions/ConFmVehicleParamReportMenuItem.xml
@@ -1,0 +1,7 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<AxMenuItemOutput xmlns="Microsoft.Dynamics.AX.Metadata.V1">
+  <Name>ConFmVehicleParamReportMenuItem</Name>
+  <Label>Fleet vehicle parameter report</Label>
+  <Object>ConFmVehicleParamReportController</Object>
+  <ObjectType>Class</ObjectType>
+</AxMenuItemOutput>

--- a/eval/goldens/L1-report-parameters/_companions/ConFmVehicleSummaryDPTmp.xml
+++ b/eval/goldens/L1-report-parameters/_companions/ConFmVehicleSummaryDPTmp.xml
@@ -1,0 +1,73 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<AxTable xmlns:i="http://www.w3.org/2001/XMLSchema-instance">
+  <Name>ConFmVehicleSummaryDPTmp</Name>
+  <ClusteredIndex>PrimaryIdx</ClusteredIndex>
+  <TableType>TempDB</TableType>
+  <FieldGroups>
+    <AxTableFieldGroup>
+      <Name>AutoReport</Name>
+      <Fields />
+    </AxTableFieldGroup>
+    <AxTableFieldGroup>
+      <Name>AutoLookup</Name>
+      <Fields />
+    </AxTableFieldGroup>
+    <AxTableFieldGroup>
+      <Name>AutoIdentification</Name>
+      <AutoPopulate>Yes</AutoPopulate>
+      <Fields />
+    </AxTableFieldGroup>
+    <AxTableFieldGroup>
+      <Name>AutoSummary</Name>
+      <Fields />
+    </AxTableFieldGroup>
+    <AxTableFieldGroup>
+      <Name>AutoBrowse</Name>
+      <Fields />
+    </AxTableFieldGroup>
+    <AxTableFieldGroup>
+      <Name>Overview</Name>
+      <Fields>
+        <AxTableFieldGroupField>
+          <DataField>VIN</DataField>
+        </AxTableFieldGroupField>
+        <AxTableFieldGroupField>
+          <DataField>Make</DataField>
+        </AxTableFieldGroupField>
+      </Fields>
+    </AxTableFieldGroup>
+    <AxTableFieldGroup>
+      <Name>General</Name>
+      <Fields>
+        <AxTableFieldGroupField>
+          <DataField>VIN</DataField>
+        </AxTableFieldGroupField>
+        <AxTableFieldGroupField>
+          <DataField>Make</DataField>
+        </AxTableFieldGroupField>
+      </Fields>
+    </AxTableFieldGroup>
+  </FieldGroups>
+  <Fields>
+    <AxTableField i:type="AxTableFieldString">
+      <Name>VIN</Name>
+      <ExtendedDataType>Description255</ExtendedDataType>
+    </AxTableField>
+    <AxTableField i:type="AxTableFieldString">
+      <Name>Make</Name>
+      <ExtendedDataType>Description255</ExtendedDataType>
+    </AxTableField>
+  </Fields>
+  <Indexes>
+    <AxTableIndex>
+      <Name>PrimaryIdx</Name>
+      <AllowDuplicates>No</AllowDuplicates>
+      <AlternateKey>Yes</AlternateKey>
+      <Fields>
+        <AxTableIndexField>
+          <DataField>VIN</DataField>
+        </AxTableIndexField>
+      </Fields>
+    </AxTableIndex>
+  </Indexes>
+</AxTable>

--- a/eval/goldens/L1-simple-list-alias/ConFmVehicleSimpleList.xml
+++ b/eval/goldens/L1-simple-list-alias/ConFmVehicleSimpleList.xml
@@ -1,0 +1,137 @@
+<?xml version="1.0" encoding="utf-8"?>
+<AxForm xmlns:i="http://www.w3.org/2001/XMLSchema-instance" xmlns="Microsoft.Dynamics.AX.Metadata.V6">
+  <Name>ConFmVehicleSimpleList</Name>
+  <SourceCode>
+    <Methods xmlns="">
+      <Method>
+        <Name>classDeclaration</Name>
+        <Source><![CDATA[
+[Form]
+public class ConFmVehicleSimpleList extends FormRun
+{
+}
+
+]]></Source>
+      </Method>
+    </Methods>
+    <DataSources xmlns="" />
+    <DataControls xmlns="" />
+    <Members xmlns="" />
+  </SourceCode>
+  <DataSources>
+    <AxFormDataSource xmlns="">
+      <Name>FmVehicle</Name>
+      <Table>FmVehicle</Table>
+      <Fields />
+      <ReferencedDataSources />
+      <InsertIfEmpty>No</InsertIfEmpty>
+      <DataSourceLinks />
+      <DerivedDataSources />
+    </AxFormDataSource>
+  </DataSources>
+  <Design>
+    <!--
+      Layout properties the AOT pattern registry requires on a SimpleList design.
+      They are not decoration: the AOS validates them and the repairer would
+      otherwise rewrite every generated form. In contract order — ArrangeMethod
+      before Caption, Columns/ColumnsMode before DataSource.
+    -->
+    <ArrangeMethod xmlns="">Vertical</ArrangeMethod>
+    <Caption xmlns="">@Fleet:Vehicle</Caption>
+    <Columns xmlns="">1</Columns>
+    <ColumnsMode xmlns="">Fixed</ColumnsMode>
+    <DataSource xmlns="">FmVehicle</DataSource>
+    <HideIfEmpty xmlns="">No</HideIfEmpty>
+    <Pattern xmlns="">SimpleList</Pattern>
+    <PatternVersion xmlns="">1.1</PatternVersion>
+    <Style xmlns="">SimpleList</Style>
+    <TitleDataSource xmlns="">FmVehicle</TitleDataSource>
+    <Controls xmlns="">
+      <AxFormControl xmlns="" i:type="AxFormActionPaneControl">
+        <Name>ActionPane</Name>
+        <ElementPosition>134217727</ElementPosition>
+        <FilterExpression>%1</FilterExpression>
+        <!-- Registry part 'ApplicationBar': the sizing and style it requires. -->
+        <Height>-1</Height>
+        <HeightMode>SizeToContent</HeightMode>
+        <Type>ActionPane</Type>
+        <VerticalSpacing>-1</VerticalSpacing>
+        <Width>-1</Width>
+        <WidthMode>SizeToAvailable</WidthMode>
+        <FormControlExtension i:nil="true" />
+        <Controls>
+          <AxFormControl xmlns="" i:type="AxFormButtonGroupControl">
+            <Name>ButtonGroup</Name>
+            <Type>ButtonGroup</Type>
+            <FormControlExtension i:nil="true" />
+            <Controls />
+            <ArrangeMethod>Vertical</ArrangeMethod>
+          </AxFormControl>
+        </Controls>
+        <AlignChild>No</AlignChild>
+        <AlignChildren>No</AlignChildren>
+        <ArrangeMethod>Vertical</ArrangeMethod>
+        <Style>Standard</Style>
+      </AxFormControl>
+      <AxFormControl xmlns="" i:type="AxFormGroupControl">
+        <Name>CustomFilterGroup</Name>
+        <Pattern>CustomAndQuickFilters</Pattern>
+        <PatternVersion>1.1</PatternVersion>
+        <Type>Group</Type>
+        <WidthMode>SizeToAvailable</WidthMode>
+        <FormControlExtension i:nil="true" />
+        <Controls>
+          <AxFormControl>
+            <Name>QuickFilterControl</Name>
+            <FormControlExtension>
+              <Name>QuickFilterControl</Name>
+              <ExtensionComponents />
+              <ExtensionProperties>
+                <AxFormControlExtensionProperty>
+                  <Name>targetControlName</Name>
+                  <Type>String</Type>
+                  <Value>Grid</Value>
+                </AxFormControlExtensionProperty>
+                <AxFormControlExtensionProperty>
+                  <Name>defaultColumnName</Name>
+                  <Type>String</Type>
+                  <Value>Grid_FmVehicle</Value>
+                </AxFormControlExtensionProperty>
+                <AxFormControlExtensionProperty>
+                  <Name>placeholderText</Name>
+                  <Type>String</Type>
+                </AxFormControlExtensionProperty>
+              </ExtensionProperties>
+            </FormControlExtension>
+          </AxFormControl>
+        </Controls>
+        <ArrangeMethod>HorizontalLeft</ArrangeMethod>
+        <FrameType>None</FrameType>
+        <Style>CustomFilter</Style>
+        <ViewEditMode>Edit</ViewEditMode>
+      </AxFormControl>
+      <AxFormControl xmlns="" i:type="AxFormGridControl">
+        <Name>Grid</Name>
+        <ElementPosition>1431655764</ElementPosition>
+        <FilterExpression>%1</FilterExpression>
+        <!-- Registry part 'SimpleListGrid'. -->
+        <Height>-1</Height>
+        <HeightMode>SizeToAvailable</HeightMode>
+        <Type>Grid</Type>
+        <VerticalSpacing>-1</VerticalSpacing>
+        <Width>-1</Width>
+        <WidthMode>SizeToAvailable</WidthMode>
+        <FormControlExtension i:nil="true" />
+        <Controls>
+        </Controls>
+        <AlternateRowShading>No</AlternateRowShading>
+        <DataGroup>Overview</DataGroup>
+        <DataSource>FmVehicle</DataSource>
+        <MultiSelect>No</MultiSelect>
+        <ShowRowLabels>No</ShowRowLabels>
+        <Style>Tabular</Style>
+      </AxFormControl>
+    </Controls>
+  </Design>
+  <Parts />
+</AxForm>

--- a/eval/goldens/L1-workflow-approval-task/ConFmVehicleServiceWorkflow.xml
+++ b/eval/goldens/L1-workflow-approval-task/ConFmVehicleServiceWorkflow.xml
@@ -1,0 +1,20 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<AxWorkflowTemplate xmlns="Microsoft.Dynamics.AX.Metadata.V2">
+  <Name>ConFmVehicleServiceWorkflow</Name>
+  <Category>FixedAssets</Category>
+  <Document>ConFmVehicleServiceWorkflowDocument</Document>
+  <DocumentMenuItem>ConFmVehicleServiceWorkflowMenuItem</DocumentMenuItem>
+  <SubmitToWorkflowMenuItem>ConFmVehicleServiceWorkflowSubmit</SubmitToWorkflowMenuItem>
+  <LineItemWorkflows />
+  <SupportedElements>
+    <AxWorkflowElementReference xmlns="">
+      <Name>ApprovalConFmVehicleServiceApproval</Name>
+      <ElementName>ConFmVehicleServiceApproval</ElementName>
+    </AxWorkflowElementReference>
+    <AxWorkflowElementReference xmlns="">
+      <Name>TaskConFmVehicleServiceTask</Name>
+      <ElementName>ConFmVehicleServiceTask</ElementName>
+      <Type>Task</Type>
+    </AxWorkflowElementReference>
+  </SupportedElements>
+</AxWorkflowTemplate>

--- a/eval/goldens/L1-workflow-approval-task/_companions/ConFmVehicleServiceApproval.xml
+++ b/eval/goldens/L1-workflow-approval-task/_companions/ConFmVehicleServiceApproval.xml
@@ -1,0 +1,23 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<AxWorkflowApproval xmlns="Microsoft.Dynamics.AX.Metadata.V2">
+  <Name>ConFmVehicleServiceApproval</Name>
+  <Document>ConFmVehicleServiceWorkflowDocument</Document>
+  <DocumentMenuItem>ConFmVehicleServiceWorkflowMenuItem</DocumentMenuItem>
+  <Approve>
+    <Name xmlns="">Approve</Name>
+  </Approve>
+  <Deny>
+    <Name xmlns="">Deny</Name>
+    <Enabled xmlns="">No</Enabled>
+    <Type xmlns="">Deny</Type>
+  </Deny>
+  <Reject>
+    <Name xmlns="">Reject</Name>
+    <Type xmlns="">Return</Type>
+  </Reject>
+  <RequestChange>
+    <Name xmlns="">RequestChange</Name>
+    <Enabled xmlns="">No</Enabled>
+    <Type xmlns="">RequestChange</Type>
+  </RequestChange>
+</AxWorkflowApproval>

--- a/eval/goldens/L1-workflow-approval-task/_companions/ConFmVehicleServiceTask.xml
+++ b/eval/goldens/L1-workflow-approval-task/_companions/ConFmVehicleServiceTask.xml
@@ -1,0 +1,19 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<AxWorkflowTask xmlns="Microsoft.Dynamics.AX.Metadata.V2">
+  <Name>ConFmVehicleServiceTask</Name>
+  <Document>ConFmVehicleServiceWorkflowDocument</Document>
+  <DocumentMenuItem>ConFmVehicleServiceWorkflowMenuItem</DocumentMenuItem>
+  <WorkflowOutcomes>
+    <AxWorkflowOutcome xmlns="">
+      <Name>Complete</Name>
+    </AxWorkflowOutcome>
+    <AxWorkflowOutcome xmlns="">
+      <Name>Reject</Name>
+      <Type>Return</Type>
+    </AxWorkflowOutcome>
+    <AxWorkflowOutcome xmlns="">
+      <Name>RequestChange</Name>
+      <Type>RequestChange</Type>
+    </AxWorkflowOutcome>
+  </WorkflowOutcomes>
+</AxWorkflowTask>

--- a/eval/goldens/L1-workflow-approval-task/_companions/ConFmVehicleServiceWorkflowDocument.xml
+++ b/eval/goldens/L1-workflow-approval-task/_companions/ConFmVehicleServiceWorkflowDocument.xml
@@ -1,0 +1,20 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<AxClass>
+  <Name>ConFmVehicleServiceWorkflowDocument</Name>
+  <SourceCode>
+    <Declaration><![CDATA[class ConFmVehicleServiceWorkflowDocument extends WorkflowDocument
+{
+}
+]]></Declaration>
+    <Methods>
+      <Method>
+        <Name>getQueryName</Name>
+        <Source><![CDATA[public QueryName getQueryName()
+{
+    return queryStr(ConFmVehicleServiceWorkflowQuery);
+}
+]]></Source>
+      </Method>
+    </Methods>
+  </SourceCode>
+</AxClass>

--- a/eval/goldens/L1-workflow-approval-task/_companions/ConFmVehicleServiceWorkflowQuery.xml
+++ b/eval/goldens/L1-workflow-approval-task/_companions/ConFmVehicleServiceWorkflowQuery.xml
@@ -1,0 +1,23 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<AxQuery xmlns:i="http://www.w3.org/2001/XMLSchema-instance" i:type="AxQuerySimple">
+  <Name>ConFmVehicleServiceWorkflowQuery</Name>
+  <SourceCode>
+    <Methods>
+      <Method>
+        <Name>classDeclaration</Name>
+        <Source><![CDATA[[Query]
+public class ConFmVehicleServiceWorkflowQuery extends QueryRun
+{
+}
+]]></Source>
+      </Method>
+    </Methods>
+  </SourceCode>
+  <DataSources>
+    <AxQuerySimpleRootDataSource>
+      <Name>FmVehicle</Name>
+      <DynamicFields>Yes</DynamicFields>
+      <Table>FmVehicle</Table>
+    </AxQuerySimpleRootDataSource>
+  </DataSources>
+</AxQuery>

--- a/eval/goldens/L1-workflow-approval-task/_companions/FmVehicle_Workflow_Extension.xml
+++ b/eval/goldens/L1-workflow-approval-task/_companions/FmVehicle_Workflow_Extension.xml
@@ -1,0 +1,26 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<AxClass>
+  <Name>FmVehicle_Workflow_Extension</Name>
+  <SourceCode>
+    <Declaration><![CDATA[[ExtensionOf(tableStr(FmVehicle))]
+final class FmVehicle_Workflow_Extension
+{
+}
+]]></Declaration>
+    <Methods>
+      <Method>
+        <Name>canSubmitToWorkflow</Name>
+        <Source><![CDATA[public boolean canSubmitToWorkflow(str _workflowType)
+{
+    boolean canSubmit = next canSubmitToWorkflow(_workflowType);
+
+    // Add conditions under which this record can be submitted:
+    // canSubmit = canSubmit && this.Status == MyStatus::Draft;
+
+    return canSubmit;
+}
+]]></Source>
+      </Method>
+    </Methods>
+  </SourceCode>
+</AxClass>

--- a/eval/goldens/L2-data-entity-extension/CustCustomerV3Entity.ConFleet.xml
+++ b/eval/goldens/L2-data-entity-extension/CustCustomerV3Entity.ConFleet.xml
@@ -1,0 +1,10 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<AxDataEntityViewExtension xmlns:i="http://www.w3.org/2001/XMLSchema-instance">
+  <Name>CustCustomerV3Entity.ConFleet</Name>
+  <DataSources />
+  <FieldGroupExtensions />
+  <FieldGroups />
+  <FieldModifications />
+  <Fields />
+  <PropertyModifications />
+</AxDataEntityViewExtension>

--- a/eval/goldens/L2-find-methods-basic/FmServiceOrder.xml
+++ b/eval/goldens/L2-find-methods-basic/FmServiceOrder.xml
@@ -1,0 +1,156 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<AxTable xmlns:i="http://www.w3.org/2001/XMLSchema-instance">
+  <!--
+    A table that has NOT had its EDT reference migrated to a relation, and that carries its own
+    alternate key. It is the starting point the two table-augmenting generators need: one derives
+    the missing <Relations> entry, the other the standard find()/exists() keyed on the index.
+    Deliberately kept without a <Relations> block, which is the state those commands exist for.
+  -->
+  <Name>FmServiceOrder</Name>
+  <SourceCode>
+    <Declaration><![CDATA[public class FmServiceOrder extends common
+{
+}
+]]></Declaration>
+    <Methods>
+      <Method>
+        <Name>find</Name>
+        <Source><![CDATA[/// <summary>
+/// Finds the <c>FmServiceOrder</c> record matching the supplied key.
+/// </summary>
+public static FmServiceOrder find(str _serviceOrderId, boolean _forUpdate = false)
+{
+    FmServiceOrder fmServiceOrder;
+
+    if (_serviceOrderId)
+    {
+        fmServiceOrder.selectForUpdate(_forUpdate);
+
+        select firstonly fmServiceOrder
+            where fmServiceOrder.ServiceOrderId == _serviceOrderId;
+    }
+
+    return fmServiceOrder;
+}
+]]></Source>
+      </Method>
+      <Method>
+        <Name>exists</Name>
+        <Source><![CDATA[/// <summary>
+/// Determines whether a <c>FmServiceOrder</c> record exists for the supplied key.
+/// </summary>
+public static boolean exists(str _serviceOrderId)
+{
+    return _serviceOrderId
+        && (select firstonly RecId from fmServiceOrder
+               where fmServiceOrder.ServiceOrderId == _serviceOrderId).RecId != 0;
+}
+]]></Source>
+      </Method>
+      <Method>
+        <Name>findRecId</Name>
+        <Source><![CDATA[/// <summary>
+/// Finds the <c>FmServiceOrder</c> record with the supplied <c>RecId</c>.
+/// </summary>
+public static FmServiceOrder findRecId(RefRecId _recId, boolean _forUpdate = false)
+{
+    FmServiceOrder fmServiceOrder;
+
+    if (_recId)
+    {
+        fmServiceOrder.selectForUpdate(_forUpdate);
+
+        select firstonly fmServiceOrder
+            where fmServiceOrder.RecId == _recId;
+    }
+
+    return fmServiceOrder;
+}
+]]></Source>
+      </Method>
+    </Methods>
+  </SourceCode>
+  <Label>@Fleet:ServiceOrder</Label>
+  <TableGroup>Transaction</TableGroup>
+  <FieldGroups>
+    <AxTableFieldGroup>
+      <Name>AutoReport</Name>
+      <Fields />
+    </AxTableFieldGroup>
+    <AxTableFieldGroup>
+      <Name>AutoLookup</Name>
+      <Fields />
+    </AxTableFieldGroup>
+    <AxTableFieldGroup>
+      <Name>AutoIdentification</Name>
+      <AutoPopulate>Yes</AutoPopulate>
+      <Fields />
+    </AxTableFieldGroup>
+    <AxTableFieldGroup>
+      <Name>AutoSummary</Name>
+      <Fields />
+    </AxTableFieldGroup>
+    <AxTableFieldGroup>
+      <Name>AutoBrowse</Name>
+      <Fields />
+    </AxTableFieldGroup>
+    <AxTableFieldGroup>
+      <Name>Overview</Name>
+      <Fields>
+        <AxTableFieldGroupField>
+          <DataField>ServiceOrderId</DataField>
+        </AxTableFieldGroupField>
+        <AxTableFieldGroupField>
+          <DataField>VIN</DataField>
+        </AxTableFieldGroupField>
+        <AxTableFieldGroupField>
+          <DataField>ServiceDate</DataField>
+        </AxTableFieldGroupField>
+      </Fields>
+    </AxTableFieldGroup>
+    <AxTableFieldGroup>
+      <Name>General</Name>
+      <Fields>
+        <AxTableFieldGroupField>
+          <DataField>ServiceOrderId</DataField>
+        </AxTableFieldGroupField>
+        <AxTableFieldGroupField>
+          <DataField>VIN</DataField>
+        </AxTableFieldGroupField>
+        <AxTableFieldGroupField>
+          <DataField>ServiceDate</DataField>
+        </AxTableFieldGroupField>
+      </Fields>
+    </AxTableFieldGroup>
+  </FieldGroups>
+  <Fields>
+    <AxTableField i:type="AxTableFieldString">
+      <Name>ServiceOrderId</Name>
+      <Mandatory>Yes</Mandatory>
+      <StringSize>20</StringSize>
+    </AxTableField>
+    <AxTableField i:type="AxTableFieldString">
+      <Name>VIN</Name>
+      <ExtendedDataType>VIN</ExtendedDataType>
+      <Mandatory>Yes</Mandatory>
+      <StringSize>17</StringSize>
+    </AxTableField>
+    <AxTableField i:type="AxTableFieldDate">
+      <Name>ServiceDate</Name>
+    </AxTableField>
+  </Fields>
+  <FullTextIndexes />
+  <Indexes>
+    <AxTableIndex>
+      <Name>ServiceOrderIdx</Name>
+      <AlternateKey>Yes</AlternateKey>
+      <Fields>
+        <AxTableIndexField>
+          <DataField>ServiceOrderId</DataField>
+        </AxTableIndexField>
+      </Fields>
+    </AxTableIndex>
+  </Indexes>
+  <Relations />
+  <StateMachines />
+</AxTable>

--- a/eval/goldens/L2-query-extension/FmVehicleQuery.ConFleet.xml
+++ b/eval/goldens/L2-query-extension/FmVehicleQuery.ConFleet.xml
@@ -1,0 +1,8 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<AxQuerySimpleExtension xmlns:i="http://www.w3.org/2001/XMLSchema-instance">
+  <Name>FmVehicleQuery.ConFleet</Name>
+  <DataSources />
+  <Fields />
+  <PropertyModifications />
+  <Ranges />
+</AxQuerySimpleExtension>

--- a/eval/goldens/L2-report-extension-dataset/AssetBarCodeDPConFleet_EventHandler.xml
+++ b/eval/goldens/L2-report-extension-dataset/AssetBarCodeDPConFleet_EventHandler.xml
@@ -1,0 +1,56 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<AxClass>
+  <Name>AssetBarCodeDPConFleet_EventHandler</Name>
+  <SourceCode>
+    <Declaration><![CDATA[/// <summary>
+/// Fills the column(s) this model added to <c>AssetBarCodeTmp</c>, after <c>AssetBarCodeDP</c>
+/// has finished building its rows.
+/// </summary>
+public final class AssetBarCodeDPConFleet_EventHandler
+{
+}
+]]></Declaration>
+    <Methods>
+      <Method>
+        <Name>AssetBarCodeDP_Post_processReport</Name>
+        <Source><![CDATA[/// <summary>
+/// Runs after AssetBarCodeDP has populated its dataset.
+/// </summary>
+/// <remarks>
+/// The parameter type is fixed: anything but XppPrePostArgs is a COMPILE error
+/// ("cannot be used as an event handler ... because the parameter profile does
+/// not match"). getThis() is typed Object, so the provider is downcast before
+/// use, and the temp table instance is SHARED through linkPhysicalTableInstance —
+/// a buffer merely declared here would be a different, empty table, and this
+/// handler would appear to work while updating nothing.
+/// </remarks>
+[PostHandlerFor(classStr(AssetBarCodeDP), methodStr(AssetBarCodeDP, processReport))]
+public static void AssetBarCodeDP_Post_processReport(XppPrePostArgs _args)
+{
+    AssetBarCodeDP dataProvider = _args.getThis() as AssetBarCodeDP;
+    AssetBarCodeTmp providerRows;
+    AssetBarCodeTmp tmpUpdate;
+
+    if (!dataProvider)
+    {
+        return;
+    }
+
+    providerRows = dataProvider.geAssetBarCodeTmp();
+    tmpUpdate.linkPhysicalTableInstance(providerRows);
+
+    ttsbegin;
+
+    while select forupdate tmpUpdate
+    {
+        // TODO: set the field(s) your table extension added to AssetBarCodeTmp.
+        tmpUpdate.update();
+    }
+
+    ttscommit;
+}
+]]></Source>
+      </Method>
+    </Methods>
+  </SourceCode>
+</AxClass>

--- a/eval/goldens/L2-table-relation-migrated/FmServiceOrder.xml
+++ b/eval/goldens/L2-table-relation-migrated/FmServiceOrder.xml
@@ -1,0 +1,108 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<AxTable xmlns:i="http://www.w3.org/2001/XMLSchema-instance">
+  <Name>FmServiceOrder</Name>
+  <Label>@Fleet:ServiceOrder</Label>
+  <!--
+    A table that has NOT had its EDT reference migrated to a relation, and that carries its own
+    alternate key. It is the starting point the two table-augmenting generators need: one derives
+    the missing <Relations> entry, the other the standard find()/exists() keyed on the index.
+    Deliberately kept without a <Relations> block, which is the state those commands exist for.
+  -->
+  <TableGroup>Transaction</TableGroup>
+  <FieldGroups>
+    <AxTableFieldGroup>
+      <Name>AutoReport</Name>
+      <Fields />
+    </AxTableFieldGroup>
+    <AxTableFieldGroup>
+      <Name>AutoLookup</Name>
+      <Fields />
+    </AxTableFieldGroup>
+    <AxTableFieldGroup>
+      <Name>AutoIdentification</Name>
+      <AutoPopulate>Yes</AutoPopulate>
+      <Fields />
+    </AxTableFieldGroup>
+    <AxTableFieldGroup>
+      <Name>AutoSummary</Name>
+      <Fields />
+    </AxTableFieldGroup>
+    <AxTableFieldGroup>
+      <Name>AutoBrowse</Name>
+      <Fields />
+    </AxTableFieldGroup>
+    <AxTableFieldGroup>
+      <Name>Overview</Name>
+      <Fields>
+        <AxTableFieldGroupField>
+          <DataField>ServiceOrderId</DataField>
+        </AxTableFieldGroupField>
+        <AxTableFieldGroupField>
+          <DataField>VIN</DataField>
+        </AxTableFieldGroupField>
+        <AxTableFieldGroupField>
+          <DataField>ServiceDate</DataField>
+        </AxTableFieldGroupField>
+      </Fields>
+    </AxTableFieldGroup>
+    <AxTableFieldGroup>
+      <Name>General</Name>
+      <Fields>
+        <AxTableFieldGroupField>
+          <DataField>ServiceOrderId</DataField>
+        </AxTableFieldGroupField>
+        <AxTableFieldGroupField>
+          <DataField>VIN</DataField>
+        </AxTableFieldGroupField>
+        <AxTableFieldGroupField>
+          <DataField>ServiceDate</DataField>
+        </AxTableFieldGroupField>
+      </Fields>
+    </AxTableFieldGroup>
+  </FieldGroups>
+  <Fields>
+    <AxTableField i:type="AxTableFieldString">
+      <Name>ServiceOrderId</Name>
+      <Mandatory>Yes</Mandatory>
+      <StringSize>20</StringSize>
+    </AxTableField>
+    <AxTableField i:type="AxTableFieldString">
+      <Name>VIN</Name>
+      <ExtendedDataType>VIN</ExtendedDataType>
+      <Mandatory>Yes</Mandatory>
+      <StringSize>17</StringSize>
+    </AxTableField>
+    <AxTableField i:type="AxTableFieldDate">
+      <Name>ServiceDate</Name>
+    </AxTableField>
+  </Fields>
+  <FullTextIndexes />
+  <Indexes>
+    <AxTableIndex>
+      <Name>ServiceOrderIdx</Name>
+      <AlternateKey>Yes</AlternateKey>
+      <Fields>
+        <AxTableIndexField>
+          <DataField>ServiceOrderId</DataField>
+        </AxTableIndexField>
+      </Fields>
+    </AxTableIndex>
+  </Indexes>
+  <Relations>
+    <AxTableRelation>
+      <Name>VIN</Name>
+      <Cardinality>ZeroMore</Cardinality>
+      <RelatedTable>FmVehicle</RelatedTable>
+      <RelatedTableCardinality>ExactlyOne</RelatedTableCardinality>
+      <RelationshipType>Association</RelationshipType>
+      <Constraints>
+        <AxTableRelationConstraint i:type="AxTableRelationConstraintField">
+          <Name>VIN</Name>
+          <Field>VIN</Field>
+          <RelatedField>VIN</RelatedField>
+        </AxTableRelationConstraint>
+      </Constraints>
+    </AxTableRelation>
+  </Relations>
+  <StateMachines />
+</AxTable>

--- a/eval/goldens/L2-view-extension/CustAccountName.ConFleet.xml
+++ b/eval/goldens/L2-view-extension/CustAccountName.ConFleet.xml
@@ -1,0 +1,10 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<AxViewExtension xmlns:i="http://www.w3.org/2001/XMLSchema-instance">
+  <Name>CustAccountName.ConFleet</Name>
+  <DataSources />
+  <FieldGroupExtensions />
+  <FieldGroups />
+  <FieldModifications />
+  <Fields />
+  <PropertyModifications />
+</AxViewExtension>

--- a/eval/knowledge-audit.snapshot.json
+++ b/eval/knowledge-audit.snapshot.json
@@ -1,6 +1,6 @@
 {
-  "capturedAt": "2026-09-01T16:08:15.2062917Z",
-  "indexedAt": "2026-09-01T15:30:37.8522496Z",
+  "capturedAt": "2026-09-02T05:49:11.2566625Z",
+  "indexedAt": "2026-09-01T17:31:30.2827165Z",
   "ok": [
     "analytics-and-er|static-call|ERModelDefinitionInputParametersAction::addParameter",
     "analytics-and-er|static-call|ERObjectsFactory::createFormatMappingRunByFormatMappingId",
@@ -201,6 +201,7 @@
     "x\u002B\u002B-class-authoring|attribute|SysOperationContractProcessingAttribute",
     "x\u002B\u002B-class-authoring|declaration|NumberSeq",
     "x\u002B\u002B-class-authoring|extends|NumberSeqApplicationModule",
+    "x\u002B\u002B-class-authoring|extends|RunBaseBatch",
     "x\u002B\u002B-class-authoring|intrinsic|NumberSeqModuleCustomer",
     "x\u002B\u002B-class-authoring|static-call|CustParameters::numRefCustAccount",
     "x\u002B\u002B-class-authoring|static-call|NumberSeq::newGetNum",

--- a/eval/seeds/FmServiceOrder.xml
+++ b/eval/seeds/FmServiceOrder.xml
@@ -1,0 +1,93 @@
+<?xml version="1.0" encoding="utf-8"?>
+<AxTable xmlns:i="http://www.w3.org/2001/XMLSchema-instance">
+  <Name>FmServiceOrder</Name>
+  <Label>@Fleet:ServiceOrder</Label>
+  <!--
+    A table that has NOT had its EDT reference migrated to a relation, and that carries its own
+    alternate key. It is the starting point the two table-augmenting generators need: one derives
+    the missing <Relations> entry, the other the standard find()/exists() keyed on the index.
+    Deliberately kept without a <Relations> block, which is the state those commands exist for.
+  -->
+  <TableGroup>Transaction</TableGroup>
+  <FieldGroups>
+    <AxTableFieldGroup>
+      <Name>AutoReport</Name>
+      <Fields />
+    </AxTableFieldGroup>
+    <AxTableFieldGroup>
+      <Name>AutoLookup</Name>
+      <Fields />
+    </AxTableFieldGroup>
+    <AxTableFieldGroup>
+      <Name>AutoIdentification</Name>
+      <AutoPopulate>Yes</AutoPopulate>
+      <Fields />
+    </AxTableFieldGroup>
+    <AxTableFieldGroup>
+      <Name>AutoSummary</Name>
+      <Fields />
+    </AxTableFieldGroup>
+    <AxTableFieldGroup>
+      <Name>AutoBrowse</Name>
+      <Fields />
+    </AxTableFieldGroup>
+    <AxTableFieldGroup>
+      <Name>Overview</Name>
+      <Fields>
+        <AxTableFieldGroupField>
+          <DataField>ServiceOrderId</DataField>
+        </AxTableFieldGroupField>
+        <AxTableFieldGroupField>
+          <DataField>VIN</DataField>
+        </AxTableFieldGroupField>
+        <AxTableFieldGroupField>
+          <DataField>ServiceDate</DataField>
+        </AxTableFieldGroupField>
+      </Fields>
+    </AxTableFieldGroup>
+    <AxTableFieldGroup>
+      <Name>General</Name>
+      <Fields>
+        <AxTableFieldGroupField>
+          <DataField>ServiceOrderId</DataField>
+        </AxTableFieldGroupField>
+        <AxTableFieldGroupField>
+          <DataField>VIN</DataField>
+        </AxTableFieldGroupField>
+        <AxTableFieldGroupField>
+          <DataField>ServiceDate</DataField>
+        </AxTableFieldGroupField>
+      </Fields>
+    </AxTableFieldGroup>
+  </FieldGroups>
+  <Fields>
+    <AxTableField i:type="AxTableFieldString">
+      <Name>ServiceOrderId</Name>
+      <Mandatory>Yes</Mandatory>
+      <StringSize>20</StringSize>
+    </AxTableField>
+    <AxTableField i:type="AxTableFieldString">
+      <Name>VIN</Name>
+      <ExtendedDataType>VIN</ExtendedDataType>
+      <Mandatory>Yes</Mandatory>
+      <StringSize>17</StringSize>
+    </AxTableField>
+    <AxTableField i:type="AxTableFieldDate">
+      <Name>ServiceDate</Name>
+    </AxTableField>
+  </Fields>
+  <FullTextIndexes />
+  <Indexes>
+    <AxTableIndex>
+      <Name>ServiceOrderIdx</Name>
+      <AlternateKey>Yes</AlternateKey>
+      <Fields>
+        <AxTableIndexField>
+          <DataField>ServiceOrderId</DataField>
+        </AxTableIndexField>
+      </Fields>
+    </AxTableIndex>
+  </Indexes>
+  <Relations />
+  <StateMachines />
+</AxTable>

--- a/eval/seeds/README.md
+++ b/eval/seeds/README.md
@@ -1,0 +1,14 @@
+# Seeds
+
+Artefacts a case starts **from** rather than produces.
+
+`generate table-relation` and `generate find-methods` augment a table that already exists: they
+merge into its XML and refuse `--out`/`--install-to` outright, because accepting a scaffold-output
+option and quietly dropping it would be worse than refusing it. A case for either therefore needs
+an input artefact, which is what a seed is. `eval run` copies the seed named by the case's
+`apply_to_seed` into the replay's work directory as `actual.xml` and passes `--apply-to` at it, so
+the golden is the merged table and nothing here is ever mutated in place.
+
+A seed whose name matches an `AxTable` in `tests/Samples/MiniAot` must stay byte-identical to it —
+the index the replay builds comes from the fixture, and a seed that had drifted from it would be a
+case merging into a table the tool never saw. `EvalSeedTests` asserts exactly that.

--- a/scripts/check-build-warnings.ps1
+++ b/scripts/check-build-warnings.ps1
@@ -21,7 +21,7 @@
 #>
 [CmdletBinding()]
 param(
-    [int]$Baseline = 117,
+    [int]$Baseline = 114,
     [string]$Solution = "d365fo-cli.slnx",
     [string]$Configuration = "Release"
 )

--- a/skills/_source/form-pattern-scaffolding.md
+++ b/skills/_source/form-pattern-scaffolding.md
@@ -132,6 +132,15 @@ d365fo generate form FmFleetWorkspace \
 `--field <F>` is repeatable — these become grid / detail columns. The
 section template is `--section Name:Caption` (split on the first `:`).
 
+## The deprecated alias
+
+`d365fo generate simple-list <Name> --table <T>` still exists and produces exactly
+what `generate form <Name> --pattern SimpleList --table <T>` produces — it is a
+kept-for-compatibility alias, not a second scaffolder. Prefer the `--pattern` form:
+the alias reaches one of the nine patterns and cannot express any of the other
+eight, so a workflow built on it has to be rewritten the moment the form turns
+out to want SimpleListDetails or ListPage.
+
 ## Hard rules
 
 - Never hand-roll AxForm XML — always use `--pattern`.

--- a/skills/_source/forms-and-navigation.md
+++ b/skills/_source/forms-and-navigation.md
@@ -81,6 +81,41 @@ d365fo generate event-handler --source-kind Form --source CustTable \
 `d365fo form-pattern spec <Pattern> --output json` lists the structure the pattern
 requires before you start.
 
+### Overrides on the form itself
+
+When the method belongs on the form rather than in an extension class — a new
+form, or one this model owns — write it into the AxForm XML through the two
+method scaffolders instead of by hand. Both take the form's XML file as their
+first argument and merge into it:
+
+```sh
+# Data source override: init, active, validateWrite, initValue, executeQuery, write, delete …
+d365fo generate datasource-method c:/AOT/MyModel/AxForm/FmVehicleList.xml   --datasource FmVehicle --method validateWrite
+
+# Control event: clicked, modified, lookup, enter, leave …
+d365fo generate control-method c:/AOT/MyModel/AxForm/FmVehicleList.xml   --control Grid_VIN --method clicked
+```
+
+The scaffold carries the correct signature and the `super()` call the override
+needs — the two things that are easy to get wrong from memory and that decide
+whether the form still saves. A method the form already declares is left alone
+rather than overwritten.
+
+### Starting from a form that already works
+
+`generate form-clone` copies an existing AxForm under a new name, keeping its
+pattern, controls and data source wiring, and optionally re-pointing the data
+sources at other tables:
+
+```sh
+d365fo generate form-clone FmServiceOrderInquiry   --from FmVehicleServiceOrder   --rebind FmVehicleLine=FmServiceOrder   --install-to FleetManagement
+```
+
+`--from` takes a form name resolved through the index, or a path to an AxForm
+XML file. `--rebind <OldTable>=<NewTable>` is repeatable and moves the data
+sources; everything the clone keeps is what the original had, so start from a
+form whose pattern is the one you want rather than from the nearest one.
+
 ## 3. Menus and menu items
 
 An `AxMenu` is a flat `<Elements>` collection of `AxMenuElement` entries. Which

--- a/skills/_source/object-extension-authoring.md
+++ b/skills/_source/object-extension-authoring.md
@@ -99,6 +99,49 @@ d365fo generate extension Edt CustAccount --suffix Fleet --install-to FleetManag
 d365fo generate extension Enum NoYes --suffix Fleet --install-to FleetManagement
 ```
 
+Five more kinds take the same two positional arguments:
+
+```sh
+# Project an extra column through a standard view
+d365fo generate extension View CustAccountName --suffix Fleet --install-to FleetManagement
+
+# Add a range or data source to a standard query
+d365fo generate extension Query AccountingSourceExplorerQuery --suffix Fleet --install-to FleetManagement
+
+# Expose a model's field through a shipped data entity
+d365fo generate extension DataEntityView CustCustomerV3Entity --suffix Fleet --install-to FleetManagement
+
+# Add a privilege to a Microsoft duty / a duty to a Microsoft role
+d365fo generate extension SecurityDuty MaintainFA_RU --suffix Fleet --install-to FleetManagement
+d365fo generate extension SecurityRole BudgetBudgetClerk --suffix Fleet --install-to FleetManagement
+```
+
+## What lands on disk
+
+Recognise the root element before editing an extension by hand — the AOT folder
+and the root element always agree, and the file name is `<Target>.<Suffix>.xml`:
+
+| Kind | Root element / AOT folder |
+|---|---|
+| `Table` | `AxTableExtension` |
+| `Form` | `AxFormExtension` |
+| `Edt` | `AxEdtExtension` |
+| `Enum` | `AxEnumExtension` |
+| `View` | `AxViewExtension` |
+| `Query` | `AxQuerySimpleExtension` |
+| `DataEntityView` | `AxDataEntityViewExtension` |
+| `SecurityDuty` | `AxSecurityDutyExtension` |
+| `SecurityRole` | `AxSecurityRoleExtension` |
+
+`AxQuerySimpleExtension` is the one to watch: the folder, the root element and
+the metadata provider collection are all `QuerySimpleExtension(s)`. There is no
+`AxQueryExtension` type in the platform at all, so an extension written under
+that name resolves to nothing.
+
+There is no Map extension kind. `AxMapExtension` is a folder every model ships
+and no standard model has a file in — extend the tables the map is mapped onto
+instead.
+
 `generate extension` takes exactly two positional arguments (`<KIND> <TARGET>`);
 the suffix is a named `--suffix <SUFFIX>` option, not a third positional
 argument — passing it positionally fails with "Could not match '<value>' with

--- a/skills/_source/security-modeling.md
+++ b/skills/_source/security-modeling.md
@@ -63,6 +63,22 @@ d365fo generate duty FmVehicleMaintenanceDuty \
 d365fo generate role FmFleetClerk --duty FmVehicleMaintenanceDuty --install-to FleetManagement
 ```
 
+Extending a Microsoft duty or role goes through the same `generate extension`
+command as every other extension — kind first, target second:
+
+```sh
+d365fo generate extension SecurityDuty MaintainFA_RU   --suffix Fleet --install-to FleetManagement
+
+d365fo generate extension SecurityRole BudgetBudgetClerk   --suffix Fleet --install-to FleetManagement
+```
+
+The scaffolds are `AxSecurityDutyExtension` and `AxSecurityRoleExtension` —
+root element and AOT folder in both cases — named `<Target>.<Suffix>`. Add the
+privilege (duty extension) or the duty (role extension) to the scaffold; the
+standard element itself stays untouched, which is what keeps the customisation
+upgradeable and what `d365fo security role <Role>` will read back as the merged
+result.
+
 ## 3. Tracing what a user can actually reach
 
 The chain is only as good as its weakest link, and reading it from XML is

--- a/skills/_source/table-scaffolding.md
+++ b/skills/_source/table-scaffolding.md
@@ -160,6 +160,44 @@ d365fo search query <NamePart> --output json
 
 `--join target:joinKind:parentDs` (repeatable). JoinKind: `InnerJoin`, `OuterJoin`, `ExistsJoin`, `NoExistsJoin` (no "t" — this is the real `AxQuerySimpleEmbeddedDataSource.JoinMode` spelling, confirmed against shipped platform `AxQuery` XML; `NotExistsJoin` is rejected). The join is emitted as `<UseRelations>Yes</UseRelations>`, which tells the platform to auto-derive the join key from the target table's existing AOT relation — this only works when such a relation actually exists between the two tables.
 
+### AxView — a query projected as a read-only table
+
+A view is a query with a field list: the AOS turns it into a database view, and
+X++ selects from it like a table. It is the right answer whenever the reporting
+or entity shape is a fixed join that nothing writes to.
+
+```sh
+# A view over an existing query — the query is required, a view projects one
+d365fo generate view FmVehicleView   --query FmVehicleQuery --field VIN:FmVehicle --field Make:FmVehicle   --out c:/AOT/MyModel/AxView/FmVehicleView.xml
+```
+
+`--field <name>:<dataSource>[:<dataField>]` is repeatable and names the query
+data source the column comes from; `--computed <name>:<method>:<type>` adds a
+computed column backed by a static method on the view. The root element and AOT
+folder are `AxView`. Generate the backing `AxQuery` first — a view whose query
+does not exist compiles to nothing usable.
+
+### AxMap — one field template mapped onto several tables
+
+A map declares fields once and maps them onto tables that already have those
+columns under different names, so a single X++ routine can run over all of them
+(`SalesPurchLine` is the platform's own example).
+
+```sh
+# Field declared once, mapped onto two tables
+d365fo generate map FmVehicleSharedMap   --field VIN:VinEdt --map-to FmVehicle --map-to FmVehicleLine   --out c:/AOT/MyModel/AxMap/FmVehicleSharedMap.xml
+
+# Column names that differ per table: <table>:<mapField>=<tableField>
+d365fo generate map FmVehicleMap   --field Make:Name --map-to FmVehicle:Make=Make   --out c:/AOT/MyModel/AxMap/FmVehicleMap.xml
+```
+
+`--field <name>:<edt>[:<label>]` — the EDT decides the concrete field type, so
+the map field and the mapped columns have to agree on it. `--map-to <table>`
+alone maps every field by identical name; the `<table>:<mapField>=<tableField>`
+form is for the ones that differ. The root element and AOT folder are `AxMap`.
+There is no map extension: to change a map's reach, extend the tables it maps
+onto.
+
 ### Number sequence integration
 
 If the table needs an auto-generated document number:

--- a/skills/_source/x++-class-authoring.md
+++ b/skills/_source/x++-class-authoring.md
@@ -45,6 +45,25 @@ conversation with long metadata dumps.
    d365fo bp check             # (when available) — xppbp.exe runner
    ```
 
+## The plain class
+
+When none of the framework shapes below fits — the class is a helper, a
+container, a small piece of domain logic — scaffold it directly rather than
+hand-writing the `<AxClass>` wrapper around the source:
+
+```sh
+d365fo generate class FmVehicleLogHelper --out c:/AOT/MyModel/AxClass/FmVehicleLogHelper.xml
+
+# Derive from a base class, and drop the default `final`
+d365fo generate class FmVehicleImportJob --extends RunBaseBatch --non-final   --install-to FleetManagement
+```
+
+The scaffold is `final` by default, because a class nobody has a reason to
+inherit from is the safer default in a model others extend; `--non-final` opts
+out where inheritance is actually intended. Add methods with
+`generate event-handler`, `generate coc` or by editing the `<Methods>` block —
+never by rewriting the file wholesale.
+
 ## Hard rules
 
 - **Never** emit X++ that references a field you have not verified with

--- a/skills/anthropic/form-pattern-scaffolding/SKILL.md
+++ b/skills/anthropic/form-pattern-scaffolding/SKILL.md
@@ -124,6 +124,15 @@ d365fo generate form FmFleetWorkspace \
 `--field <F>` is repeatable — these become grid / detail columns. The
 section template is `--section Name:Caption` (split on the first `:`).
 
+## The deprecated alias
+
+`d365fo generate simple-list <Name> --table <T>` still exists and produces exactly
+what `generate form <Name> --pattern SimpleList --table <T>` produces — it is a
+kept-for-compatibility alias, not a second scaffolder. Prefer the `--pattern` form:
+the alias reaches one of the nine patterns and cannot express any of the other
+eight, so a workflow built on it has to be rewritten the moment the form turns
+out to want SimpleListDetails or ListPage.
+
 ## Hard rules
 
 - Never hand-roll AxForm XML — always use `--pattern`.

--- a/skills/anthropic/forms-and-navigation/SKILL.md
+++ b/skills/anthropic/forms-and-navigation/SKILL.md
@@ -73,6 +73,41 @@ d365fo generate event-handler --source-kind Form --source CustTable \
 `d365fo form-pattern spec <Pattern> --output json` lists the structure the pattern
 requires before you start.
 
+### Overrides on the form itself
+
+When the method belongs on the form rather than in an extension class — a new
+form, or one this model owns — write it into the AxForm XML through the two
+method scaffolders instead of by hand. Both take the form's XML file as their
+first argument and merge into it:
+
+```sh
+# Data source override: init, active, validateWrite, initValue, executeQuery, write, delete …
+d365fo generate datasource-method c:/AOT/MyModel/AxForm/FmVehicleList.xml   --datasource FmVehicle --method validateWrite
+
+# Control event: clicked, modified, lookup, enter, leave …
+d365fo generate control-method c:/AOT/MyModel/AxForm/FmVehicleList.xml   --control Grid_VIN --method clicked
+```
+
+The scaffold carries the correct signature and the `super()` call the override
+needs — the two things that are easy to get wrong from memory and that decide
+whether the form still saves. A method the form already declares is left alone
+rather than overwritten.
+
+### Starting from a form that already works
+
+`generate form-clone` copies an existing AxForm under a new name, keeping its
+pattern, controls and data source wiring, and optionally re-pointing the data
+sources at other tables:
+
+```sh
+d365fo generate form-clone FmServiceOrderInquiry   --from FmVehicleServiceOrder   --rebind FmVehicleLine=FmServiceOrder   --install-to FleetManagement
+```
+
+`--from` takes a form name resolved through the index, or a path to an AxForm
+XML file. `--rebind <OldTable>=<NewTable>` is repeatable and moves the data
+sources; everything the clone keeps is what the original had, so start from a
+form whose pattern is the one you want rather than from the nearest one.
+
 ## 3. Menus and menu items
 
 An `AxMenu` is a flat `<Elements>` collection of `AxMenuElement` entries. Which

--- a/skills/anthropic/object-extension-authoring/SKILL.md
+++ b/skills/anthropic/object-extension-authoring/SKILL.md
@@ -87,6 +87,49 @@ d365fo generate extension Edt CustAccount --suffix Fleet --install-to FleetManag
 d365fo generate extension Enum NoYes --suffix Fleet --install-to FleetManagement
 ```
 
+Five more kinds take the same two positional arguments:
+
+```sh
+# Project an extra column through a standard view
+d365fo generate extension View CustAccountName --suffix Fleet --install-to FleetManagement
+
+# Add a range or data source to a standard query
+d365fo generate extension Query AccountingSourceExplorerQuery --suffix Fleet --install-to FleetManagement
+
+# Expose a model's field through a shipped data entity
+d365fo generate extension DataEntityView CustCustomerV3Entity --suffix Fleet --install-to FleetManagement
+
+# Add a privilege to a Microsoft duty / a duty to a Microsoft role
+d365fo generate extension SecurityDuty MaintainFA_RU --suffix Fleet --install-to FleetManagement
+d365fo generate extension SecurityRole BudgetBudgetClerk --suffix Fleet --install-to FleetManagement
+```
+
+## What lands on disk
+
+Recognise the root element before editing an extension by hand — the AOT folder
+and the root element always agree, and the file name is `<Target>.<Suffix>.xml`:
+
+| Kind | Root element / AOT folder |
+|---|---|
+| `Table` | `AxTableExtension` |
+| `Form` | `AxFormExtension` |
+| `Edt` | `AxEdtExtension` |
+| `Enum` | `AxEnumExtension` |
+| `View` | `AxViewExtension` |
+| `Query` | `AxQuerySimpleExtension` |
+| `DataEntityView` | `AxDataEntityViewExtension` |
+| `SecurityDuty` | `AxSecurityDutyExtension` |
+| `SecurityRole` | `AxSecurityRoleExtension` |
+
+`AxQuerySimpleExtension` is the one to watch: the folder, the root element and
+the metadata provider collection are all `QuerySimpleExtension(s)`. There is no
+`AxQueryExtension` type in the platform at all, so an extension written under
+that name resolves to nothing.
+
+There is no Map extension kind. `AxMapExtension` is a folder every model ships
+and no standard model has a file in — extend the tables the map is mapped onto
+instead.
+
 `generate extension` takes exactly two positional arguments (`<KIND> <TARGET>`);
 the suffix is a named `--suffix <SUFFIX>` option, not a third positional
 argument — passing it positionally fails with "Could not match '<value>' with

--- a/skills/anthropic/security-modeling/SKILL.md
+++ b/skills/anthropic/security-modeling/SKILL.md
@@ -55,6 +55,22 @@ d365fo generate duty FmVehicleMaintenanceDuty \
 d365fo generate role FmFleetClerk --duty FmVehicleMaintenanceDuty --install-to FleetManagement
 ```
 
+Extending a Microsoft duty or role goes through the same `generate extension`
+command as every other extension — kind first, target second:
+
+```sh
+d365fo generate extension SecurityDuty MaintainFA_RU   --suffix Fleet --install-to FleetManagement
+
+d365fo generate extension SecurityRole BudgetBudgetClerk   --suffix Fleet --install-to FleetManagement
+```
+
+The scaffolds are `AxSecurityDutyExtension` and `AxSecurityRoleExtension` —
+root element and AOT folder in both cases — named `<Target>.<Suffix>`. Add the
+privilege (duty extension) or the duty (role extension) to the scaffold; the
+standard element itself stays untouched, which is what keeps the customisation
+upgradeable and what `d365fo security role <Role>` will read back as the merged
+result.
+
 ## 3. Tracing what a user can actually reach
 
 The chain is only as good as its weakest link, and reading it from XML is

--- a/skills/anthropic/table-scaffolding/SKILL.md
+++ b/skills/anthropic/table-scaffolding/SKILL.md
@@ -155,6 +155,44 @@ d365fo search query <NamePart> --output json
 
 `--join target:joinKind:parentDs` (repeatable). JoinKind: `InnerJoin`, `OuterJoin`, `ExistsJoin`, `NoExistsJoin` (no "t" — this is the real `AxQuerySimpleEmbeddedDataSource.JoinMode` spelling, confirmed against shipped platform `AxQuery` XML; `NotExistsJoin` is rejected). The join is emitted as `<UseRelations>Yes</UseRelations>`, which tells the platform to auto-derive the join key from the target table's existing AOT relation — this only works when such a relation actually exists between the two tables.
 
+### AxView — a query projected as a read-only table
+
+A view is a query with a field list: the AOS turns it into a database view, and
+X++ selects from it like a table. It is the right answer whenever the reporting
+or entity shape is a fixed join that nothing writes to.
+
+```sh
+# A view over an existing query — the query is required, a view projects one
+d365fo generate view FmVehicleView   --query FmVehicleQuery --field VIN:FmVehicle --field Make:FmVehicle   --out c:/AOT/MyModel/AxView/FmVehicleView.xml
+```
+
+`--field <name>:<dataSource>[:<dataField>]` is repeatable and names the query
+data source the column comes from; `--computed <name>:<method>:<type>` adds a
+computed column backed by a static method on the view. The root element and AOT
+folder are `AxView`. Generate the backing `AxQuery` first — a view whose query
+does not exist compiles to nothing usable.
+
+### AxMap — one field template mapped onto several tables
+
+A map declares fields once and maps them onto tables that already have those
+columns under different names, so a single X++ routine can run over all of them
+(`SalesPurchLine` is the platform's own example).
+
+```sh
+# Field declared once, mapped onto two tables
+d365fo generate map FmVehicleSharedMap   --field VIN:VinEdt --map-to FmVehicle --map-to FmVehicleLine   --out c:/AOT/MyModel/AxMap/FmVehicleSharedMap.xml
+
+# Column names that differ per table: <table>:<mapField>=<tableField>
+d365fo generate map FmVehicleMap   --field Make:Name --map-to FmVehicle:Make=Make   --out c:/AOT/MyModel/AxMap/FmVehicleMap.xml
+```
+
+`--field <name>:<edt>[:<label>]` — the EDT decides the concrete field type, so
+the map field and the mapped columns have to agree on it. `--map-to <table>`
+alone maps every field by identical name; the `<table>:<mapField>=<tableField>`
+form is for the ones that differ. The root element and AOT folder are `AxMap`.
+There is no map extension: to change a map's reach, extend the tables it maps
+onto.
+
 ### Number sequence integration
 
 If the table needs an auto-generated document number:

--- a/skills/anthropic/x++-class-authoring/SKILL.md
+++ b/skills/anthropic/x++-class-authoring/SKILL.md
@@ -39,6 +39,25 @@ conversation with long metadata dumps.
    d365fo bp check             # (when available) — xppbp.exe runner
    ```
 
+## The plain class
+
+When none of the framework shapes below fits — the class is a helper, a
+container, a small piece of domain logic — scaffold it directly rather than
+hand-writing the `<AxClass>` wrapper around the source:
+
+```sh
+d365fo generate class FmVehicleLogHelper --out c:/AOT/MyModel/AxClass/FmVehicleLogHelper.xml
+
+# Derive from a base class, and drop the default `final`
+d365fo generate class FmVehicleImportJob --extends RunBaseBatch --non-final   --install-to FleetManagement
+```
+
+The scaffold is `final` by default, because a class nobody has a reason to
+inherit from is the safer default in a model others extend; `--non-final` opts
+out where inheritance is actually intended. Add methods with
+`generate event-handler`, `generate coc` or by editing the `<Methods>` block —
+never by rewriting the file wholesale.
+
 ## Hard rules
 
 - **Never** emit X++ that references a field you have not verified with

--- a/skills/copilot/form-pattern-scaffolding.instructions.md
+++ b/skills/copilot/form-pattern-scaffolding.instructions.md
@@ -123,6 +123,15 @@ d365fo generate form FmFleetWorkspace \
 `--field <F>` is repeatable — these become grid / detail columns. The
 section template is `--section Name:Caption` (split on the first `:`).
 
+## The deprecated alias
+
+`d365fo generate simple-list <Name> --table <T>` still exists and produces exactly
+what `generate form <Name> --pattern SimpleList --table <T>` produces — it is a
+kept-for-compatibility alias, not a second scaffolder. Prefer the `--pattern` form:
+the alias reaches one of the nine patterns and cannot express any of the other
+eight, so a workflow built on it has to be rewritten the moment the form turns
+out to want SimpleListDetails or ListPage.
+
 ## Hard rules
 
 - Never hand-roll AxForm XML — always use `--pattern`.

--- a/skills/copilot/forms-and-navigation.instructions.md
+++ b/skills/copilot/forms-and-navigation.instructions.md
@@ -72,6 +72,41 @@ d365fo generate event-handler --source-kind Form --source CustTable \
 `d365fo form-pattern spec <Pattern> --output json` lists the structure the pattern
 requires before you start.
 
+### Overrides on the form itself
+
+When the method belongs on the form rather than in an extension class — a new
+form, or one this model owns — write it into the AxForm XML through the two
+method scaffolders instead of by hand. Both take the form's XML file as their
+first argument and merge into it:
+
+```sh
+# Data source override: init, active, validateWrite, initValue, executeQuery, write, delete …
+d365fo generate datasource-method c:/AOT/MyModel/AxForm/FmVehicleList.xml   --datasource FmVehicle --method validateWrite
+
+# Control event: clicked, modified, lookup, enter, leave …
+d365fo generate control-method c:/AOT/MyModel/AxForm/FmVehicleList.xml   --control Grid_VIN --method clicked
+```
+
+The scaffold carries the correct signature and the `super()` call the override
+needs — the two things that are easy to get wrong from memory and that decide
+whether the form still saves. A method the form already declares is left alone
+rather than overwritten.
+
+### Starting from a form that already works
+
+`generate form-clone` copies an existing AxForm under a new name, keeping its
+pattern, controls and data source wiring, and optionally re-pointing the data
+sources at other tables:
+
+```sh
+d365fo generate form-clone FmServiceOrderInquiry   --from FmVehicleServiceOrder   --rebind FmVehicleLine=FmServiceOrder   --install-to FleetManagement
+```
+
+`--from` takes a form name resolved through the index, or a path to an AxForm
+XML file. `--rebind <OldTable>=<NewTable>` is repeatable and moves the data
+sources; everything the clone keeps is what the original had, so start from a
+form whose pattern is the one you want rather than from the nearest one.
+
 ## 3. Menus and menu items
 
 An `AxMenu` is a flat `<Elements>` collection of `AxMenuElement` entries. Which

--- a/skills/copilot/object-extension-authoring.instructions.md
+++ b/skills/copilot/object-extension-authoring.instructions.md
@@ -86,6 +86,49 @@ d365fo generate extension Edt CustAccount --suffix Fleet --install-to FleetManag
 d365fo generate extension Enum NoYes --suffix Fleet --install-to FleetManagement
 ```
 
+Five more kinds take the same two positional arguments:
+
+```sh
+# Project an extra column through a standard view
+d365fo generate extension View CustAccountName --suffix Fleet --install-to FleetManagement
+
+# Add a range or data source to a standard query
+d365fo generate extension Query AccountingSourceExplorerQuery --suffix Fleet --install-to FleetManagement
+
+# Expose a model's field through a shipped data entity
+d365fo generate extension DataEntityView CustCustomerV3Entity --suffix Fleet --install-to FleetManagement
+
+# Add a privilege to a Microsoft duty / a duty to a Microsoft role
+d365fo generate extension SecurityDuty MaintainFA_RU --suffix Fleet --install-to FleetManagement
+d365fo generate extension SecurityRole BudgetBudgetClerk --suffix Fleet --install-to FleetManagement
+```
+
+## What lands on disk
+
+Recognise the root element before editing an extension by hand — the AOT folder
+and the root element always agree, and the file name is `<Target>.<Suffix>.xml`:
+
+| Kind | Root element / AOT folder |
+|---|---|
+| `Table` | `AxTableExtension` |
+| `Form` | `AxFormExtension` |
+| `Edt` | `AxEdtExtension` |
+| `Enum` | `AxEnumExtension` |
+| `View` | `AxViewExtension` |
+| `Query` | `AxQuerySimpleExtension` |
+| `DataEntityView` | `AxDataEntityViewExtension` |
+| `SecurityDuty` | `AxSecurityDutyExtension` |
+| `SecurityRole` | `AxSecurityRoleExtension` |
+
+`AxQuerySimpleExtension` is the one to watch: the folder, the root element and
+the metadata provider collection are all `QuerySimpleExtension(s)`. There is no
+`AxQueryExtension` type in the platform at all, so an extension written under
+that name resolves to nothing.
+
+There is no Map extension kind. `AxMapExtension` is a folder every model ships
+and no standard model has a file in — extend the tables the map is mapped onto
+instead.
+
 `generate extension` takes exactly two positional arguments (`<KIND> <TARGET>`);
 the suffix is a named `--suffix <SUFFIX>` option, not a third positional
 argument — passing it positionally fails with "Could not match '<value>' with

--- a/skills/copilot/security-modeling.instructions.md
+++ b/skills/copilot/security-modeling.instructions.md
@@ -54,6 +54,22 @@ d365fo generate duty FmVehicleMaintenanceDuty \
 d365fo generate role FmFleetClerk --duty FmVehicleMaintenanceDuty --install-to FleetManagement
 ```
 
+Extending a Microsoft duty or role goes through the same `generate extension`
+command as every other extension — kind first, target second:
+
+```sh
+d365fo generate extension SecurityDuty MaintainFA_RU   --suffix Fleet --install-to FleetManagement
+
+d365fo generate extension SecurityRole BudgetBudgetClerk   --suffix Fleet --install-to FleetManagement
+```
+
+The scaffolds are `AxSecurityDutyExtension` and `AxSecurityRoleExtension` —
+root element and AOT folder in both cases — named `<Target>.<Suffix>`. Add the
+privilege (duty extension) or the duty (role extension) to the scaffold; the
+standard element itself stays untouched, which is what keeps the customisation
+upgradeable and what `d365fo security role <Role>` will read back as the merged
+result.
+
 ## 3. Tracing what a user can actually reach
 
 The chain is only as good as its weakest link, and reading it from XML is

--- a/skills/copilot/table-scaffolding.instructions.md
+++ b/skills/copilot/table-scaffolding.instructions.md
@@ -154,6 +154,44 @@ d365fo search query <NamePart> --output json
 
 `--join target:joinKind:parentDs` (repeatable). JoinKind: `InnerJoin`, `OuterJoin`, `ExistsJoin`, `NoExistsJoin` (no "t" — this is the real `AxQuerySimpleEmbeddedDataSource.JoinMode` spelling, confirmed against shipped platform `AxQuery` XML; `NotExistsJoin` is rejected). The join is emitted as `<UseRelations>Yes</UseRelations>`, which tells the platform to auto-derive the join key from the target table's existing AOT relation — this only works when such a relation actually exists between the two tables.
 
+### AxView — a query projected as a read-only table
+
+A view is a query with a field list: the AOS turns it into a database view, and
+X++ selects from it like a table. It is the right answer whenever the reporting
+or entity shape is a fixed join that nothing writes to.
+
+```sh
+# A view over an existing query — the query is required, a view projects one
+d365fo generate view FmVehicleView   --query FmVehicleQuery --field VIN:FmVehicle --field Make:FmVehicle   --out c:/AOT/MyModel/AxView/FmVehicleView.xml
+```
+
+`--field <name>:<dataSource>[:<dataField>]` is repeatable and names the query
+data source the column comes from; `--computed <name>:<method>:<type>` adds a
+computed column backed by a static method on the view. The root element and AOT
+folder are `AxView`. Generate the backing `AxQuery` first — a view whose query
+does not exist compiles to nothing usable.
+
+### AxMap — one field template mapped onto several tables
+
+A map declares fields once and maps them onto tables that already have those
+columns under different names, so a single X++ routine can run over all of them
+(`SalesPurchLine` is the platform's own example).
+
+```sh
+# Field declared once, mapped onto two tables
+d365fo generate map FmVehicleSharedMap   --field VIN:VinEdt --map-to FmVehicle --map-to FmVehicleLine   --out c:/AOT/MyModel/AxMap/FmVehicleSharedMap.xml
+
+# Column names that differ per table: <table>:<mapField>=<tableField>
+d365fo generate map FmVehicleMap   --field Make:Name --map-to FmVehicle:Make=Make   --out c:/AOT/MyModel/AxMap/FmVehicleMap.xml
+```
+
+`--field <name>:<edt>[:<label>]` — the EDT decides the concrete field type, so
+the map field and the mapped columns have to agree on it. `--map-to <table>`
+alone maps every field by identical name; the `<table>:<mapField>=<tableField>`
+form is for the ones that differ. The root element and AOT folder are `AxMap`.
+There is no map extension: to change a map's reach, extend the tables it maps
+onto.
+
 ### Number sequence integration
 
 If the table needs an auto-generated document number:

--- a/skills/copilot/x++-class-authoring.instructions.md
+++ b/skills/copilot/x++-class-authoring.instructions.md
@@ -38,6 +38,25 @@ conversation with long metadata dumps.
    d365fo bp check             # (when available) — xppbp.exe runner
    ```
 
+## The plain class
+
+When none of the framework shapes below fits — the class is a helper, a
+container, a small piece of domain logic — scaffold it directly rather than
+hand-writing the `<AxClass>` wrapper around the source:
+
+```sh
+d365fo generate class FmVehicleLogHelper --out c:/AOT/MyModel/AxClass/FmVehicleLogHelper.xml
+
+# Derive from a base class, and drop the default `final`
+d365fo generate class FmVehicleImportJob --extends RunBaseBatch --non-final   --install-to FleetManagement
+```
+
+The scaffold is `final` by default, because a class nobody has a reason to
+inherit from is the safer default in a model others extend; `--non-final` opts
+out where inheritance is actually intended. Add methods with
+`generate event-handler`, `generate coc` or by editing the `<Methods>` block —
+never by rewriting the file wholesale.
+
 ## Hard rules
 
 - **Never** emit X++ that references a field you have not verified with

--- a/skills/d365fo-cli/references/form-pattern-scaffolding.md
+++ b/skills/d365fo-cli/references/form-pattern-scaffolding.md
@@ -119,6 +119,15 @@ d365fo generate form FmFleetWorkspace \
 `--field <F>` is repeatable — these become grid / detail columns. The
 section template is `--section Name:Caption` (split on the first `:`).
 
+## The deprecated alias
+
+`d365fo generate simple-list <Name> --table <T>` still exists and produces exactly
+what `generate form <Name> --pattern SimpleList --table <T>` produces — it is a
+kept-for-compatibility alias, not a second scaffolder. Prefer the `--pattern` form:
+the alias reaches one of the nine patterns and cannot express any of the other
+eight, so a workflow built on it has to be rewritten the moment the form turns
+out to want SimpleListDetails or ListPage.
+
 ## Hard rules
 
 - Never hand-roll AxForm XML — always use `--pattern`.

--- a/skills/d365fo-cli/references/forms-and-navigation.md
+++ b/skills/d365fo-cli/references/forms-and-navigation.md
@@ -68,6 +68,41 @@ d365fo generate event-handler --source-kind Form --source CustTable \
 `d365fo form-pattern spec <Pattern> --output json` lists the structure the pattern
 requires before you start.
 
+### Overrides on the form itself
+
+When the method belongs on the form rather than in an extension class — a new
+form, or one this model owns — write it into the AxForm XML through the two
+method scaffolders instead of by hand. Both take the form's XML file as their
+first argument and merge into it:
+
+```sh
+# Data source override: init, active, validateWrite, initValue, executeQuery, write, delete …
+d365fo generate datasource-method c:/AOT/MyModel/AxForm/FmVehicleList.xml   --datasource FmVehicle --method validateWrite
+
+# Control event: clicked, modified, lookup, enter, leave …
+d365fo generate control-method c:/AOT/MyModel/AxForm/FmVehicleList.xml   --control Grid_VIN --method clicked
+```
+
+The scaffold carries the correct signature and the `super()` call the override
+needs — the two things that are easy to get wrong from memory and that decide
+whether the form still saves. A method the form already declares is left alone
+rather than overwritten.
+
+### Starting from a form that already works
+
+`generate form-clone` copies an existing AxForm under a new name, keeping its
+pattern, controls and data source wiring, and optionally re-pointing the data
+sources at other tables:
+
+```sh
+d365fo generate form-clone FmServiceOrderInquiry   --from FmVehicleServiceOrder   --rebind FmVehicleLine=FmServiceOrder   --install-to FleetManagement
+```
+
+`--from` takes a form name resolved through the index, or a path to an AxForm
+XML file. `--rebind <OldTable>=<NewTable>` is repeatable and moves the data
+sources; everything the clone keeps is what the original had, so start from a
+form whose pattern is the one you want rather than from the nearest one.
+
 ## 3. Menus and menu items
 
 An `AxMenu` is a flat `<Elements>` collection of `AxMenuElement` entries. Which

--- a/skills/d365fo-cli/references/object-extension-authoring.md
+++ b/skills/d365fo-cli/references/object-extension-authoring.md
@@ -82,6 +82,49 @@ d365fo generate extension Edt CustAccount --suffix Fleet --install-to FleetManag
 d365fo generate extension Enum NoYes --suffix Fleet --install-to FleetManagement
 ```
 
+Five more kinds take the same two positional arguments:
+
+```sh
+# Project an extra column through a standard view
+d365fo generate extension View CustAccountName --suffix Fleet --install-to FleetManagement
+
+# Add a range or data source to a standard query
+d365fo generate extension Query AccountingSourceExplorerQuery --suffix Fleet --install-to FleetManagement
+
+# Expose a model's field through a shipped data entity
+d365fo generate extension DataEntityView CustCustomerV3Entity --suffix Fleet --install-to FleetManagement
+
+# Add a privilege to a Microsoft duty / a duty to a Microsoft role
+d365fo generate extension SecurityDuty MaintainFA_RU --suffix Fleet --install-to FleetManagement
+d365fo generate extension SecurityRole BudgetBudgetClerk --suffix Fleet --install-to FleetManagement
+```
+
+## What lands on disk
+
+Recognise the root element before editing an extension by hand — the AOT folder
+and the root element always agree, and the file name is `<Target>.<Suffix>.xml`:
+
+| Kind | Root element / AOT folder |
+|---|---|
+| `Table` | `AxTableExtension` |
+| `Form` | `AxFormExtension` |
+| `Edt` | `AxEdtExtension` |
+| `Enum` | `AxEnumExtension` |
+| `View` | `AxViewExtension` |
+| `Query` | `AxQuerySimpleExtension` |
+| `DataEntityView` | `AxDataEntityViewExtension` |
+| `SecurityDuty` | `AxSecurityDutyExtension` |
+| `SecurityRole` | `AxSecurityRoleExtension` |
+
+`AxQuerySimpleExtension` is the one to watch: the folder, the root element and
+the metadata provider collection are all `QuerySimpleExtension(s)`. There is no
+`AxQueryExtension` type in the platform at all, so an extension written under
+that name resolves to nothing.
+
+There is no Map extension kind. `AxMapExtension` is a folder every model ships
+and no standard model has a file in — extend the tables the map is mapped onto
+instead.
+
 `generate extension` takes exactly two positional arguments (`<KIND> <TARGET>`);
 the suffix is a named `--suffix <SUFFIX>` option, not a third positional
 argument — passing it positionally fails with "Could not match '<value>' with

--- a/skills/d365fo-cli/references/security-modeling.md
+++ b/skills/d365fo-cli/references/security-modeling.md
@@ -50,6 +50,22 @@ d365fo generate duty FmVehicleMaintenanceDuty \
 d365fo generate role FmFleetClerk --duty FmVehicleMaintenanceDuty --install-to FleetManagement
 ```
 
+Extending a Microsoft duty or role goes through the same `generate extension`
+command as every other extension — kind first, target second:
+
+```sh
+d365fo generate extension SecurityDuty MaintainFA_RU   --suffix Fleet --install-to FleetManagement
+
+d365fo generate extension SecurityRole BudgetBudgetClerk   --suffix Fleet --install-to FleetManagement
+```
+
+The scaffolds are `AxSecurityDutyExtension` and `AxSecurityRoleExtension` —
+root element and AOT folder in both cases — named `<Target>.<Suffix>`. Add the
+privilege (duty extension) or the duty (role extension) to the scaffold; the
+standard element itself stays untouched, which is what keeps the customisation
+upgradeable and what `d365fo security role <Role>` will read back as the merged
+result.
+
 ## 3. Tracing what a user can actually reach
 
 The chain is only as good as its weakest link, and reading it from XML is

--- a/skills/d365fo-cli/references/table-scaffolding.md
+++ b/skills/d365fo-cli/references/table-scaffolding.md
@@ -150,6 +150,44 @@ d365fo search query <NamePart> --output json
 
 `--join target:joinKind:parentDs` (repeatable). JoinKind: `InnerJoin`, `OuterJoin`, `ExistsJoin`, `NoExistsJoin` (no "t" — this is the real `AxQuerySimpleEmbeddedDataSource.JoinMode` spelling, confirmed against shipped platform `AxQuery` XML; `NotExistsJoin` is rejected). The join is emitted as `<UseRelations>Yes</UseRelations>`, which tells the platform to auto-derive the join key from the target table's existing AOT relation — this only works when such a relation actually exists between the two tables.
 
+### AxView — a query projected as a read-only table
+
+A view is a query with a field list: the AOS turns it into a database view, and
+X++ selects from it like a table. It is the right answer whenever the reporting
+or entity shape is a fixed join that nothing writes to.
+
+```sh
+# A view over an existing query — the query is required, a view projects one
+d365fo generate view FmVehicleView   --query FmVehicleQuery --field VIN:FmVehicle --field Make:FmVehicle   --out c:/AOT/MyModel/AxView/FmVehicleView.xml
+```
+
+`--field <name>:<dataSource>[:<dataField>]` is repeatable and names the query
+data source the column comes from; `--computed <name>:<method>:<type>` adds a
+computed column backed by a static method on the view. The root element and AOT
+folder are `AxView`. Generate the backing `AxQuery` first — a view whose query
+does not exist compiles to nothing usable.
+
+### AxMap — one field template mapped onto several tables
+
+A map declares fields once and maps them onto tables that already have those
+columns under different names, so a single X++ routine can run over all of them
+(`SalesPurchLine` is the platform's own example).
+
+```sh
+# Field declared once, mapped onto two tables
+d365fo generate map FmVehicleSharedMap   --field VIN:VinEdt --map-to FmVehicle --map-to FmVehicleLine   --out c:/AOT/MyModel/AxMap/FmVehicleSharedMap.xml
+
+# Column names that differ per table: <table>:<mapField>=<tableField>
+d365fo generate map FmVehicleMap   --field Make:Name --map-to FmVehicle:Make=Make   --out c:/AOT/MyModel/AxMap/FmVehicleMap.xml
+```
+
+`--field <name>:<edt>[:<label>]` — the EDT decides the concrete field type, so
+the map field and the mapped columns have to agree on it. `--map-to <table>`
+alone maps every field by identical name; the `<table>:<mapField>=<tableField>`
+form is for the ones that differ. The root element and AOT folder are `AxMap`.
+There is no map extension: to change a map's reach, extend the tables it maps
+onto.
+
 ### Number sequence integration
 
 If the table needs an auto-generated document number:

--- a/skills/d365fo-cli/references/x++-class-authoring.md
+++ b/skills/d365fo-cli/references/x++-class-authoring.md
@@ -34,6 +34,25 @@ conversation with long metadata dumps.
    d365fo bp check             # (when available) — xppbp.exe runner
    ```
 
+## The plain class
+
+When none of the framework shapes below fits — the class is a helper, a
+container, a small piece of domain logic — scaffold it directly rather than
+hand-writing the `<AxClass>` wrapper around the source:
+
+```sh
+d365fo generate class FmVehicleLogHelper --out c:/AOT/MyModel/AxClass/FmVehicleLogHelper.xml
+
+# Derive from a base class, and drop the default `final`
+d365fo generate class FmVehicleImportJob --extends RunBaseBatch --non-final   --install-to FleetManagement
+```
+
+The scaffold is `final` by default, because a class nobody has a reason to
+inherit from is the safer default in a model others extend; `--non-final` opts
+out where inheritance is actually intended. Add methods with
+`generate event-handler`, `generate coc` or by editing the `<Methods>` block —
+never by rewriting the file wholesale.
+
 ## Hard rules
 
 - **Never** emit X++ that references a field you have not verified with

--- a/src/D365FO.Cli/CliApp.cs
+++ b/src/D365FO.Cli/CliApp.cs
@@ -348,6 +348,16 @@ public static class CliApp
                 b.AddCommand<D365FO.Cli.Commands.Journal.JournalListCommand>("list").WithDescription("List journal entries, most-recent-first.");
             });
 
+            cfg.AddBranch("oracle", b =>
+            {
+                b.SetDescription("Measure the tool against the installation: the checks that judge the validator rather than what it produces.");
+                b.AddCommand<OracleSweepCommand>("sweep").WithDescription("Run every rule over every shipped file. The bar is ZERO errors on Microsoft's own code — a rule that fires there is wrong, not strict.");
+                b.AddCommand<OracleCensusCommand>("census").WithDescription("What the installation actually writes for one element — the measurement that has to precede a rule.");
+                b.AddCommand<OracleMembersCommand>("members").WithDescription("The metadata contract's declared members against the ones shipped files carry: dead declarations one way, catalog drift the other.");
+                b.AddCommand<OracleProbeCommand>("probe").WithDescription("Compile ONE artefact with the real xppc — the claim the offline validator cannot make. Windows + a D365FO installation.");
+                b.AddCommand<OracleRuntimeCommand>("runtime").WithDescription("Is the SysTest runner wired to a database, and can it tell a pass from a fail? --configure derives the settings from the AOS; --negative-control emits the class that proves discrimination.");
+            });
+
             cfg.AddBranch("eval", b =>
             {
                 b.SetDescription("Self-improving agent eval loop: run/score catalog cases against golden metadata (docs/AGENT_EVAL_LOOP.md).");

--- a/src/D365FO.Cli/Commands/Eval/EvalRunCommand.cs
+++ b/src/D365FO.Cli/Commands/Eval/EvalRunCommand.cs
@@ -198,7 +198,23 @@ public sealed class EvalRunCommand : Command<EvalRunCommand.Settings>
                     repo.ApplyExtract(batch);
             }
 
-            var args = @case.CanonicalArgs!.Concat(new[] { "--out", outPath, "--overwrite", "--output", "json" }).ToArray();
+            // A case that augments an existing table starts FROM an artefact instead of producing
+            // one: the seed is copied in as the run's output file and merged into in place, so
+            // everything downstream (scoring, capture) sees the same actual.xml it always did.
+            string[] args;
+            if (@case.ApplyToSeed is { Length: > 0 } seedName)
+            {
+                var seed = Path.Combine(EvalPaths.SeedsDir(root), seedName);
+                if (!File.Exists(seed))
+                    return (null, new ReplayFailure("EVAL_SEED_MISSING", $"Seed artefact not found: {seed}"));
+                File.Copy(seed, outPath);
+                args = @case.CanonicalArgs!.Concat(new[] { "--apply-to", outPath, "--output", "json" }).ToArray();
+            }
+            else
+            {
+                args = @case.CanonicalArgs!.Concat(new[] { "--out", outPath, "--overwrite", "--output", "json" }).ToArray();
+            }
+
             var (exitCode, replayError) = RunReplay(dllPath, dbPath, args);
 
             if (replayError is not null)
@@ -206,7 +222,7 @@ public sealed class EvalRunCommand : Command<EvalRunCommand.Settings>
             if (exitCode != 0 || !File.Exists(outPath))
                 return (null, new ReplayFailure("EVAL_GENERATE_FAILED", $"`d365fo {string.Join(' ', args)}` exited {exitCode} or produced no output file at {outPath}."));
 
-            var score = EvalScorer.Score(@case, outPath, EvalPaths.GoldensDir(root), repo);
+            var score = EvalScorer.Score(@case, outPath, EvalPaths.GoldensDir(root), repo, producedDir: workDir);
 
             if (write)
             {

--- a/src/D365FO.Cli/Commands/Eval/EvalVerifyBuildCommand.cs
+++ b/src/D365FO.Cli/Commands/Eval/EvalVerifyBuildCommand.cs
@@ -119,11 +119,20 @@ public sealed class EvalVerifyBuildCommand : Command<EvalVerifyBuildCommand.Sett
             ? Path.Combine(Path.GetTempPath(), $"d365fo-l3-{Guid.NewGuid():N}")
             : Path.GetFullPath(settings.WorkDir!);
 
+        // Resolved before provisioning, because it decides the model's reference list. A
+        // missing installation is not fatal here: --provision-only is meant to run anywhere.
+        var packagesRoot = settings.PackagesPath ?? D365FoSettings.Resolve("D365FO_PACKAGES_PATH");
+
         try
         {
             Directory.CreateDirectory(workDir);
 
-            var model = L3ModelProvisioner.Provision(cases, EvalPaths.GoldensDir(root!), workDir, modelName);
+            // Every package on the installation, not the usual three: a golden that EXTENDS a
+            // standard object drags in whatever that object references, which is not confined to
+            // ApplicationSuite/Foundation/Platform.
+            var model = L3ModelProvisioner.Provision(
+                cases, EvalPaths.GoldensDir(root!), workDir, modelName,
+                moduleReferences: L3ModelProvisioner.ModulesIn(packagesRoot ?? ""));
 
             // The fixture's objects go into the same module as the goldens: the goldens
             // bind to its tables, and one module has no cross-module visibility question
@@ -153,8 +162,6 @@ public sealed class EvalVerifyBuildCommand : Command<EvalVerifyBuildCommand.Sett
             var guard = SdlcRunner.WindowsGuard("d365fo eval verify-build");
             if (guard is not null) return RenderHelpers.Render(kind, guard);
 
-            var packagesRoot = settings.PackagesPath
-                ?? D365FoSettings.Resolve("D365FO_PACKAGES_PATH");
             if (string.IsNullOrWhiteSpace(packagesRoot) || !Directory.Exists(packagesRoot))
             {
                 return RenderHelpers.Render(kind, ToolResult<object>.Fail(

--- a/src/D365FO.Cli/Commands/Eval/OracleCommands.cs
+++ b/src/D365FO.Cli/Commands/Eval/OracleCommands.cs
@@ -1,0 +1,226 @@
+using D365FO.Core;
+using D365FO.Core.Eval;
+using Spectre.Console.Cli;
+
+namespace D365FO.Cli.Commands.Eval;
+
+// `d365fo oracle` — the measurements that decide whether the validator can be trusted.
+//
+// Every other gate in this repository judges what the tool produces. These judge the tool
+// itself, against the one corpus nobody can argue with: the installation on disk.
+
+/// <summary>
+/// <c>d365fo oracle sweep</c> — run every rule over every shipped file and count what it says.
+/// </summary>
+/// <remarks>
+/// The bar is zero ERRORS on Microsoft's own X++ and XML. A rule that fires on shipped code is
+/// not a strict rule, it is a wrong one: it teaches a caller that findings are noise, and the
+/// next finding — the real one — is ignored too.
+/// </remarks>
+public sealed class OracleSweepCommand : Command<OracleSweepCommand.Settings>
+{
+    public sealed class Settings : D365OutputSettings
+    {
+        [CommandOption("--packages <PATH>")]
+        [System.ComponentModel.Description("Root to sweep. Defaults to D365FO_PACKAGES_PATH.")]
+        public string? PackagesPath { get; init; }
+
+        [CommandOption("--model <NAME>")]
+        [System.ComponentModel.Description("Sweep one model instead of the whole installation.")]
+        public string? Model { get; init; }
+
+        [CommandOption("--kind <FOLDER>")]
+        [System.ComponentModel.Description("Sweep one AOT folder, e.g. AxTable or AxClass.")]
+        public string? Kind { get; init; }
+
+        [CommandOption("-l|--limit <N>")]
+        [System.ComponentModel.Description("Stop after N files. 0 (default) sweeps everything.")]
+        public int Limit { get; init; }
+
+        [CommandOption("--samples <N>")]
+        [System.ComponentModel.Description("Example findings kept per rule (default 3).")]
+        public int Samples { get; init; } = 3;
+
+        [CommandOption("--warnings")]
+        [System.ComponentModel.Description("Report warnings too. Off by default: only errors are held to the zero bar.")]
+        public bool Warnings { get; init; }
+
+        [CommandOption("--parallelism <N>")]
+        public int? Parallelism { get; init; }
+
+        [CommandOption("--dry")]
+        [System.ComponentModel.Description("Sweep the checked-in fixtures instead of an installation, so CI without a D365FO host still exercises the sweep itself.")]
+        public bool Dry { get; init; }
+    }
+
+    public override int Execute(CommandContext ctx, Settings settings)
+    {
+        var kind = OutputMode.Resolve(settings.Output);
+
+        // --dry sweeps the checked-in MiniAot fixture, which is packages-shaped
+        // (<root>/<package>/<model>/Ax*) precisely so it can stand in for an installation.
+        var root = settings.Dry
+            ? (EvalPaths.FindRepoRoot() is { } repoRoot ? EvalPaths.FixtureDir(repoRoot) : null)
+            : settings.PackagesPath ?? D365FoSettings.Resolve("D365FO_PACKAGES_PATH");
+
+        if (string.IsNullOrWhiteSpace(root) || !Directory.Exists(root))
+            return RenderHelpers.Render(kind, ToolResult<object>.Fail(
+                D365FoErrorCodes.PackagesPathNotFound,
+                settings.Dry
+                    ? $"No fixture root at {root}."
+                    : $"No packages path to sweep{(root is null ? "" : $": {root}")}.",
+                "Pass --packages <PATH>, set D365FO_PACKAGES_PATH, or use --dry to sweep the checked-in fixtures."));
+
+        var report = OracleSweep.Run(root!, new OracleSweep.Options(
+            settings.Model, settings.Kind, settings.Limit, settings.Samples,
+            settings.Warnings, settings.Parallelism), RepoOrNull());
+
+        var warnings = new List<string>();
+        if (!report.BarHeld)
+            warnings.Add($"{report.Errors} ERROR-severity finding(s) against shipped code. Each one is a rule "
+                       + "claiming an artefact does not work, contradicted by the fact that it ships and builds — "
+                       + "fix the rule, not the file.");
+        if (report.FilesUnreadable > 0)
+            warnings.Add($"{report.FilesUnreadable} file(s) could not be read and were not judged.");
+        if (report.FilesScanned == 0)
+            warnings.Add("Nothing was swept — the root holds no <package>/<model>/Ax* folders.");
+
+        var rc = RenderHelpers.Render(kind, ToolResult<object>.Success(report, warnings.Count > 0 ? warnings : null));
+        return rc != 0 ? rc : report.BarHeld ? 0 : 2;
+    }
+
+    /// <summary>The index, when there is one: the property rules are sharper with mined stats.</summary>
+    private static D365FO.Core.Validation.IPropertyStatsProvider? RepoOrNull()
+    {
+        try
+        {
+            var repo = RepoFactory.Create();
+            return repo.HasPropertyStats() ? repo : null;
+        }
+        catch { return null; }
+    }
+}
+
+/// <summary>
+/// <c>d365fo oracle census</c> — what the installation actually writes for one element.
+/// </summary>
+/// <remarks>
+/// The measurement that has to precede a rule. Enforcing a shape the installation does not keep
+/// produces findings against files that ship and build, and this repository has already released
+/// one such rule and withdrawn it — the census is what would have refused it first.
+/// </remarks>
+public sealed class OracleCensusCommand : Command<OracleCensusCommand.Settings>
+{
+    public sealed class Settings : D365OutputSettings
+    {
+        [CommandArgument(0, "<ELEMENT>")]
+        [System.ComponentModel.Description("Root element to measure, e.g. AxTable, AxEnum, AxForm.")]
+        public string Element { get; init; } = "";
+
+        [CommandOption("--packages <PATH>")]
+        [System.ComponentModel.Description("Installation to measure. Defaults to D365FO_PACKAGES_PATH.")]
+        public string? PackagesPath { get; init; }
+
+        [CommandOption("-l|--limit <N>")]
+        [System.ComponentModel.Description("Stop after N documents. 0 (default) reads them all.")]
+        public int Limit { get; init; }
+
+        [CommandOption("--values <N>")]
+        [System.ComponentModel.Description("Distinct leaf values to keep per member (default 5).")]
+        public int Values { get; init; } = 5;
+
+        [CommandOption("--parallelism <N>")]
+        public int? Parallelism { get; init; }
+    }
+
+    public override int Execute(CommandContext ctx, Settings settings)
+    {
+        var kind = OutputMode.Resolve(settings.Output);
+
+        if (string.IsNullOrWhiteSpace(settings.Element))
+            return RenderHelpers.Render(kind, ToolResult<object>.Fail(D365FoErrorCodes.BadInput, "An element is required."));
+
+        var root = settings.PackagesPath ?? D365FoSettings.Resolve("D365FO_PACKAGES_PATH");
+        if (string.IsNullOrWhiteSpace(root) || !Directory.Exists(root))
+            return RenderHelpers.Render(kind, ToolResult<object>.Fail(
+                D365FoErrorCodes.PackagesPathNotFound,
+                "No installation to measure.",
+                "Pass --packages <PATH> or set D365FO_PACKAGES_PATH. A census needs real files; there is no offline form of it."));
+
+        var report = OracleCensus.Run(root!, settings.Element, settings.Limit, settings.Values, settings.Parallelism);
+
+        var warnings = new List<string>();
+        if (report.FilesScanned == 0)
+            warnings.Add($"No <{settings.Element}> document was found under {root} — check the element name against the AOT folder names.");
+        if (!report.OrderIsStable)
+            warnings.Add($"Member order is NOT stable across the corpus ({report.OrderCounterExamples.Count} pair(s) seen both ways). "
+                       + "Do not write a rule that depends on it.");
+        if (report.SeenNotDeclared.Count > 0)
+            warnings.Add($"{report.SeenNotDeclared.Count} member(s) the installation writes are not in the metadata contract: "
+                       + string.Join(", ", report.SeenNotDeclared.Take(10))
+                       + ". That is the contract being behind, not the files being wrong.");
+
+        return RenderHelpers.Render(kind, ToolResult<object>.Success(report, warnings.Count > 0 ? warnings : null));
+    }
+}
+
+/// <summary>
+/// <c>d365fo oracle members</c> — the contract's declared members against the ones files carry.
+/// </summary>
+/// <remarks>
+/// The same measurement read the other way: which declared members no file uses (dead contract),
+/// and which used members are undeclared (drift). Both directions matter, because the validator
+/// judges documents against the contract and the contract is a snapshot of a shipped assembly.
+/// </remarks>
+public sealed class OracleMembersCommand : Command<OracleMembersCommand.Settings>
+{
+    public sealed class Settings : D365OutputSettings
+    {
+        [CommandArgument(0, "<ELEMENT>")]
+        [System.ComponentModel.Description("Root element, e.g. AxTable.")]
+        public string Element { get; init; } = "";
+
+        [CommandOption("--packages <PATH>")]
+        public string? PackagesPath { get; init; }
+
+        [CommandOption("-l|--limit <N>")]
+        [System.ComponentModel.Description("Documents to read. 0 (default) reads them all.")]
+        public int Limit { get; init; }
+    }
+
+    public override int Execute(CommandContext ctx, Settings settings)
+    {
+        var kind = OutputMode.Resolve(settings.Output);
+
+        if (string.IsNullOrWhiteSpace(settings.Element))
+            return RenderHelpers.Render(kind, ToolResult<object>.Fail(D365FoErrorCodes.BadInput, "An element is required."));
+
+        var root = settings.PackagesPath ?? D365FoSettings.Resolve("D365FO_PACKAGES_PATH");
+        if (string.IsNullOrWhiteSpace(root) || !Directory.Exists(root))
+            return RenderHelpers.Render(kind, ToolResult<object>.Fail(
+                D365FoErrorCodes.PackagesPathNotFound, "No installation to measure.",
+                "Pass --packages <PATH> or set D365FO_PACKAGES_PATH."));
+
+        var census = OracleCensus.Run(root!, settings.Element, settings.Limit, sampleValues: 0);
+
+        return RenderHelpers.Render(kind, ToolResult<object>.Success(new
+        {
+            element = census.Element,
+            contract = census.Contract,
+            filesScanned = census.FilesScanned,
+            declaredNeverSeen = census.DeclaredNeverSeen,
+            seenNotDeclared = census.SeenNotDeclared,
+            usage = census.Members.Select(m => new
+            {
+                m.Member,
+                m.Declared,
+                m.Files,
+                share = census.FilesScanned == 0 ? "0%" : Math.Round(100.0 * m.Files / census.FilesScanned) + "%",
+            }),
+            note = "share is the proportion of documents carrying the member — the evidence a property rule "
+                 + "needs before it can call the member required.",
+        }, census.SeenNotDeclared.Count > 0
+            ? [$"{census.SeenNotDeclared.Count} member(s) in the files are absent from the contract — the contract snapshot is behind."]
+            : null));
+    }
+}

--- a/src/D365FO.Cli/Commands/Eval/OracleProbeCommand.cs
+++ b/src/D365FO.Cli/Commands/Eval/OracleProbeCommand.cs
@@ -1,0 +1,155 @@
+using D365FO.Core;
+using D365FO.Core.Eval;
+using D365FO.Core.Ops;
+using Spectre.Console.Cli;
+
+namespace D365FO.Cli.Commands.Eval;
+
+/// <summary>
+/// <c>d365fo oracle probe</c> — compile one artefact (or a handful) with the real X++ compiler.
+/// </summary>
+/// <remarks>
+/// <para>
+/// The offline validator says whether an artefact looks right. This says whether it compiles,
+/// which is the only claim that settles an argument. It exists because the eval goldens cover
+/// only what the case catalog covers: everything a new <c>generate</c> sub-command or form
+/// pattern produces had never met the compiler, and the first hand-run of this recipe turned up
+/// uncompilable output from three of them.
+/// </para>
+/// <para>
+/// A clean run is only evidence when the compiler actually ran. If xppc rejects the argument
+/// list it prints its own usage, which parses as "no diagnostics" — so that case is reported as
+/// a failure of the probe, never as a pass.
+/// </para>
+/// </remarks>
+public sealed class OracleProbeCommand : Command<OracleProbeCommand.Settings>
+{
+    public sealed class Settings : D365OutputSettings
+    {
+        [CommandArgument(0, "<ARTIFACT>")]
+        [System.ComponentModel.Description("AOT XML to compile. Repeat the argument to probe several together.")]
+        public string[] Artifacts { get; init; } = Array.Empty<string>();
+
+        [CommandOption("--work-dir <PATH>")]
+        [System.ComponentModel.Description("Where to build the throwaway metadata store (default: a temp directory, deleted afterwards).")]
+        public string? WorkDir { get; init; }
+
+        [CommandOption("--model <NAME>")]
+        [System.ComponentModel.Description("Throwaway model name (default: D365FoCliProbe).")]
+        public string? Model { get; init; }
+
+        [CommandOption("--packages <PATH>")]
+        [System.ComponentModel.Description("PackagesLocalDirectory to resolve references against (default: D365FO_PACKAGES_PATH).")]
+        public string? PackagesPath { get; init; }
+
+        [CommandOption("--compiler <PATH>")]
+        [System.ComponentModel.Description("xppc.exe (default: <packages>\\Bin\\xppc.exe).")]
+        public string? CompilerPath { get; init; }
+
+        [CommandOption("--compiler-args <TEMPLATE>")]
+        [System.ComponentModel.Description("Override the argument template. Placeholders: {metadata} {packages} {model} {output} {log}.")]
+        public string? CompilerArgs { get; init; }
+
+        [CommandOption("--no-fixture")]
+        [System.ComponentModel.Description("Do not lay down the MiniAot fixture; probe the artefact against the installation alone.")]
+        public bool NoFixture { get; init; }
+
+        [CommandOption("--keep")]
+        [System.ComponentModel.Description("Keep the work directory after the run, to inspect what was compiled.")]
+        public bool Keep { get; init; }
+    }
+
+    public override int Execute(CommandContext ctx, Settings settings)
+    {
+        var kind = OutputMode.Resolve(settings.Output);
+
+        var guard = SdlcRunner.WindowsGuard("d365fo oracle probe");
+        if (guard is not null) return RenderHelpers.Render(kind, guard);
+
+        if (settings.Artifacts.Length == 0)
+            return RenderHelpers.Render(kind, ToolResult<object>.Fail(D365FoErrorCodes.BadInput,
+                "At least one artefact is required."));
+
+        var packagesRoot = settings.PackagesPath ?? D365FoSettings.Resolve("D365FO_PACKAGES_PATH");
+        if (string.IsNullOrWhiteSpace(packagesRoot) || !Directory.Exists(packagesRoot))
+            return RenderHelpers.Render(kind, ToolResult<object>.Fail("PACKAGES_NOT_FOUND",
+                $"No PackagesLocalDirectory at: {packagesRoot ?? "(unset)"}",
+                "Set D365FO_PACKAGES_PATH (or pass --packages) to the installation to compile against."));
+
+        var compiler = settings.CompilerPath ?? Path.Combine(packagesRoot!, "Bin", "xppc.exe");
+        if (!File.Exists(compiler))
+            return RenderHelpers.Render(kind, ToolResult<object>.Fail("XPPC_NOT_FOUND",
+                $"xppc.exe not found at: {compiler}",
+                "Pass --compiler, or point --packages at the FrameworkDirectory that contains Bin\\xppc.exe."));
+
+        var modelName = string.IsNullOrWhiteSpace(settings.Model) ? "D365FoCliProbe" : settings.Model!;
+        var workDir = settings.WorkDir ?? Path.Combine(Path.GetTempPath(), "d365fo-probe-" + Guid.NewGuid().ToString("N")[..8]);
+        var ephemeral = settings.WorkDir is null && !settings.Keep;
+
+        try
+        {
+            Directory.CreateDirectory(workDir);
+            var prep = OracleProbe.Prepare(
+                settings.Artifacts, workDir, modelName, !settings.NoFixture, packagesRoot);
+
+            if (prep.Placed.Count == 0)
+                return RenderHelpers.Render(kind, ToolResult<object>.Fail("NOTHING_TO_COMPILE",
+                    "None of the given files is a usable AOT document, so the compiler was not run.",
+                    string.Join("; ", prep.Rejected.Select(r => $"{Path.GetFileName(r.File)}: {r.Reason}"))));
+
+            var result = XppcRunner.Compile(workDir, packagesRoot!, compiler, modelName, settings.CompilerArgs);
+
+            if (result.InvocationRejected)
+                return RenderHelpers.Render(kind, ToolResult<object>.Fail("PROBE_INVOCATION",
+                    "The compiler rejected the argument list, so nothing was compiled — this run says nothing about the artefacts.",
+                    $"Args: {string.Join(' ', result.Args)}\n\n{result.LogTail}"));
+
+            var (attributed, unattributed) = OracleProbe.Attribute(prep, result.Diagnostics);
+            var errors = result.Diagnostics.Where(d => d.Severity == "error").ToList();
+
+            var warnings = new List<string>();
+            if (prep.Rejected.Count > 0)
+                warnings.Add($"{prep.Rejected.Count} file(s) were not compiled: "
+                           + string.Join("; ", prep.Rejected.Select(r => $"{Path.GetFileName(r.File)} — {r.Reason}")));
+            if (unattributed.Count > 0)
+                warnings.Add($"{unattributed.Count} diagnostic(s) name no probed artefact — they belong to the fixture "
+                           + "or to a reference, not to what you asked about.");
+
+            var payload = ToolResult<object>.Success(new
+            {
+                compiled = prep.Placed.Select(p => new { p.ObjectName, p.AxFolder, source = p.Source }),
+                clean = errors.Count == 0,
+                errorCount = errors.Count,
+                diagnosticCount = result.Diagnostics.Count,
+                elapsedMs = result.ElapsedMs,
+                findings = attributed.Select(a => new
+                {
+                    artifact = a.Artifact,
+                    severity = a.Diagnostic.Severity,
+                    member = a.Diagnostic.Member,
+                    line = a.Diagnostic.Line,
+                    message = a.Diagnostic.Message,
+                    hint = a.Diagnostic.Hint,
+                }),
+                unattributed = unattributed.Select(d => new { d.Severity, d.Object, d.Message }),
+                workDir = settings.Keep || settings.WorkDir is not null ? workDir : null,
+                compilerArgs = string.Join(' ', result.Args),
+            }, warnings.Count > 0 ? warnings : null);
+
+            var rc = RenderHelpers.Render(kind, payload);
+            return rc != 0 ? rc : errors.Count == 0 ? 0 : 2;
+        }
+        catch (Exception ex)
+        {
+            return RenderHelpers.Render(kind, ToolResult<object>.Fail("PROBE_FAILED", ex.Message));
+        }
+        finally
+        {
+            if (ephemeral)
+            {
+                try { Directory.Delete(workDir, recursive: true); }
+                catch { /* a temp directory the compiler still holds is not worth failing over */ }
+            }
+        }
+    }
+}

--- a/src/D365FO.Cli/Commands/Eval/OracleRuntimeCommand.cs
+++ b/src/D365FO.Cli/Commands/Eval/OracleRuntimeCommand.cs
@@ -1,0 +1,150 @@
+using D365FO.Core;
+using D365FO.Core.Eval;
+using D365FO.Core.Ops;
+using Spectre.Console.Cli;
+
+namespace D365FO.Cli.Commands.Eval;
+
+/// <summary>
+/// <c>d365fo oracle runtime</c> — is the SysTest runner wired to anything, and can it tell a
+/// passing test from a failing one?
+/// </summary>
+/// <remarks>
+/// <para>
+/// Two questions that decide whether a test result means anything, and neither is answered by
+/// running the tests. A runner whose config carries no database dies with <c>Login failed</c>,
+/// which reads like a broken test model; the keys it needs are in the AOS <c>web.config</c>, so
+/// the answer is derivable rather than guessable.
+/// </para>
+/// <para>
+/// The second question is the one nobody asks: "all tests passed" is also what a runner prints
+/// when it ran nothing. <c>--negative-control</c> emits a class whose three methods pass, fail
+/// and throw on purpose — until the failure is reported AS a failure, a green suite is not
+/// evidence.
+/// </para>
+/// </remarks>
+public sealed class OracleRuntimeCommand : Command<OracleRuntimeCommand.Settings>
+{
+    public sealed class Settings : D365OutputSettings
+    {
+        [CommandOption("--packages <PATH>")]
+        [System.ComponentModel.Description("PackagesLocalDirectory; the runner lives under its bin. Defaults to D365FO_PACKAGES_PATH.")]
+        public string? PackagesPath { get; init; }
+
+        [CommandOption("--web-config <PATH>")]
+        [System.ComponentModel.Description("AOS web.config to take the database settings from. Found beside the packages root when omitted.")]
+        public string? WebConfig { get; init; }
+
+        [CommandOption("--configure")]
+        [System.ComponentModel.Description("Write the MISSING database settings into SysTestConsole.exe.config, taken from the AOS web.config. Keeps a .bak beside it — this edits a Microsoft-installed file.")]
+        public bool Configure { get; init; }
+
+        [CommandOption("--negative-control")]
+        [System.ComponentModel.Description("Emit the negative-control test class (a pass, a deliberate fail, a deliberate throw) instead of diagnosing.")]
+        public bool NegativeControl { get; init; }
+
+        [CommandOption("--out <PATH>")]
+        [System.ComponentModel.Description("Write the negative control here instead of to stdout.")]
+        public string? Out { get; init; }
+
+        [CommandOption("--class <NAME>")]
+        [System.ComponentModel.Description("Class name for the negative control (default D365FoCliNegativeControlTest).")]
+        public string? ClassName { get; init; }
+    }
+
+    public override int Execute(CommandContext ctx, Settings settings)
+    {
+        var kind = OutputMode.Resolve(settings.Output);
+
+        if (settings.NegativeControl)
+        {
+            var className = string.IsNullOrWhiteSpace(settings.ClassName)
+                ? "D365FoCliNegativeControlTest"
+                : settings.ClassName!;
+            var source = RuntimeOracle.NegativeControlSource(className);
+
+            string? written = null;
+            if (!string.IsNullOrWhiteSpace(settings.Out))
+            {
+                var full = Path.GetFullPath(settings.Out!);
+                var dir = Path.GetDirectoryName(full);
+                if (!string.IsNullOrEmpty(dir)) Directory.CreateDirectory(dir);
+                File.WriteAllText(full, source);
+                written = full;
+            }
+
+            return RenderHelpers.Render(kind, ToolResult<object>.Success(new
+            {
+                className,
+                path = written,
+                source = written is null ? source : null,
+                howToUse = $"Compile it into a test model, then `d365fo test run --test {className} --results <PATH>`. "
+                         + "A run that reports all three as passed is not running them; one that reports the failure "
+                         + "and the throw distinctly is one whose verdicts mean something.",
+            }));
+        }
+
+        var packagesRoot = settings.PackagesPath ?? D365FoSettings.Resolve("D365FO_PACKAGES_PATH");
+        if (string.IsNullOrWhiteSpace(packagesRoot))
+            return RenderHelpers.Render(kind, ToolResult<object>.Fail(
+                D365FoErrorCodes.PackagesPathNotFound,
+                "No packages path.",
+                "Set D365FO_PACKAGES_PATH or pass --packages <PATH>."));
+
+        var diagnosis = RuntimeOracle.Diagnose(packagesRoot!, settings.WebConfig);
+
+        if (settings.Configure)
+        {
+            var guard = SdlcRunner.WindowsGuard("d365fo oracle runtime --configure");
+            if (guard is not null) return RenderHelpers.Render(kind, guard);
+
+            if (diagnosis.RunnerConfigPath is null)
+                return RenderHelpers.Render(kind, ToolResult<object>.Fail("RUNNER_NOT_FOUND",
+                    "SysTestConsole.exe.config is not where the runner should be.",
+                    $"Looked under {Path.Combine(packagesRoot!, "bin")}. The runner ships with the platform; a "
+                    + "development VM has it and a build agent may not."));
+
+            if (diagnosis.WebConfigPath is null)
+                return RenderHelpers.Render(kind, ToolResult<object>.Fail("WEB_CONFIG_NOT_FOUND",
+                    "No AOS web.config to take the settings from.",
+                    "Pass --web-config <PATH>. The settings are copied from the AOS this installation runs, never invented."));
+
+            var result = RuntimeOracle.Configure(diagnosis.RunnerConfigPath, diagnosis.WebConfigPath);
+            return RenderHelpers.Render(kind, ToolResult<object>.Success(new
+            {
+                configured = result.RunnerConfigPath,
+                backup = result.Written.Count > 0 ? result.BackupPath : null,
+                written = result.Written,
+                unavailable = result.Unavailable,
+                verdict = result.Written.Count == 0
+                    ? "Nothing to do — the runner already carries every database setting."
+                    : $"Copied {result.Written.Count} setting(s) from the AOS configuration.",
+            }, result.Unavailable.Count > 0
+                ? [$"{result.Unavailable.Count} setting(s) are missing from the web.config too and were not invented: "
+                   + string.Join(", ", result.Unavailable)]
+                : null));
+        }
+
+        var warnings = new List<string>();
+        if (!diagnosis.RunnerPresent)
+            warnings.Add("SysTestConsole.exe is not under the packages bin — there is no runtime oracle on this host.");
+        else if (!diagnosis.Configured)
+            warnings.Add($"The runner carries no value for: {string.Join(", ", diagnosis.Missing)}. It will fail with "
+                       + "\"Login failed\", which reads like a broken test model rather than a runner pointed at nothing. "
+                       + "Run with --configure to copy them from the AOS web.config.");
+
+        var rc = RenderHelpers.Render(kind, ToolResult<object>.Success(new
+        {
+            runner = diagnosis.RunnerPath,
+            runnerConfig = diagnosis.RunnerConfigPath,
+            webConfig = diagnosis.WebConfigPath,
+            configured = diagnosis.Configured,
+            settings = diagnosis.Settings,
+            missing = diagnosis.Missing,
+            note = "Configuration is necessary and not sufficient: a configured runner still has to be shown to "
+                 + "FAIL a test that should fail. `--negative-control` emits the class that proves it.",
+        }, warnings.Count > 0 ? warnings : null));
+
+        return rc != 0 ? rc : diagnosis.Configured ? 0 : 2;
+    }
+}

--- a/src/D365FO.Core/Eval/EvalCase.cs
+++ b/src/D365FO.Core/Eval/EvalCase.cs
@@ -15,4 +15,5 @@ public sealed record EvalCase(
     IReadOnlyList<string> Tags,
     IReadOnlyList<string> Ignore,
     bool RequiresFixtureIndex,
-    bool GoldenPending);
+    bool GoldenPending,
+    string? ApplyToSeed = null);

--- a/src/D365FO.Core/Eval/EvalCaseCatalog.cs
+++ b/src/D365FO.Core/Eval/EvalCaseCatalog.cs
@@ -111,6 +111,24 @@ public static class EvalCaseCatalog
             return false;
         }
 
+        // The replay supplies the output option itself — a case that also carries one would
+        // either fight it or, worse, write somewhere real.
+        var reserved = new[] { "--out", "--overwrite", "--install-to", "--output", "--apply-to" };
+        var offending = (dto.CanonicalArgs ?? Array.Empty<string>())
+            .FirstOrDefault(a => reserved.Contains(a, StringComparer.OrdinalIgnoreCase));
+        if (offending is not null)
+        {
+            error = $"{fileName}: canonical_args must not carry '{offending}' — `eval run` supplies the output options";
+            return false;
+        }
+
+        if (!string.IsNullOrWhiteSpace(dto.ApplyToSeed)
+            && Path.GetFileName(dto.ApplyToSeed) != dto.ApplyToSeed)
+        {
+            error = $"{fileName}: apply_to_seed '{dto.ApplyToSeed}' must be a bare file name under eval/seeds/";
+            return false;
+        }
+
         result = new EvalCase(
             Id: dto.Id!,
             Title: dto.Title!,
@@ -122,7 +140,8 @@ public static class EvalCaseCatalog
             Tags: dto.Tags ?? Array.Empty<string>(),
             Ignore: dto.Ignore ?? Array.Empty<string>(),
             RequiresFixtureIndex: dto.RequiresFixtureIndex,
-            GoldenPending: dto.GoldenPending);
+            GoldenPending: dto.GoldenPending,
+            ApplyToSeed: string.IsNullOrWhiteSpace(dto.ApplyToSeed) ? null : dto.ApplyToSeed);
         error = null;
         return true;
     }
@@ -140,5 +159,6 @@ public static class EvalCaseCatalog
         [JsonPropertyName("ignore")] public string[]? Ignore { get; set; }
         [JsonPropertyName("requires_fixture_index")] public bool RequiresFixtureIndex { get; set; }
         [JsonPropertyName("golden_pending")] public bool GoldenPending { get; set; }
+        [JsonPropertyName("apply_to_seed")] public string? ApplyToSeed { get; set; }
     }
 }

--- a/src/D365FO.Core/Eval/EvalPaths.cs
+++ b/src/D365FO.Core/Eval/EvalPaths.cs
@@ -30,6 +30,13 @@ public static class EvalPaths
     public static string GoldensDir(string repoRoot) => Path.Combine(repoRoot, "eval", "goldens");
     public static string CorpusRunsDir(string repoRoot) => Path.Combine(repoRoot, "eval", "corpus", "runs");
 
+    /// <summary>
+    /// Artefacts a case starts FROM rather than produces: the existing AxTable a
+    /// <c>--apply-to</c> command merges into. Copied into the replay's work directory, never
+    /// mutated in place.
+    /// </summary>
+    public static string SeedsDir(string repoRoot) => Path.Combine(repoRoot, "eval", "seeds");
+
     /// <summary>The checked-in mini-AOT fixture also used by MiniAotEndToEndTests / GoldenQualityGateTests.</summary>
     public static string FixtureDir(string repoRoot) => Path.Combine(repoRoot, "tests", "Samples", "MiniAot");
 

--- a/src/D365FO.Core/Eval/EvalScorer.cs
+++ b/src/D365FO.Core/Eval/EvalScorer.cs
@@ -13,7 +13,19 @@ namespace D365FO.Core.Eval;
 /// </summary>
 public static class EvalScorer
 {
-    public static EvalScoreCard Score(EvalCase @case, string actualXmlPath, string goldensRoot, MetadataRepository repo)
+    /// <param name="case">The case being scored — its golden path and ignore list.</param>
+    /// <param name="actualXmlPath">The artefact the run produced (or merged into).</param>
+    /// <param name="goldensRoot">The <c>eval/goldens</c> directory.</param>
+    /// <param name="repo">Index the reference check resolves against.</param>
+    /// <param name="producedDir">
+    /// The directory the run wrote into, when the caller owns it exclusively (the replay's work
+    /// directory). Given one, a companion the golden does not have is reported as an extra;
+    /// without one, only the companions the golden names are compared — a directory that
+    /// happens to hold the artefact says nothing about what produced the files beside it.
+    /// </param>
+    public static EvalScoreCard Score(
+        EvalCase @case, string actualXmlPath, string goldensRoot, MetadataRepository repo,
+        string? producedDir = null)
     {
         var actualXml = File.ReadAllText(actualXmlPath);
         var actualRoot = XElement.Parse(actualXml);
@@ -42,6 +54,8 @@ public static class EvalScorer
             diff = new XmlGoldenDiff(new[] { note }, Array.Empty<string>(), Array.Empty<XmlGoldenChange>());
         }
 
+        diff = WithCompanions(diff, actualXmlPath, producedDir, goldenDir, @case.Ignore);
+
         return new EvalScoreCard(
             XppClean: xppErrors == 0,
             XppErrors: xppErrors,
@@ -49,6 +63,84 @@ public static class EvalScorer
             ReferenceErrors: refErrors,
             GoldenMatch: diff.IsMatch,
             GoldenDiff: diff);
+    }
+
+    /// <summary>
+    /// Fold the companions into the diff: every artefact the case produces beside its main one.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// Several <c>generate</c> commands emit more than one file — a custom service is a class, a
+    /// service and a service group; a workflow is a template, a query, a document class and a
+    /// CoC extension. Only the main artefact used to be diffed, so the companions were captured
+    /// under <c>_companions/</c>, reviewed once, and then never checked again: any later drift in
+    /// them was invisible to the whole corpus. That also made a case's
+    /// <c>target_artifact_types</c> half true, because the families it named were the companions'
+    /// families and nothing compared them to anything.
+    /// </para>
+    /// <para>
+    /// A companion the golden has and the run did not produce is <c>Missing</c>; one the run
+    /// produced and the golden does not have is <c>Extra</c> — a new file appearing unannounced
+    /// is exactly the drift worth failing on, and it is only reported when the caller passed the
+    /// directory the run owns. Paths are prefixed with the companion's file name so a diff line
+    /// says which artefact it is about.
+    /// </para>
+    /// </remarks>
+    private static XmlGoldenDiff WithCompanions(
+        XmlGoldenDiff diff, string actualXmlPath, string? producedDir, string goldenDir,
+        IReadOnlyList<string> ignore)
+    {
+        var companionDir = Path.Combine(goldenDir, "_companions");
+        var actualDir = producedDir ?? Path.GetDirectoryName(Path.GetFullPath(actualXmlPath))!;
+        var actualName = Path.GetFileName(actualXmlPath);
+
+        var expected = Directory.Exists(companionDir)
+            ? Directory.GetFiles(companionDir, "*.xml")
+            : Array.Empty<string>();
+        var produced = Directory.GetFiles(actualDir, "*.xml")
+            .Where(f => !string.Equals(Path.GetFileName(f), actualName, StringComparison.OrdinalIgnoreCase))
+            .ToDictionary(f => Path.GetFileName(f)!, f => f, StringComparer.OrdinalIgnoreCase);
+
+        if (expected.Length == 0 && produced.Count == 0) return diff;
+
+        var missing = diff.Missing.ToList();
+        var extra = diff.Extra.ToList();
+        var changed = diff.Changed.ToList();
+
+        foreach (var goldenCompanion in expected.OrderBy(f => f, StringComparer.Ordinal))
+        {
+            var name = Path.GetFileName(goldenCompanion);
+            if (!produced.Remove(name, out var actualCompanion))
+            {
+                missing.Add($"_companions/{name}");
+                continue;
+            }
+
+            XElement expectedRoot, actualRoot;
+            try
+            {
+                expectedRoot = XElement.Parse(File.ReadAllText(goldenCompanion));
+                actualRoot = XElement.Parse(File.ReadAllText(actualCompanion));
+            }
+            catch (System.Xml.XmlException ex)
+            {
+                changed.Add(new XmlGoldenChange($"_companions/{name}", "<well-formed XML>", ex.Message));
+                continue;
+            }
+
+            var sub = XmlGolden.Diff(expectedRoot, actualRoot, ignore);
+            missing.AddRange(sub.Missing.Select(m => $"_companions/{name}:{m}"));
+            extra.AddRange(sub.Extra.Select(e => $"_companions/{name}:{e}"));
+            changed.AddRange(sub.Changed.Select(c => c with { Path = $"_companions/{name}:{c.Path}" }));
+        }
+
+        if (producedDir is not null)
+        {
+            foreach (var unexpected in produced.Keys.OrderBy(k => k, StringComparer.Ordinal))
+                extra.Add($"_companions/{unexpected}");
+        }
+
+        return new XmlGoldenDiff(missing, extra, changed);
     }
 
     /// <summary>Same heuristic as <c>ValidateXppCommand.DetectCodeType</c> (Cli project) — duplicated rather than shared across the Core/Cli boundary for a 3-line check.</summary>

--- a/src/D365FO.Core/Eval/L3ModelProvisioner.cs
+++ b/src/D365FO.Core/Eval/L3ModelProvisioner.cs
@@ -50,6 +50,44 @@ public static class L3ModelProvisioner
     public static readonly IReadOnlyList<string> StandardModuleReferences =
         ["ApplicationPlatform", "ApplicationFoundation", "ApplicationSuite"];
 
+    /// <summary>
+    /// Every package in an installation, for goldens that extend a standard object.
+    /// </summary>
+    /// <remarks>
+    /// Extending a shipped element pulls in what that element references, and it does not stay
+    /// inside the three modules above: a view extension over <c>CustAccountName</c> needs
+    /// <c>DirPartyTable</c>, which is in <c>Directory</c>, and a data-entity extension over
+    /// <c>CustCustomerV3Entity</c> reaches a dozen packages further. Guessing the transitive set
+    /// per case is a maintenance trap — the list here is read off the installation, and a
+    /// package on the reference list that nothing uses costs the compiler nothing.
+    /// </remarks>
+    public static IReadOnlyList<string> ModulesIn(string packagesRoot)
+    {
+        if (string.IsNullOrWhiteSpace(packagesRoot) || !Directory.Exists(packagesRoot))
+            return StandardModuleReferences;
+
+        try
+        {
+            // A package is a directory with a bin — which is what the compiler resolves a module
+            // reference to. The root also holds DataStack, GeneratedXppSource, InstallationRecords,
+            // Plugins, StaticMetadata, the shared bin, and (on this machine) a directory whose name
+            // is a path with its separators removed; referencing any of them earns a warning per
+            // compile and resolves nothing.
+            var all = Directory.EnumerateDirectories(packagesRoot)
+                .Where(d => Directory.Exists(Path.Combine(d, "bin")))
+                .Select(Path.GetFileName)
+                .Where(n => !string.IsNullOrEmpty(n))
+                .Select(n => n!)
+                .OrderBy(n => n, StringComparer.Ordinal)
+                .ToList();
+            return all.Count == 0 ? StandardModuleReferences : all;
+        }
+        catch
+        {
+            return StandardModuleReferences;
+        }
+    }
+
     public static ProvisionedModel Provision(
         IReadOnlyList<EvalCase> cases,
         string goldensDir,
@@ -264,6 +302,19 @@ public static class L3ModelProvisioner
     /// arrays namespace. Members are emitted in contract (alphabetical) order for
     /// the same reason every other writer in this repo does.
     /// </remarks>
+    /// <summary>
+    /// Write the model descriptor for a throwaway model built around arbitrary artefacts.
+    /// </summary>
+    /// <remarks>
+    /// Same descriptor the golden provisioner writes, exposed because the single-artefact probe
+    /// builds its model the same way and a second descriptor writer would be a second place for
+    /// the module reference list to go stale.
+    /// </remarks>
+    public static void WriteDescriptorFor(
+        string modelRoot, string modelName, string publisher = "d365fo-cli", string layer = "usr",
+        IReadOnlyList<string>? moduleReferences = null)
+        => WriteDescriptor(modelRoot, modelName, publisher, layer, moduleReferences ?? StandardModuleReferences);
+
     private static void WriteDescriptor(
         string modelRoot, string modelName, string publisher, string layer, IReadOnlyList<string> moduleReferences)
     {

--- a/src/D365FO.Core/Eval/OracleCensus.cs
+++ b/src/D365FO.Core/Eval/OracleCensus.cs
@@ -1,0 +1,196 @@
+using System.Collections.Concurrent;
+using System.Diagnostics;
+using System.Xml.Linq;
+using D365FO.Core.Metadata;
+
+namespace D365FO.Core.Eval;
+
+/// <summary>
+/// Counts what the installation actually writes, so a rule can be built on evidence instead of
+/// on what the documentation implies.
+/// </summary>
+/// <remarks>
+/// <para>
+/// This is the measurement that has to come before enforcement. A rule invented from a contract
+/// and released without a census is a guess with an error severity attached: this repository
+/// shipped one (a member-order rule) that looked right, passed a 150-file sample, and flagged
+/// files Microsoft ships — an <c>AxEnum</c> with <c>ConfigurationKey</c> after
+/// <c>UseEnumValue</c>, an <c>AccessGrant</c> with <c>Create</c> after <c>Update</c>. The census
+/// is what answers "does shipped code really do this?" before anyone writes the rule.
+/// </para>
+/// <para>
+/// It also answers the reverse, which is where catalog drift shows: a member the installation
+/// writes and the contract does not declare means the contract is behind, not that the file is
+/// wrong.
+/// </para>
+/// </remarks>
+public static class OracleCensus
+{
+    /// <param name="Member">Child element name.</param>
+    /// <param name="Files">How many documents carry it at least once.</param>
+    /// <param name="Occurrences">How many times it appears in total.</param>
+    /// <param name="Declared">Whether the metadata contract declares it.</param>
+    /// <param name="SampleValues">Distinct leaf values seen, capped — empty for container members.</param>
+    public sealed record MemberTally(
+        string Member, int Files, int Occurrences, bool? Declared, IReadOnlyList<string> SampleValues);
+
+    /// <param name="Root">The installation the census was taken over.</param>
+    /// <param name="Element">The element the census was taken over, e.g. AxTable.</param>
+    /// <param name="Contract">The metadata contract governing it, when one is known.</param>
+    /// <param name="OrderIsStable">
+    /// Whether every document writes the shared members in one consistent relative order. False
+    /// means the order carries no rule — the fact that decided a rule not to write.
+    /// </param>
+    /// <param name="FilesScanned">Documents read.</param>
+    /// <param name="ElapsedMs">Wall-clock time of the census.</param>
+    /// <param name="OrderCounterExamples">Member pairs seen in both orders — the evidence behind an unstable order.</param>
+    /// <param name="Members">One tally per child element, most-carried first.</param>
+    /// <param name="DeclaredNeverSeen">Members the contract declares that no file uses.</param>
+    /// <param name="SeenNotDeclared">Members files carry that the contract does not declare — catalog drift.</param>
+    public sealed record Report(
+        string Root,
+        string Element,
+        string? Contract,
+        int FilesScanned,
+        long ElapsedMs,
+        bool OrderIsStable,
+        IReadOnlyList<string> OrderCounterExamples,
+        IReadOnlyList<MemberTally> Members,
+        IReadOnlyList<string> DeclaredNeverSeen,
+        IReadOnlyList<string> SeenNotDeclared);
+
+    /// <param name="root">Installation (or any packages-shaped root) to read.</param>
+    /// <param name="element">Root element to census, e.g. <c>AxTable</c>.</param>
+    /// <param name="limit">Stop after this many documents. 0 reads every one.</param>
+    /// <param name="sampleValues">Distinct leaf values to keep per member.</param>
+    /// <param name="parallelism">Documents parsed at once. Defaults to half the cores.</param>
+    public static Report Run(string root, string element, int limit = 0, int sampleValues = 5, int? parallelism = null)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(element);
+        var sw = Stopwatch.StartNew();
+
+        var files = EnumerateDocuments(root, element).ToList();
+        if (limit > 0 && files.Count > limit) files = files.Take(limit).ToList();
+
+        var occurrences = new ConcurrentDictionary<string, int>(StringComparer.Ordinal);
+        var fileCounts = new ConcurrentDictionary<string, int>(StringComparer.Ordinal);
+        var values = new ConcurrentDictionary<string, ConcurrentDictionary<string, byte>>(StringComparer.Ordinal);
+        // member -> the members it has been seen AFTER. A pair seen in both directions is proof
+        // that the order is not fixed.
+        var seenAfter = new ConcurrentDictionary<string, ConcurrentDictionary<string, byte>>(StringComparer.Ordinal);
+        var scanned = 0;
+
+        Parallel.ForEach(
+            files,
+            new ParallelOptions { MaxDegreeOfParallelism = parallelism ?? Math.Max(1, Environment.ProcessorCount / 2) },
+            path =>
+            {
+                XDocument doc;
+                try { doc = XDocument.Load(path); }
+                catch { return; }
+                if (doc.Root is null || !string.Equals(doc.Root.Name.LocalName, element, StringComparison.OrdinalIgnoreCase))
+                    return;
+
+                Interlocked.Increment(ref scanned);
+
+                var here = new List<string>();
+                foreach (var child in doc.Root.Elements())
+                {
+                    var name = child.Name.LocalName;
+                    occurrences.AddOrUpdate(name, 1, (_, n) => n + 1);
+                    if (!here.Contains(name, StringComparer.Ordinal)) here.Add(name);
+
+                    if (!child.HasElements)
+                    {
+                        var text = child.Value.Trim();
+                        if (text.Length is > 0 and <= 60)
+                            values.GetOrAdd(name, _ => new(StringComparer.Ordinal)).TryAdd(text, 0);
+                    }
+                }
+
+                foreach (var name in here.Distinct(StringComparer.Ordinal))
+                    fileCounts.AddOrUpdate(name, 1, (_, n) => n + 1);
+
+                // Record the pairwise order this document used.
+                for (var i = 0; i < here.Count; i++)
+                for (var j = i + 1; j < here.Count; j++)
+                    seenAfter.GetOrAdd(here[j], _ => new(StringComparer.Ordinal)).TryAdd(here[i], 0);
+            });
+
+        var contract = MetadataContracts.Find(element)
+                       ?? MetadataContracts.ForElement(element, null);
+        var declared = contract?.Members ?? Array.Empty<string>();
+
+        var members = occurrences.Keys
+            .OrderByDescending(m => fileCounts.TryGetValue(m, out var f) ? f : 0)
+            .ThenBy(m => m, StringComparer.Ordinal)
+            .Select(m => new MemberTally(
+                m,
+                fileCounts.TryGetValue(m, out var f) ? f : 0,
+                occurrences[m],
+                contract is null ? null : declared.Contains(m, StringComparer.Ordinal),
+                values.TryGetValue(m, out var vs)
+                    ? vs.Keys.OrderBy(v => v, StringComparer.Ordinal).Take(sampleValues).ToList()
+                    : Array.Empty<string>()))
+            .ToList();
+
+        // A pair seen in both directions across the corpus is a counter-example to any order rule.
+        var counterExamples = new List<string>();
+        foreach (var (later, earlier) in seenAfter.SelectMany(kv => kv.Value.Keys.Select(e => (kv.Key, e))))
+        {
+            if (seenAfter.TryGetValue(earlier, out var reverse) && reverse.ContainsKey(later)
+                && string.CompareOrdinal(later, earlier) < 0)
+                counterExamples.Add($"{later} ↔ {earlier}");
+        }
+        counterExamples = counterExamples.Distinct(StringComparer.Ordinal).OrderBy(c => c, StringComparer.Ordinal).ToList();
+
+        sw.Stop();
+        return new Report(
+            root,
+            element,
+            contract?.Name,
+            scanned,
+            sw.ElapsedMilliseconds,
+            OrderIsStable: counterExamples.Count == 0,
+            counterExamples.Take(20).ToList(),
+            members,
+            contract is null
+                ? Array.Empty<string>()
+                : declared.Where(d => !occurrences.ContainsKey(d)).ToList(),
+            contract is null
+                ? Array.Empty<string>()
+                : occurrences.Keys
+                    .Where(m => !declared.Contains(m, StringComparer.Ordinal)
+                                && MetadataContracts.Find(m) is null)   // a collection item is not a member
+                    .OrderBy(m => m, StringComparer.Ordinal)
+                    .ToList());
+    }
+
+    /// <summary>Documents whose root is <paramref name="element"/>, found by folder convention.</summary>
+    /// <remarks>
+    /// The AOT folder is named after the element it holds (<c>AxTable</c> → <c>AxTable/</c>), so
+    /// the census reads only the folders that can contain the element rather than every file in
+    /// the installation.
+    /// </remarks>
+    private static IEnumerable<string> EnumerateDocuments(string root, string element)
+    {
+        if (!Directory.Exists(root)) yield break;
+
+        foreach (var package in Safe(root))
+        foreach (var model in Safe(package))
+        foreach (var axDir in Safe(model))
+        {
+            if (!string.Equals(Path.GetFileName(axDir), element, StringComparison.OrdinalIgnoreCase)) continue;
+            IEnumerable<string> files;
+            try { files = Directory.EnumerateFiles(axDir, "*.xml", SearchOption.TopDirectoryOnly); }
+            catch { continue; }
+            foreach (var f in files) yield return f;
+        }
+    }
+
+    private static IEnumerable<string> Safe(string dir)
+    {
+        try { return Directory.EnumerateDirectories(dir); }
+        catch { return Array.Empty<string>(); }
+    }
+}

--- a/src/D365FO.Core/Eval/OracleProbe.cs
+++ b/src/D365FO.Core/Eval/OracleProbe.cs
@@ -1,0 +1,145 @@
+using System.Xml.Linq;
+using D365FO.Core.ObjectTypes;
+using D365FO.Core.Validation;
+
+namespace D365FO.Core.Eval;
+
+/// <summary>
+/// Compiles ONE artefact — anything, not only an eval golden — with the real X++ compiler.
+/// </summary>
+/// <remarks>
+/// <para>
+/// The eval goldens compile clean, and they only cover what the catalog covers: every new
+/// <c>generate</c> sub-command, form pattern and report flag has to meet the compiler somehow,
+/// and until now that meant driving the golden provisioner by hand and remembering three rules
+/// that cost an hour each when forgotten — the file name must equal the emitted <c>&lt;Name&gt;</c>,
+/// the artefact must sit in the folder named after its ROOT ELEMENT, and a multi-file scaffold
+/// leaves its companions beside the one you asked for.
+/// </para>
+/// <para>
+/// This is that recipe as a command. It places each artefact where the compiler expects it,
+/// which is what the manual version kept getting wrong.
+/// </para>
+/// </remarks>
+public static class OracleProbe
+{
+    /// <param name="Source">Where the artefact came from.</param>
+    /// <param name="Placed">Where it was put for the compiler.</param>
+    /// <param name="AxFolder">The AOT folder its root element demands.</param>
+    /// <param name="ObjectName">The name the document declares, which is also its file name.</param>
+    public sealed record PlacedArtifact(string Source, string Placed, string AxFolder, string ObjectName);
+
+    /// <param name="WorkDir">The throwaway metadata store that was built.</param>
+    /// <param name="ModelName">Name of the throwaway model the artefacts were placed in.</param>
+    /// <param name="ContentRoot">The model's content root — the folder the Ax* folders live under.</param>
+    /// <param name="Placed">Artefacts copied into the store, ready to compile.</param>
+    /// <param name="FixtureFiles">MiniAot fixture files laid down beside them, when the fixture was used.</param>
+    /// <param name="Rejected">Files that are not a usable AOT document, with the reason.</param>
+    public sealed record Preparation(
+        string WorkDir,
+        string ModelName,
+        string ContentRoot,
+        IReadOnlyList<PlacedArtifact> Placed,
+        IReadOnlyList<string> FixtureFiles,
+        IReadOnlyList<(string File, string Reason)> Rejected);
+
+    /// <summary>
+    /// Build a throwaway model around the given artefacts, ready for the compiler.
+    /// </summary>
+    /// <param name="artifacts">AOT XML files to compile.</param>
+    /// <param name="workDir">Metadata store to build in — one directory per package.</param>
+    /// <param name="modelName">Throwaway model name.</param>
+    /// <param name="withFixture">
+    /// Also lay down the MiniAot fixture, so an artefact that references the usual test symbols
+    /// resolves. Off when the artefact is meant to stand alone.
+    /// </param>
+    /// <param name="packagesRoot">
+    /// The installation to reference. Given one, the throwaway model references every package on
+    /// it, because an artefact that EXTENDS a standard object drags in whatever that object
+    /// references and that does not stay inside the usual three modules. Omitted, the model gets
+    /// those three.
+    /// </param>
+    public static Preparation Prepare(
+        IReadOnlyList<string> artifacts, string workDir, string modelName, bool withFixture = true,
+        string? packagesRoot = null)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(workDir);
+        ArgumentException.ThrowIfNullOrWhiteSpace(modelName);
+
+        var modelRoot = Path.Combine(workDir, modelName);
+        var contentRoot = Path.Combine(modelRoot, modelName);
+        Directory.CreateDirectory(contentRoot);
+
+        L3ModelProvisioner.WriteDescriptorFor(
+            modelRoot, modelName,
+            moduleReferences: packagesRoot is null ? null : L3ModelProvisioner.ModulesIn(packagesRoot));
+
+        var fixtureFiles = withFixture
+            ? L3ModelProvisioner.ProvisionFixtureInto(workDir, contentRoot)
+            : Array.Empty<string>();
+
+        var placed = new List<PlacedArtifact>();
+        var rejected = new List<(string, string)>();
+
+        foreach (var source in artifacts ?? Array.Empty<string>())
+        {
+            if (!File.Exists(source)) { rejected.Add((source, "no such file")); continue; }
+
+            XDocument doc;
+            try { doc = XDocument.Load(source); }
+            catch (Exception ex) { rejected.Add((source, $"not readable XML: {ex.Message}")); continue; }
+
+            var root = doc.Root?.Name.LocalName;
+            if (string.IsNullOrEmpty(root) || !root.StartsWith("Ax", StringComparison.Ordinal))
+            {
+                rejected.Add((source, $"root <{root ?? "?"}> is not an AOT element"));
+                continue;
+            }
+
+            // The name the document declares — not the file name it happens to carry. A
+            // scaffolder's class name often differs from the name it was asked for, and the
+            // compiler resolves by the declared name.
+            var declared = doc.Root!.Elements().FirstOrDefault(e => e.Name.LocalName == "Name")?.Value?.Trim();
+            if (string.IsNullOrEmpty(declared))
+            {
+                rejected.Add((source, "the document declares no <Name>, so the compiler cannot resolve it"));
+                continue;
+            }
+
+            var axFolder = ObjectTypeRegistry.Find(root)?.AotSubfolder ?? root;
+            var targetDir = Path.Combine(contentRoot, axFolder);
+            Directory.CreateDirectory(targetDir);
+
+            var target = Path.Combine(targetDir, declared + ".xml");
+            File.Copy(source, target, overwrite: true);
+            placed.Add(new PlacedArtifact(source, target, axFolder, declared));
+        }
+
+        return new Preparation(workDir, modelName, contentRoot, placed, fixtureFiles, rejected);
+    }
+
+    /// <param name="Artifact">The artefact the diagnostic was attributed to, or null when it names none.</param>
+    /// <param name="Diagnostic">The compiler diagnostic itself.</param>
+    public sealed record AttributedDiagnostic(string? Artifact, XppcDiagnostic Diagnostic);
+
+    /// <summary>
+    /// Attribute diagnostics to the artefacts they name, so a probe of several says which one
+    /// failed rather than that something did.
+    /// </summary>
+    public static (IReadOnlyList<AttributedDiagnostic> Attributed, IReadOnlyList<XppcDiagnostic> Unattributed)
+        Attribute(Preparation preparation, IReadOnlyList<XppcDiagnostic> diagnostics)
+    {
+        var byName = preparation.Placed.ToDictionary(p => p.ObjectName, StringComparer.OrdinalIgnoreCase);
+        var attributed = new List<AttributedDiagnostic>();
+        var unattributed = new List<XppcDiagnostic>();
+
+        foreach (var d in diagnostics ?? Array.Empty<XppcDiagnostic>())
+        {
+            var owner = d.Object is { Length: > 0 } o && byName.ContainsKey(o) ? o : null;
+            if (owner is null) unattributed.Add(d);
+            else attributed.Add(new AttributedDiagnostic(owner, d));
+        }
+
+        return (attributed, unattributed);
+    }
+}

--- a/src/D365FO.Core/Eval/OracleSweep.cs
+++ b/src/D365FO.Core/Eval/OracleSweep.cs
@@ -1,0 +1,238 @@
+using System.Collections.Concurrent;
+using System.Diagnostics;
+using System.Xml.Linq;
+using D365FO.Core.Validation;
+
+namespace D365FO.Core.Eval;
+
+/// <summary>
+/// Runs the offline validator over an entire installation and reports what it says about code
+/// nobody is allowed to be wrong about.
+/// </summary>
+/// <remarks>
+/// <para>
+/// The validator's rules are written from documentation, from the compiler's own messages and
+/// from what the AOT appears to do. None of that proves a rule does not fire on correct code —
+/// and a rule that flags Microsoft's own X++ is worse than a missing rule, because it teaches a
+/// caller to ignore findings. The bar is therefore not "few" false positives on shipped code but
+/// <b>zero errors</b>, and the only way to hold it is to run every rule over every file and look.
+/// </para>
+/// <para>
+/// Warnings are counted and reported but do not fail the bar: several are style rules that
+/// shipped code legitimately breaks (a table with one index, a method without a doc comment).
+/// Errors are the claim that the artefact does not work, and that claim is falsifiable by the
+/// fact that the file ships and builds.
+/// </para>
+/// </remarks>
+public static class OracleSweep
+{
+    /// <param name="Model">Restrict to one model.</param>
+    /// <param name="AxFolder">Restrict to one AOT folder, e.g. AxTable.</param>
+    /// <param name="Limit">Stop after this many files. 0 sweeps everything.</param>
+    /// <param name="SamplesPerRule">How many example findings to keep per rule.</param>
+    /// <param name="IncludeWarnings">Report warnings alongside errors.</param>
+    /// <param name="Parallelism">Files parsed at once. Defaults to half the cores.</param>
+    public sealed record Options(
+        string? Model = null,
+        string? AxFolder = null,
+        int Limit = 0,
+        int SamplesPerRule = 3,
+        bool IncludeWarnings = false,
+        int? Parallelism = null);
+
+    /// <param name="Rule">Rule id, e.g. XML007 or SEL001.</param>
+    /// <param name="Where">xml | xpp — which half of the file the rule judged.</param>
+    /// <param name="Severity">error | warning, as the rule reported it.</param>
+    /// <param name="Model">Model the file belongs to.</param>
+    /// <param name="File">Full path to the file the rule fired on.</param>
+    /// <param name="Line">Line the rule points at, when it knows one.</param>
+    /// <param name="Excerpt">What the rule was looking at.</param>
+    /// <param name="Fix">What the rule says to do about it.</param>
+    public sealed record Finding(
+        string Rule, string Severity, string Where, string Model, string File, int? Line, string Excerpt, string Fix);
+
+    public sealed record RuleTally(string Rule, string Severity, string Where, int Count, IReadOnlyList<Finding> Samples);
+
+    public sealed record Report(
+        string Root,
+        int FilesScanned,
+        int FilesUnreadable,
+        int XppBlocksScanned,
+        int Errors,
+        int Warnings,
+        bool BarHeld,
+        long ElapsedMs,
+        IReadOnlyList<RuleTally> ByRule);
+
+    /// <summary>Sweep an installation (or any packages-shaped root).</summary>
+    public static Report Run(string root, Options? options = null, IPropertyStatsProvider? stats = null)
+    {
+        var opts = options ?? new Options();
+        var sw = Stopwatch.StartNew();
+
+        var files = EnumerateAotFiles(root, opts).ToList();
+        if (opts.Limit > 0 && files.Count > opts.Limit) files = files.Take(opts.Limit).ToList();
+
+        // Tallied as the sweep runs, not collected and grouped afterwards. An installation is
+        // 200 000 files and several million findings once warnings are counted; keeping each one
+        // to group it at the end costs gigabytes and tells you nothing the counters do not. Only
+        // the first few examples per rule are held.
+        var tallies = new ConcurrentDictionary<(string Rule, string Severity, string Where), Tally>();
+        var unreadable = 0;
+        var xppBlocks = 0;
+
+        Parallel.ForEach(
+            files,
+            new ParallelOptions { MaxDegreeOfParallelism = opts.Parallelism ?? Math.Max(1, Environment.ProcessorCount / 2) },
+            file =>
+            {
+                string text;
+                try { text = File.ReadAllText(file.Path); }
+                catch { Interlocked.Increment(ref unreadable); return; }
+
+                // The XML half: the document's own shape.
+                try
+                {
+                    foreach (var v in XppValidator.Validate(text, XppValidator.CodeTypeXmlAny, stats, file.Path))
+                        Keep(tallies, v, "xml", file, opts.SamplesPerRule);
+                }
+                catch (Exception ex)
+                {
+                    // A rule that throws is itself a defect, and silence would hide it.
+                    Keep(tallies, new XppViolation("SWEEP_THREW", "error", null, ex.GetType().Name, ex.Message),
+                        "xml", file, opts.SamplesPerRule);
+                }
+
+                // The X++ half: every Declaration/Source block the document carries.
+                var xpp = ExtractXpp(text);
+                if (xpp.Length == 0) return;
+                Interlocked.Increment(ref xppBlocks);
+                try
+                {
+                    foreach (var v in XppValidator.Validate(xpp, XppValidator.CodeTypeXpp, stats, file.Path))
+                        Keep(tallies, v, "xpp", file, opts.SamplesPerRule);
+                }
+                catch (Exception ex)
+                {
+                    Keep(tallies, new XppViolation("SWEEP_THREW", "error", null, ex.GetType().Name, ex.Message),
+                        "xpp", file, opts.SamplesPerRule);
+                }
+            });
+
+        var errors = tallies.Where(t => t.Key.Severity == "error").Sum(t => t.Value.Count);
+        var warnings = tallies.Where(t => t.Key.Severity != "error").Sum(t => t.Value.Count);
+
+        var byRule = tallies
+            .Where(t => opts.IncludeWarnings || t.Key.Severity == "error")
+            .OrderByDescending(t => t.Key.Severity == "error")
+            .ThenByDescending(t => t.Value.Count)
+            .ThenBy(t => t.Key.Rule, StringComparer.Ordinal)
+            .Select(t => new RuleTally(
+                t.Key.Rule, t.Key.Severity, t.Key.Where, t.Value.Count, t.Value.Snapshot()))
+            .ToList();
+
+        sw.Stop();
+        return new Report(
+            root, files.Count, unreadable, xppBlocks, errors, warnings,
+            BarHeld: errors == 0,
+            sw.ElapsedMilliseconds,
+            byRule);
+    }
+
+    /// <summary>One rule's running count, plus the first few examples of it.</summary>
+    /// <remarks>
+    /// Bounded on purpose: the count is what the bar is judged on, and a few examples are what
+    /// makes a count actionable. Holding the rest would make the sweep's memory a function of how
+    /// wrong the rules are, which is the wrong thing to be unable to measure.
+    /// </remarks>
+    private sealed class Tally
+    {
+        private readonly List<Finding> _samples = [];
+        private int _count;
+
+        public int Count => Volatile.Read(ref _count);
+
+        public void Add(Finding finding, int sampleCap)
+        {
+            Interlocked.Increment(ref _count);
+            if (sampleCap <= 0) return;
+            lock (_samples)
+            {
+                if (_samples.Count < sampleCap) _samples.Add(finding);
+            }
+        }
+
+        public IReadOnlyList<Finding> Snapshot()
+        {
+            lock (_samples) return _samples.ToList();
+        }
+    }
+
+    private static void Keep(
+        ConcurrentDictionary<(string, string, string), Tally> into,
+        XppViolation v, string where, AotFile file, int sampleCap) =>
+        into.GetOrAdd((v.Rule, v.Severity, where), _ => new Tally())
+            .Add(new Finding(v.Rule, v.Severity, where, file.Model, file.Path, v.Line, v.Excerpt, v.Fix), sampleCap);
+
+    /// <param name="Path">Full path to the AOT XML.</param>
+    /// <param name="Model">Model the file belongs to.</param>
+    private readonly record struct AotFile(string Path, string Model);
+
+    private static IEnumerable<AotFile> EnumerateAotFiles(string root, Options opts)
+    {
+        if (!Directory.Exists(root)) yield break;
+
+        foreach (var package in SafeDirectories(root))
+        foreach (var model in SafeDirectories(package))
+        {
+            var modelName = Path.GetFileName(model);
+            if (opts.Model is { Length: > 0 } wanted
+                && !string.Equals(modelName, wanted, StringComparison.OrdinalIgnoreCase))
+                continue;
+
+            foreach (var axDir in SafeDirectories(model))
+            {
+                var folder = Path.GetFileName(axDir);
+                if (!folder.StartsWith("Ax", StringComparison.Ordinal)) continue;
+                if (opts.AxFolder is { Length: > 0 } kind
+                    && !string.Equals(folder, kind, StringComparison.OrdinalIgnoreCase))
+                    continue;
+
+                IEnumerable<string> xml;
+                try { xml = Directory.EnumerateFiles(axDir, "*.xml", SearchOption.TopDirectoryOnly); }
+                catch { continue; }
+
+                foreach (var path in xml) yield return new AotFile(path, modelName);
+            }
+        }
+    }
+
+    private static IEnumerable<string> SafeDirectories(string dir)
+    {
+        try { return Directory.EnumerateDirectories(dir); }
+        catch { return Array.Empty<string>(); }
+    }
+
+    /// <summary>Every X++ block a document carries, concatenated.</summary>
+    /// <remarks>
+    /// Parsed rather than regexed: a <c>&lt;Source&gt;</c> inside a comment or a doc-comment
+    /// mentioning one would otherwise be swept as if it were code, and the finding would name a
+    /// line that is not there.
+    /// </remarks>
+    private static string ExtractXpp(string text)
+    {
+        try
+        {
+            var doc = XDocument.Parse(text);
+            var parts = doc.Root?.Descendants()
+                .Where(e => e.Name.LocalName is "Declaration" or "Source")
+                .Select(e => e.Value)
+                .Where(s => !string.IsNullOrWhiteSpace(s));
+            return parts is null ? "" : string.Join("\n", parts);
+        }
+        catch
+        {
+            return "";
+        }
+    }
+}

--- a/src/D365FO.Core/Eval/RuntimeOracle.cs
+++ b/src/D365FO.Core/Eval/RuntimeOracle.cs
@@ -1,0 +1,224 @@
+using System.Xml.Linq;
+
+namespace D365FO.Core.Eval;
+
+/// <summary>
+/// Whether the SysTest runner is actually wired to a database — and can it tell a passing test
+/// from a failing one.
+/// </summary>
+/// <remarks>
+/// <para>
+/// Two questions, both of which have to be answered before a test result means anything.
+/// </para>
+/// <para>
+/// The first is configuration. <c>SysTestConsole.exe</c> reads its own
+/// <c>.exe.config</c> for the database the AOS uses, and a stock install can leave those keys
+/// empty: the runner then dies with <c>Login failed</c>, which reads like a broken test model
+/// rather than a runner that was never pointed anywhere. The keys are in the AOS
+/// <c>web.config</c> a few directories away, so the answer is derivable rather than guessable.
+/// </para>
+/// <para>
+/// The second is discrimination, and it is the one nobody checks. "All tests passed" is also
+/// what a runner prints when it ran nothing at all. Until a test that is MEANT to fail actually
+/// fails, and one that is meant to throw actually throws, a green run is not evidence — that is
+/// what the negative control is for.
+/// </para>
+/// </remarks>
+public static class RuntimeOracle
+{
+    /// <summary>The keys the runner needs to reach the database the AOS uses.</summary>
+    public static readonly IReadOnlyList<string> RequiredKeys =
+    [
+        "DataAccess.DbServer",
+        "DataAccess.Database",
+        "DataAccess.SqlUser",
+        "DataAccess.SqlPwd",
+    ];
+
+    /// <param name="Key">Setting name.</param>
+    /// <param name="PresentInRunner">Whether the runner's config declares the key at all.</param>
+    /// <param name="NonEmptyInRunner">Whether it declares it with a value — an empty value is what makes the runner fail as if the model were broken.</param>
+    /// <param name="AvailableInWebConfig">Whether the AOS web.config carries a value the runner could be given.</param>
+    public sealed record SettingState(string Key, bool PresentInRunner, bool NonEmptyInRunner, bool AvailableInWebConfig);
+
+    public sealed record Diagnosis(
+        string? RunnerPath,
+        string? RunnerConfigPath,
+        string? WebConfigPath,
+        bool RunnerPresent,
+        bool Configured,
+        IReadOnlyList<SettingState> Settings,
+        IReadOnlyList<string> Missing);
+
+    /// <summary>Look at what is installed and say whether a test run would mean anything.</summary>
+    /// <param name="packagesRoot">PackagesLocalDirectory; the runner lives under its <c>bin</c>.</param>
+    /// <param name="webConfigPath">AOS web.config. Searched near the packages root when omitted.</param>
+    public static Diagnosis Diagnose(string packagesRoot, string? webConfigPath = null)
+    {
+        var runner = Path.Combine(packagesRoot ?? "", "bin", "SysTestConsole.exe");
+        var runnerConfig = runner + ".config";
+        var web = webConfigPath ?? FindWebConfig(packagesRoot);
+
+        var runnerSettings = ReadAppSettings(File.Exists(runnerConfig) ? runnerConfig : null);
+        var webSettings = ReadAppSettings(File.Exists(web ?? "") ? web : null);
+
+        var settings = RequiredKeys.Select(k => new SettingState(
+            k,
+            PresentInRunner: runnerSettings.ContainsKey(k),
+            NonEmptyInRunner: runnerSettings.TryGetValue(k, out var v) && !string.IsNullOrWhiteSpace(v),
+            AvailableInWebConfig: webSettings.TryGetValue(k, out var w) && !string.IsNullOrWhiteSpace(w))).ToList();
+
+        var missing = settings.Where(s => !s.NonEmptyInRunner).Select(s => s.Key).ToList();
+
+        return new Diagnosis(
+            File.Exists(runner) ? runner : null,
+            File.Exists(runnerConfig) ? runnerConfig : null,
+            File.Exists(web ?? "") ? web : null,
+            RunnerPresent: File.Exists(runner),
+            Configured: File.Exists(runner) && missing.Count == 0,
+            settings,
+            missing);
+    }
+
+    /// <param name="RunnerConfigPath">The runner config that was written.</param>
+    /// <param name="BackupPath">Where the previous file was kept — this edits a Microsoft-installed configuration.</param>
+    /// <param name="Written">Keys copied into the runner's config.</param>
+    /// <param name="Unavailable">Keys still missing because the web.config has no value either.</param>
+    public sealed record ConfigureResult(
+        string RunnerConfigPath, string BackupPath, IReadOnlyList<string> Written, IReadOnlyList<string> Unavailable);
+
+    /// <summary>
+    /// Copy the database settings the runner is missing out of the AOS web.config.
+    /// </summary>
+    /// <remarks>
+    /// Only the missing ones, and only from the installation's own web.config — the point is to
+    /// make the runner agree with the AOS it is testing, not to invent credentials. The previous
+    /// file is kept beside the new one: this edits a Microsoft-installed configuration.
+    /// </remarks>
+    public static ConfigureResult Configure(string runnerConfigPath, string webConfigPath)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(runnerConfigPath);
+        ArgumentException.ThrowIfNullOrWhiteSpace(webConfigPath);
+
+        var web = ReadAppSettings(webConfigPath);
+        var doc = XDocument.Load(runnerConfigPath, LoadOptions.PreserveWhitespace);
+        var appSettings = doc.Root?.Element("appSettings");
+        if (appSettings is null)
+        {
+            appSettings = new XElement("appSettings");
+            doc.Root?.Add(appSettings);
+        }
+
+        var written = new List<string>();
+        var unavailable = new List<string>();
+
+        foreach (var key in RequiredKeys)
+        {
+            var existing = appSettings.Elements("add")
+                .FirstOrDefault(e => string.Equals((string?)e.Attribute("key"), key, StringComparison.Ordinal));
+            if (existing is not null && !string.IsNullOrWhiteSpace((string?)existing.Attribute("value"))) continue;
+
+            if (!web.TryGetValue(key, out var value) || string.IsNullOrWhiteSpace(value))
+            {
+                unavailable.Add(key);
+                continue;
+            }
+
+            if (existing is null) appSettings.Add(new XElement("add", new XAttribute("key", key), new XAttribute("value", value)));
+            else existing.SetAttributeValue("value", value);
+            written.Add(key);
+        }
+
+        var backup = runnerConfigPath + ".d365fo-cli.bak";
+        if (written.Count > 0)
+        {
+            if (!File.Exists(backup)) File.Copy(runnerConfigPath, backup);
+            doc.Save(runnerConfigPath);
+        }
+
+        return new ConfigureResult(runnerConfigPath, backup, written, unavailable);
+    }
+
+    /// <summary>
+    /// The negative control: a test class whose three methods pass, fail and throw on purpose.
+    /// </summary>
+    /// <remarks>
+    /// Run it before trusting a green suite. A runner that reports all three as passing is not
+    /// running them, and a runner that reports the failure and the throw distinctly is one whose
+    /// verdicts mean something. The passing method is there so that "everything failed" is
+    /// distinguishable too.
+    /// </remarks>
+    public static string NegativeControlSource(string className = "D365FoCliNegativeControlTest") =>
+        $$"""
+        [SysTestTargetAttribute(classStr({{className}}), 'class')]
+        class {{className}} extends SysTestCase
+        {
+            /// <summary>
+            /// Passes. Its purpose is to prove the run happened at all: if this one does not
+            /// report as passed, the runner never reached the class.
+            /// </summary>
+            [SysTestMethodAttribute]
+            public void passesOnPurpose()
+            {
+                this.assertEquals(1, 1);
+            }
+
+            /// <summary>
+            /// Fails on purpose. A suite in which this reports as PASSED is not discriminating,
+            /// and every other green result in it is worthless.
+            /// </summary>
+            [SysTestMethodAttribute]
+            public void failsOnPurpose()
+            {
+                this.assertEquals(1, 2, 'Negative control: this assert is meant to fail.');
+            }
+
+            /// <summary>
+            /// Throws on purpose. A thrown error and a failed assert are different verdicts, and
+            /// a runner that collapses them tells you less than it appears to.
+            /// </summary>
+            [SysTestMethodAttribute]
+            public void throwsOnPurpose()
+            {
+                throw error('Negative control: this throw is meant to be reported as an error.');
+            }
+        }
+        """;
+
+    // ── reading configuration ──────────────────────────────────────────────
+
+    private static Dictionary<string, string> ReadAppSettings(string? path)
+    {
+        var result = new Dictionary<string, string>(StringComparer.Ordinal);
+        if (string.IsNullOrWhiteSpace(path) || !File.Exists(path)) return result;
+
+        try
+        {
+            var doc = XDocument.Load(path);
+            foreach (var add in doc.Descendants("appSettings").Elements("add"))
+            {
+                var key = (string?)add.Attribute("key");
+                if (string.IsNullOrEmpty(key)) continue;
+                result[key] = (string?)add.Attribute("value") ?? "";
+            }
+        }
+        catch { /* an unreadable config is reported as "absent", which is what it is to the runner */ }
+
+        return result;
+    }
+
+    /// <summary>The AOS web.config, looked for beside the packages root.</summary>
+    private static string? FindWebConfig(string? packagesRoot)
+    {
+        if (string.IsNullOrWhiteSpace(packagesRoot)) return null;
+        var service = Path.GetDirectoryName(packagesRoot);
+        if (service is null) return null;
+
+        foreach (var folder in new[] { "WebRoot", "webroot" })
+        {
+            var candidate = Path.Combine(service, folder, "web.config");
+            if (File.Exists(candidate)) return candidate;
+        }
+        return null;
+    }
+}

--- a/src/D365FO.Core/Eval/XppcRunner.cs
+++ b/src/D365FO.Core/Eval/XppcRunner.cs
@@ -1,0 +1,101 @@
+using System.Text.RegularExpressions;
+using D365FO.Core.Ops;
+using D365FO.Core.Validation;
+
+namespace D365FO.Core.Eval;
+
+/// <summary>
+/// Invokes the real X++ compiler over a provisioned model and reads its verdict.
+/// </summary>
+/// <remarks>
+/// <para>
+/// One invocation, shared by the golden verification and by the single-artefact probe. The
+/// argument list is the part worth having in one place: it was read off <c>xppc.exe -?</c> on a
+/// real installation, <c>{metadata}</c> is the metadata STORE rather than the model root, and
+/// getting either wrong produces a usage dump that parses as "no errors" — a green run that
+/// compiled nothing.
+/// </para>
+/// <para>
+/// That last failure mode is why <see cref="Result.InvocationRejected"/> exists: a compiler that
+/// printed its own usage did not judge the code, and reporting that as clean is the worst
+/// possible answer from an oracle.
+/// </para>
+/// </remarks>
+public static class XppcRunner
+{
+    /// <summary>
+    /// The argument list, read off <c>xppc.exe -?</c> on a real installation.
+    /// </summary>
+    public const string DefaultArgs =
+        "-metadata={metadata} -modelmodule={model} -output={output} -referencefolder={packages} -refPath={output} -log={log}";
+
+    /// <summary>xppc printing its own usage means the arguments were rejected, not that the code is broken.</summary>
+    private static readonly Regex UsageTextPattern = new(
+        @"^usage:|Microsoft \(R\) X\+\+ Compiler|unrecognized option|Invalid option",
+        RegexOptions.IgnoreCase | RegexOptions.Multiline | RegexOptions.Compiled);
+
+    /// <param name="ExitCode">What xppc returned. Non-zero without diagnostics usually means the invocation itself failed.</param>
+    /// <param name="ElapsedMs">Wall-clock time of the compiler run.</param>
+    /// <param name="Compiler">The xppc.exe that ran.</param>
+    /// <param name="Args">The argument list it was given, so a rejected invocation can be read back.</param>
+    /// <param name="Diagnostics">Everything the compiler said, parsed.</param>
+    /// <param name="InvocationRejected">
+    /// The compiler printed usage instead of compiling — the run says nothing about the code.
+    /// </param>
+    /// <param name="LogTail">The end of the compiler log, which carries the message when parsing found nothing.</param>
+    public sealed record Result(
+        int ExitCode,
+        long ElapsedMs,
+        string Compiler,
+        IReadOnlyList<string> Args,
+        IReadOnlyList<XppcDiagnostic> Diagnostics,
+        bool InvocationRejected,
+        string LogTail);
+
+    /// <summary>Compile <paramref name="modelName"/> out of the metadata store at <paramref name="workDir"/>.</summary>
+    public static Result Compile(
+        string workDir, string packagesRoot, string compiler, string modelName, string? argsTemplate = null)
+    {
+        var outputDir = Path.Combine(workDir, "bin");
+        var logPath = Path.Combine(workDir, $"Dynamics.AX.{modelName}.xppc.log");
+        Directory.CreateDirectory(outputDir);
+
+        var args = Expand(
+            string.IsNullOrWhiteSpace(argsTemplate) ? DefaultArgs : argsTemplate!,
+            workDir, packagesRoot, modelName, outputDir, logPath);
+
+        var (exit, stdout, stderr, elapsed) = SdlcRunner.Run(compiler, args);
+        var log = stdout + "\n" + stderr;
+        if (File.Exists(logPath))
+        {
+            try { log += "\n" + File.ReadAllText(logPath); }
+            catch (IOException) { /* the compiler may still hold the handle; stdout is enough */ }
+        }
+
+        var diagnostics = XppcDiagnostics.Parse(log);
+        var rejected = diagnostics.Count == 0 && UsageTextPattern.IsMatch(log);
+
+        return new Result(exit, (long)elapsed.TotalMilliseconds, compiler, args, diagnostics, rejected, Tail(log, 20));
+    }
+
+    /// <summary>
+    /// Expand the argument template into a real argument list.
+    /// </summary>
+    /// <remarks>
+    /// Split before substitution, so a path containing a space stays one argument — the
+    /// process runner passes each element through without re-parsing it.
+    /// </remarks>
+    public static IReadOnlyList<string> Expand(
+        string template, string metadata, string packages, string model, string output, string log) =>
+        template.Split(' ', StringSplitOptions.RemoveEmptyEntries)
+            .Select(a => a
+                .Replace("{metadata}", metadata, StringComparison.Ordinal)
+                .Replace("{packages}", packages, StringComparison.Ordinal)
+                .Replace("{model}", model, StringComparison.Ordinal)
+                .Replace("{output}", output, StringComparison.Ordinal)
+                .Replace("{log}", log, StringComparison.Ordinal))
+            .ToList();
+
+    private static string Tail(string text, int lines) =>
+        string.Join('\n', text.Split('\n').TakeLast(lines));
+}

--- a/src/D365FO.Core/Metadata/MetadataContracts.cs
+++ b/src/D365FO.Core/Metadata/MetadataContracts.cs
@@ -166,10 +166,21 @@ public static class MetadataContracts
         var local = element.Name.LocalName;
         var xsiType = element.Attribute(XsiType)?.Value;
 
-        if (!string.IsNullOrEmpty(xsiType) || Find(local) is not null)
+        if (!string.IsNullOrEmpty(xsiType))
             return ForElement(local, xsiType);
 
-        return MemberContract(parent, local);
+        // A name that is BOTH a member of the parent and a type in the catalog is a member:
+        // what the parent says it holds beats what the name happens to collide with. Two names
+        // collide this way in the whole catalog (DataSource, Method), and one of them cost
+        // 4 574 findings on a stock installation — <DataSource> inside
+        // AxQueryExtensionEmbeddedDataSource is declared as an AxQuerySimpleEmbeddedDataSource,
+        // but there is also a type called DataSource (the form data-source property collection,
+        // three members), so every real data-source property under it was judged against a type
+        // it has nothing to do with.
+        var declared = MemberContract(parent, local);
+        if (declared is not null) return declared;
+
+        return Find(local) is not null ? ForElement(local, xsiType) : null;
     }
 
     private static readonly XName XsiType =

--- a/src/D365FO.Core/ObjectTypes/ObjectTypeRegistry.cs
+++ b/src/D365FO.Core/ObjectTypes/ObjectTypeRegistry.cs
@@ -206,13 +206,15 @@ namespace D365FO.Core.ObjectTypes
                 // declares no AxEdt*Extension subtypes, so an i:type here would name nothing.
                 New("edtextension", "AxEdtExtension", "EdtExtensions", "extension", null, "EdtExtension", xsi: true),
                 New("enumextension", "AxEnumExtension", "EnumExtensions", "extension", null, "EnumExtension"),
-                New("viewextension", "AxViewExtension", "ViewExtensions", null, null, "ViewExtension"),
+                New("viewextension", "AxViewExtension", "ViewExtensions", "extension", null, "ViewExtension"),
                 // Query extensions are concrete on disk: folder and root element are both
                 // AxQuerySimpleExtension, and the provider property is QuerySimpleExtensions.
                 // There is no AxQueryExtension type at all — the bridge used to name one.
-                New("queryextension", "AxQuerySimpleExtension", "QuerySimpleExtensions", null, null, "QueryExtension"),
-                New("dataentityviewextension", "AxDataEntityViewExtension", "DataEntityViewExtensions", null, null, "DataEntityViewExtension"),
-                // Folder ships in every model; no standard model has a file in it yet.
+                New("queryextension", "AxQuerySimpleExtension", "QuerySimpleExtensions", "extension", null, "QueryExtension"),
+                New("dataentityviewextension", "AxDataEntityViewExtension", "DataEntityViewExtensions", "extension", null, "DataEntityViewExtension"),
+                // Folder ships in every model; no standard model has a file in it yet, and
+                // `generate extension` takes no Map kind — the null is the truth here, unlike
+                // the three rows above, which named no command while the command built them.
                 New("mapextension", "AxMapExtension", "MapExtensions", null, null, "MapExtension"),
                 New("securitydutyextension", "AxSecurityDutyExtension", "SecurityDutyExtensions", "extension", null, "SecurityDutyExtension"),
                 New("securityroleextension", "AxSecurityRoleExtension", "SecurityRoleExtensions", "extension", null, "SecurityRoleExtension"),

--- a/src/D365FO.Core/Scaffolding/WorkflowScaffolder.cs
+++ b/src/D365FO.Core/Scaffolding/WorkflowScaffolder.cs
@@ -223,8 +223,18 @@ public static class WorkflowScaffolder
     /// after the element kind followed by the element name
     /// (<c>ApprovalBankReconciliationApproval</c> → <c>BankReconciliationApproval</c>).
     /// </summary>
+    /// <remarks>
+    /// The kind is carried by <c>&lt;Type&gt;</c>, and only for the kinds that are not the
+    /// default: across the templates on a live installation the element carries <c>Task</c> 49
+    /// times and <c>AutomatedTask</c> 28, and is absent 117 times — absent meaning approval.
+    /// Written without it, a task reference is read as an approval and xppc answers
+    /// "Workflow approval '&lt;task&gt;' does not exist", naming a kind the file never mentions.
+    /// The L3 build oracle is what caught it: the offline rules cannot know this, and the
+    /// document is otherwise perfectly well-formed.
+    /// </remarks>
     private static XElement ElementReference(string kind, string elementName) =>
         new("AxWorkflowElementReference",
             new XElement("Name", kind + elementName),
-            new XElement("ElementName", elementName));
+            new XElement("ElementName", elementName),
+            kind == "Approval" ? null : new XElement("Type", kind));
 }

--- a/src/D365FO.Core/Validation/ContractShapeRules.cs
+++ b/src/D365FO.Core/Validation/ContractShapeRules.cs
@@ -56,12 +56,28 @@ public static class ContractShapeRules
             return; // Not well-formed — other rules and the parser report that.
         }
 
-        if (doc.Root is not null)
-            CheckElement(
-                doc.Root,
-                doc.Root.Name.LocalName,
-                MetadataContracts.GoverningContract(doc.Root, parent: null),
-                violations);
+        if (doc.Root is null) return;
+
+        // An unrecognised root means this is not an AOT document, and nothing inside it is
+        // governed by the metadata contracts — descending anyway made the rule speak about
+        // whatever element name happened to collide with a type name. That is not hypothetical:
+        // every model ships a BP suppression list (AxIgnoreDiagnosticList/<Model>_BPSuppressions.xml,
+        // root <IgnoreDiagnostics>), whose <Diagnostic> entries collided with the catalog's
+        // Diagnostic type and produced 1 463 findings in one model alone.
+        var rootContract = MetadataContracts.GoverningContract(doc.Root, parent: null);
+        if (rootContract is null) return;
+
+        // A BP suppression list is not read by the metadata serializer. Every model ships one
+        // (AxIgnoreDiagnosticList/<Model>_BPSuppressions.xml), and every entry in it carries
+        // <ItemSpecific> and <Line>, which AxIgnoreDiagnosticItem genuinely does not declare —
+        // reflected off Microsoft.Dynamics.AX.Metadata.dll on a live installation, the type has
+        // exactly seven members and neither is among them. So the elements ARE outside that
+        // contract, and the file is still correct: it is written and read by the best-practice
+        // tooling, not by the metadata provider. Saying "dropped on read" about it would be
+        // stating a consequence that does not follow, 1 463 times in one model.
+        if (string.Equals(doc.Root.Name.LocalName, "IgnoreDiagnostics", StringComparison.Ordinal)) return;
+
+        CheckElement(doc.Root, doc.Root.Name.LocalName, rootContract, violations);
     }
 
     private static void CheckElement(XElement element, string path, MetadataContract? contract, List<XppViolation> violations)
@@ -73,8 +89,12 @@ public static class ContractShapeRules
 
             // An element named after a type is a collection item or a nested object, not a
             // member of the enclosing one — judging <AxTableField> as a member of AxTableField
-            // would flag every collection in every file.
-            var isMember = MetadataContracts.Find(name) is null;
+            // would flag every collection in every file. Unless the enclosing type declares a
+            // member by that name, in which case that is what it is: a handful of member names
+            // collide with type names, and reading them as types judged their contents against
+            // an unrelated contract.
+            var isMember = MetadataContracts.Find(name) is null
+                || (contract is not null && MetadataContracts.AcceptsMember(contract, name));
 
             if (contract is not null && isMember)
             {

--- a/src/D365FO.Core/Validation/XppValidator.cs
+++ b/src/D365FO.Core/Validation/XppValidator.cs
@@ -453,7 +453,9 @@ public static class XppValidator
             var decl = ClassDeclarationAfter(maskedLines, i);
             if (decl is null) continue;
             var m = Regex.Match(decl.Value.Text, @"\bclass\s+(\w+)", RegexOptions.IgnoreCase);
-            if (m.Success && !m.Groups[1].Value.EndsWith("_Extension", StringComparison.Ordinal))
+            // Case-insensitively: X++ identifiers are, and the platform ships
+            // `JournalCheckPostIV_extension`, which compiles and IS named after the convention.
+            if (m.Success && !m.Groups[1].Value.EndsWith("_Extension", StringComparison.OrdinalIgnoreCase))
             {
                 v.Add(new XppViolation("COC003", "error", decl.Value.Index + 1,
                     (decl.Value.Index < lines.Length ? lines[decl.Value.Index] : decl.Value.Text).Trim(),
@@ -784,6 +786,10 @@ public static class XppValidator
             // `MyClass::year(…)` is that class's own static; only Global:: shares the
             // predefined names.
             if (before.EndsWith("::") && !Regex.IsMatch(before, @"\bGlobal\s*::$")) continue;
+            // `new Info()` constructs the class of that name; a predefined function is never
+            // reached through new. Shipped code carries seven of these (SysTest,
+            // SysPrintArchive, …) and each was reported as info() called with no arguments.
+            if (Regex.IsMatch(before, @"\bnew\s*$")) continue;
             // A DECLARATION, not a call: `public IntEditAdaptor Year()` in a form adaptor
             // reads as a call to the predefined year() unless the preceding token is
             // recognised as a type name. In a call the previous token is an operator, a
@@ -964,41 +970,53 @@ public static class XppValidator
     /// </summary>
     private static void CheckCSharpIsms(string masked, List<XppViolation> v)
     {
-        var patterns = new (string Re, RegexOptions Options, string Fix)[]
+        // A file may ALIAS a CLR type into scope — `using string = System.String;` — and then
+        // `string groupKey` is a declaration of that alias, not C# that fails to compile. The
+        // platform's GlobalUnifiedPricing classes do exactly this to implement Commerce runtime
+        // interfaces, and were the only files on a stock installation this rule fired on.
+        var aliased = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+        foreach (Match u in Regex.Matches(masked, @"^\s*using\s+([A-Za-z_]\w*)\s*=", RegexOptions.Multiline))
+            aliased.Add(u.Groups[1].Value);
+
+        // `About` names the C# type a pattern is about, when it is about one — read from the
+        // tuple rather than dug back out of the regex, where a leading  left the name without
+        // a word boundary in front of it and the alias never matched.
+        var patterns = new (string Re, RegexOptions Options, string Fix, string? About)[]
         {
             (@"\$""", RegexOptions.None,
-                "X++ has no string interpolation ($\"…\") — use strFmt(\"%1 / %2\", a, b)."),
+                "X++ has no string interpolation ($\"…\") — use strFmt(\"%1 / %2\", a, b).", null),
             (@"=>", RegexOptions.None,
-                "X++ has no lambdas/anonymous methods (=>) — use a named (private) method, or a delegate plus an eventhandler subscription."),
+                "X++ has no lambdas/anonymous methods (=>) — use a named (private) method, or a delegate plus an eventhandler subscription.", null),
             (@"\bforeach\b", RegexOptions.None,
-                "X++ has no foreach — iterate collections with their Enumerator (while (en.moveNext()) { en.current(); }) and tables with while select."),
+                "X++ has no foreach — iterate collections with their Enumerator (while (en.moveNext()) { en.current(); }) and tables with while select.", null),
             (@"\?\?", RegexOptions.None,
-                "X++ has no null-coalescing operator (??) — value types hold null-EQUIVALENT values (0, empty string, 1900-01-01); test explicitly."),
+                "X++ has no null-coalescing operator (??) — value types hold null-EQUIVALENT values (0, empty string, 1900-01-01); test explicitly.", null),
             (@"\bstring\s+\w+\s*[;=]", RegexOptions.None,
-                "The X++ string type is str (or an EDT) — \"string\" is C#."),
+                "The X++ string type is str (or an EDT) — \"string\" is C#.", "string"),
             // xppc: "The name 'bool' does not denote a class, a table, or an extended data type."
             (@"\b(?:bool|decimal|double|long|uint)\s+\w+\s*[;=,)]", RegexOptions.None,
                 "C# primitive names do not exist in X++: use boolean, real, int64 and int. " +
-                "There are no unsigned types."),
+                "There are no unsigned types.", "bool|decimal|double|long|uint"),
             // xppc: "';' expected." — X++ has no override/virtual; every non-final
             // instance method is virtual and redeclaring the signature overrides it.
             (@"\b(?:public|protected|private|internal)\s+(?:override|virtual)\b", RegexOptions.None,
                 "X++ has no override/virtual keywords — redeclare the method with the same signature " +
-                "to override it, and mark it final to forbid further overriding."),
+                "to override it, and mark it final to forbid further overriding.", null),
             // xppc: "Conflicting modifiers 'protected private'."
             (@"\bprivate\s+protected\b", RegexOptions.None,
                 "private protected is not an X++ access combination (\"Conflicting modifiers\"). " +
-                "protected internal does compile."),
+                "protected internal does compile.", null),
             // NO generics rule — ApplicationSuite ships `private List<str> …;`, so an offline
             // rule would report Microsoft's own compiling code (see upstream note).
             // xppc: "')' expected." — the catch variable must be DECLARED first and then
             // named alone: `System.Exception ex; … catch (ex)`.
             (@"\bcatch\s*\(\s*(?:System|Microsoft)\.[\w.]+\s+\w+\s*\)", RegexOptions.None,
                 "X++ cannot declare the exception variable in the catch: declare it first " +
-                "(\"System.ArgumentException ex;\") and write catch (ex)."),
+                "(\"System.ArgumentException ex;\") and write catch (ex).", null),
         };
-        foreach (var (re, options, fix) in patterns)
+        foreach (var (re, options, fix, about) in patterns)
         {
+            if (about is not null && about.Split('|').Any(aliased.Contains)) continue;
             MatchAll(masked, re, "CS001", "error", fix, v, options: options);
         }
     }
@@ -1161,7 +1179,14 @@ public static class XppValidator
     {
         foreach (Match m in Regex.Matches(masked, @"\bselect\b[^;{]*[;{]", RegexOptions.IgnoreCase))
         {
-            yield return (m.Value, m.Index);
+            // A select inside a #localmacro body has no terminator, so the match ran on into
+            // the NEXT macro and read two statements as one — which is how a `where` in one
+            // macro and an `order by` in the next were reported as a clause-order error in
+            // shipped platform code. A directive at the start of a line ends the statement.
+            var text = m.Value;
+            var directive = Regex.Match(text, @"\n[ \t]*#");
+            if (directive.Success) text = text[..directive.Index];
+            yield return (text, m.Index);
         }
     }
 
@@ -1316,6 +1341,12 @@ public static class XppValidator
         // expected") are all parse errors.
         foreach (Match m in Regex.Matches(masked, @"\bvalidTimeState\s*\(([^)]*)\)", RegexOptions.IgnoreCase))
         {
+            // The rule is about the SELECT clause. The same name is a method on the query
+            // classes (`query.validTimeState(range)`) and a parameter name on their own
+            // declarations (`public ... validTimeState(SysDaValidTimeState _v = null)`) —
+            // both correct code, and both of which this fired on across the platform packages.
+            if (!InSelectClause(masked, m.Index)) continue;
+
             var operands = m.Groups[1].Value.Split(',').Select(s => s.Trim()).Where(s => s.Length > 0).ToList();
             if (operands.Count > 0 && operands.All(o => Regex.IsMatch(o, @"^[A-Za-z_]\w*$"))) continue;
             v.Add(new XppViolation("SEL010", "error", LineNumber(masked, m.Index), m.Value.Trim(),
@@ -1323,6 +1354,24 @@ public static class XppValidator
                 "not a field (\"Invalid token '.'\") and not a date literal (\"'identifier' expected\"). " +
                 "Assign it first: \"utcdatetime asOf = DateTimeUtil::utcNow(); select validTimeState(asOf) t;\"."));
         }
+    }
+
+    /// <summary>
+    /// True when the offset sits in the clause list of a <c>select</c>, rather than in a method
+    /// call or a declaration that happens to use a clause keyword as a name.
+    /// </summary>
+    /// <remarks>
+    /// Backwards to the start of the statement — a <c>;</c>, a brace, or the start of the text —
+    /// and the statement has to contain <c>select</c>. A dot immediately before settles it the
+    /// other way: <c>x.validTimeState(…)</c> is a method on the query classes, which is how the
+    /// platform's own query builders use the name.
+    /// </remarks>
+    private static bool InSelectClause(string masked, int at)
+    {
+        var head = masked.LastIndexOfAny([';', '{', '}'], Math.Max(0, at - 1));
+        var statement = masked[(head + 1)..at];
+        if (statement.TrimEnd().EndsWith('.')) return false;
+        return Regex.IsMatch(statement, @"\bselect\b", RegexOptions.IgnoreCase);
     }
 
     /// <summary>Values an attribute argument may take: the compiler stores literals, nothing else.</summary>
@@ -1448,8 +1497,14 @@ public static class XppValidator
             }
             if (buf.Trim().Length > 0) args.Add(buf.Trim());
 
-            foreach (var arg in args)
+            foreach (var raw in args)
             {
+                // Masking blanks a comment's content AND its closing delimiter, keeping only
+                // the opening `/*`, so `[SysSetupConfig(true /*ContinueOnError*/, 600)]` — which
+                // the platform ships — reached the literal test as the argument "true /*". A
+                // comment is not part of the argument the compiler stores, so it goes: to its
+                // close where one survives, and to the end of the argument where it does not.
+                var arg = Regex.Replace(raw, @"/\*[\s\S]*?(?:\*/|$)|//[^\n]*", " ").Trim();
                 if (arg.Length == 0) continue;
                 if (AttributeLiteralRe.IsMatch(arg)) continue;
                 var call = Regex.Match(arg, @"^([A-Za-z_]\w*)\s*\(");
@@ -1633,7 +1688,11 @@ public static class XppValidator
         var label = PropertyRuleApplies(stats, "AxTable", "Label");
         if (label.Applies && !Regex.IsMatch(header, @"<Label>[^<]+</Label>", RegexOptions.IgnoreCase))
         {
-            v.Add(new XppViolation("XML002", "error", null, "<AxTable> — missing <Label>",
+            // Warning, not error. The rule is a majority convention — the evidence string says
+            // so — and the minority is Microsoft's own: a full sweep of this installation found
+            // 229 shipped tables in ApplicationFoundation alone with no <Label>, all of which
+            // build and run. An error claims the artefact does not work.
+            v.Add(new XppViolation("XML002", "warning", null, "<AxTable> — missing <Label>",
                 $"Add <Label>@YourModel:TableLabel</Label> to the table header (create the label first via `d365fo label create`). Evidence: {label.Evidence}."));
         }
 
@@ -1654,7 +1713,9 @@ public static class XppValidator
                 }
                 catch { /* keep static suggestion */ }
             }
-            v.Add(new XppViolation("XML003", "error", null, "<AxTable> — missing <TableGroup>",
+            // Warning for the same reason as XML002: a property most standard tables set is not
+            // a property a table must set to work.
+            v.Add(new XppViolation("XML003", "warning", null, "<AxTable> — missing <TableGroup>",
                 $"Add <TableGroup> to the table header. Most common standard values: {suggestion}. Evidence: {tableGroup.Evidence}."));
         }
 

--- a/src/D365FO.Core/Validation/XppValidator.cs
+++ b/src/D365FO.Core/Validation/XppValidator.cs
@@ -771,6 +771,14 @@ public static class XppValidator
     {
         var lines = code.Split('\n');
 
+        // Functions declared inside this source: `<type> name(args)` followed by a body. X++
+        // allows them inside a method body, and they take precedence over the predefined name
+        // of the same spelling.
+        var localFunctions = new HashSet<string>(
+            Regex.Matches(masked, @"\b[A-Za-z_]\w*\s+([A-Za-z_]\w*)\s*\([^)]*\)\s*\{")
+                .Select(d => d.Groups[1].Value),
+            StringComparer.OrdinalIgnoreCase);
+
         foreach (Match m in Regex.Matches(masked, @"\b([A-Za-z_]\w*)\s*\("))
         {
             var called = m.Groups[1].Value;
@@ -786,6 +794,11 @@ public static class XppValidator
             // `MyClass::year(…)` is that class's own static; only Global:: shares the
             // predefined names.
             if (before.EndsWith("::") && !Regex.IsMatch(before, @"\bGlobal\s*::$")) continue;
+            // A local function declared in this source shadows the predefined name — the
+            // compiler's own message says so ("nor a previously defined local function"). The
+            // platform's BatchRun.runJob declares `void info()` inside the method body and
+            // calls it twice.
+            if (localFunctions.Contains(called)) continue;
             // `new Info()` constructs the class of that name; a predefined function is never
             // reached through new. Shipped code carries seven of these (SysTest,
             // SysPrintArchive, …) and each was reported as info() called with no arguments.
@@ -1102,6 +1115,12 @@ public static class XppValidator
     {
         var extendsMatch = Regex.Match(masked, @"\bextends\s+(SRSReportDataProvider(?:Base|PreProcess(?:TempDB)?))\b", RegexOptions.IgnoreCase);
         if (!extendsMatch.Success) return;
+
+        // An abstract DP is a base for concrete ones, and the contract belongs on those: the
+        // platform's own CustVendAdvanceInvoiceDP reads parmDataContract() and declares none,
+        // because CustAdvanceInvoiceDP and VendAdvanceInvoiceDP each declare their own.
+        if (Regex.IsMatch(masked, @"\babstract\s+(?:final\s+)?class\b", RegexOptions.IgnoreCase)) return;
+
         var isPreProcess = extendsMatch.Groups[1].Value.Contains("PreProcess", StringComparison.OrdinalIgnoreCase);
 
         var parmContract = Regex.Match(masked, @"\bparmDataContract\s*\(", RegexOptions.IgnoreCase);

--- a/tests/D365FO.Cli.Tests/CliMcpParityTests.cs
+++ b/tests/D365FO.Cli.Tests/CliMcpParityTests.cs
@@ -59,6 +59,16 @@ public class CliMcpParityTests
         ["index export"] = "Index transport for CI caching.",
         ["index import"] = "Index transport for CI caching.",
         ["validate form-pattern-repair"] = "Alias of `form-pattern repair`, published under its own branch.",
+        ["oracle sweep"] = "Oracle harness — runs this tool's own validator over an installation to find rules that "
+            + "fire on correct Microsoft code. A measurement of the tool, not an operation on the user's X++.",
+        ["oracle census"] = "Oracle harness — measures what shipped AOT XML actually contains, which is where this "
+            + "tool's metadata facts come from.",
+        ["oracle members"] = "Oracle harness — the per-member half of the census.",
+        ["oracle probe"] = "Oracle harness — compiles a throwaway model with xppc to check a scaffold against the "
+            + "real compiler. An agent that wants its work compiled has `build`, which builds the model it "
+            + "installed into rather than a temporary copy of it.",
+        ["oracle runtime"] = "Oracle harness — diagnoses whether the SysTest runner is wired to a database and can "
+            + "tell a passing test from a failing one. Configures a Microsoft-installed file; an operator task.",
     };
 
     /// <summary>

--- a/tests/D365FO.Cli.Tests/Eval/EvalListCommandTests.cs
+++ b/tests/D365FO.Cli.Tests/Eval/EvalListCommandTests.cs
@@ -33,7 +33,7 @@ public class EvalListCommandTests
 
         Assert.Equal(0, exit);
         Assert.Contains("\"ok\":true", stdout);
-        Assert.Contains("\"count\":52", stdout);
+        Assert.Contains("\"count\":60", stdout);
         Assert.Contains("L0-edt-basic", stdout);
         Assert.Contains("L2-coc-extension", stdout);
         Assert.Contains("L1-form-workspace", stdout);

--- a/tests/D365FO.Cli.Tests/TablePatternScaffoldingTests.cs
+++ b/tests/D365FO.Cli.Tests/TablePatternScaffoldingTests.cs
@@ -70,7 +70,9 @@ public class TablePatternScaffoldingTests
     /// `validate xpp` raises XML003 on that table, so `generate table` warns about
     /// the consequence instead of leaving the caller to hit it one command later.
     /// This test pins the tension the warning describes: if XML003 ever stops
-    /// firing here, the warning is stale and must go.
+    /// firing here, the warning is stale and must go. It fires as a WARNING: a full
+    /// sweep of a live installation found hundreds of shipped tables with no
+    /// TableGroup, so a majority convention is what it is — not a defect.
     /// </summary>
     [Fact]
     public void Pattern_None_table_trips_the_XML003_rule_the_command_warns_about()
@@ -78,7 +80,7 @@ public class TablePatternScaffoldingTests
         var withoutPattern = XppScaffolder.Table("FmThing", label: "@Fm:Thing").ToString();
         var violations = D365FO.Core.Validation.XppValidator.Validate(
             withoutPattern, D365FO.Core.Validation.XppValidator.CodeTypeXmlTable);
-        Assert.Contains(violations, v => v.Rule == "XML003" && v.Severity == "error");
+        Assert.Contains(violations, v => v.Rule == "XML003" && v.Severity == "warning");
 
         var withPattern = XppScaffolder.Table("FmThing", label: "@Fm:Thing",
             pattern: TablePattern.Miscellaneous).ToString();

--- a/tests/D365FO.Core.Tests/Eval/EvalCaseCatalogTests.cs
+++ b/tests/D365FO.Core.Tests/Eval/EvalCaseCatalogTests.cs
@@ -14,7 +14,7 @@ public class EvalCaseCatalogTests
         var (cases, errors) = EvalCaseCatalog.LoadAll(EvalPaths.CasesDir(RepoRoot));
 
         Assert.Empty(errors);
-        Assert.Equal(52, cases.Count);
+        Assert.Equal(60, cases.Count);
         Assert.Contains(cases, c => c.Id == "L0-edt-basic");
         Assert.Contains(cases, c => c.Id == "L0-enum-basic");
         Assert.Contains(cases, c => c.Id == "L1-table-basic");
@@ -50,7 +50,7 @@ public class EvalCaseCatalogTests
     public void Only_cases_grounded_against_the_FmVehicle_fixture_require_the_fixture_index()
     {
         var (cases, _) = EvalCaseCatalog.LoadAll(EvalPaths.CasesDir(RepoRoot));
-        string[] fixtureObjects = { "FmVehicleService", "FmVehicleLine", "FmVehicle" };
+        string[] fixtureObjects = { "FmVehicleService", "FmVehicleLine", "FmServiceOrder", "FmVehicle" };
 
         foreach (var c in cases.Where(c => c.RequiresFixtureIndex))
         {
@@ -76,6 +76,11 @@ public class EvalCaseCatalogTests
     [InlineData("tier-mismatch.json", "{\"id\":\"L1-x\",\"title\":\"x\",\"tier\":2,\"instruction\":\"x\",\"target_artifact_types\":[\"AxEdt\"],\"golden_path\":\"x\"}", "does not match id prefix")]
     [InlineData("missing-title.json", "{\"id\":\"L1-x\",\"tier\":1,\"instruction\":\"x\",\"target_artifact_types\":[\"AxEdt\"],\"golden_path\":\"x\"}", "'title' is required")]
     [InlineData("missing-types.json", "{\"id\":\"L1-x\",\"title\":\"x\",\"tier\":1,\"instruction\":\"x\",\"target_artifact_types\":[],\"golden_path\":\"x\"}", "'target_artifact_types' must be non-empty")]
+    // `eval run` appends the output options itself. A case carrying one would either fight it
+    // or, on --install-to, write into a real model from a replay.
+    [InlineData("owns-the-output.json", "{\"id\":\"L1-x\",\"title\":\"x\",\"tier\":1,\"instruction\":\"x\",\"canonical_args\":[\"generate\",\"edt\",\"X\",\"--out\",\"x.xml\"],\"target_artifact_types\":[\"AxEdt\"],\"golden_path\":\"x\"}", "canonical_args must not carry '--out'")]
+    // A seed is a bare file name under eval/seeds/ — a path would let a case read anywhere.
+    [InlineData("seed-with-a-path.json", "{\"id\":\"L1-x\",\"title\":\"x\",\"tier\":1,\"instruction\":\"x\",\"target_artifact_types\":[\"AxTable\"],\"golden_path\":\"x\",\"apply_to_seed\":\"../../secrets.xml\"}", "must be a bare file name")]
     public void Rejects_malformed_case_files_with_a_specific_reason(string fileName, string json, string expectedFragment)
     {
         var dir = Path.Combine(Path.GetTempPath(), $"d365fo-eval-catalog-{Guid.NewGuid():N}");

--- a/tests/D365FO.Core.Tests/Eval/EvalCompanionAndSeedTests.cs
+++ b/tests/D365FO.Core.Tests/Eval/EvalCompanionAndSeedTests.cs
@@ -1,0 +1,195 @@
+using D365FO.Core.Eval;
+using D365FO.Core.Index;
+using Xunit;
+
+namespace D365FO.Core.Tests.Eval;
+
+/// <summary>
+/// Scoring the artefacts a case produces BESIDE its main one, and the seeds a case starts from.
+/// </summary>
+/// <remarks>
+/// <para>
+/// Several <c>generate</c> commands emit more than one file — a report is a report plus a TempDB
+/// table, a DP, a controller and an output menu item. Only the main one used to be diffed, so
+/// the companions were captured once under <c>_companions/</c> and then never checked again:
+/// the first run with this in place found ten companions across the two report cases that no
+/// golden had ever pinned.
+/// </para>
+/// <para>
+/// Seeds are the other direction: <c>table-relation</c> and <c>find-methods</c> augment a table
+/// that already exists and refuse <c>--out</c> outright, so a case for either needs an input
+/// artefact rather than producing one.
+/// </para>
+/// </remarks>
+public class EvalCompanionAndSeedTests : IDisposable
+{
+    private readonly string _dbPath = Path.Combine(Path.GetTempPath(), $"eval-comp-{Guid.NewGuid():N}.sqlite");
+    private readonly string _goldensRoot = Path.Combine(Path.GetTempPath(), $"eval-comp-goldens-{Guid.NewGuid():N}");
+    private readonly string _workDir = Path.Combine(Path.GetTempPath(), $"eval-comp-work-{Guid.NewGuid():N}");
+    private readonly MetadataRepository _repo;
+
+    public EvalCompanionAndSeedTests()
+    {
+        _repo = new MetadataRepository(_dbPath);
+        _repo.EnsureSchema();
+        Directory.CreateDirectory(_goldensRoot);
+        Directory.CreateDirectory(_workDir);
+    }
+
+    public void Dispose()
+    {
+        SqlitePool.ReleaseFor(_dbPath);
+        foreach (var ext in new[] { "", "-wal", "-shm" })
+        {
+            var p = _dbPath + ext;
+            if (File.Exists(p)) { try { File.Delete(p); } catch { } }
+        }
+        foreach (var dir in new[] { _goldensRoot, _workDir })
+            if (Directory.Exists(dir)) { try { Directory.Delete(dir, recursive: true); } catch { } }
+    }
+
+    private static EvalCase Case(string goldenPath) => new(
+        Id: "L0-test", Title: "Test", Tier: 0, Instruction: "test",
+        CanonicalArgs: null, TargetArtifactTypes: new[] { "AxEdt" },
+        GoldenPath: goldenPath, Tags: Array.Empty<string>(),
+        Ignore: Array.Empty<string>(), RequiresFixtureIndex: false, GoldenPending: false);
+
+    private string Golden(string body, string name = "Foo.xml")
+    {
+        var dir = Path.Combine(_goldensRoot, "L0-test");
+        Directory.CreateDirectory(dir);
+        File.WriteAllText(Path.Combine(dir, name), body);
+        return dir;
+    }
+
+    private void GoldenCompanion(string name, string body)
+    {
+        var dir = Path.Combine(_goldensRoot, "L0-test", "_companions");
+        Directory.CreateDirectory(dir);
+        File.WriteAllText(Path.Combine(dir, name), body);
+    }
+
+    private string Produce(string name, string body)
+    {
+        var path = Path.Combine(_workDir, name);
+        File.WriteAllText(path, body);
+        return path;
+    }
+
+    private const string Main = "<AxEdt><Name>Foo</Name></AxEdt>";
+
+    [Fact]
+    public void A_companion_that_matches_its_golden_keeps_the_case_passing()
+    {
+        Golden(Main);
+        GoldenCompanion("FooHelper.xml", "<AxClass><Name>FooHelper</Name></AxClass>");
+        var actual = Produce("actual.xml", Main);
+        Produce("FooHelper.xml", "<AxClass><Name>FooHelper</Name></AxClass>");
+
+        var score = EvalScorer.Score(Case("L0-test"), actual, _goldensRoot, _repo, producedDir: _workDir);
+
+        Assert.True(score.GoldenMatch);
+    }
+
+    [Fact]
+    public void A_companion_that_differs_is_reported_under_its_own_name()
+    {
+        Golden(Main);
+        GoldenCompanion("FooHelper.xml", "<AxClass><Name>FooHelper</Name><IsFinal>Yes</IsFinal></AxClass>");
+        var actual = Produce("actual.xml", Main);
+        Produce("FooHelper.xml", "<AxClass><Name>FooHelper</Name></AxClass>");
+
+        var score = EvalScorer.Score(Case("L0-test"), actual, _goldensRoot, _repo, producedDir: _workDir);
+
+        Assert.False(score.GoldenMatch);
+        Assert.Contains(score.GoldenDiff.Missing, m => m.StartsWith("_companions/FooHelper.xml:", StringComparison.Ordinal));
+    }
+
+    [Fact]
+    public void A_companion_the_run_did_not_produce_is_missing()
+    {
+        Golden(Main);
+        GoldenCompanion("FooHelper.xml", "<AxClass><Name>FooHelper</Name></AxClass>");
+        var actual = Produce("actual.xml", Main);
+
+        var score = EvalScorer.Score(Case("L0-test"), actual, _goldensRoot, _repo, producedDir: _workDir);
+
+        Assert.Contains("_companions/FooHelper.xml", score.GoldenDiff.Missing);
+    }
+
+    /// <summary>
+    /// The drift this exists for: a command starts emitting a file nobody reviewed, and every
+    /// other check still passes because the main artefact is unchanged.
+    /// </summary>
+    [Fact]
+    public void A_companion_no_golden_names_is_extra()
+    {
+        Golden(Main);
+        var actual = Produce("actual.xml", Main);
+        Produce("FooSurprise.xml", "<AxClass><Name>FooSurprise</Name></AxClass>");
+
+        var score = EvalScorer.Score(Case("L0-test"), actual, _goldensRoot, _repo, producedDir: _workDir);
+
+        Assert.False(score.GoldenMatch);
+        Assert.Contains("_companions/FooSurprise.xml", score.GoldenDiff.Extra);
+    }
+
+    /// <summary>
+    /// Without a directory the caller owns, a sibling file says nothing about what produced it —
+    /// the scorer must not read the whole temp directory as this run's output.
+    /// </summary>
+    [Fact]
+    public void Siblings_are_not_treated_as_output_when_no_produced_directory_is_given()
+    {
+        Golden(Main);
+        var actual = Produce("actual.xml", Main);
+        Produce("SomeoneElses.xml", "<AxClass><Name>SomeoneElses</Name></AxClass>");
+
+        var score = EvalScorer.Score(Case("L0-test"), actual, _goldensRoot, _repo);
+
+        Assert.True(score.GoldenMatch);
+    }
+
+    // ── the seeds themselves ──────────────────────────────────────────────
+
+    /// <summary>
+    /// The index a replay builds comes from the MiniAot fixture. A seed that had drifted from
+    /// the fixture file of the same name would be a case merging into a table the tool never saw.
+    /// </summary>
+    [Fact]
+    public void A_seed_named_after_a_fixture_table_is_identical_to_it()
+    {
+        var root = EvalPaths.FindRepoRoot(AppContext.BaseDirectory);
+        Assert.NotNull(root);
+
+        var seedsDir = EvalPaths.SeedsDir(root!);
+        if (!Directory.Exists(seedsDir)) return;
+
+        foreach (var seed in Directory.GetFiles(seedsDir, "*.xml"))
+        {
+            var name = Path.GetFileName(seed);
+            var fixture = Directory
+                .EnumerateFiles(EvalPaths.FixtureDir(root!), name, SearchOption.AllDirectories)
+                .FirstOrDefault();
+            if (fixture is null) continue;
+
+            Assert.True(
+                File.ReadAllBytes(seed).SequenceEqual(File.ReadAllBytes(fixture)),
+                $"eval/seeds/{name} has drifted from the fixture file it mirrors ({fixture}).");
+        }
+    }
+
+    [Fact]
+    public void Every_seed_a_case_names_exists()
+    {
+        var root = EvalPaths.FindRepoRoot(AppContext.BaseDirectory);
+        Assert.NotNull(root);
+
+        var (cases, _) = EvalCaseCatalog.LoadAll(EvalPaths.CasesDir(root!));
+        foreach (var c in cases.Where(c => c.ApplyToSeed is not null))
+        {
+            var seed = Path.Combine(EvalPaths.SeedsDir(root!), c.ApplyToSeed!);
+            Assert.True(File.Exists(seed), $"{c.Id}: apply_to_seed names {c.ApplyToSeed}, which is not in eval/seeds/.");
+        }
+    }
+}

--- a/tests/D365FO.Core.Tests/MiniAotEndToEndTests.cs
+++ b/tests/D365FO.Core.Tests/MiniAotEndToEndTests.cs
@@ -118,12 +118,15 @@ public class MiniAotEndToEndTests : IDisposable
     public void Repository_counts_match_fixture()
     {
         var counts = _repo.CountAll();
-        // FmVehicle (3 fields) + FmVehicleLine (3 fields). The second table exists
-        // so eval cases can exercise header/lines and join-shaped generators
-        // (query --join, form --pattern DetailsTransaction) against a real
-        // relation instead of a phantom target.
-        Assert.Equal(2, counts.Tables);
-        Assert.Equal(6, counts.Fields);
+        // FmVehicle (3 fields) + FmVehicleLine (3 fields) + FmServiceOrder (3 fields).
+        // The second table exists so eval cases can exercise header/lines and join-shaped
+        // generators (query --join, form --pattern DetailsTransaction) against a real
+        // relation instead of a phantom target. The third exists for the two table-augmenting
+        // generators: it carries an un-migrated EDT reference (the VIN EDT declares
+        // ReferenceTable) and its own alternate key, which is what `generate table-relation`
+        // and `generate find-methods` respectively derive from.
+        Assert.Equal(3, counts.Tables);
+        Assert.Equal(9, counts.Fields);
         Assert.Equal(1, counts.Classes);
     }
 
@@ -143,11 +146,16 @@ public class MiniAotEndToEndTests : IDisposable
         var ex = new MetadataExtractor();
         var batch = ex.ExtractAll(SamplesDir).Single();
 
-        var edt = Assert.Single(batch.Edts);
-        Assert.Equal("VinEdt", edt.Name);
+        var edt = Assert.Single(batch.Edts, e => e.Name == "VinEdt");
         Assert.Equal(
             edt.Name,
             batch.Tables.Single(t => t.Name == "FmVehicle").Fields.Single(f => f.Name == "VIN").EdtName);
+
+        // The second EDT is the one that carries a reference. `generate table-relation` reads
+        // exactly this to derive the relation D365FO requires in its place, so the extractor
+        // has to bring ReferenceTable across — an EDT indexed without it looks migrated.
+        var referencing = Assert.Single(batch.Edts, e => e.Name == "VIN");
+        Assert.Equal("FmVehicle", referencing.ReferenceTable);
 
         var @enum = Assert.Single(batch.Enums);
         Assert.Equal("FmVehicleStatus", @enum.Name);
@@ -243,8 +251,8 @@ public class MiniAotEndToEndTests : IDisposable
             _repo.ApplyExtract(b);
 
         var counts = _repo.CountAll();
-        Assert.Equal(2, counts.Tables);
-        Assert.Equal(6, counts.Fields);
+        Assert.Equal(3, counts.Tables);
+        Assert.Equal(9, counts.Fields);
         Assert.Equal(1, counts.Classes);
     }
 }

--- a/tests/D365FO.Core.Tests/OracleTests.cs
+++ b/tests/D365FO.Core.Tests/OracleTests.cs
@@ -1,0 +1,325 @@
+using D365FO.Core.Eval;
+using Xunit;
+
+namespace D365FO.Core.Tests;
+
+/// <summary>
+/// The measurements that judge the tool rather than what it produces.
+/// </summary>
+/// <remarks>
+/// These run without an installation: they exercise the machinery over a hand-built packages
+/// tree. What they cannot prove is the thing the sweep exists for — that the rules are silent on
+/// Microsoft's code — because that needs Microsoft's code. That claim is made by running
+/// <c>oracle sweep</c> on a host that has an installation, and is recorded in the wave notes.
+/// </remarks>
+public class OracleTests : IDisposable
+{
+    private readonly string _root = Path.Combine(Path.GetTempPath(), $"d365fo-oracle-{Guid.NewGuid():N}");
+
+    public OracleTests() => Directory.CreateDirectory(_root);
+
+    public void Dispose()
+    {
+        if (Directory.Exists(_root)) Directory.Delete(_root, recursive: true);
+        GC.SuppressFinalize(this);
+    }
+
+    /// <summary>Lay a file down in packages shape: &lt;root&gt;/&lt;package&gt;/&lt;model&gt;/Ax*/&lt;name&gt;.xml.</summary>
+    private string Write(string model, string axFolder, string name, string xml)
+    {
+        var dir = Path.Combine(_root, model, model, axFolder);
+        Directory.CreateDirectory(dir);
+        var path = Path.Combine(dir, name + ".xml");
+        File.WriteAllText(path, xml);
+        return path;
+    }
+
+    private const string CleanTable = """
+        <?xml version="1.0" encoding="utf-8"?>
+        <AxTable xmlns:i="http://www.w3.org/2001/XMLSchema-instance">
+          <Name>ConCleanTable</Name>
+          <Label>@ConFleet:Label</Label>
+          <TableGroup>Main</TableGroup>
+          <Fields><AxTableField i:type="AxTableFieldString"><Name>ConField</Name><ExtendedDataType>Name</ExtendedDataType></AxTableField></Fields>
+          <Indexes><AxTableIndex><Name>ConIdx</Name><AlternateKey>Yes</AlternateKey></AxTableIndex></Indexes>
+        </AxTable>
+        """;
+
+    // ── sweep ──────────────────────────────────────────────────────────────
+
+    [Fact]
+    public void The_sweep_walks_the_packages_shape_and_counts_what_it_finds()
+    {
+        Write("ConFleet", "AxTable", "ConCleanTable", CleanTable);
+        Write("ConFleet", "AxClass", "ConClass", """
+            <?xml version="1.0" encoding="utf-8"?>
+            <AxClass><Name>ConClass</Name><SourceCode><Declaration><![CDATA[class ConClass
+            {
+            }
+            ]]></Declaration></SourceCode></AxClass>
+            """);
+
+        var report = OracleSweep.Run(_root, new OracleSweep.Options(IncludeWarnings: true));
+
+        Assert.Equal(2, report.FilesScanned);
+        Assert.Equal(1, report.XppBlocksScanned);   // only the class carries a Declaration
+        Assert.Equal(0, report.FilesUnreadable);
+    }
+
+    /// <summary>
+    /// The bar is errors, not findings: a warning is a style opinion that shipped code is allowed
+    /// to disagree with, and folding the two together would make the bar unmeetable and therefore
+    /// ignored.
+    /// </summary>
+    [Fact]
+    public void Warnings_do_not_break_the_bar_and_errors_do()
+    {
+        // No alternate key: XML001, a warning.
+        Write("ConFleet", "AxTable", "ConNoKey", """
+            <?xml version="1.0" encoding="utf-8"?>
+            <AxTable xmlns:i="http://www.w3.org/2001/XMLSchema-instance">
+              <Name>ConNoKey</Name><Label>@ConFleet:L</Label><TableGroup>Main</TableGroup>
+              <Fields><AxTableField i:type="AxTableFieldString"><Name>F</Name><ExtendedDataType>Name</ExtendedDataType></AxTableField></Fields>
+            </AxTable>
+            """);
+
+        var report = OracleSweep.Run(_root, new OracleSweep.Options(IncludeWarnings: true));
+
+        Assert.True(report.Warnings > 0);
+        Assert.Equal(0, report.Errors);
+        Assert.True(report.BarHeld);
+    }
+
+    [Fact]
+    public void An_unreadable_file_is_counted_rather_than_swallowed()
+    {
+        var path = Write("ConFleet", "AxTable", "ConBroken", "<AxTable><Name>ConBroken</Name>");  // truncated
+        Assert.True(File.Exists(path));
+
+        var report = OracleSweep.Run(_root, new OracleSweep.Options(IncludeWarnings: true));
+
+        // It is read as text without trouble; it is the PARSE that fails, and the rules that need
+        // a document simply say nothing. What must not happen is a crash or a silent skip.
+        Assert.Equal(1, report.FilesScanned);
+    }
+
+    [Fact]
+    public void Samples_are_bounded_so_the_sweep_costs_the_same_however_wrong_the_rules_are()
+    {
+        for (var i = 0; i < 12; i++)
+            Write("ConFleet", "AxTable", $"ConNoKey{i}", CleanTable.Replace("ConCleanTable", $"ConNoKey{i}")
+                .Replace("<Indexes><AxTableIndex><Name>ConIdx</Name><AlternateKey>Yes</AlternateKey></AxTableIndex></Indexes>", ""));
+
+        var report = OracleSweep.Run(_root, new OracleSweep.Options(SamplesPerRule: 2, IncludeWarnings: true));
+
+        Assert.All(report.ByRule, r => Assert.True(r.Samples.Count <= 2));
+        Assert.Contains(report.ByRule, r => r.Count > 2);   // counted beyond what was kept
+    }
+
+    [Fact]
+    public void A_model_filter_narrows_the_sweep()
+    {
+        Write("ConFleet", "AxTable", "ConA", CleanTable);
+        Write("ConOther", "AxTable", "ConB", CleanTable.Replace("ConCleanTable", "ConB"));
+
+        Assert.Equal(2, OracleSweep.Run(_root).FilesScanned);
+        Assert.Equal(1, OracleSweep.Run(_root, new OracleSweep.Options(Model: "ConOther")).FilesScanned);
+        Assert.Equal(2, OracleSweep.Run(_root, new OracleSweep.Options(AxFolder: "AxTable")).FilesScanned);
+        Assert.Equal(0, OracleSweep.Run(_root, new OracleSweep.Options(AxFolder: "AxForm")).FilesScanned);
+    }
+
+    // ── census ─────────────────────────────────────────────────────────────
+
+    [Fact]
+    public void The_census_counts_members_and_the_files_that_carry_them()
+    {
+        Write("ConFleet", "AxTable", "ConA", CleanTable);
+        Write("ConFleet", "AxTable", "ConB", """
+            <?xml version="1.0" encoding="utf-8"?>
+            <AxTable><Name>ConB</Name><TableGroup>Transaction</TableGroup></AxTable>
+            """);
+
+        var census = OracleCensus.Run(_root, "AxTable");
+
+        Assert.Equal(2, census.FilesScanned);
+
+        var name = census.Members.Single(m => m.Member == "Name");
+        Assert.Equal(2, name.Files);
+
+        var label = census.Members.Single(m => m.Member == "Label");
+        Assert.Equal(1, label.Files);
+
+        // Leaf values are sampled, so a property rule can be built on what the values really are.
+        var group = census.Members.Single(m => m.Member == "TableGroup");
+        Assert.Contains("Main", group.SampleValues);
+        Assert.Contains("Transaction", group.SampleValues);
+    }
+
+    /// <summary>
+    /// The measurement that refuses an order rule. Two documents writing the same pair of members
+    /// in opposite orders is a counter-example, and one is enough.
+    /// </summary>
+    [Fact]
+    public void An_order_seen_both_ways_is_reported_as_unstable()
+    {
+        Write("ConFleet", "AxTable", "ConA", "<AxTable><Name>ConA</Name><Label>x</Label></AxTable>");
+        Write("ConFleet", "AxTable", "ConB", "<AxTable><Label>y</Label><Name>ConB</Name></AxTable>");
+
+        var census = OracleCensus.Run(_root, "AxTable");
+
+        Assert.False(census.OrderIsStable);
+        Assert.NotEmpty(census.OrderCounterExamples);
+    }
+
+    [Fact]
+    public void One_consistent_order_is_reported_as_stable()
+    {
+        Write("ConFleet", "AxTable", "ConA", "<AxTable><Name>ConA</Name><Label>x</Label></AxTable>");
+        Write("ConFleet", "AxTable", "ConB", "<AxTable><Name>ConB</Name><Label>y</Label></AxTable>");
+
+        Assert.True(OracleCensus.Run(_root, "AxTable").OrderIsStable);
+    }
+
+    [Fact]
+    public void A_member_the_contract_does_not_declare_is_reported_as_drift()
+    {
+        Write("ConFleet", "AxTable", "ConA",
+            "<AxTable><Name>ConA</Name><ConNoSuchMember>x</ConNoSuchMember></AxTable>");
+
+        var census = OracleCensus.Run(_root, "AxTable");
+
+        Assert.Contains("ConNoSuchMember", census.SeenNotDeclared);
+        Assert.DoesNotContain("Name", census.SeenNotDeclared);
+    }
+
+    // ── probe ──────────────────────────────────────────────────────────────
+
+    /// <summary>
+    /// The three rules the hand-run recipe kept getting wrong: the folder comes from the root
+    /// element, the file name from the declared &lt;Name&gt;, and anything that is not an AOT
+    /// document is refused rather than copied somewhere the compiler will trip over it.
+    /// </summary>
+    [Fact]
+    public void The_probe_places_an_artefact_where_the_compiler_expects_it()
+    {
+        var source = Path.Combine(_root, "written-under-another-name.xml");
+        File.WriteAllText(source, """
+            <?xml version="1.0" encoding="utf-8"?>
+            <AxClass><Name>ConProbeClass</Name><SourceCode><Declaration><![CDATA[class ConProbeClass
+            {
+            }
+            ]]></Declaration></SourceCode></AxClass>
+            """);
+
+        var work = Path.Combine(_root, "work");
+        var prep = OracleProbe.Prepare([source], work, "ConProbeModel", withFixture: false);
+
+        var placed = Assert.Single(prep.Placed);
+        Assert.Equal("ConProbeClass", placed.ObjectName);
+        Assert.Equal("AxClass", placed.AxFolder);
+        Assert.EndsWith(Path.Combine("AxClass", "ConProbeClass.xml"), placed.Placed, StringComparison.Ordinal);
+        Assert.True(File.Exists(placed.Placed));
+        Assert.True(File.Exists(Path.Combine(work, "ConProbeModel", "Descriptor", "ConProbeModel.xml")));
+    }
+
+    [Theory]
+    [InlineData("<notaot><Name>X</Name></notaot>", "not an AOT element")]
+    [InlineData("<AxClass></AxClass>", "declares no <Name>")]
+    [InlineData("<AxClass><Name>X</Name>", "not readable XML")]
+    public void Something_that_is_not_a_usable_document_is_refused_with_the_reason(string xml, string reason)
+    {
+        var source = Path.Combine(_root, "candidate.xml");
+        File.WriteAllText(source, xml);
+
+        var prep = OracleProbe.Prepare([source], Path.Combine(_root, "work"), "ConProbeModel", withFixture: false);
+
+        Assert.Empty(prep.Placed);
+        var rejected = Assert.Single(prep.Rejected);
+        Assert.Contains(reason, rejected.Reason, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void A_missing_file_is_refused_rather_than_reported_as_compiled()
+    {
+        var prep = OracleProbe.Prepare(
+            [Path.Combine(_root, "absent.xml")], Path.Combine(_root, "work"), "ConProbeModel", withFixture: false);
+
+        Assert.Empty(prep.Placed);
+        Assert.Contains(prep.Rejected, r => r.Reason.Contains("no such file", StringComparison.Ordinal));
+    }
+
+    // ── runtime ────────────────────────────────────────────────────────────
+
+    [Fact]
+    public void An_unconfigured_runner_is_reported_as_unconfigured()
+    {
+        var bin = Path.Combine(_root, "packages", "bin");
+        Directory.CreateDirectory(bin);
+        File.WriteAllText(Path.Combine(bin, "SysTestConsole.exe"), "");
+        File.WriteAllText(Path.Combine(bin, "SysTestConsole.exe.config"), """
+            <configuration><appSettings>
+              <add key="DataAccess.Database" value="" />
+            </appSettings></configuration>
+            """);
+
+        var diagnosis = RuntimeOracle.Diagnose(Path.Combine(_root, "packages"));
+
+        Assert.True(diagnosis.RunnerPresent);
+        Assert.False(diagnosis.Configured);
+        Assert.Contains("DataAccess.Database", diagnosis.Missing);   // present but empty still counts as missing
+        Assert.Contains("DataAccess.DbServer", diagnosis.Missing);
+    }
+
+    [Fact]
+    public void Configuring_copies_only_what_is_missing_and_keeps_the_original()
+    {
+        var bin = Path.Combine(_root, "packages", "bin");
+        Directory.CreateDirectory(bin);
+        var runnerConfig = Path.Combine(bin, "SysTestConsole.exe.config");
+        File.WriteAllText(Path.Combine(bin, "SysTestConsole.exe"), "");
+        File.WriteAllText(runnerConfig, """
+            <configuration><appSettings>
+              <add key="DataAccess.Database" value="AlreadySet" />
+            </appSettings></configuration>
+            """);
+
+        var web = Path.Combine(_root, "web.config");
+        File.WriteAllText(web, """
+            <configuration><appSettings>
+              <add key="DataAccess.Database" value="FromWeb" />
+              <add key="DataAccess.DbServer" value="SERVER1" />
+              <add key="DataAccess.SqlUser" value="axdbadmin" />
+            </appSettings></configuration>
+            """);
+
+        var result = RuntimeOracle.Configure(runnerConfig, web);
+
+        // The one already set is left alone: this is a repair, not an overwrite.
+        Assert.DoesNotContain("DataAccess.Database", result.Written);
+        Assert.Contains("DataAccess.DbServer", result.Written);
+        Assert.Contains("DataAccess.SqlUser", result.Written);
+        // And what the web.config does not carry is not invented.
+        Assert.Contains("DataAccess.SqlPwd", result.Unavailable);
+
+        Assert.True(File.Exists(result.BackupPath));
+        var written = File.ReadAllText(runnerConfig);
+        Assert.Contains("AlreadySet", written, StringComparison.Ordinal);
+        Assert.Contains("SERVER1", written, StringComparison.Ordinal);
+    }
+
+    /// <summary>
+    /// The control has to contain all three outcomes, or it cannot tell a runner that discriminates
+    /// from one that reports everything the same way.
+    /// </summary>
+    [Fact]
+    public void The_negative_control_passes_fails_and_throws_on_purpose()
+    {
+        var source = RuntimeOracle.NegativeControlSource("ConControlTest");
+
+        Assert.Equal(3, source.Split("[SysTestMethodAttribute]").Length - 1);
+        Assert.Contains("class ConControlTest extends SysTestCase", source, StringComparison.Ordinal);
+        Assert.Contains("assertEquals(1, 1)", source, StringComparison.Ordinal);
+        Assert.Contains("assertEquals(1, 2", source, StringComparison.Ordinal);
+        Assert.Contains("throw error(", source, StringComparison.Ordinal);
+    }
+}

--- a/tests/D365FO.Core.Tests/SweepFalsePositiveTests.cs
+++ b/tests/D365FO.Core.Tests/SweepFalsePositiveTests.cs
@@ -173,6 +173,72 @@ public class SweepFalsePositiveTests
         Assert.Contains(Xpp(code), v => v.Rule == "FN001");
     }
 
+    /// <summary>
+    /// X++ allows a function to be declared inside a method body, and it takes precedence over
+    /// the predefined name — the compiler's own message says as much ("nor a previously defined
+    /// local function"). The platform's <c>BatchRun.runJob</c> declares <c>void info()</c> and
+    /// calls it twice.
+    /// </summary>
+    [Fact]
+    public void A_local_function_shadows_the_predefined_name()
+    {
+        const string code = """
+            public static void runJob()
+            {
+                void info()
+                {
+                    infolog.add(Exception::Info, 'x');
+                }
+
+                info();
+                info();
+            }
+            """;
+
+        Assert.DoesNotContain(Xpp(code), v => v.Rule == "FN001");
+    }
+
+    // ── RPT001: 1 finding ─────────────────────────────────────────────────
+
+    /// <summary>
+    /// An abstract DP is a base for concrete ones and carries no contract of its own — the
+    /// platform's CustVendAdvanceInvoiceDP reads parmDataContract() and declares none, because
+    /// CustAdvanceInvoiceDP and VendAdvanceInvoiceDP each declare their own.
+    /// </summary>
+    [Fact]
+    public void An_abstract_data_provider_is_not_missing_its_contract()
+    {
+        const string code = """
+            abstract class CustVendAdvanceInvoiceDP extends SRSReportDataProviderBase
+            {
+            }
+
+            public void processReport()
+            {
+                contract = this.parmDataContract() as CustVendAdvanceInvoiceContract;
+            }
+            """;
+
+        Assert.DoesNotContain(Xpp(code), v => v.Rule == "RPT001");
+    }
+
+    [Fact]
+    public void A_concrete_data_provider_without_a_contract_is_still_reported()
+    {
+        const string code = """
+            class FmVehicleReportDP extends SRSReportDataProviderBase
+            {
+            }
+
+            public void processReport()
+            {
+                contract = this.parmDataContract() as FmVehicleReportContract;
+            }
+            """;
+
+        Assert.Contains(Xpp(code), v => v.Rule == "RPT001");
+    }
+
     // ── SEL010: 15 findings ───────────────────────────────────────────────
 
     [Fact]

--- a/tests/D365FO.Core.Tests/SweepFalsePositiveTests.cs
+++ b/tests/D365FO.Core.Tests/SweepFalsePositiveTests.cs
@@ -1,0 +1,319 @@
+using D365FO.Core.Metadata;
+using D365FO.Core.Validation;
+using Xunit;
+
+namespace D365FO.Core.Tests;
+
+/// <summary>
+/// The rules that fired on Microsoft's own shipped code, one test each.
+/// </summary>
+/// <remarks>
+/// <para>
+/// The first full sweep of this machine's installation (<c>d365fo oracle sweep</c>, 242 858
+/// files) reported 4 674 errors. Every one was the validator being wrong rather than the
+/// platform: the bar is zero errors on shipped X++ precisely because a rule that fires on
+/// correct code teaches the caller to ignore findings, which costs more than the rule earns.
+/// </para>
+/// <para>
+/// Each test below pins one of those, with the count it accounted for. The positive half — the
+/// code the rule exists for — is asserted alongside, so a "fix" that silences the rule
+/// altogether fails here rather than passing quietly.
+/// </para>
+/// </remarks>
+public class SweepFalsePositiveTests
+{
+    private static IReadOnlyList<XppViolation> Xpp(string code) =>
+        XppValidator.Validate(code, XppValidator.CodeTypeXpp);
+
+    private static IReadOnlyList<XppViolation> Xml(string xml) =>
+        XppValidator.Validate(xml, XppValidator.CodeTypeXmlAny);
+
+    // ── XML007: 4 574 findings ────────────────────────────────────────────
+
+    /// <summary>
+    /// A member name that is also a type name is a member.
+    /// <c>AxQueryExtensionEmbeddedDataSource</c> declares <c>DataSource</c> as an
+    /// <c>AxQuerySimpleEmbeddedDataSource</c>; the catalog also holds an unrelated type called
+    /// <c>DataSource</c> with three members, and reading the element as that type reported every
+    /// real property under it as unknown.
+    /// </summary>
+    [Fact]
+    public void Member_named_after_another_type_is_read_as_the_member()
+    {
+        const string xml = """
+            <AxDataEntityViewExtension>
+              <Name>SomeEntity.Model</Name>
+              <DataSources>
+                <AxQueryExtensionEmbeddedDataSource>
+                  <Parent>InventParameters</Parent>
+                  <DataSource>
+                    <Name>QMSHcmWorker</Name>
+                    <DynamicFields>Yes</DynamicFields>
+                    <IsReadOnly>Yes</IsReadOnly>
+                    <Table>HcmWorker</Table>
+                    <JoinMode>OuterJoin</JoinMode>
+                  </DataSource>
+                </AxQueryExtensionEmbeddedDataSource>
+              </DataSources>
+            </AxDataEntityViewExtension>
+            """;
+
+        Assert.DoesNotContain(Xml(xml), v => v.Rule == "XML007");
+    }
+
+    [Fact]
+    public void The_contract_for_a_declared_member_beats_a_type_of_the_same_name()
+    {
+        var parent = MetadataContracts.Find("AxQueryExtensionEmbeddedDataSource");
+        Assert.NotNull(parent);
+
+        var element = System.Xml.Linq.XElement.Parse("<DataSource><Name>x</Name></DataSource>");
+        var governing = MetadataContracts.GoverningContract(element, parent);
+
+        Assert.Equal("AxQuerySimpleEmbeddedDataSource", governing?.Name);
+    }
+
+    /// <summary>
+    /// A member the type really does not declare is still reported — the fix is about which
+    /// contract governs the element, not about softening the rule.
+    /// </summary>
+    [Fact]
+    public void An_unknown_member_is_still_reported()
+    {
+        const string xml = "<AxEdt><Name>Foo</Name><NotAMemberOfEdt>1</NotAMemberOfEdt></AxEdt>";
+        Assert.Contains(Xml(xml), v => v.Rule == "XML007" && v.Severity == "error");
+    }
+
+    /// <summary>
+    /// The BP suppression list every model ships: its entries carry <c>ItemSpecific</c> and
+    /// <c>Line</c>, which <c>AxIgnoreDiagnosticItem</c> genuinely does not declare (seven
+    /// members, reflected off the metadata assembly on a live installation). The file is written
+    /// and read by the best-practice tooling rather than by the metadata serializer, so "dropped
+    /// on read" does not follow — 1 463 findings in one model.
+    /// </summary>
+    [Fact]
+    public void A_best_practice_suppression_list_is_not_judged_against_the_metadata_contract()
+    {
+        const string xml = """
+            <IgnoreDiagnostics>
+              <Name>Model_BPSuppressions</Name>
+              <Items>
+                <Diagnostic>
+                  <DiagnosticType>BestPractices</DiagnosticType>
+                  <Moniker>BPErrorPrivilegeNotCoveredByDuty</Moniker>
+                  <Line>12</Line>
+                  <ItemSpecific><Fields><ElementName>X</ElementName></Fields></ItemSpecific>
+                </Diagnostic>
+              </Items>
+            </IgnoreDiagnostics>
+            """;
+
+        Assert.DoesNotContain(Xml(xml), v => v.Rule == "XML007");
+    }
+
+    // ── ATTR001: 72 findings ──────────────────────────────────────────────
+
+    /// <summary>
+    /// Masking blanks a comment's content and its closing delimiter but keeps the opening
+    /// <c>/*</c>, so a commented attribute argument reached the literal test as "false /*".
+    /// </summary>
+    [Fact]
+    public void A_comment_between_attribute_arguments_is_not_part_of_the_argument()
+    {
+        const string code = """
+            [SysODataAction("DebugModeStartSession", false /* static method */)]
+            public static void debugModeStartSession()
+            {
+            }
+            """;
+
+        Assert.DoesNotContain(Xpp(code), v => v.Rule == "ATTR001");
+    }
+
+    [Fact]
+    public void An_attribute_argument_that_is_a_variable_is_still_reported()
+    {
+        const string code = """
+            [SysObsolete(replacementMessage, false, 31\12\2026)]
+            public void old()
+            {
+            }
+            """;
+
+        Assert.Contains(Xpp(code), v => v.Rule == "ATTR001");
+    }
+
+    // ── FN001: 7 findings ─────────────────────────────────────────────────
+
+    [Fact]
+    public void New_Info_constructs_a_class_rather_than_calling_the_predefined_info()
+    {
+        const string code = """
+            public void run()
+            {
+                Info infolog = new Info();
+            }
+            """;
+
+        Assert.DoesNotContain(Xpp(code), v => v.Rule == "FN001");
+    }
+
+    [Fact]
+    public void The_predefined_function_called_with_no_arguments_is_still_reported()
+    {
+        const string code = """
+            public void run()
+            {
+                if (info())
+                {
+                }
+            }
+            """;
+
+        Assert.Contains(Xpp(code), v => v.Rule == "FN001");
+    }
+
+    // ── SEL010: 15 findings ───────────────────────────────────────────────
+
+    [Fact]
+    public void ValidTimeState_as_a_method_declaration_is_not_a_select_clause()
+    {
+        const string code = """
+            public SysDaQueryObject validTimeState(SysDaValidTimeState _validTimeState = null)
+            {
+                return this;
+            }
+            """;
+
+        Assert.DoesNotContain(Xpp(code), v => v.Rule == "SEL010");
+    }
+
+    [Fact]
+    public void ValidTimeState_called_on_an_object_is_not_a_select_clause()
+    {
+        const string code = """
+            public void build()
+            {
+                query.validTimeState(new SysDaValidTimeStateDateRange(fromDate, toDate));
+            }
+            """;
+
+        Assert.DoesNotContain(Xpp(code), v => v.Rule == "SEL010");
+    }
+
+    [Fact]
+    public void ValidTimeState_given_an_expression_inside_a_select_is_still_reported()
+    {
+        const string code = """
+            public void read()
+            {
+                select validTimeState(DateTimeUtil::utcNow()) custTable;
+            }
+            """;
+
+        Assert.Contains(Xpp(code), v => v.Rule == "SEL010");
+    }
+
+    // ── CS001: 3 findings ─────────────────────────────────────────────────
+
+    /// <summary>
+    /// The platform's Commerce pricing classes alias CLR types into X++ scope
+    /// (<c>using string = System.String;</c>), which makes <c>string</c> a declared name in that
+    /// file rather than the C# keyword the rule is about.
+    /// </summary>
+    [Fact]
+    public void An_aliased_clr_type_is_not_a_csharp_ism()
+    {
+        const string code = """
+            using string = System.String;
+            using decimal = System.Decimal;
+
+            public class GUPThing
+            {
+            }
+
+            public string constructGroupKey()
+            {
+                string groupKey = '';
+                decimal amount = 0;
+                return groupKey;
+            }
+            """;
+
+        Assert.DoesNotContain(Xpp(code), v => v.Rule == "CS001");
+    }
+
+    [Fact]
+    public void The_csharp_string_type_without_an_alias_is_still_reported()
+    {
+        const string code = """
+            public void run()
+            {
+                string groupKey = '';
+            }
+            """;
+
+        Assert.Contains(Xpp(code), v => v.Rule == "CS001");
+    }
+
+    // ── SEL008: 1 finding ─────────────────────────────────────────────────
+
+    /// <summary>
+    /// A select inside a <c>#localmacro</c> has no terminating semicolon, so the statement scan
+    /// ran on into the next macro and paired one macro's <c>where</c> with the next macro's
+    /// <c>order by</c>.
+    /// </summary>
+    [Fact]
+    public void A_select_does_not_run_past_a_precompiler_directive()
+    {
+        const string code = """
+            public void find()
+            {
+                #localmacro.queryByType
+                    select noFetch docuRef
+                        where docuRef.refRecId == common.recId
+                #endmacro
+
+                #localmacro.querySortByCreatedDateTime
+                    select noFetch docuRef
+                        order by CreatedDateTime desc
+                        where docuRef.refRecId == common.recId
+                #endmacro
+            }
+            """;
+
+        Assert.DoesNotContain(Xpp(code), v => v.Rule == "SEL008");
+    }
+
+    [Fact]
+    public void Order_by_after_the_where_of_the_same_select_is_still_reported()
+    {
+        const string code = """
+            public void find()
+            {
+                select custTable where custTable.AccountNum != '' order by AccountNum;
+            }
+            """;
+
+        Assert.Contains(Xpp(code), v => v.Rule == "SEL008");
+    }
+
+    // ── XML002 / XML003: 229 findings in one model ────────────────────────
+
+    /// <summary>
+    /// Both are majority conventions mined from standard models, and the minority is Microsoft's
+    /// own. A convention most artefacts follow is not a defect in the ones that do not, so
+    /// neither may be an error.
+    /// </summary>
+    [Fact]
+    public void The_table_property_conventions_are_warnings_not_errors()
+    {
+        const string xml = "<AxTable><Name>FmThing</Name><Fields /></AxTable>";
+        var violations = XppValidator.Validate(xml, XppValidator.CodeTypeXmlTable);
+
+        var label = Assert.Single(violations, v => v.Rule == "XML002");
+        var group = Assert.Single(violations, v => v.Rule == "XML003");
+        Assert.Equal("warning", label.Severity);
+        Assert.Equal("warning", group.Severity);
+    }
+}

--- a/tests/Samples/MiniAot/TestModel/TestModel/AxEdt/VIN.xml
+++ b/tests/Samples/MiniAot/TestModel/TestModel/AxEdt/VIN.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="utf-8"?>
+<AxEdt xmlns:i="http://www.w3.org/2001/XMLSchema-instance" i:type="AxEdtString">
+  <Name>VIN</Name>
+  <Label>@Fleet:VIN</Label>
+  <!--
+    The EDT that CARRIES a reference, as opposed to the plain VinEdt beside it. D365FO
+    requires such a reference to be migrated to an explicit table relation
+    (BPErrorEDTNotMigrated), and `generate table-relation` derives that relation from exactly
+    these two elements — so the fixture has to contain one for the case to be about anything.
+    The EDT is named after FmVehicle's key field because that convention is what supplies the
+    constraint's RelatedField.
+  -->
+  <ReferenceTable>FmVehicle</ReferenceTable>
+  <StringSize>17</StringSize>
+</AxEdt>

--- a/tests/Samples/MiniAot/TestModel/TestModel/AxTable/FmServiceOrder.xml
+++ b/tests/Samples/MiniAot/TestModel/TestModel/AxTable/FmServiceOrder.xml
@@ -1,0 +1,93 @@
+<?xml version="1.0" encoding="utf-8"?>
+<AxTable xmlns:i="http://www.w3.org/2001/XMLSchema-instance">
+  <Name>FmServiceOrder</Name>
+  <Label>@Fleet:ServiceOrder</Label>
+  <!--
+    A table that has NOT had its EDT reference migrated to a relation, and that carries its own
+    alternate key. It is the starting point the two table-augmenting generators need: one derives
+    the missing <Relations> entry, the other the standard find()/exists() keyed on the index.
+    Deliberately kept without a <Relations> block, which is the state those commands exist for.
+  -->
+  <TableGroup>Transaction</TableGroup>
+  <FieldGroups>
+    <AxTableFieldGroup>
+      <Name>AutoReport</Name>
+      <Fields />
+    </AxTableFieldGroup>
+    <AxTableFieldGroup>
+      <Name>AutoLookup</Name>
+      <Fields />
+    </AxTableFieldGroup>
+    <AxTableFieldGroup>
+      <Name>AutoIdentification</Name>
+      <AutoPopulate>Yes</AutoPopulate>
+      <Fields />
+    </AxTableFieldGroup>
+    <AxTableFieldGroup>
+      <Name>AutoSummary</Name>
+      <Fields />
+    </AxTableFieldGroup>
+    <AxTableFieldGroup>
+      <Name>AutoBrowse</Name>
+      <Fields />
+    </AxTableFieldGroup>
+    <AxTableFieldGroup>
+      <Name>Overview</Name>
+      <Fields>
+        <AxTableFieldGroupField>
+          <DataField>ServiceOrderId</DataField>
+        </AxTableFieldGroupField>
+        <AxTableFieldGroupField>
+          <DataField>VIN</DataField>
+        </AxTableFieldGroupField>
+        <AxTableFieldGroupField>
+          <DataField>ServiceDate</DataField>
+        </AxTableFieldGroupField>
+      </Fields>
+    </AxTableFieldGroup>
+    <AxTableFieldGroup>
+      <Name>General</Name>
+      <Fields>
+        <AxTableFieldGroupField>
+          <DataField>ServiceOrderId</DataField>
+        </AxTableFieldGroupField>
+        <AxTableFieldGroupField>
+          <DataField>VIN</DataField>
+        </AxTableFieldGroupField>
+        <AxTableFieldGroupField>
+          <DataField>ServiceDate</DataField>
+        </AxTableFieldGroupField>
+      </Fields>
+    </AxTableFieldGroup>
+  </FieldGroups>
+  <Fields>
+    <AxTableField i:type="AxTableFieldString">
+      <Name>ServiceOrderId</Name>
+      <Mandatory>Yes</Mandatory>
+      <StringSize>20</StringSize>
+    </AxTableField>
+    <AxTableField i:type="AxTableFieldString">
+      <Name>VIN</Name>
+      <ExtendedDataType>VIN</ExtendedDataType>
+      <Mandatory>Yes</Mandatory>
+      <StringSize>17</StringSize>
+    </AxTableField>
+    <AxTableField i:type="AxTableFieldDate">
+      <Name>ServiceDate</Name>
+    </AxTableField>
+  </Fields>
+  <FullTextIndexes />
+  <Indexes>
+    <AxTableIndex>
+      <Name>ServiceOrderIdx</Name>
+      <AlternateKey>Yes</AlternateKey>
+      <Fields>
+        <AxTableIndexField>
+          <DataField>ServiceOrderId</DataField>
+        </AxTableIndexField>
+      </Fields>
+    </AxTableIndex>
+  </Indexes>
+  <Relations />
+  <StateMachines />
+</AxTable>

--- a/tests/Samples/MiniAot/TestModel/TestModel/AxTable/FmVehicle.xml
+++ b/tests/Samples/MiniAot/TestModel/TestModel/AxTable/FmVehicle.xml
@@ -1,4 +1,4 @@
-<AxTable>
+<AxTable xmlns:i="http://www.w3.org/2001/XMLSchema-instance">
   <Name>FmVehicle</Name>
   <Label>@Fleet:Vehicle</Label>
   <!--
@@ -62,17 +62,17 @@
     </AxTableFieldGroup>
   </FieldGroups>
   <Fields>
-    <AxTableField xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:type="AxTableFieldString">
+    <AxTableField i:type="AxTableFieldString">
       <Name>VIN</Name>
       <ExtendedDataType>VinEdt</ExtendedDataType>
       <Mandatory>Yes</Mandatory>
       <StringSize>17</StringSize>
     </AxTableField>
-    <AxTableField xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:type="AxTableFieldString">
+    <AxTableField i:type="AxTableFieldString">
       <Name>Make</Name>
       <ExtendedDataType>Name</ExtendedDataType>
     </AxTableField>
-    <AxTableField xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:type="AxTableFieldInt">
+    <AxTableField i:type="AxTableFieldInt">
       <Name>Year</Name>
     </AxTableField>
   </Fields>

--- a/tests/Samples/MiniAot/TestModel/TestModel/AxTable/FmVehicleLine.xml
+++ b/tests/Samples/MiniAot/TestModel/TestModel/AxTable/FmVehicleLine.xml
@@ -1,4 +1,4 @@
-<AxTable>
+<AxTable xmlns:i="http://www.w3.org/2001/XMLSchema-instance">
   <Name>FmVehicleLine</Name>
   <Label>@Fleet:VehicleLine</Label>
   <!-- See the note on FmVehicle: Overview/General are what generated forms bind to. -->
@@ -54,16 +54,16 @@
     </AxTableFieldGroup>
   </FieldGroups>
   <Fields>
-    <AxTableField xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:type="AxTableFieldString">
+    <AxTableField i:type="AxTableFieldString">
       <Name>VIN</Name>
       <ExtendedDataType>VinEdt</ExtendedDataType>
       <Mandatory>Yes</Mandatory>
       <StringSize>17</StringSize>
     </AxTableField>
-    <AxTableField xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:type="AxTableFieldInt">
+    <AxTableField i:type="AxTableFieldInt">
       <Name>LineNum</Name>
     </AxTableField>
-    <AxTableField xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:type="AxTableFieldString">
+    <AxTableField i:type="AxTableFieldString">
       <Name>ServiceNote</Name>
       <ExtendedDataType>Notes</ExtendedDataType>
     </AxTableField>
@@ -91,7 +91,7 @@
       <RelatedTableCardinality>ExactlyOne</RelatedTableCardinality>
       <RelationshipType>Association</RelationshipType>
       <Constraints>
-        <AxTableRelationConstraint xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:type="AxTableRelationConstraintField">
+        <AxTableRelationConstraint i:type="AxTableRelationConstraintField">
           <Name>VIN</Name>
           <Field>VIN</Field>
           <RelatedField>VIN</RelatedField>


### PR DESCRIPTION
Wave 05 of the gap analysis — **Oracle a eval korpus**. Two halves that turn out to be one thing: the oracles measure this tool against the installation it claims to understand, and the first measurement rewrote a large part of the validator.

| Wave 05 item | Status |
|---|---|
| `oracle sweep` over the whole PackagesLocalDirectory, `--dry` for CI | ✅ |
| `oracle probe` — compile one artefact with the real xppc | ✅ |
| `oracle census` / `oracle members` | ✅ |
| Runtime oracle: configure `SysTestConsole.exe.config`, negative control | ✅ |
| Eval corpus covering all 74 leaves | ⚠️ **64 of 74** — the remaining ten need a `generate` subcommand that does not exist |

## What the first sweep found

242 858 files, 107 241 X++ blocks, **4 674 errors** — every one of them the validator being wrong, not the platform. The bar for this command is zero errors on Microsoft's own X++, not "few": a rule that fires on shipped code teaches a caller to ignore findings, which costs more than the rule ever earned.

| Rule | Findings | What it actually was |
|---|---|---|
| **XML007** | 4 574 | A member name that is also a type name was read as the type. The catalog holds exactly two such collisions; one is `DataSource`, which `AxQueryExtensionEmbeddedDataSource` declares as an `AxQuerySimpleEmbeddedDataSource` while an unrelated three-member type of that name exists. What the parent declares now beats what the name coincides with. |
| **XML007** | 1 463 in one model | The rule descended into documents whose root it did not recognise — which is how the BP suppression list every model ships got judged against the metadata contracts. It now stops at an unknown root, as its own remarks always claimed. Those entries really do carry members `AxIgnoreDiagnosticItem` does not declare (reflected off the assembly: it has seven); the file is read by the best-practice tooling, not by the metadata serializer, so "dropped on read" did not follow. |
| **XML002 / XML003** | 229 in one model | Downgraded to warnings. Both are majority conventions mined from standard models, and the minority is Microsoft's own. A convention most artefacts follow is not a defect in the ones that do not. |
| **ATTR001** | 72 | Masking blanks a comment's content *and* its closing delimiter, so `[SysSetupConfig(true /*ContinueOnError*/, 600)]` reached the literal test as the argument `true /*`. |
| **SEL010** | 15 | `validTimeState` is also a method on the query classes and a parameter name on their declarations. The rule is about the select clause and now only looks there. |
| **FN001** | 7 + 2 | `new Info()` constructs the class of that name; and a function declared inside a method body takes precedence over the predefined name — which the compiler's own message says, and the rule quotes. `BatchRun.runJob` declares `void info()` and calls it twice. |
| **CS001** | 3 | A file may alias a CLR type into scope (`using string = System.String;`), which is what the platform's Commerce pricing classes do. |
| **SEL008** | 1 | A select inside a `#localmacro` has no terminating semicolon, so the scan ran into the next macro and paired one macro's `where` with the next one's `order by`. |
| **COC003** | 1 | The `_Extension` suffix is matched case-insensitively now, as X++ identifiers are — the platform ships `JournalCheckPostIV_extension`. |
| **RPT001** | 1 | An abstract DP is a base for concrete ones and carries no contract of its own. |

`SweepFalsePositiveTests` pins each one with the count it accounted for, alongside the code the rule exists for — so a "fix" that silences a rule fails there rather than passing quietly.

Re-swept end to end after the last fix: **242 858 files, 107 241 X++ blocks, zero errors**, in 48 minutes. The 41 473 warnings are counted and left alone; the bar was never about them.

## The corpus reaches the artefacts nothing was checking

**Companions are scored.** A report is a report plus a TempDB table, a DP, a controller and an output menu item; only the main artefact was ever diffed, so companions were captured under `_companions/`, reviewed once, and never checked again. That also made a case's `target_artifact_types` half true, because the families it named were the companions' families and nothing compared them to anything. Turning it on found **ten companions across the two report cases that no golden had pinned**. A companion the golden names and the run did not produce is missing; one the run produced that no golden names is extra.

**Cases can start from an artefact.** `generate table-relation` and `generate find-methods` augment a table that already exists and refuse `--out` outright, so neither was reachable by a replay at all. A case may now name an `apply_to_seed` under `eval/seeds/`, which the replay copies in as its output file and merges into.

**Eight new cases**, goldens captured on the VM through the real CLI (52 → 60), and three families that gained the command that already built them (`AxViewExtension`, `AxQuerySimpleExtension`, `AxDataEntityViewExtension` were reported as having no generator while `generate extension` was building all three). Plus knowledge for twelve leaves the corpus taught nothing about.

Coverage: **64 of 74 leaves** K ∧ E ∧ T, up from 42.

## Two defects the L3 build oracle caught, neither visible offline

- **`generate workflow` wrote a task reference without `<Type>`**, so xppc answered *"Workflow approval '&lt;task&gt;' does not exist"* — naming a kind the file never mentions. Across this installation the element carries `Task` 49 times, `AutomatedTask` 28, and is absent 117 times, absent meaning approval.
- **A golden that extends a standard object drags in what that object references**, which does not stay inside ApplicationSuite/Foundation/Platform: a view extension over `CustAccountName` needs `DirPartyTable`, from `Directory`. The throwaway model now references every package on the installation that has a `bin`, read off the disk rather than guessed at per case.

## What is left of the wave, and why

Ten leaves are still not K ∧ E ∧ T, and none of them is corpus work: `AxAggregateDataEntity`, `AxCompositeDataEntityView`, `AxConfigurationKey`, `AxFormPart`, `AxLabelFile`, `AxMapExtension`, `AxMenu`, `AxResource`, `AxTile`, `AxWorkflowCategory`. Each needs a `generate` subcommand that does not exist yet — surface work of the kind wave 04 was made of, not eval-corpus work, and large enough to deserve its own PR rather than being folded in here.

## Verification, all on this host's live installation

- **1 813 tests** green; warning ratchet **tightened 117 → 114**.
- `eval run --all` **60/60**, `eval coverage --check` clean, `knowledge audit --verify` clean.
- `eval verify-build` — **60 of 60 goldens compile with the real xppc**, zero unattributed diagnostics.
- `oracle sweep --dry` holds the bar on the checked-in fixtures (now in CI), which is what made the fixture XML declare the schema-instance namespace on the root the way the platform does.
- `oracle runtime` on this VM: runner present, all four DataAccess keys configured, negative control emitted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HoeL3ZT1QLerLfjgQHGSB4
