### PR TITLE
Wave 05 follow-up — the sweep that confirms the bar

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -87,9 +87,10 @@ silences a rule fails there rather than passing quietly.
   contract of its own; `CustVendAdvanceInvoiceDP` reads `parmDataContract()` and declares none,
   because `CustAdvanceInvoiceDP` and `VendAdvanceInvoiceDP` each declare their own.
 
-Re-swept after each fix: the four rules above were the last errors on the installation. The
-warnings (41 475) are counted and left alone — they are style rules that shipped code
-legitimately breaks, and the bar was never about them.
+Re-swept end to end after the last fix: **242 858 files, 107 241 X++ blocks, zero errors** —
+the bar holds on Microsoft's own X++, in 48 minutes. The 41 473 warnings are counted and left
+alone; they are style rules that shipped code legitimately breaks, and the bar was never about
+them.
 
 ### Added — the eval corpus reaches the artefacts nothing was checking
 

--- a/docs/CAPABILITIES.md
+++ b/docs/CAPABILITIES.md
@@ -641,9 +641,10 @@ d365fo oracle runtime --negative-control  # a test class that passes, fails and 
 **The bar for `sweep` is zero errors on Microsoft's own X++.** Not "few": a rule that fires on
 shipped code teaches a caller to ignore findings, which costs more than the rule ever earned.
 Warnings are counted separately and do not fail the bar — several are style rules that shipped
-code legitimately breaks. The first full run (242 858 files) reported 4 674 errors, every one of
-them the validator being wrong; `SweepFalsePositiveTests` pins each with the count it accounted
-for.
+code legitimately breaks. The first full run (242 858 files, 107 241 X++ blocks) reported 4 674
+errors, every one of them the validator being wrong; `SweepFalsePositiveTests` pins each with the
+count it accounted for. The bar holds as of that work: the same sweep now reports **zero errors**
+in 48 minutes.
 
 `probe` compiles into a throwaway model built around the artefact, so a clean result means the
 compiler ran and said nothing — an xppc that rejects its own argument list prints usage, which


### PR DESCRIPTION
The last commit of wave 05 missed the [#197](https://github.com/dynamics365ninja/d365fo-cli/pull/197) merge by a minute, so it needs its own PR.

Wave 05 fixed twelve validator rules that fired on Microsoft's own X++. The per-model re-sweeps after each fix said the bar was held, but a re-sweep of one model is not the claim the document makes. This is the whole-installation run, after the last fix:

| | |
|---|---|
| Files scanned | **242 858** |
| X++ blocks | **107 241** |
| Errors | **0** |
| Warnings | 41 473 |
| Elapsed | 48 minutes |

`CHANGELOG.md` and `docs/CAPABILITIES.md` now state that as measured rather than inferred. The warnings are style rules that shipped code legitimately breaks; nothing gates on them, and nobody should read the number as 41 473 problems.

Two files, +8/−6. No code.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HoeL3ZT1QLerLfjgQHGSB4
