### PR TITLE
fix(audit): the two 1.16.0 ports the parity audit found still missing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,35 @@ was ported from.
 
 ## [Unreleased]
 
+### Fixed — the two 1.16.0 ports the parity audit found still missing
+
+Auditing the repository against the gap analysis, with each of its twelve upstream fixes probed
+on the live index rather than ticked off the list, found two that no wave had ported:
+
+- **A multi-word search answered nothing.** `search class "ProcessGuide AdjustIn"` returned
+  `count: 0` while `InventProcessGuideAdjustInController` sat in the index and the exact-name
+  search found it (upstream c43bf51). No AOT name contains a space, so a multi-word query never
+  meant one verbatim string; it means "a name carrying every token", in any order. Every
+  name-search method — classes, tables, EDTs, enums, queries, views, data entities, reports,
+  services, workflow types, maps, business events, security policies, configuration keys, tiles,
+  workspaces — now goes through one `NameFilter`, one `LIKE` per token ANDed; where a method
+  matches several columns (a data entity's public names) every token must land in the same
+  column. Label search is deliberately untouched: label text has spaces, and a multi-word label
+  query is verbatim.
+- **An extension's name was invisible to the collision check.** `prepare create
+  NumberSeqModule.Kitting --type enum` answered "No collision — does not exist in the index"
+  for an enum extension the installation ships, immediately before a write, and in the same
+  answer listed 25 sibling extensions spelled exactly that way while flagging the dot as
+  `INVALID_CHARS` (upstream 0b363e5). An extension row records the object it *extends*, so it
+  lived in none of the tables `SymbolKinds` consulted. It now reports as `<kind>-extension`, the
+  collision verdict says to modify the existing extension or pick another suffix, and a dotted
+  name under a base type is judged by the naming rules as the extension it is.
+
+Also brought back in line with the code: the README's token-economics section still carried the
+~1 800-tokens-per-turn estimate wave 06 had measured to be off by six times, and its adapter
+tool count (28) and `generate` command list (29 of 33) had drifted.
+
+
 ### Added — wave 06: the ten missing documents, and two of them generated
 
 The documentation set upstream has and this repository did not. Two are not written but

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
 [![.NET](https://img.shields.io/badge/.NET-10-purple.svg)](https://dotnet.microsoft.com/)
 [![Platform](https://img.shields.io/badge/platform-Windows%20%7C%20macOS%20%7C%20Linux-lightgrey.svg)]()
-[![Tests](https://img.shields.io/badge/tests-1813-brightgreen.svg)]()
+[![Tests](https://img.shields.io/badge/tests-1817-brightgreen.svg)]()
 [![Successor to d365fo-mcp-server](https://img.shields.io/badge/successor%20to-d365fo--mcp--server-orange.svg)](https://github.com/dynamics365ninja/d365fo-mcp-server)
 
 *Grounded AI development for Dynamics 365 Finance & Operations — works with GitHub Copilot, Claude Code, Codex, Gemini CLI, and any agent with a shell*
@@ -32,7 +32,7 @@ This CLI pre-indexes your entire D365FO installation (hundreds of thousands of s
 | Labels | Hardcoded strings | Right `@SYS`/`@MODULE` key found instantly |
 | Security chains | Hours of manual tracing | Role → Duty → Privilege → Entry Point in one call |
 | Generated code | Hallucinated fields and types | Every reference proven against the index, gated before write |
-| Agent context cost | 26–28 MCP tool schemas every turn | 1 shell tool + lazy-loaded Skills (~85 % fewer tokens) |
+| Agent context cost | 32 MCP tool schemas every turn (40 132 chars, ~11 100 tokens — measured) | 1 shell tool + lazy-loaded Skills (366 chars, ~100 tokens) |
 
 ---
 
@@ -236,7 +236,7 @@ Reference the `SKILL.md` files from `skills/anthropic/` in your session prompt o
 
 ### MCP (Claude Desktop, Continue, VS Code MCP)
 
-The bundled `d365fo-mcp` adapter speaks JSON-RPC 2.0 over the same index. Its tool surface is **consolidated** into 28 discriminator-based tools (e.g. `search`, `get_object_info`, `get_method`, `labels`, `security_info`, `extension_info`, `object_patterns`, `generate_object`, `modify_method`, `analyze`, `models`) — see [docs/MIGRATION_FROM_MCP.md](docs/MIGRATION_FROM_MCP.md):
+The bundled `d365fo-mcp` adapter speaks JSON-RPC 2.0 over the same index. Its tool surface is **consolidated** into 32 discriminator-based tools (e.g. `search`, `get_object_info`, `get_method`, `labels`, `security_info`, `extension_info`, `object_patterns`, `generate_object`, `modify_method`, `analyze`, `models`) — see [docs/MIGRATION_FROM_MCP.md](docs/MIGRATION_FROM_MCP.md):
 
 ```json
 {
@@ -266,15 +266,15 @@ A `d365fo search` shell call returning results from your codebase = you're conne
 
 ## Why CLI instead of MCP?
 
-MCP servers inject every tool definition into the model's context on every single turn. Tool consolidation trimmed that surface — the upstream MCP server went from ~61 per-type tools (≈3,500 tok/turn) to 26 discriminator-based tools, and this repo's adapter to 27 — but it is still ~1,800 tokens per turn versus one shell tool.
+MCP servers inject every tool definition into the model's context on every single turn. Tool consolidation trimmed that surface — the upstream MCP server went from ~61 per-type tools to 26 discriminator-based tools, and this repo's adapter advertises 32 — but the schemas remain. Measured on this repository (`scripts/measure-context-cost.py`, see [docs/TOKEN_ECONOMICS.md](docs/TOKEN_ECONOMICS.md)): those 32 schemas are **40 132 characters** (~11 100 tokens) in context every turn, against **366 characters** (~100 tokens) for the CLI's one-skill layout. Characters are measured; tokens are approximate (chars ÷ 3.6).
 
 | | MCP server | CLI + Skills |
 |---|---|---|
-| Tool definitions per turn | 26–28 tools (~1,800 tokens) | 1 shell tool (~100 tokens) |
+| Tool definitions per turn | 32 tools, 40 132 chars (~11 100 tokens) | 1 skill, 366 chars (~100 tokens) |
 | Discovery round-trips | 2–3 per task | often 1 (`d365fo prepare change`) |
 | Scriptable (shell, CI/CD) | No | Yes |
 | Works in any AI harness | No — MCP hosts only | Yes — Copilot, Claude, Codex, Gemini, … |
-| Token cost over 15-turn workflow | baseline | **~85 % reduction** |
+| Per-turn context cost | baseline | **~99 % less** (ratio does not depend on the tokenizer) |
 
 See [docs/TOKEN_ECONOMICS.md](docs/TOKEN_ECONOMICS.md) for the full analysis and the cases where MCP still wins. Migrating from `d365fo-mcp-server`? Start with **[docs/MIGRATION_FROM_MCP.md](docs/MIGRATION_FROM_MCP.md)**.
 
@@ -293,7 +293,7 @@ See [docs/TOKEN_ECONOMICS.md](docs/TOKEN_ECONOMICS.md) for the full analysis and
 | **Form patterns** | `form-pattern analyze` (advisor), `form-pattern spec` (catalog), `form-pattern validate` (FP001–FP010) — mirrors the MCP `object_patterns` tool (`domain=form`) |
 | **Find** | `find related`, `find coc`, `find relations`, `find usages`, `find extensions`, `find event-handlers`, `find references`, `find form-patterns`, `find batch-jobs` (the extensibility ones mirror the MCP `extension_info` tool) |
 | **Read** | `read class`, `read table`, `read form` (= MCP `get_method`) |
-| **Generate** | `generate table\|class\|coc\|form\|datasource-method\|control-method\|simple-list\|entity\|extension\|event-handler\|privilege\|duty\|role\|report\|sysoperation\|number-sequence\|workflow\|menu-item\|edt\|enum\|query\|view\|map\|business-event\|custom-service\|migration-script\|runbase\|security-policy\|systest` |
+| **Generate** | `generate table\|table-relation\|find-methods\|class\|coc\|form\|form-clone\|datasource-method\|control-method\|simple-list\|entity\|extension\|event-handler\|privilege\|duty\|role\|report\|report-extension\|sysoperation\|number-sequence\|workflow\|menu-item\|edt\|enum\|query\|view\|map\|business-event\|custom-service\|migration-script\|runbase\|security-policy\|systest` (33) |
 | **Labels** | `labels search\|resolve\|info\|create\|rename\|delete` — search/resolve plus in-place `*.label.txt` edits, multi-language via `--lang` (mirrors the MCP `labels` tool) |
 | **Journal / undo** | `undo [--steps N] [--dry-run]`, `journal list`, `delete` (kind/name, bridge or on-disk) — deterministic single-command rollback for every write path (mirrors the MCP `undo_last_modification` tool) |
 | **Modify** | `modify property\|method`, `modify add-field\|add-enum-value\|add-control`, `modify add-index\|add-relation\|add-field-group\|add-delete-action`, `modify rename-field`, `modify add-query-range\|remove-query-range`, `modify add-entry-point\|remove-entry-point`, seven `modify remove-*` forms, and `modify batch` (several changes in one read-edit-write) — 22 operations over all 41 bridge-writable kinds, extension-aware and journalled for `undo` |

--- a/src/D365FO.Core/Index/MetadataRepository.Validation.cs
+++ b/src/D365FO.Core/Index/MetadataRepository.Validation.cs
@@ -13,6 +13,14 @@ public sealed partial class MetadataRepository : IReferenceIndex, IPropertyStats
     private const int InheritanceWalkLimit = 10;
 
     /// <inheritdoc />
+    /// <remarks>
+    /// Extensions are symbols too. An extension row does not live in any of the object tables —
+    /// it records the object it EXTENDS — so <c>NumberSeqModule.Kitting</c>, an enum extension the
+    /// installation ships, used to come back empty here, and <c>prepare create</c> answered
+    /// "no collision" for a name that is taken, immediately before a write (upstream 0b363e5).
+    /// An extension reports as <c>&lt;kind&gt;-extension</c> (<c>enum-extension</c>,
+    /// <c>table-extension</c>), so callers that look for a base kind by name are unaffected.
+    /// </remarks>
     public IReadOnlyList<string> SymbolKinds(string name)
     {
         using var conn = OpenReadOnly();
@@ -25,7 +33,9 @@ public sealed partial class MetadataRepository : IReferenceIndex, IPropertyStats
             UNION SELECT 'query'        FROM Queries      WHERE Name = @name COLLATE NOCASE
             UNION SELECT 'view'         FROM Views        WHERE Name = @name COLLATE NOCASE
             UNION SELECT 'data-entity'  FROM DataEntities WHERE Name = @name COLLATE NOCASE
-            UNION SELECT 'map'          FROM Maps         WHERE Name = @name COLLATE NOCASE",
+            UNION SELECT 'map'          FROM Maps         WHERE Name = @name COLLATE NOCASE
+            UNION SELECT lower(Kind) || '-extension'
+                                        FROM ObjectExtensions WHERE ExtensionName = @name COLLATE NOCASE",
             new { name }).ToList();
     }
 

--- a/src/D365FO.Core/Index/MetadataRepository.cs
+++ b/src/D365FO.Core/Index/MetadataRepository.cs
@@ -301,17 +301,17 @@ public sealed partial class MetadataRepository
     {
         limit = ClampLimit(limit, 50);
         using var conn = OpenReadOnly();
-        var like = $"%{EscapeLike(query)}%";
-        var sql = @"
+        var (nameWhere, p) = NameFilter(query, new { model, limit }, "c.Name");
+        var sql = $@"
             SELECT c.ClassId, c.Name, m.Name AS Model, c.ExtendsName AS Extends,
                    c.IsAbstract, c.IsFinal, c.SourcePath
             FROM Classes c
             JOIN Models m ON m.ModelId = c.ModelId
-            WHERE c.Name LIKE @like ESCAPE '!'
+            WHERE {nameWhere}
               AND (@model IS NULL OR m.Name = @model)
             ORDER BY m.IsCustom DESC, c.Name
             LIMIT @limit";
-        return conn.Query<ClassInfo>(sql, new { like, model, limit }).ToList();
+        return conn.Query<ClassInfo>(sql, p).ToList();
     }
 
     /// <summary>Maximum <c>extends</c> hops walked when collecting inherited methods.</summary>
@@ -1324,12 +1324,12 @@ public sealed partial class MetadataRepository
     {
         limit = ClampLimit(limit, 50);
         using var conn = OpenReadOnly();
-        var like = $"%{EscapeLike(query)}%";
-        return conn.Query<QueryInfo>(@"
+        var (nameWhere, p) = NameFilter(query, new { limit }, "q.Name");
+        return conn.Query<QueryInfo>($@"
             SELECT q.QueryId, q.Name, m.Name AS Model, q.SourcePath
             FROM Queries q JOIN Models m ON m.ModelId = q.ModelId
-            WHERE q.Name LIKE @like ESCAPE '!' ORDER BY m.IsCustom DESC, q.Name LIMIT @limit",
-            new { like, limit }).ToList();
+            WHERE {nameWhere} ORDER BY m.IsCustom DESC, q.Name LIMIT @limit",
+            p).ToList();
     }
 
     public QueryDetails? GetQuery(string name)
@@ -1350,12 +1350,12 @@ public sealed partial class MetadataRepository
     {
         limit = ClampLimit(limit, 50);
         using var conn = OpenReadOnly();
-        var like = $"%{EscapeLike(query)}%";
-        return conn.Query<ViewInfo>(@"
+        var (nameWhere, p) = NameFilter(query, new { limit }, "v.Name");
+        return conn.Query<ViewInfo>($@"
             SELECT v.ViewId, v.Name, m.Name AS Model, v.Label, v.QueryName, v.SourcePath
             FROM Views v JOIN Models m ON m.ModelId = v.ModelId
-            WHERE v.Name LIKE @like ESCAPE '!' ORDER BY m.IsCustom DESC, v.Name LIMIT @limit",
-            new { like, limit }).ToList();
+            WHERE {nameWhere} ORDER BY m.IsCustom DESC, v.Name LIMIT @limit",
+            p).ToList();
     }
 
     public ViewDetails? GetView(string name)
@@ -1376,14 +1376,14 @@ public sealed partial class MetadataRepository
     {
         limit = ClampLimit(limit, 50);
         using var conn = OpenReadOnly();
-        var like = $"%{EscapeLike(query)}%";
-        return conn.Query<DataEntityInfo>(@"
+        var (nameWhere, p) = NameFilter(query, new { limit }, "e.Name", "e.PublicEntityName", "e.PublicCollectionName");
+        return conn.Query<DataEntityInfo>($@"
             SELECT e.EntityId, e.Name, m.Name AS Model, e.PublicEntityName, e.PublicCollectionName,
                    e.StagingTable, e.QueryName, e.Label, e.SourcePath
             FROM DataEntities e JOIN Models m ON m.ModelId = e.ModelId
-            WHERE e.Name LIKE @like ESCAPE '!' OR e.PublicEntityName LIKE @like ESCAPE '!' OR e.PublicCollectionName LIKE @like ESCAPE '!'
+            WHERE {nameWhere}
             ORDER BY m.IsCustom DESC, e.Name LIMIT @limit",
-            new { like, limit }).ToList();
+            p).ToList();
     }
 
     public DataEntityDetails? GetDataEntity(string name)
@@ -1405,12 +1405,12 @@ public sealed partial class MetadataRepository
     {
         limit = ClampLimit(limit, 50);
         using var conn = OpenReadOnly();
-        var like = $"%{EscapeLike(query)}%";
-        return conn.Query<ReportInfo>(@"
+        var (nameWhere, p) = NameFilter(query, new { limit }, "r.Name");
+        return conn.Query<ReportInfo>($@"
             SELECT r.ReportId, r.Name, r.Kind, m.Name AS Model, r.SourcePath
             FROM Reports r JOIN Models m ON m.ModelId = r.ModelId
-            WHERE r.Name LIKE @like ESCAPE '!' ORDER BY m.IsCustom DESC, r.Name LIMIT @limit",
-            new { like, limit }).ToList();
+            WHERE {nameWhere} ORDER BY m.IsCustom DESC, r.Name LIMIT @limit",
+            p).ToList();
     }
 
     public ReportDetails? GetReport(string name)
@@ -1431,12 +1431,12 @@ public sealed partial class MetadataRepository
     {
         limit = ClampLimit(limit, 50);
         using var conn = OpenReadOnly();
-        var like = $"%{EscapeLike(query)}%";
-        return conn.Query<ServiceInfo>(@"
+        var (nameWhere, p) = NameFilter(query, new { limit }, "s.Name");
+        return conn.Query<ServiceInfo>($@"
             SELECT s.ServiceId, s.Name, s.Class, m.Name AS Model, s.SourcePath
             FROM Services s JOIN Models m ON m.ModelId = s.ModelId
-            WHERE s.Name LIKE @like ESCAPE '!' ORDER BY m.IsCustom DESC, s.Name LIMIT @limit",
-            new { like, limit }).ToList();
+            WHERE {nameWhere} ORDER BY m.IsCustom DESC, s.Name LIMIT @limit",
+            p).ToList();
     }
 
     public ServiceDetails? GetService(string name)
@@ -1471,13 +1471,13 @@ public sealed partial class MetadataRepository
     {
         limit = ClampLimit(limit, 50);
         using var conn = OpenReadOnly();
-        var like = $"%{EscapeLike(query)}%";
-        return conn.Query<WorkflowTypeInfo>(@"
+        var (nameWhere, p) = NameFilter(query, new { limit }, "w.Name", "w.DocumentClass");
+        return conn.Query<WorkflowTypeInfo>($@"
             SELECT w.Name, w.Category, w.DocumentClass, m.Name AS Model, w.SourcePath
             FROM WorkflowTypes w JOIN Models m ON m.ModelId = w.ModelId
-            WHERE w.Name LIKE @like ESCAPE '!' OR w.DocumentClass LIKE @like ESCAPE '!'
+            WHERE {nameWhere}
             ORDER BY m.IsCustom DESC, w.Name LIMIT @limit",
-            new { like, limit }).ToList();
+            p).ToList();
     }
 
     // ---- AxMap queries (v10) ----
@@ -1487,13 +1487,13 @@ public sealed partial class MetadataRepository
     {
         limit = ClampLimit(limit, 50);
         using var conn = OpenReadOnly();
-        var like = $"%{EscapeLike(query)}%";
-        return conn.Query<MapInfo>(@"
+        var (nameWhere, p) = NameFilter(query, new { limit }, "mp.Name");
+        return conn.Query<MapInfo>($@"
             SELECT mp.MapId, mp.Name, m.Name AS Model, mp.Label, mp.SourcePath
             FROM Maps mp JOIN Models m ON m.ModelId = mp.ModelId
-            WHERE mp.Name LIKE @like ESCAPE '!'
+            WHERE {nameWhere}
             ORDER BY m.IsCustom DESC, mp.Name LIMIT @limit",
-            new { like, limit }).ToList();
+            p).ToList();
     }
 
     /// <summary>Returns full details of an AxMap including fields and mapped tables.</summary>
@@ -1523,14 +1523,16 @@ public sealed partial class MetadataRepository
     {
         limit = ClampLimit(limit, 50);
         using var conn = OpenReadOnly();
-        var like = $"%{EscapeLike(query)}%";
-        return conn.Query<BusinessEventInfo>(@"
+        var (nameWhere, p) = NameFilter(query,
+            new { category, catLike = category is not null ? $"%{EscapeLike(category)}%" : null, limit },
+            "be.Name", "be.ContractClass");
+        return conn.Query<BusinessEventInfo>($@"
             SELECT be.Id, be.Name, be.Category, be.ContractClass, m.Name AS Model, be.SourcePath
             FROM BusinessEvents be JOIN Models m ON m.ModelId = be.ModelId
-            WHERE (be.Name LIKE @like ESCAPE '!' OR be.ContractClass LIKE @like ESCAPE '!')
+            WHERE {nameWhere}
               AND (@category IS NULL OR be.Category LIKE @catLike ESCAPE '!')
             ORDER BY m.IsCustom DESC, be.Name LIMIT @limit",
-            new { like, category, catLike = category is not null ? $"%{EscapeLike(category)}%" : null, limit }).ToList();
+            p).ToList();
     }
 
     public BusinessEventInfo? GetBusinessEvent(string name)
@@ -1546,14 +1548,14 @@ public sealed partial class MetadataRepository
     {
         limit = ClampLimit(limit, 50);
         using var conn = OpenReadOnly();
-        var like = $"%{EscapeLike(query)}%";
-        return conn.Query<SecurityPolicyInfo>(@"
+        var (nameWhere, p) = NameFilter(query, new { limit }, "sp.Name", "sp.ConstrainedTable");
+        return conn.Query<SecurityPolicyInfo>($@"
             SELECT sp.Id, sp.Name, sp.ConstrainedTable, sp.PolicyQuery, sp.OperationType, sp.ContextType,
                    sp.IsEnabled, sp.IsMandatory, m.Name AS Model, sp.SourcePath
             FROM SecurityPolicies sp JOIN Models m ON m.ModelId = sp.ModelId
-            WHERE sp.Name LIKE @like ESCAPE '!' OR sp.ConstrainedTable LIKE @like ESCAPE '!'
+            WHERE {nameWhere}
             ORDER BY m.IsCustom DESC, sp.Name LIMIT @limit",
-            new { like, limit }).ToList();
+            p).ToList();
     }
 
     public SecurityPolicyInfo? GetSecurityPolicy(string name)
@@ -1570,39 +1572,39 @@ public sealed partial class MetadataRepository
     {
         limit = ClampLimit(limit, 50);
         using var conn = OpenReadOnly();
-        var like = $"%{EscapeLike(query)}%";
-        return conn.Query<ConfigurationKeyInfo>(@"
+        var (nameWhere, p) = NameFilter(query, new { limit }, "ck.Name");
+        return conn.Query<ConfigurationKeyInfo>($@"
             SELECT ck.Id, ck.Name, ck.Label, ck.IsEnabled, ck.ParentKey, ck.LicenseCode, m.Name AS Model
             FROM ConfigurationKeys ck JOIN Models m ON m.ModelId = ck.ModelId
-            WHERE ck.Name LIKE @like ESCAPE '!'
+            WHERE {nameWhere}
             ORDER BY m.IsCustom DESC, ck.Name LIMIT @limit",
-            new { like, limit }).ToList();
+            p).ToList();
     }
 
     public IReadOnlyList<TileInfo> SearchTiles(string query, int limit = 50)
     {
         limit = ClampLimit(limit, 50);
         using var conn = OpenReadOnly();
-        var like = $"%{EscapeLike(query)}%";
-        return conn.Query<TileInfo>(@"
+        var (nameWhere, p) = NameFilter(query, new { limit }, "t.Name", "t.MenuItemName");
+        return conn.Query<TileInfo>($@"
             SELECT t.Id, t.Name, t.MenuItemName, t.MenuItemType, t.Label, t.TileType, m.Name AS Model, t.SourcePath
             FROM Tiles t JOIN Models m ON m.ModelId = t.ModelId
-            WHERE t.Name LIKE @like ESCAPE '!' OR t.MenuItemName LIKE @like ESCAPE '!'
+            WHERE {nameWhere}
             ORDER BY m.IsCustom DESC, t.Name LIMIT @limit",
-            new { like, limit }).ToList();
+            p).ToList();
     }
 
     public IReadOnlyList<WorkspaceInfo> SearchWorkspaces(string query, int limit = 50)
     {
         limit = ClampLimit(limit, 50);
         using var conn = OpenReadOnly();
-        var like = $"%{EscapeLike(query)}%";
-        return conn.Query<WorkspaceInfo>(@"
+        var (nameWhere, p) = NameFilter(query, new { limit }, "ws.Name");
+        return conn.Query<WorkspaceInfo>($@"
             SELECT ws.Id, ws.Name, ws.Label, m.Name AS Model, ws.SourcePath
             FROM Workspaces ws JOIN Models m ON m.ModelId = ws.ModelId
-            WHERE ws.Name LIKE @like ESCAPE '!'
+            WHERE {nameWhere}
             ORDER BY m.IsCustom DESC, ws.Name LIMIT @limit",
-            new { like, limit }).ToList();
+            p).ToList();
     }
 
     // ---- Phase 7: developer experience ----
@@ -1999,44 +2001,44 @@ public sealed partial class MetadataRepository
     {
         limit = ClampLimit(limit, 50);
         using var conn = OpenReadOnly();
-        var like = $"%{EscapeLike(query)}%";
-        return conn.Query<TableInfo>(@"
+        var (nameWhere, p) = NameFilter(query, new { model, limit }, "t.Name");
+        return conn.Query<TableInfo>($@"
             SELECT t.TableId, t.Name, m.Name AS Model, t.Label, t.SourcePath,
                    t.SaveDataPerCompany, t.CacheLookup, t.OccEnabled, t.ValidTimeStateFieldType,
                    t.TableExtends, t.AOSAuthorization, t.FormRef, t.ListPageRef, t.SystemTable
             FROM Tables t JOIN Models m ON m.ModelId = t.ModelId
-            WHERE t.Name LIKE @like ESCAPE '!'
+            WHERE {nameWhere}
               AND (@model IS NULL OR m.Name = @model)
             ORDER BY m.IsCustom DESC, t.Name
-            LIMIT @limit", new { like, model, limit }).ToList();
+            LIMIT @limit", p).ToList();
     }
 
     public IReadOnlyList<EdtInfo> SearchEdts(string query, int limit = 50)
     {
         limit = ClampLimit(limit, 50);
         using var conn = OpenReadOnly();
-        var like = $"%{EscapeLike(query)}%";
-        return conn.Query<EdtInfo>(@"
+        var (nameWhere, p) = NameFilter(query, new { limit }, "e.Name");
+        return conn.Query<EdtInfo>($@"
             SELECT e.Name, m.Name AS Model, e.ExtendsName AS Extends,
                    e.BaseType, e.Label, e.StringSize,
                    e.ReferenceTable, e.FormHelp, e.AnalysisUsage, e.EnumType
             FROM Edts e JOIN Models m ON m.ModelId = e.ModelId
-            WHERE e.Name LIKE @like ESCAPE '!'
+            WHERE {nameWhere}
             ORDER BY m.IsCustom DESC, e.Name
-            LIMIT @limit", new { like, limit }).ToList();
+            LIMIT @limit", p).ToList();
     }
 
     public IReadOnlyList<EnumInfo> SearchEnums(string query, int limit = 50)
     {
         limit = ClampLimit(limit, 50);
         using var conn = OpenReadOnly();
-        var like = $"%{EscapeLike(query)}%";
-        return conn.Query<EnumInfo>(@"
+        var (nameWhere, p) = NameFilter(query, new { limit }, "e.Name");
+        return conn.Query<EnumInfo>($@"
             SELECT e.Name, m.Name AS Model, e.Label
             FROM Enums e JOIN Models m ON m.ModelId = e.ModelId
-            WHERE e.Name LIKE @like ESCAPE '!'
+            WHERE {nameWhere}
             ORDER BY m.IsCustom DESC, e.Name
-            LIMIT @limit", new { like, limit }).ToList();
+            LIMIT @limit", p).ToList();
     }
 
     public EnumDetails? GetEnum(string name)
@@ -3152,6 +3154,42 @@ public sealed partial class MetadataRepository
     /// </summary>
     private static string EscapeLike(string value) =>
         value.Replace("!", "!!").Replace("%", "!%").Replace("_", "!_");
+
+    /// <summary>
+    /// The WHERE fragment that matches a name query against one or more columns, with its
+    /// parameters bound on the returned <see cref="DynamicParameters"/> alongside
+    /// <paramref name="extra"/> (the caller's other parameters, as an anonymous object).
+    /// </summary>
+    /// <remarks>
+    /// One word is one substring match, as it always was. A multi-word query never meant one
+    /// verbatim string — no AOT name contains a space — so <c>"ProcessGuide AdjustIn"</c> used to
+    /// match nothing while <c>InventProcessGuideAdjustInController</c> sat in the index and an
+    /// exact-name search found it. An agent reads that empty answer as evidence and targets
+    /// something else. It now means "a name carrying every token", in any order: one LIKE per
+    /// token, ANDed. Where a method matches several columns (a data entity's public names, a
+    /// tile's menu item), every token must land in the same column, so <c>Cust Entity</c> does
+    /// not match a row whose name has one word and whose public name has the other.
+    /// </remarks>
+    private static (string Where, DynamicParameters Params) NameFilter(string query, object? extra, params string[] columns)
+    {
+        var p = new DynamicParameters(extra);
+        var tokens = (query ?? "").Split((char[]?)null, StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries);
+        if (tokens.Length == 0) tokens = new[] { query ?? "" };
+
+        var perColumn = new List<string>(columns.Length);
+        foreach (var column in columns)
+        {
+            var perToken = new List<string>(tokens.Length);
+            for (var i = 0; i < tokens.Length; i++)
+            {
+                var key = i == 0 ? "like" : $"like{i}";
+                if (perColumn.Count == 0) p.Add(key, $"%{EscapeLike(tokens[i])}%");
+                perToken.Add($"{column} LIKE @{key} ESCAPE '!'");
+            }
+            perColumn.Add(perToken.Count == 1 ? perToken[0] : "(" + string.Join(" AND ", perToken) + ")");
+        }
+        return (perColumn.Count == 1 ? perColumn[0] : "(" + string.Join(" OR ", perColumn) + ")", p);
+    }
 
     /// <summary>
     /// Clamps a caller-supplied row limit into a sane range. SQLite treats a

--- a/src/D365FO.Mcp/ToolHandlers.cs
+++ b/src/D365FO.Mcp/ToolHandlers.cs
@@ -2190,6 +2190,25 @@ public sealed partial class ToolHandlers
     /// and <c>Base_Extension</c>. The type alone is not enough to tell — a caller naming
     /// <c>CustTable.Fleet</c> without a type is still creating an extension.
     /// </remarks>
+    /// <summary>
+    /// The <see cref="ObjectNamingRules"/> kind for an extension of <paramref name="objectType"/>:
+    /// <c>enum</c> → <c>EnumExtension</c>, <c>data-entity</c> → <c>DataEntityViewExtension</c>,
+    /// and a type that already says "extension" passes through in PascalCase.
+    /// </summary>
+    private static string ExtensionNamingKind(string objectType)
+    {
+        var t = objectType.Trim().ToLowerInvariant();
+        return t switch
+        {
+            "data-entity" or "data-entity-extension" or "entity" => "DataEntityViewExtension",
+            "role" or "security-role" => "SecurityRoleExtension",
+            "duty" or "security-duty" => "SecurityDutyExtension",
+            "privilege" or "security-privilege" => "SecurityPrivilegeExtension",
+            _ => string.Concat(t.Replace("-extension", "").Split('-', StringSplitOptions.RemoveEmptyEntries)
+                                .Select(w => char.ToUpperInvariant(w[0]) + w[1..])) + "Extension",
+        };
+    }
+
     private static string? ExtensionBaseOf(string objectType, string name)
     {
         var looksLikeExtension = objectType.Contains("extension", StringComparison.OrdinalIgnoreCase)
@@ -2221,20 +2240,25 @@ public sealed partial class ToolHandlers
                 collisions.Add(new { name = candidate, existsAs = hit });
         }
 
-        var namingKind = objectType switch
-        {
-            "data-entity" => "Entity",
-            "menu-item" => "MenuItem",
-            _ => char.ToUpperInvariant(objectType[0]) + objectType[1..],
-        };
-        var violations = ObjectNamingRules.Validate(namingKind, finalName, prefix);
-
         // An extension is created against an object that already exists, and everything worth
         // knowing before writing one is about THAT object: does it exist, what model owns it,
         // and who is already extending it. Grounding on the extension's own name asks about a
         // name that by definition is not there yet, and answers "no collision, nothing similar"
         // — true, and useless.
         var extendedObject = ExtensionBaseOf(objectType, baseName);
+
+        // A dotted name under --type enum IS an enum extension, and the naming rules must judge
+        // it as one: judged as a plain enum, the dot that every shipped extension carries came
+        // back as INVALID_CHARS in the same answer that listed 25 siblings spelled that way.
+        var namingKind = extendedObject is not null
+            ? ExtensionNamingKind(objectType)
+            : objectType switch
+            {
+                "data-entity" => "Entity",
+                "menu-item" => "MenuItem",
+                _ => char.ToUpperInvariant(objectType[0]) + objectType[1..],
+            };
+        var violations = ObjectNamingRules.Validate(namingKind, finalName, prefix);
         object? extensionBase = null;
         if (extendedObject is not null)
         {
@@ -2324,7 +2348,9 @@ public sealed partial class ToolHandlers
             finalName,
             collisions = collisions.Count > 0 ? collisions : null,
             collisionVerdict = collisions.Count > 0
-                ? "Name already exists — pick a different name or extend the existing object instead."
+                ? extendedObject is not null
+                    ? "An extension of that name already exists — modify it (`d365fo modify`) or pick a different suffix."
+                    : "Name already exists — pick a different name or extend the existing object instead."
                 : string.Equals(finalName, baseName, StringComparison.Ordinal)
                     ? $"No collision — \"{finalName}\" does not exist in the index."
                     : $"No collision — neither \"{finalName}\" nor \"{baseName}\" exists in the index.",

--- a/tests/D365FO.Core.Tests/NameSearchAndExtensionSymbolTests.cs
+++ b/tests/D365FO.Core.Tests/NameSearchAndExtensionSymbolTests.cs
@@ -1,0 +1,135 @@
+using System.Text.Json;
+using D365FO.Core.Index;
+using D365FO.Mcp;
+using Xunit;
+
+namespace D365FO.Core.Tests;
+
+/// <summary>
+/// Two 1.16.0 upstream fixes the parity audit found unported (c43bf51, 0b363e5): a multi-word
+/// name query answered nothing, and an extension's name was invisible to the collision check.
+/// </summary>
+public class NameSearchAndExtensionSymbolTests : IDisposable
+{
+    private readonly string _dbPath = Path.Combine(Path.GetTempPath(), $"d365fo-test-{Guid.NewGuid():N}.sqlite");
+
+    public void Dispose()
+    {
+        SqlitePool.ReleaseFor(_dbPath);
+        foreach (var ext in new[] { "", "-wal", "-shm" })
+        {
+            var p = _dbPath + ext;
+            if (File.Exists(p)) File.Delete(p);
+        }
+    }
+
+    private MetadataRepository Seed()
+    {
+        var repo = new MetadataRepository(_dbPath);
+        repo.EnsureSchema();
+        repo.ApplyExtract(ExtractBatch.Empty("ProcessGuide") with
+        {
+            Classes = new[]
+            {
+                new ExtractedClass("InventProcessGuideAdjustInController", "ProcessGuideController", false, false, "/a", Array.Empty<ExtractedMethod>()),
+                new ExtractedClass("InventProcessGuideAdjustOutController", "ProcessGuideController", false, false, "/b", Array.Empty<ExtractedMethod>()),
+                new ExtractedClass("WhsAdjustInHelper", null, false, false, "/c", Array.Empty<ExtractedMethod>()),
+            },
+            Tables = new[]
+            {
+                new ExtractedTable("CustTrans", null, "/t1", Array.Empty<ExtractedTableField>()),
+                new ExtractedTable("CustTable", null, "/t2", Array.Empty<ExtractedTableField>()),
+            },
+            Enums = new[] { new ExtractedEnum("NumberSeqModule", null, Array.Empty<ExtractedEnumValue>()) },
+            Extensions = new[]
+            {
+                new ExtractedObjectExtension("Enum", "NumberSeqModule", "NumberSeqModule.Kitting", "/e1"),
+                new ExtractedObjectExtension("Enum", "NumberSeqModule", "NumberSeqModule.CredMan", "/e2"),
+            },
+            DataEntities = new[]
+            {
+                new ExtractedDataEntity("CustCustomerV3Entity", "CustomerV3", "CustomersV3", null, null, null, "/d1", Array.Empty<ExtractedDataEntityField>()),
+                new ExtractedDataEntity("VendVendorV2Entity", "CustomerLikeVendor", "Vendors", null, null, null, "/d2", Array.Empty<ExtractedDataEntityField>()),
+            },
+        });
+        return repo;
+    }
+
+    [Fact]
+    public void Multi_word_query_finds_the_name_carrying_every_token_in_any_order()
+    {
+        var repo = Seed();
+
+        // The exact-name search always found it; the two-word query returned nothing, and an
+        // agent read that empty answer as evidence. Confirmed on a live index before the fix.
+        Assert.Single(repo.SearchClasses("InventProcessGuideAdjustInController"));
+        Assert.Equal("InventProcessGuideAdjustInController", Assert.Single(repo.SearchClasses("ProcessGuide AdjustIn")).Name);
+        Assert.Equal("InventProcessGuideAdjustInController", Assert.Single(repo.SearchClasses("AdjustIn ProcessGuide")).Name);
+
+        // Every token, not any token: a name carrying one of the two words does not qualify.
+        Assert.DoesNotContain(repo.SearchClasses("ProcessGuide AdjustIn"), c => c.Name == "WhsAdjustInHelper");
+
+        // Whitespace around a single word is not part of the name being looked for.
+        Assert.Equal(2, repo.SearchClasses("  AdjustIn ").Count);
+
+        Assert.Equal("CustTrans", Assert.Single(repo.SearchTables("Cust Trans")).Name);
+    }
+
+    [Fact]
+    public void Multi_word_query_over_several_columns_needs_every_token_in_one_column()
+    {
+        var repo = Seed();
+
+        // Name and public name are alternatives for the whole query, not a pool the tokens may
+        // be spread across: "Customer Vendor" must not match a row whose name holds one word
+        // and whose public entity name holds the other.
+        Assert.Equal("CustCustomerV3Entity", Assert.Single(repo.SearchDataEntities("Customer V3")).Name);
+        Assert.Contains(repo.SearchDataEntities("CustomerLike Vendor"), e => e.Name == "VendVendorV2Entity");
+        Assert.Empty(repo.SearchDataEntities("VendVendor CustomerLike Cust"));
+    }
+
+    [Fact]
+    public void SymbolKinds_reports_an_extension_under_its_own_name()
+    {
+        var repo = Seed();
+
+        Assert.Equal(new[] { "enum" }, repo.SymbolKinds("NumberSeqModule"));
+        Assert.Equal(new[] { "enum-extension" }, repo.SymbolKinds("numberseqmodule.kitting"));
+        Assert.Empty(repo.SymbolKinds("NumberSeqModule.ConDemoRent"));
+    }
+
+    [Fact]
+    public void Prepare_create_calls_a_taken_extension_name_a_collision_and_its_dot_legal()
+    {
+        var repo = Seed();
+        var handlers = new ToolHandlers(repo);
+
+        // Taken: the installation ships NumberSeqModule.Kitting. This used to answer
+        // "No collision — does not exist in the index", right before a write.
+        var taken = JsonSerializer.Serialize(handlers.PrepareCreate("NumberSeqModule.Kitting", "enum", null, null, null).Data);
+        using (var doc = JsonDocument.Parse(taken))
+        {
+            var root = doc.RootElement;
+            var collision = Assert.Single(root.GetProperty("collisions").EnumerateArray());
+            Assert.Equal("NumberSeqModule.Kitting", collision.GetProperty("name").GetString());
+            Assert.Equal("enum-extension", collision.GetProperty("existsAs")[0].GetString());
+            Assert.Contains("already exists", root.GetProperty("collisionVerdict").GetString());
+            Assert.DoesNotContain(root.GetProperty("namingViolations").EnumerateArray(),
+                v => v.GetProperty("code").GetString() == "INVALID_CHARS");
+        }
+
+        // Free: a new suffix on the same base is no collision, and the dot every shipped
+        // extension carries is not an invalid character — the same answer lists the
+        // siblings spelled exactly that way.
+        var free = JsonSerializer.Serialize(handlers.PrepareCreate("NumberSeqModule.ConDemoRent", "enum", null, null, null).Data);
+        using (var doc = JsonDocument.Parse(free))
+        {
+            var root = doc.RootElement;
+            Assert.Equal(JsonValueKind.Null, root.GetProperty("collisions").ValueKind);
+            Assert.StartsWith("No collision", root.GetProperty("collisionVerdict").GetString());
+            Assert.DoesNotContain(root.GetProperty("namingViolations").EnumerateArray(),
+                v => v.GetProperty("code").GetString() == "INVALID_CHARS");
+            Assert.Equal(2, root.GetProperty("extensionBase").GetProperty("existingExtensions").GetInt32());
+        }
+    }
+}


### PR DESCRIPTION
## What

An audit of the repository against the parity gap analysis, probing each of the twelve upstream 1.16.0 fixes on the live index instead of ticking them off, found two that no wave had ported. Both are fixed here with regression tests, plus the README truth debt the audit turned up.

### Multi-word search answered nothing (upstream c43bf51)
`search class "ProcessGuide AdjustIn"` returned `count: 0` while `InventProcessGuideAdjustInController` sat in the index and the exact-name search found it. No AOT name contains a space, so a multi-word query means "a name carrying every token", in any order.

- One `NameFilter` helper behind all 16 name-search methods (classes, tables, EDTs, enums, queries, views, data entities, reports, services, workflow types, maps, business events, security policies, configuration keys, tiles, workspaces): one `LIKE` per token, ANDed.
- Where a method matches several columns (a data entity's public names, a tile's menu item), every token must land in the same column.
- Label search deliberately untouched: label text has spaces, so a multi-word label query is verbatim.

### An extension's name was invisible to the collision check (upstream 0b363e5)
`prepare create NumberSeqModule.Kitting --type enum` answered "No collision — does not exist in the index" for an enum extension the installation ships, immediately before a write, and in the same answer listed 25 sibling extensions spelled that way while flagging the dot as `INVALID_CHARS`.

- `SymbolKinds` now also reads `ObjectExtensions` and reports an extension as `<kind>-extension`, so base-kind lookups are unaffected.
- The collision verdict for an extension says to modify the existing one or pick another suffix.
- A dotted name under a base type (`--type enum`) is judged by the naming rules as the extension it is.

### README truth debt
- "Why CLI" still carried the ~1 800 tokens/turn estimate wave 06 measured as six times off; now the measured figures (32 tools, 40 132 chars vs 366).
- Adapter tool count 28 → 32; `generate` list 29 → 33 (four subcommands missing from the table).

## Verification
- `dotnet test`: 620 CLI + 1 197 Core = **1 817** passed, 0 failed (4 new tests in `NameSearchAndExtensionSymbolTests`).
- Warning ratchet: 114 / baseline 114.
- `eval run --all`: 60/60. `oracle sweep --dry`: bar held. `emit-mcp-tools.py --check`: current.
- Live probes on this VM's index: the two-word query now returns 8 rows in either token order; `prepare create NumberSeqModule.Kitting --type enum` reports the collision with `existsAs: ["enum-extension"]` and no `INVALID_CHARS`; a fresh suffix reports no collision.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01731LGnSpmFm5jqkhWLVoaC
