### PR TITLE
fix(generate): the seven defects the review of the ten new kinds found

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,8 +39,9 @@ every golden compiled by the real `xppc`.
 - **`generate resource`** — `AxResource` manifest; `--source` copies the file into
   `ResourceContent/<Type>/`. A manifest whose content is missing is a **Metadata Error** at
   compile time ("Resource content file 'X.png' not found"), which the first L3 run proved.
-- **`generate tile`** — `AxTile` bound to a menu item; `Type` written only when not `Standard`,
-  a KPI tile needs `--kpi`. The menu item is checked against the index and reported in
+- **`generate tile`** — `AxTile` bound to whatever its `Type` opens: `--menu-item` for
+  `Standard` and `Count`, `--kpi` for `KPI`, `--url` for `Link`. `Type` is written only when it
+  is not `Standard`. The menu item is checked against the index and reported in
   `unknownMenuItems` rather than refused.
 - **`generate workflow-category`** — `AxWorkflowCategory` (V2 namespace) whose `--module` is
   validated against `ModuleAxapta` in the index; the contract types it as a string and the
@@ -77,12 +78,62 @@ Around them:
 
 `forms-and-navigation` taught that a sub-menu is nested through a `<SubMenu>` member and that
 `AxMenuElementMenuReference` was "a different, legacy concept". Counted on the installation:
-of 81 shipped menus, 60 nest sub-menus **inline** — `AxMenuElementSubMenu` carries its own
+of 80 shipped menus, 59 nest sub-menus **inline** — `AxMenuElementSubMenu` carries its own
 `<Elements>` — one references another menu through `AxMenuElementMenuReference/<MenuName>`,
 and **no file carries a `<SubMenu>` member**; the contract declares none. The topic now says
 what the files say. The tile size list lost its `Small` (the `TileSize` enum has none) and
 `object-extension-authoring` no longer claims there is no Map extension kind.
 
+
+### Fixed — the review of the ten new subcommands
+
+Reviewing `feat/generate-the-ten-missing-kinds` against the installation rather than against
+its own commit message. Every gate it claimed reproduces; these are what the review found
+underneath them.
+
+- **`generate label-file --overwrite` destroyed the labels it was not asked about.** With no
+  `--entry`, the content write ran anyway and put an empty string over an existing
+  `.label.txt` — a 35-byte file became a 3-byte byte-order mark, and since the content file
+  goes to disk outside `ScaffoldFileWriter` there was no `.bak` and no journal entry to
+  recover from. Re-running the command to refresh a manifest silently emptied the label file
+  beside it. Now: no `--entry` and a file already there means the file is left alone (with a
+  warning); `--entry` with `--overwrite` keeps the previous content as `.bak` and reports it
+  as `contentBackup`.
+- **A KPI or Link tile could not be written at all.** `--menu-item` was required of every
+  tile, justified as "every shipped tile has one". Counted here: of 770 tiles, 762 carry
+  `<MenuItemName>` and every one of those is `Standard` or `Count`. The eight that do not are
+  the other two types — a KPI tile binds `<KPI>` (`QMSCAPAAvgDaysToCloseAllCases`), a Link
+  tile binds `<URL>` (`CTPTechDocumentation`) — so the command offered `--type KPI` and
+  `--type Link` while refusing to produce either shape, and had no `--url` option to begin
+  with. The requirement now follows the type, `--url` exists, and both new shapes compile
+  clean under the real `xppc`.
+- **A tile's `size` was unreachable over MCP.** One flat `generate_object` schema with
+  `additionalProperties: false` declared `size` as an integer for `edt`, while the tile branch
+  read the same key as a string: a validating client could not send `"Wide"`, and one that
+  obeyed the declared type crashed the handler on `JsonElement.GetString()`. Tiles now take
+  `tileSize` (with `size` still accepted), and `Str` renders a number instead of throwing.
+- **A cyclic `--embedded` chain was reported as bundled and written as nothing.**
+  `generate composite-entity --embedded A:relA:B --embedded B:relB:A` passed every check — each
+  parent name resolves — and produced an empty `<EmbeddedDataEntities />` while the payload
+  and `requiredSymbols` listed both entities. Both surfaces now walk each parent chain to a
+  root and refuse the ones that loop.
+- **Content companions were never scored.** `eval run` diffed `_companions/*.xml`
+  non-recursively, so the `.label.txt` and `.png` added with the ten subcommands were
+  invisible: `L1-label-file-basic` and `L1-resource-basic` would both have stayed green with
+  the truncation bug above in place. The scorer now walks companions recursively and compares
+  non-XML ones as content (BOM and line endings normalised, since git owns both), and the
+  replay writes its artefacts into a directory of its own so the temp index and the write
+  journal are not mistaken for output.
+- **`generate resource --source` failed a command that had half succeeded.** An existing
+  content file without `--overwrite` threw out of `File.Copy` *after* the manifest was on
+  disk, reporting `WRITE_FAILED` for a write that happened. It warns now, as the label-file
+  path already did.
+- Property honesty no longer reports a contract default as a dropped value: `--type Standard`,
+  `--menu-item-type Display` and `--display Auto` are omitted from the XML by design.
+- The L3 provisioner no longer copies a golden's content companions into the throwaway model
+  when the golden itself is skipped, and two comments in `ObjectTypeRegistry` that the feature
+  commit made false — "the null is the truth here" over a row whose null it had just filled in,
+  "nothing generates" over nine rows that all name a command — say what the rows say.
 
 ### Fixed — the two 1.16.0 ports the parity audit found still missing
 

--- a/docs/EXAMPLES.md
+++ b/docs/EXAMPLES.md
@@ -503,6 +503,10 @@ d365fo generate menu ConFleet --label "@FLM540"   --submenu "Vehicles:@FLM95"   
 # A wide tile that opens a menu item; --type Count with --query makes it a cue
 d365fo generate tile ConFmVehiclesTile --menu-item FMVehicle   --label "@FLM95" --size Wide --install-to FleetManagement
 
+# The other two types open something else instead of a menu item
+d365fo generate tile ConFmUtilizationKpi --type KPI --kpi ConFmUtilization   --size Wide --install-to FleetManagement
+d365fo generate tile ConFmDocsLink --type Link --url "https://learn.microsoft.com/dynamics365/"   --display TextOnly --install-to FleetManagement
+
 # Register a form as a hostable part (preview pane, fact box)
 d365fo generate form-part ConFmVehiclePreviewPart --form FMVehicle   --caption "@FLM95" --install-to FleetManagement
 ```
@@ -510,7 +514,10 @@ d365fo generate form-part ConFmVehiclePreviewPart --form FMVehicle   --caption "
 `--item [<submenu>/]<menuItem>[:Display|Action|Output]`: Display is the contract
 default and is not written. A menu item the index does not know is reported in
 `unknownMenuItems` rather than refused — the index is a mirror, and the item may
-live in a model that has not been extracted.
+live in a model that has not been extracted. A tile's target follows its `--type`:
+762 of the 770 shipped tiles carry `<MenuItemName>` and all of them are Standard
+or Count; the eight that do not are the KPI and Link tiles, which bind `<KPI>` and
+`<URL>` instead.
 
 ### Configuration key, workflow category, label file, resource
 

--- a/skills/_source/forms-and-navigation.md
+++ b/skills/_source/forms-and-navigation.md
@@ -131,7 +131,7 @@ decides whether it works:
 | `AxMenuElementMenuReference` | pull in **another `AxMenu`** by name | `<MenuName>` |
 | `AxMenuElementSeparator` | visual separator | — |
 
-Counted on a stock installation (81 menus): 60 nest sub-menus inline this way,
+Counted on a stock installation (80 menus): 59 nest sub-menus inline this way,
 1 references another menu through `AxMenuElementMenuReference`/`<MenuName>`,
 and **no file carries a `<SubMenu>` member** — the type declares none. The
 element types are what `Microsoft.Dynamics.AX.Metadata.dll` declares;
@@ -166,9 +166,13 @@ d365fo validate metadata <path-to-menu-xml> --output json
 
 ### Tiles, form parts and image resources
 
-- A **tile** (`AxTile`) opens a menu item and sits on a workspace; every one of
-  the 775 the platform ships carries `<MenuItemName>`. `generate tile <Name>
-  --menu-item <MenuItem> [--type Count --query <AxQuery>]` — see
+- A **tile** (`AxTile`) sits on a workspace and opens whatever its `<Type>`
+  says. Of the 770 the platform ships, 762 are Standard or Count and carry
+  `<MenuItemName>`; the other two types bind something else — a KPI tile carries
+  `<KPI>` (`QMSCAPAAvgDaysToCloseAllCases`) and a Link tile `<URL>`
+  (`CTPTechDocumentation`), neither with a menu item.
+  `generate tile <Name> --menu-item <MenuItem> [--type Count --query <AxQuery>]`,
+  or `--type KPI --kpi <AxKPI>` / `--type Link --url <address>` — see
   `d365fo knowledge get analytics-and-er` for cues and KPIs.
 - A **form part** (`AxFormPart`) registers a form so another form can host it as
   an info part, fact box or preview pane. Three members, all mandatory in

--- a/skills/anthropic/forms-and-navigation/SKILL.md
+++ b/skills/anthropic/forms-and-navigation/SKILL.md
@@ -123,7 +123,7 @@ decides whether it works:
 | `AxMenuElementMenuReference` | pull in **another `AxMenu`** by name | `<MenuName>` |
 | `AxMenuElementSeparator` | visual separator | — |
 
-Counted on a stock installation (81 menus): 60 nest sub-menus inline this way,
+Counted on a stock installation (80 menus): 59 nest sub-menus inline this way,
 1 references another menu through `AxMenuElementMenuReference`/`<MenuName>`,
 and **no file carries a `<SubMenu>` member** — the type declares none. The
 element types are what `Microsoft.Dynamics.AX.Metadata.dll` declares;
@@ -158,9 +158,13 @@ d365fo validate metadata <path-to-menu-xml> --output json
 
 ### Tiles, form parts and image resources
 
-- A **tile** (`AxTile`) opens a menu item and sits on a workspace; every one of
-  the 775 the platform ships carries `<MenuItemName>`. `generate tile <Name>
-  --menu-item <MenuItem> [--type Count --query <AxQuery>]` — see
+- A **tile** (`AxTile`) sits on a workspace and opens whatever its `<Type>`
+  says. Of the 770 the platform ships, 762 are Standard or Count and carry
+  `<MenuItemName>`; the other two types bind something else — a KPI tile carries
+  `<KPI>` (`QMSCAPAAvgDaysToCloseAllCases`) and a Link tile `<URL>`
+  (`CTPTechDocumentation`), neither with a menu item.
+  `generate tile <Name> --menu-item <MenuItem> [--type Count --query <AxQuery>]`,
+  or `--type KPI --kpi <AxKPI>` / `--type Link --url <address>` — see
   `d365fo knowledge get analytics-and-er` for cues and KPIs.
 - A **form part** (`AxFormPart`) registers a form so another form can host it as
   an info part, fact box or preview pane. Three members, all mandatory in

--- a/skills/copilot/forms-and-navigation.instructions.md
+++ b/skills/copilot/forms-and-navigation.instructions.md
@@ -122,7 +122,7 @@ decides whether it works:
 | `AxMenuElementMenuReference` | pull in **another `AxMenu`** by name | `<MenuName>` |
 | `AxMenuElementSeparator` | visual separator | — |
 
-Counted on a stock installation (81 menus): 60 nest sub-menus inline this way,
+Counted on a stock installation (80 menus): 59 nest sub-menus inline this way,
 1 references another menu through `AxMenuElementMenuReference`/`<MenuName>`,
 and **no file carries a `<SubMenu>` member** — the type declares none. The
 element types are what `Microsoft.Dynamics.AX.Metadata.dll` declares;
@@ -157,9 +157,13 @@ d365fo validate metadata <path-to-menu-xml> --output json
 
 ### Tiles, form parts and image resources
 
-- A **tile** (`AxTile`) opens a menu item and sits on a workspace; every one of
-  the 775 the platform ships carries `<MenuItemName>`. `generate tile <Name>
-  --menu-item <MenuItem> [--type Count --query <AxQuery>]` — see
+- A **tile** (`AxTile`) sits on a workspace and opens whatever its `<Type>`
+  says. Of the 770 the platform ships, 762 are Standard or Count and carry
+  `<MenuItemName>`; the other two types bind something else — a KPI tile carries
+  `<KPI>` (`QMSCAPAAvgDaysToCloseAllCases`) and a Link tile `<URL>`
+  (`CTPTechDocumentation`), neither with a menu item.
+  `generate tile <Name> --menu-item <MenuItem> [--type Count --query <AxQuery>]`,
+  or `--type KPI --kpi <AxKPI>` / `--type Link --url <address>` — see
   `d365fo knowledge get analytics-and-er` for cues and KPIs.
 - A **form part** (`AxFormPart`) registers a form so another form can host it as
   an info part, fact box or preview pane. Three members, all mandatory in

--- a/skills/d365fo-cli/references/forms-and-navigation.md
+++ b/skills/d365fo-cli/references/forms-and-navigation.md
@@ -118,7 +118,7 @@ decides whether it works:
 | `AxMenuElementMenuReference` | pull in **another `AxMenu`** by name | `<MenuName>` |
 | `AxMenuElementSeparator` | visual separator | — |
 
-Counted on a stock installation (81 menus): 60 nest sub-menus inline this way,
+Counted on a stock installation (80 menus): 59 nest sub-menus inline this way,
 1 references another menu through `AxMenuElementMenuReference`/`<MenuName>`,
 and **no file carries a `<SubMenu>` member** — the type declares none. The
 element types are what `Microsoft.Dynamics.AX.Metadata.dll` declares;
@@ -153,9 +153,13 @@ d365fo validate metadata <path-to-menu-xml> --output json
 
 ### Tiles, form parts and image resources
 
-- A **tile** (`AxTile`) opens a menu item and sits on a workspace; every one of
-  the 775 the platform ships carries `<MenuItemName>`. `generate tile <Name>
-  --menu-item <MenuItem> [--type Count --query <AxQuery>]` — see
+- A **tile** (`AxTile`) sits on a workspace and opens whatever its `<Type>`
+  says. Of the 770 the platform ships, 762 are Standard or Count and carry
+  `<MenuItemName>`; the other two types bind something else — a KPI tile carries
+  `<KPI>` (`QMSCAPAAvgDaysToCloseAllCases`) and a Link tile `<URL>`
+  (`CTPTechDocumentation`), neither with a menu item.
+  `generate tile <Name> --menu-item <MenuItem> [--type Count --query <AxQuery>]`,
+  or `--type KPI --kpi <AxKPI>` / `--type Link --url <address>` — see
   `d365fo knowledge get analytics-and-er` for cues and KPIs.
 - A **form part** (`AxFormPart`) registers a form so another form can host it as
   an info part, fact box or preview pane. Three members, all mandatory in

--- a/src/D365FO.Cli/Commands/Eval/EvalRunCommand.cs
+++ b/src/D365FO.Cli/Commands/Eval/EvalRunCommand.cs
@@ -178,8 +178,12 @@ public sealed class EvalRunCommand : Command<EvalRunCommand.Settings>
         EvalCase @case, string root, string dllPath, bool write, string? note)
     {
         var workDir = Path.Combine(Path.GetTempPath(), $"d365fo-eval-{Guid.NewGuid():N}");
-        Directory.CreateDirectory(workDir);
-        var outPath = Path.Combine(workDir, "actual.xml");
+        // The run's artefacts get a directory of their own, separate from the replay's own
+        // furniture — the temp index and the write journal share workDir, and the scorer reads
+        // the produced directory as "everything the command wrote", extras included.
+        var artifactDir = Path.Combine(workDir, "artifacts");
+        Directory.CreateDirectory(artifactDir);
+        var outPath = Path.Combine(artifactDir, "actual.xml");
         var dbPath = Path.Combine(workDir, "index.sqlite");
 
         try
@@ -222,7 +226,7 @@ public sealed class EvalRunCommand : Command<EvalRunCommand.Settings>
             if (exitCode != 0 || !File.Exists(outPath))
                 return (null, new ReplayFailure("EVAL_GENERATE_FAILED", $"`d365fo {string.Join(' ', args)}` exited {exitCode} or produced no output file at {outPath}."));
 
-            var score = EvalScorer.Score(@case, outPath, EvalPaths.GoldensDir(root), repo, producedDir: workDir);
+            var score = EvalScorer.Score(@case, outPath, EvalPaths.GoldensDir(root), repo, producedDir: artifactDir);
 
             if (write)
             {

--- a/src/D365FO.Cli/Commands/Generate/GenerateConfigurationCommands.cs
+++ b/src/D365FO.Cli/Commands/Generate/GenerateConfigurationCommands.cs
@@ -285,8 +285,19 @@ public sealed class GenerateResourceCommand : Command<GenerateResourceCommand.Se
             if (!string.IsNullOrWhiteSpace(settings.Source))
             {
                 Directory.CreateDirectory(contentDir);
-                File.Copy(settings.Source!, contentPath, overwrite: settings.Overwrite);
-                copied = contentPath;
+                if (File.Exists(contentPath) && !settings.Overwrite)
+                {
+                    // The manifest is on disk by now, so throwing here would report a failed
+                    // command that half succeeded. Warn like the label-file path does and let
+                    // the caller decide — the file that is already there may well be the right
+                    // one.
+                    warnings.Add($"{contentPath} already exists and was left alone; --source was not copied over it. Pass --overwrite to replace it.");
+                }
+                else
+                {
+                    File.Copy(settings.Source!, contentPath, overwrite: settings.Overwrite);
+                    copied = contentPath;
+                }
             }
             else if (!File.Exists(contentPath))
             {
@@ -368,6 +379,14 @@ public sealed class GenerateLabelFileCommand : Command<GenerateLabelFileCommand.
             package = model = id;
             warnings.Add($"No --model given and --out is not inside a <package>/<model>/AxLabelFile/ folder, so RelativeUriInModelStore starts with '{id}\\{id}'. Pass --model <Model> for the real path.");
         }
+        else if (string.IsNullOrWhiteSpace(package))
+        {
+            // A model folder with no package folder above it — an --out pointing at a bare
+            // <model>/AxLabelFile/. The convention is package == model, which is what the
+            // single-model packages on an AOS look like anyway.
+            package = model;
+            warnings.Add($"--out has a model folder but no package folder above it, so RelativeUriInModelStore starts with '{model}\\{model}'. Pass --model <Model> if the package is named differently.");
+        }
 
         XDocument doc;
         try { doc = ConfigurationScaffolder.LabelFile(id, language, package!, model!); }
@@ -387,12 +406,30 @@ public sealed class GenerateLabelFileCommand : Command<GenerateLabelFileCommand.
             var contentPath = Path.Combine(Path.GetDirectoryName(Path.GetFullPath(outPath!))!,
                 "LabelResources", language, ConfigurationScaffolder.LabelContentFileName(id, language));
             Directory.CreateDirectory(Path.GetDirectoryName(contentPath)!);
-            if (File.Exists(contentPath) && !settings.Overwrite)
+            string? contentBackup = null;
+            var contentExists = File.Exists(contentPath);
+            if (contentExists && entries.Count == 0)
+            {
+                // Re-running the command to refresh the manifest must not empty the labels
+                // beside it. --overwrite is about the file this command owns; the .label.txt
+                // holds work `labels create` put there, and writing nothing over it is data
+                // loss dressed up as a successful generate.
+                warnings.Add($"{contentPath} already holds labels and no --entry was given, so it was left untouched. Add to it with `d365fo labels create`.");
+            }
+            else if (contentExists && !settings.Overwrite)
             {
                 warnings.Add($"{contentPath} already exists and was left alone; --entry values were not written. Use `d365fo labels create` to add to it, or --overwrite to replace it.");
             }
             else
             {
+                if (contentExists)
+                {
+                    // The manifest is written through ScaffoldFileWriter, which keeps a .bak and
+                    // journals the pre-image; the content file is written here and would have
+                    // neither. Same convention, so the recovery story is the same on both files.
+                    contentBackup = contentPath + ".bak";
+                    File.Copy(contentPath, contentBackup, overwrite: true);
+                }
                 var sb = new StringBuilder();
                 foreach (var (key, text) in entries) sb.Append(key).Append('=').Append(text).Append("\r\n");
                 File.WriteAllText(contentPath, sb.ToString(), new UTF8Encoding(encoderShouldEmitUTF8Identifier: true));
@@ -407,6 +444,7 @@ public sealed class GenerateLabelFileCommand : Command<GenerateLabelFileCommand.
                 model,
                 labels = entries.Count,
                 content = contentPath,
+                contentBackup,
                 path = res.Path,
                 bytes = res.Bytes,
                 backup = res.BackupPath,

--- a/src/D365FO.Cli/Commands/Generate/GenerateEntityShapeCommands.cs
+++ b/src/D365FO.Cli/Commands/Generate/GenerateEntityShapeCommands.cs
@@ -87,6 +87,15 @@ public sealed class GenerateCompositeEntityCommand : Command<GenerateCompositeEn
                     $"--embedded '{e.Entity}' names parent '{e.Parent}', which is neither a root nor an embedded reference."));
         }
 
+        // A parent that resolves is not the same as a parent chain that arrives somewhere: two
+        // entities naming each other are dropped by the tree walk below and would be reported
+        // as bundled anyway.
+        var unrooted = EntityShapeScaffolder.UnrootedEmbedded(embedded.Select(e => (e.RefName, e.Parent)));
+        if (unrooted.Count > 0)
+            return RenderHelpers.Render(kind, ToolResult<object>.Fail(D365FoErrorCodes.BadInput,
+                $"--embedded {string.Join(", ", unrooted.Select(u => $"'{u}'"))} never reaches a --root: the parent chain loops.",
+                hint: "Every embedded entity hangs, directly or through other embedded entities, off a root."));
+
         CompositeEntityReferenceSpec Build(string refName)
         {
             var n = nodes[refName];

--- a/src/D365FO.Cli/Commands/Generate/GenerateNavigationCommands.cs
+++ b/src/D365FO.Cli/Commands/Generate/GenerateNavigationCommands.cs
@@ -187,7 +187,7 @@ public sealed class GenerateTileCommand : Command<GenerateTileCommand.Settings>
         public string Name { get; init; } = "";
 
         [CommandOption("--menu-item <NAME>")]
-        [System.ComponentModel.Description("Menu item the tile opens. Required — every shipped tile has one.")]
+        [System.ComponentModel.Description("Menu item the tile opens. Required for a Standard or Count tile; a KPI tile binds --kpi and a Link tile --url instead.")]
         public string? MenuItem { get; init; }
 
         [CommandOption("--menu-item-type <TYPE>")]
@@ -195,7 +195,7 @@ public sealed class GenerateTileCommand : Command<GenerateTileCommand.Settings>
         public string? MenuItemType { get; init; }
 
         [CommandOption("--type <TYPE>")]
-        [System.ComponentModel.Description("Standard (default, omitted) | Count (shows a record count from --query) | KPI (needs --kpi) | Link.")]
+        [System.ComponentModel.Description("Standard (default, omitted) | Count (shows a record count from --query) | KPI (needs --kpi) | Link (needs --url).")]
         public string? Type { get; init; }
 
         [CommandOption("--label <KEY>")]
@@ -224,6 +224,10 @@ public sealed class GenerateTileCommand : Command<GenerateTileCommand.Settings>
         [System.ComponentModel.Description("AxKPI a KPI tile shows.")]
         public string? Kpi { get; init; }
 
+        [CommandOption("--url <ADDRESS>")]
+        [System.ComponentModel.Description("Address a Link tile opens, e.g. https://learn.microsoft.com/dynamics365/. Link tiles only.")]
+        public string? Url { get; init; }
+
         [CommandOption("--configuration-key <NAME>")]
         public string? ConfigurationKey { get; init; }
     }
@@ -233,27 +237,30 @@ public sealed class GenerateTileCommand : Command<GenerateTileCommand.Settings>
         var kind = OutputMode.Resolve(settings.Output);
         if (string.IsNullOrWhiteSpace(settings.Name))
             return RenderHelpers.Render(kind, ToolResult<object>.Fail(D365FoErrorCodes.BadInput, "Tile name required."));
-        if (string.IsNullOrWhiteSpace(settings.MenuItem))
-            return RenderHelpers.Render(kind, ToolResult<object>.Fail(D365FoErrorCodes.BadInput,
-                "--menu-item <NAME> required.", hint: "A tile opens a menu item; create one first with `d365fo generate menu-item`."));
 
         XDocument doc;
         try
         {
-            doc = NavigationScaffolder.Tile(settings.Name, settings.MenuItem!, settings.Type, settings.Label, settings.Size,
+            // What a tile has to bind to depends on its type, so the scaffolder decides — it is
+            // the one place that knows Standard and Count open a menu item while KPI and Link
+            // do not.
+            doc = NavigationScaffolder.Tile(settings.Name, settings.MenuItem, settings.Type, settings.Label, settings.Size,
                 settings.Image, settings.Display, settings.Query, settings.Kpi, settings.ConfigurationKey,
-                settings.MenuItemType, settings.HelpText);
+                settings.MenuItemType, settings.HelpText, settings.Url);
         }
         catch (ArgumentException ex)
         {
-            return RenderHelpers.Render(kind, ToolResult<object>.Fail(D365FoErrorCodes.BadInput, ex.Message));
+            return RenderHelpers.Render(kind, ToolResult<object>.Fail(D365FoErrorCodes.BadInput, ex.Message,
+                hint: ex.ParamName == "menuItemName"
+                    ? "Create the menu item first with `d365fo generate menu-item`, or pass --type KPI/--type Link for a tile that opens something else."
+                    : null));
         }
 
         if (!GenerateViewCommand.TryResolveOutPath(kind, settings, Folders.Tile, settings.Name, out var outPath, out var pathFailure))
             return pathFailure;
 
         var warnings = new List<string>();
-        var unknown = NavigationGrounding.UnknownMenuItems(new[] { settings.MenuItem! });
+        var unknown = NavigationGrounding.UnknownMenuItems(new[] { settings.MenuItem ?? "" });
         if (NavigationGrounding.Warning(unknown, "Menu item") is { } w) warnings.Add(w);
 
         try
@@ -273,6 +280,7 @@ public sealed class GenerateTileCommand : Command<GenerateTileCommand.Settings>
                 type = settings.Type ?? "Standard",
                 query = settings.Query,
                 kpi = settings.Kpi,
+                url = settings.Url,
                 unknownMenuItems = unknown.Count > 0 ? unknown : null,
                 path = res.Path,
                 bytes = res.Bytes,

--- a/src/D365FO.Core/Eval/EvalScorer.cs
+++ b/src/D365FO.Core/Eval/EvalScorer.cs
@@ -1,3 +1,4 @@
+using System.Text;
 using System.Text.RegularExpressions;
 using System.Xml.Linq;
 using D365FO.Core.Index;
@@ -92,14 +93,18 @@ public static class EvalScorer
     {
         var companionDir = Path.Combine(goldenDir, "_companions");
         var actualDir = producedDir ?? Path.GetDirectoryName(Path.GetFullPath(actualXmlPath))!;
-        var actualName = Path.GetFileName(actualXmlPath);
+        var scored = Path.GetFullPath(actualXmlPath);
 
+        // Recursive, and not only XML: a content companion sits in a sub-folder that mirrors
+        // where it lands beside the artefact — LabelResources/<lang>/, ResourceContent/<Type>/ —
+        // so a flat *.xml walk saw neither the golden's copy nor the run's.
         var expected = Directory.Exists(companionDir)
-            ? Directory.GetFiles(companionDir, "*.xml")
+            ? Directory.GetFiles(companionDir, "*", SearchOption.AllDirectories)
             : Array.Empty<string>();
-        var produced = Directory.GetFiles(actualDir, "*.xml")
-            .Where(f => !string.Equals(Path.GetFileName(f), actualName, StringComparison.OrdinalIgnoreCase))
-            .ToDictionary(f => Path.GetFileName(f)!, f => f, StringComparer.OrdinalIgnoreCase);
+        var produced = Directory.GetFiles(actualDir, "*", SearchOption.AllDirectories)
+            .Where(f => !string.Equals(Path.GetFullPath(f), scored, StringComparison.OrdinalIgnoreCase))
+            .Where(f => !IsWriterSidecar(f))
+            .ToDictionary(f => RelativeName(actualDir, f), f => f, StringComparer.OrdinalIgnoreCase);
 
         if (expected.Length == 0 && produced.Count == 0) return diff;
 
@@ -109,10 +114,25 @@ public static class EvalScorer
 
         foreach (var goldenCompanion in expected.OrderBy(f => f, StringComparer.Ordinal))
         {
-            var name = Path.GetFileName(goldenCompanion);
+            var name = RelativeName(companionDir, goldenCompanion);
             if (!produced.Remove(name, out var actualCompanion))
             {
                 missing.Add($"_companions/{name}");
+                continue;
+            }
+
+            // Not every companion is XML. A label file's .label.txt and a resource's image are
+            // the artefact as far as the platform is concerned — the manifest beside them is
+            // only a pointer — so they are compared as content. Diffing only the XML is what let
+            // `generate label-file --overwrite` truncate a .label.txt to a bare BOM with both
+            // its cases still green.
+            if (!IsXml(name))
+            {
+                var expectedBytes = File.ReadAllBytes(goldenCompanion);
+                var actualBytes = File.ReadAllBytes(actualCompanion);
+                if (!ContentEquals(expectedBytes, actualBytes))
+                    changed.Add(new XmlGoldenChange($"_companions/{name}",
+                        Describe(expectedBytes), Describe(actualBytes)));
                 continue;
             }
 
@@ -141,6 +161,57 @@ public static class EvalScorer
         }
 
         return new XmlGoldenDiff(missing, extra, changed);
+    }
+
+    /// <summary>A file's path relative to <paramref name="root"/>, always with forward slashes.</summary>
+    private static string RelativeName(string root, string file)
+        => Path.GetRelativePath(root, file).Replace('\\', '/');
+
+    private static bool IsXml(string name)
+        => name.EndsWith(".xml", StringComparison.OrdinalIgnoreCase);
+
+    /// <summary>
+    /// Files the writer leaves beside what it wrote rather than artefacts the command produced:
+    /// the <c>.bak</c> an overwrite keeps for manual recovery, and the per-call
+    /// <c>.&lt;guid&gt;.tmp</c> a write stages through. A case that merges into a seed
+    /// (<c>apply_to_seed</c>) always makes the first of those, and it says nothing about the
+    /// artefact.
+    /// </summary>
+    private static bool IsWriterSidecar(string path)
+    {
+        var name = Path.GetFileName(path);
+        return name.EndsWith(".bak", StringComparison.OrdinalIgnoreCase)
+            || name.EndsWith(".tmp", StringComparison.OrdinalIgnoreCase);
+    }
+
+    /// <summary>
+    /// Whether two content companions are the same file. Bytes first; text that differs only in
+    /// its BOM or line endings is the same content, because git owns both on the way to a
+    /// checkout and neither says anything about what the tool produced.
+    /// </summary>
+    private static bool ContentEquals(byte[] expected, byte[] actual)
+    {
+        if (expected.AsSpan().SequenceEqual(actual)) return true;
+        if (!LooksTextual(expected) || !LooksTextual(actual)) return false;
+        return string.Equals(NormalizeText(expected), NormalizeText(actual), StringComparison.Ordinal);
+    }
+
+    private static bool LooksTextual(byte[] bytes) => !bytes.Contains((byte)0);
+
+    private static string NormalizeText(byte[] bytes)
+        => new UTF8Encoding(encoderShouldEmitUTF8Identifier: false).GetString(bytes)
+            .TrimStart(Bom).Replace("\r\n", "\n");
+
+    /// <summary>U+FEFF, as it arrives when a UTF-8 file with a byte-order mark is decoded.</summary>
+    private const char Bom = (char)0xFEFF;
+
+    private static string Describe(byte[] bytes)
+    {
+        if (!LooksTextual(bytes)) return $"<{bytes.Length} bytes>";
+        var text = NormalizeText(bytes);
+        return text.Length == 0
+            ? "<empty>"
+            : text.Length <= 200 ? text : text[..200] + "…";
     }
 
     /// <summary>Same heuristic as <c>ValidateXppCommand.DetectCodeType</c> (Cli project) — duplicated rather than shared across the Core/Cli boundary for a 3-line check.</summary>

--- a/src/D365FO.Core/Eval/EvalScorer.cs
+++ b/src/D365FO.Core/Eval/EvalScorer.cs
@@ -101,10 +101,22 @@ public static class EvalScorer
         var expected = Directory.Exists(companionDir)
             ? Directory.GetFiles(companionDir, "*", SearchOption.AllDirectories)
             : Array.Empty<string>();
-        var produced = Directory.GetFiles(actualDir, "*", SearchOption.AllDirectories)
-            .Where(f => !string.Equals(Path.GetFullPath(f), scored, StringComparison.OrdinalIgnoreCase))
-            .Where(f => !IsWriterSidecar(f))
-            .ToDictionary(f => RelativeName(actualDir, f), f => f, StringComparer.OrdinalIgnoreCase);
+
+        // Only a directory the caller owns gets walked. Without one the scorer looks the
+        // golden's companions up by path instead: the artefact may be sitting in a shared temp
+        // directory, where enumerating everything is both meaningless — that is why extras are
+        // not reported either — and, on Linux, an UnauthorizedAccessException from somebody
+        // else's subtree of /tmp.
+        var produced = producedDir is null
+            ? new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase)
+            : Directory.GetFiles(producedDir, "*", new EnumerationOptions
+                {
+                    RecurseSubdirectories = true,
+                    IgnoreInaccessible = true,
+                })
+                .Where(f => !string.Equals(Path.GetFullPath(f), scored, StringComparison.OrdinalIgnoreCase))
+                .Where(f => !IsWriterSidecar(f))
+                .ToDictionary(f => RelativeName(producedDir, f), f => f, StringComparer.OrdinalIgnoreCase);
 
         if (expected.Length == 0 && produced.Count == 0) return diff;
 
@@ -117,8 +129,13 @@ public static class EvalScorer
             var name = RelativeName(companionDir, goldenCompanion);
             if (!produced.Remove(name, out var actualCompanion))
             {
-                missing.Add($"_companions/{name}");
-                continue;
+                var beside = Path.Combine(actualDir, name.Replace('/', Path.DirectorySeparatorChar));
+                if (producedDir is not null || !File.Exists(beside))
+                {
+                    missing.Add($"_companions/{name}");
+                    continue;
+                }
+                actualCompanion = beside;
             }
 
             // Not every companion is XML. A label file's .label.txt and a resource's image are

--- a/src/D365FO.Core/Eval/L3ModelProvisioner.cs
+++ b/src/D365FO.Core/Eval/L3ModelProvisioner.cs
@@ -133,10 +133,12 @@ public static class L3ModelProvisioner
             files.AddRange(Companions(caseDir));
 
             // The scored golden's AOT folder is where content companions land: a label
-            // file's .label.txt, a resource's .png. Resolved before the loop so a skipped
-            // golden cannot leave the content pointing at nothing.
-            var (mainRoot, _, _) = ReadIdentity(files[0]);
-            var mainFolder = mainRoot is null ? null : ObjectTypeRegistry.Find(mainRoot)?.AotSubfolder;
+            // file's .label.txt, a resource's .png. Resolved from the same two checks the
+            // copy loop below applies to the manifest itself, so a golden that loop skips
+            // does not leave its content behind in the model with nothing pointing at it.
+            var (mainRoot, _, mainError) = ReadIdentity(files[0]);
+            var mainType = mainError is null && mainRoot is not null ? ObjectTypeRegistry.Find(mainRoot) : null;
+            var mainFolder = mainType is { ExistsInStandardAot: true } ? mainType.AotSubfolder : null;
             foreach (var (content, relativeUnderCompanions) in ContentCompanions(caseDir))
             {
                 if (mainFolder is null) break;
@@ -196,8 +198,9 @@ public static class L3ModelProvisioner
     /// buried the real defects underneath it.
     /// </para>
     /// <para>
-    /// Companions live in a <c>_companions</c> subfolder, invisible to the scorer
-    /// (which enumerates the case directory non-recursively) and compiled here. They
+    /// Companions live in a <c>_companions</c> subfolder, outside the one file the
+    /// case scores (the scorer enumerates the case directory non-recursively) though
+    /// it does diff them, and compiled here. They
     /// are captured from the same command run as the golden, so they stay honest:
     /// a companion that drifts from what the tool emits shows up as a build failure,
     /// exactly like the golden itself.

--- a/src/D365FO.Core/ObjectTypes/ObjectTypeRegistry.cs
+++ b/src/D365FO.Core/ObjectTypes/ObjectTypeRegistry.cs
@@ -223,9 +223,9 @@ namespace D365FO.Core.ObjectTypes
                 // There is no AxQueryExtension type at all — the bridge used to name one.
                 New("queryextension", "AxQuerySimpleExtension", "QuerySimpleExtensions", "extension", null, "QueryExtension"),
                 New("dataentityviewextension", "AxDataEntityViewExtension", "DataEntityViewExtensions", "extension", null, "DataEntityViewExtension"),
-                // Folder ships in every model; no standard model has a file in it yet, and
-                // `generate extension` takes no Map kind — the null is the truth here, unlike
-                // the three rows above, which named no command while the command built them.
+                // Folder ships in every model and no standard model has a file in it yet, so
+                // there is nothing here to index — but `generate extension --kind map` does
+                // build one, which is what the command name records.
                 New("mapextension", "AxMapExtension", "MapExtensions", "extension", null, "MapExtension"),
                 New("securitydutyextension", "AxSecurityDutyExtension", "SecurityDutyExtensions", "extension", null, "SecurityDutyExtension"),
                 New("securityroleextension", "AxSecurityRoleExtension", "SecurityRoleExtensions", "extension", null, "SecurityRoleExtension"),
@@ -246,7 +246,7 @@ namespace D365FO.Core.ObjectTypes
                 New("workflowapproval", "AxWorkflowApproval", "WorkflowApprovals", "workflow", null, "WorkflowApproval", ns: NsV2),
                 New("workflowtask", "AxWorkflowTask", "WorkflowTasks", "workflow", null, "WorkflowTask", ns: NsV2),
 
-                // ── Read-only types the index knows but nothing generates ───────────
+                // ── The small kinds: each has a generate subcommand of its own ──────
                 New("workflowcategory", "AxWorkflowCategory", "WorkflowCategories", "workflow-category", null, "WorkflowCategory", indexed: false, ns: NsV2),
                 New("configurationkey", "AxConfigurationKey", "ConfigurationKeys", "configuration-key", null, "ConfigurationKey"),
                 New("labelfile", "AxLabelFile", "LabelFiles", "label-file", null, "LabelFile"),

--- a/src/D365FO.Core/Scaffolding/EntityShapeScaffolder.cs
+++ b/src/D365FO.Core/Scaffolding/EntityShapeScaffolder.cs
@@ -54,6 +54,42 @@ public static class EntityShapeScaffolder
     private static readonly XNamespace V2 = "Microsoft.Dynamics.AX.Metadata.V2";
 
     /// <summary>
+    /// The embedded references whose parent chain never arrives at a root, in the order they
+    /// were declared.
+    /// </summary>
+    /// <remarks>
+    /// The tree handed to <see cref="CompositeDataEntityView"/> is built by walking down from
+    /// the roots, so a reference in a parent cycle — <c>A</c> under <c>B</c> under <c>A</c> — is
+    /// simply never reached. Every parent name resolves, nothing throws, and the entity is
+    /// reported as bundled while <c>EmbeddedDataEntities</c> comes out empty. The cycle has to
+    /// be caught where the parent map still exists, which is the caller that parsed the specs,
+    /// so both the CLI and the MCP handler ask this rather than each having its own answer.
+    /// </remarks>
+    public static IReadOnlyList<string> UnrootedEmbedded(IEnumerable<(string RefName, string Parent)> embedded)
+    {
+        ArgumentNullException.ThrowIfNull(embedded);
+        var parentOf = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
+        var order = new List<string>();
+        foreach (var (refName, parent) in embedded)
+        {
+            if (parentOf.TryAdd(refName, parent)) order.Add(refName);
+        }
+
+        var unrooted = new List<string>();
+        foreach (var refName in order)
+        {
+            var seen = new HashSet<string>(StringComparer.OrdinalIgnoreCase) { refName };
+            var at = parentOf[refName];
+            while (parentOf.TryGetValue(at, out var next))
+            {
+                if (!seen.Add(at)) { unrooted.Add(refName); break; }
+                at = next;
+            }
+        }
+        return unrooted;
+    }
+
+    /// <summary>
     /// An <c>AxCompositeDataEntityView</c> over one or more root entities, each with the
     /// entities embedded under it.
     /// </summary>

--- a/src/D365FO.Core/Scaffolding/NavigationScaffolder.cs
+++ b/src/D365FO.Core/Scaffolding/NavigationScaffolder.cs
@@ -159,13 +159,21 @@ public static class NavigationScaffolder
     }
 
     /// <summary>
-    /// An <c>AxTile</c>: a workspace or dashboard tile bound to a menu item. Of the 775 tiles
-    /// this installation ships, every one carries <c>MenuItemName</c>; <c>Type</c> is written
-    /// only when it is not the default <c>Standard</c>.
+    /// An <c>AxTile</c>: a workspace or dashboard tile, bound to whatever its type opens.
+    /// <c>Type</c> is written only when it is not the default <c>Standard</c>.
     /// </summary>
+    /// <remarks>
+    /// What a tile binds to follows from its type, counted on this installation's 770 tiles:
+    /// 762 carry <c>MenuItemName</c> and all of them are Standard or Count. The eight that do
+    /// not are the other two types — a Link tile carries <c>URL</c>
+    /// (<c>CTPTechDocumentation</c>) and a KPI tile carries <c>KPI</c>
+    /// (<c>QMSCAPAAvgDaysToCloseAllCases</c>) instead. Requiring a menu item on every tile,
+    /// as this used to, made those two types impossible to write correctly while still
+    /// offering them.
+    /// </remarks>
     public static XDocument Tile(
         string name,
-        string menuItemName,
+        string? menuItemName,
         string? type = null,
         string? label = null,
         string? size = null,
@@ -175,21 +183,31 @@ public static class NavigationScaffolder
         string? kpi = null,
         string? configurationKey = null,
         string? menuItemType = null,
-        string? helpText = null)
+        string? helpText = null,
+        string? url = null)
     {
         if (string.IsNullOrWhiteSpace(name))
             throw new ArgumentException("Tile name is required.", nameof(name));
-        if (string.IsNullOrWhiteSpace(menuItemName))
-            throw new ArgumentException("A tile opens a menu item; --menu-item is required.", nameof(menuItemName));
 
         var tileType = type is null ? "Standard" : Canonical(TileTypes, type, "tile type");
-        if (string.Equals(tileType, "KPI", StringComparison.Ordinal) && string.IsNullOrWhiteSpace(kpi))
-            throw new ArgumentException("A KPI tile names the KPI it shows; pass --kpi <AxKPI name>.", nameof(kpi));
+        switch (tileType)
+        {
+            case "KPI" when string.IsNullOrWhiteSpace(kpi):
+                throw new ArgumentException("A KPI tile names the KPI it shows; pass --kpi <AxKPI name>.", nameof(kpi));
+            case "Link" when string.IsNullOrWhiteSpace(url):
+                throw new ArgumentException("A Link tile opens a URL; pass --url <address>.", nameof(url));
+            case "Standard" or "Count" when string.IsNullOrWhiteSpace(menuItemName):
+                throw new ArgumentException(
+                    $"A {tileType} tile opens a menu item; --menu-item is required.", nameof(menuItemName));
+        }
+        if (!string.IsNullOrWhiteSpace(url) && !string.Equals(tileType, "Link", StringComparison.Ordinal))
+            throw new ArgumentException($"--url is a Link tile's target; a {tileType} tile has no URL member to put it in.", nameof(url));
 
         var root = new XElement("AxTile",
             new XAttribute(XNamespace.Xmlns + "i", Xsi.NamespaceName),
-            new XElement("Name", name),
-            new XElement("MenuItemName", menuItemName));
+            new XElement("Name", name));
+        if (!string.IsNullOrWhiteSpace(menuItemName)) root.Add(new XElement("MenuItemName", menuItemName));
+        if (!string.IsNullOrWhiteSpace(url)) root.Add(new XElement("URL", url));
         if (!string.IsNullOrEmpty(normalImage)) root.Add(new XElement("NormalImage", normalImage));
         if (!string.IsNullOrEmpty(label)) root.Add(new XElement("Label", label));
         if (size is not null) root.Add(new XElement("Size", Canonical(TileSizes, size, "tile size")));

--- a/src/D365FO.Core/Scaffolding/PropertyHonesty.cs
+++ b/src/D365FO.Core/Scaffolding/PropertyHonesty.cs
@@ -42,9 +42,19 @@ public static class PropertyHonesty
     /// Values that carry a request but never survive as text: they select a shape rather than
     /// supply a value, so their absence from the document says nothing.
     /// </summary>
+    /// <remarks>
+    /// The second row is the enum defaults the scaffolders deliberately do not write, because
+    /// shipped files do not write them either — <c>--type Standard</c> on a tile,
+    /// <c>--menu-item-type Display</c>, <c>--display Auto</c>. Asking for the default and
+    /// getting the default is the option working, so reporting it as a dropped value is a
+    /// warning that trains the reader to ignore the check. This stays a short list of words
+    /// rather than an option→member table for the reason the class remarks give: the blunt
+    /// version is wrong in one direction only.
+    /// </remarks>
     private static readonly HashSet<string> Untraceable = new(StringComparer.OrdinalIgnoreCase)
     {
         "true", "false", "yes", "no", "none", "default", "auto",
+        "standard", "display",
     };
 
     private static readonly char[] CompositeSeparators = [':', ',', ';', '|', '=', '/'];

--- a/src/D365FO.Mcp/ToolCatalog.cs
+++ b/src/D365FO.Mcp/ToolCatalog.cs
@@ -467,8 +467,9 @@ public static class ToolCatalog
             "`language`, `model`, `entries` \"<Key>=<Text>\"; returns the manifest plus the content to write beside " +
             "it) · menu (`submenus` \"<name>[:<label>]\", `items` \"[<submenu>/]<menuItem>[:Action|Output]\", " +
             "`tiles`, `menuRefs`, `inContentArea`, `setCompany`) · resource (`fileName`, `model`, `resourceType`; " +
-            "the content file is yours to place) · tile (`menuItem`, `tileType` Standard|Count|KPI|Link, `size`, " +
-            "`image`, `display`, `query`, `kpi`) · workflow-category (`module` — a ModuleAxapta value, checked " +
+            "the content file is yours to place) · tile (`tileType` Standard|Count|KPI|Link and the target it " +
+            "implies — `menuItem` for Standard/Count, `kpi` for KPI, `url` for Link; plus `tileSize` " +
+            "Medium|Wide|ShortWide|Large, `image`, `display`, `query`) · workflow-category (`module` — a ModuleAxapta value, checked " +
             "against the index) · composite-entity (`roots` \"<entity>[:<ref>]\", `embedded` " +
             "\"<entity>:<relation>[:<parentRef>]\") · aggregate-entity (`measurement`, `measures` " +
             "\"<field>:<group>:<measure>:<edt>\", `dimensions` \"<field>:<group>:<dimension>:<attribute>:<edt>\").",
@@ -513,6 +514,7 @@ public static class ToolCatalog
                    ("tiles", "array", false), ("menuRefs", "array", false), ("inContentArea", "boolean", false),
                    ("setCompany", "boolean", false), ("fileName", "string", false), ("resourceType", "string", false),
                    ("menuItem", "string", false), ("menuItemType", "string", false), ("tileType", "string", false),
+                   ("tileSize", "string", false), ("url", "string", false),
                    ("helpText", "string", false), ("image", "string", false), ("display", "string", false),
                    ("kpi", "string", false), ("module", "string", false), ("roots", "array", false),
                    ("embedded", "array", false), ("tags", "string", false), ("modules", "string", false),
@@ -593,9 +595,13 @@ public static class ToolCatalog
                                         StrOrNull(p, "configurationKey")),
                 "resource"        => h.GenerateResource(Str(p, "name"), StrOrNull(p, "fileName"), StrOrNull(p, "model"),
                                         StrOrNull(p, "resourceType"), StrOrNull(p, "label")),
+                // tileSize, not size: `size` is declared integer for `edt`, and one flat schema
+                // with additionalProperties:false means a client that obeys it cannot send
+                // "Wide" under that name at all.
                 "tile"            => h.GenerateTile(Str(p, "name"), StrOrNull(p, "menuItem"), StrOrNull(p, "tileType"), StrOrNull(p, "label"),
-                                        StrOrNull(p, "size"), StrOrNull(p, "image"), StrOrNull(p, "display"), StrOrNull(p, "query"),
-                                        StrOrNull(p, "kpi"), StrOrNull(p, "configurationKey"), StrOrNull(p, "menuItemType"), StrOrNull(p, "helpText")),
+                                        StrAliasOrNull(p, "tileSize", "size"), StrOrNull(p, "image"), StrOrNull(p, "display"), StrOrNull(p, "query"),
+                                        StrOrNull(p, "kpi"), StrOrNull(p, "configurationKey"), StrOrNull(p, "menuItemType"), StrOrNull(p, "helpText"),
+                                        StrOrNull(p, "url")),
                 "workflow-category" => h.GenerateWorkflowCategory(Str(p, "name"), StrOrNull(p, "module"), StrOrNull(p, "label"), StrOrNull(p, "helpText")),
                 "composite-entity" => h.GenerateCompositeEntity(Str(p, "name"), StrArray(p, "roots"), StrArray(p, "embedded"),
                                         StrOrNull(p, "label"), StrOrNull(p, "tags"), StrOrNull(p, "modules"), StrOrNull(p, "entityCategory")),
@@ -1021,9 +1027,23 @@ public static class ToolCatalog
         };
     }
 
+    /// <summary>
+    /// A parameter as text. Numbers and booleans are rendered rather than rejected: one flat
+    /// schema is shared by every objectType, so a property another type declares as an integer
+    /// arrives here as a JSON number, and <c>GetString()</c> throws
+    /// <c>InvalidOperationException</c> on anything but a string — a handler crash where the
+    /// honest answer is the value the client sent.
+    /// </summary>
     private static string Str(JsonElement p, string name) =>
         p.ValueKind == JsonValueKind.Object && p.TryGetProperty(name, out var v)
-            ? v.GetString() ?? "" : "";
+            ? v.ValueKind switch
+            {
+                JsonValueKind.String => v.GetString() ?? "",
+                JsonValueKind.Null or JsonValueKind.Undefined => "",
+                JsonValueKind.Object or JsonValueKind.Array => "",
+                _ => v.ToString(),
+            }
+            : "";
 
     private static string StrOr(JsonElement p, string name, string dflt)
     {

--- a/src/D365FO.Mcp/ToolHandlers.SmallObjects.cs
+++ b/src/D365FO.Mcp/ToolHandlers.SmallObjects.cs
@@ -157,18 +157,20 @@ public sealed partial class ToolHandlers
 
     public ToolResult<object> GenerateTile(
         string name, string? menuItem, string? tileType, string? label, string? size, string? image, string? display,
-        string? query, string? kpi, string? configurationKey, string? menuItemType, string? helpText)
+        string? query, string? kpi, string? configurationKey, string? menuItemType, string? helpText, string? url)
     {
         if (string.IsNullOrWhiteSpace(name)) return Required("name", "objectType=tile");
-        if (string.IsNullOrWhiteSpace(menuItem)) return Required("menuItem", "objectType=tile");
         try
         {
-            var doc = NavigationScaffolder.Tile(name, menuItem!, tileType, label, size, image, display, query, kpi,
-                configurationKey, menuItemType, helpText);
+            // menuItem is required for a Standard or Count tile and meaningless for the other
+            // two; the scaffolder holds that rule so both surfaces enforce the same one.
+            var doc = NavigationScaffolder.Tile(name, menuItem, tileType, label, size, image, display, query, kpi,
+                configurationKey, menuItemType, helpText, url);
             return ToolResult<object>.Success(new
             {
-                name, kind = "AxTile", menuItem, type = tileType ?? "Standard",
-                unknownMenuItems = SafeMenuItemExists(menuItem!) ? null : new[] { menuItem },
+                name, kind = "AxTile", menuItem, url, type = tileType ?? "Standard",
+                unknownMenuItems = string.IsNullOrWhiteSpace(menuItem) || SafeMenuItemExists(menuItem!)
+                    ? null : new[] { menuItem },
                 xml = Aot(doc),
             });
         }
@@ -242,6 +244,14 @@ public sealed partial class ToolHandlers
             if (!nodes.ContainsKey(c.Parent))
                 return ToolResult<object>.Fail(D365FoErrorCodes.BadInput,
                     $"embedded '{c.Entity}' names parent '{c.Parent}', which is neither a root nor an embedded reference.");
+
+        // Resolving is not arriving: a parent cycle is dropped by Build() and reported as
+        // bundled all the same.
+        var unrooted = EntityShapeScaffolder.UnrootedEmbedded(children.Select(c => (c.RefName, c.Parent)));
+        if (unrooted.Count > 0)
+            return ToolResult<object>.Fail(D365FoErrorCodes.BadInput,
+                $"embedded {string.Join(", ", unrooted.Select(u => $"'{u}'"))} never reaches a root: the parent chain loops.",
+                "Every embedded entity hangs, directly or through other embedded entities, off a root.");
 
         CompositeEntityReferenceSpec Build(string refName) => new(
             refName, nodes[refName].Entity, nodes[refName].Relation,

--- a/tests/D365FO.Cli.Tests/GenerateContentFileTests.cs
+++ b/tests/D365FO.Cli.Tests/GenerateContentFileTests.cs
@@ -1,0 +1,101 @@
+using D365FO.Cli.Commands.Generate;
+using Xunit;
+
+namespace D365FO.Cli.Tests;
+
+/// <summary>
+/// The two generate commands that write a file the AOT XML only points at: an
+/// <c>AxLabelFile</c>'s <c>.label.txt</c> and an <c>AxResource</c>'s content.
+/// </summary>
+/// <remarks>
+/// Both go to disk outside <c>ScaffoldFileWriter</c>, so neither gets its backup, its journal
+/// entry or its "target exists" refusal for free. <c>--overwrite</c> with no <c>--entry</c>
+/// used to truncate an existing <c>.label.txt</c> to a bare byte-order mark — a successful
+/// generate that destroyed every label in the file, with nothing to recover from.
+/// </remarks>
+[Collection("EnvIndexDb")]
+public sealed class GenerateContentFileTests : IDisposable
+{
+    private readonly string _dir = Path.Combine(Path.GetTempPath(), $"d365fo-content-{Guid.NewGuid():N}");
+
+    public GenerateContentFileTests() => Directory.CreateDirectory(Path.Combine(_dir, "AxLabelFile"));
+
+    public void Dispose()
+    {
+        try { Directory.Delete(_dir, recursive: true); } catch { }
+    }
+
+    private string LabelManifest(string id) => Path.Combine(_dir, "AxLabelFile", $"{id}_en-US.xml");
+
+    private string LabelContent(string id)
+        => Path.Combine(_dir, "AxLabelFile", "LabelResources", "en-US", $"{id}.en-US.label.txt");
+
+    private static GenerateLabelFileCommand.Settings Settings(string id, string outPath, params string[] entries)
+        => new()
+        {
+            LabelFileId = id,
+            Model = "FleetManagement",
+            Labels = entries,
+            Out = outPath,
+            Overwrite = true,
+            Output = "json",
+        };
+
+    [Fact]
+    public void Overwrite_without_entries_leaves_an_existing_label_file_alone()
+    {
+        var cmd = new GenerateLabelFileCommand();
+        Assert.Equal(0, cmd.Execute(null!, Settings("ConContentA", LabelManifest("ConContentA"),
+            "Vehicles=Vehicles", "Setup=Setup")));
+
+        var content = LabelContent("ConContentA");
+        var before = File.ReadAllText(content);
+        Assert.Contains("Vehicles=Vehicles", before);
+
+        // The manifest is regenerated; the labels beside it are not this command's to discard.
+        Assert.Equal(0, cmd.Execute(null!, Settings("ConContentA", LabelManifest("ConContentA"))));
+
+        Assert.Equal(before, File.ReadAllText(content));
+    }
+
+    [Fact]
+    public void Overwrite_with_entries_replaces_the_content_and_keeps_the_previous_one_as_bak()
+    {
+        var cmd = new GenerateLabelFileCommand();
+        Assert.Equal(0, cmd.Execute(null!, Settings("ConContentB", LabelManifest("ConContentB"), "Vehicles=Vehicles")));
+        Assert.Equal(0, cmd.Execute(null!, Settings("ConContentB", LabelManifest("ConContentB"), "Vehicles=Cars")));
+
+        var content = LabelContent("ConContentB");
+        Assert.Contains("Vehicles=Cars", File.ReadAllText(content));
+        Assert.Contains("Vehicles=Vehicles", File.ReadAllText(content + ".bak"));
+    }
+
+    [Fact]
+    public void An_existing_resource_content_file_is_a_warning_not_a_failed_command()
+    {
+        var source = Path.Combine(_dir, "ConLogo.png");
+        File.WriteAllBytes(source, [0x89, 0x50, 0x4E, 0x47]);
+        var outPath = Path.Combine(_dir, "AxResource", "ConLogo.xml");
+        Directory.CreateDirectory(Path.GetDirectoryName(outPath)!);
+
+        var target = Path.Combine(_dir, "AxResource", "ResourceContent", "Images", "ConLogo.png");
+        Directory.CreateDirectory(Path.GetDirectoryName(target)!);
+        File.WriteAllBytes(target, [0x00]);
+
+        // The manifest is already on disk by the time the copy is attempted, so refusing here
+        // has to be a warning: a thrown IOException reports a failed command that half ran.
+        var exit = new GenerateResourceCommand().Execute(null!, new GenerateResourceCommand.Settings
+        {
+            Name = "ConLogo",
+            Source = source,
+            Model = "FleetManagement",
+            Out = outPath,
+            Overwrite = false,
+            Output = "json",
+        });
+
+        Assert.Equal(0, exit);
+        Assert.True(File.Exists(outPath));
+        Assert.Equal([0x00], File.ReadAllBytes(target));
+    }
+}

--- a/tests/D365FO.Core.Tests/Eval/EvalCompanionAndSeedTests.cs
+++ b/tests/D365FO.Core.Tests/Eval/EvalCompanionAndSeedTests.cs
@@ -150,6 +150,43 @@ public class EvalCompanionAndSeedTests : IDisposable
         Assert.True(score.GoldenMatch);
     }
 
+    /// <summary>
+    /// <c>eval score</c> is handed an artefact, not a directory it owns, and the companions the
+    /// golden names are looked up beside it.
+    /// </summary>
+    [Fact]
+    public void Without_a_produced_directory_a_named_companion_is_still_compared_beside_the_artefact()
+    {
+        Golden(Main);
+        GoldenCompanion("FooHelper.xml", "<AxClass><Name>FooHelper</Name><IsFinal>Yes</IsFinal></AxClass>");
+        var actual = Produce("actual.xml", Main);
+        Produce("FooHelper.xml", "<AxClass><Name>FooHelper</Name></AxClass>");
+
+        var score = EvalScorer.Score(Case("L0-test"), actual, _goldensRoot, _repo);
+
+        Assert.False(score.GoldenMatch);
+        Assert.Contains(score.GoldenDiff.Missing, m => m.StartsWith("_companions/FooHelper.xml:", StringComparison.Ordinal));
+    }
+
+    /// <summary>
+    /// Nothing but the golden's own companions is read from a directory the caller does not own.
+    /// Walking it recursively found the sub-directories of a shared temp directory — on Linux,
+    /// an <c>UnauthorizedAccessException</c> out of another process's subtree of <c>/tmp</c>.
+    /// </summary>
+    [Fact]
+    public void A_directory_the_caller_does_not_own_is_not_walked()
+    {
+        Golden(Main);
+        var actual = Produce("actual.xml", Main);
+        Directory.CreateDirectory(Path.Combine(_workDir, "someone-elses"));
+        File.WriteAllText(Path.Combine(_workDir, "someone-elses", "Whatever.xml"), "<AxClass><Name>Whatever</Name></AxClass>");
+
+        var score = EvalScorer.Score(Case("L0-test"), actual, _goldensRoot, _repo);
+
+        Assert.True(score.GoldenMatch);
+        Assert.Empty(score.GoldenDiff.Extra);
+    }
+
     // ── content companions: the non-XML half of an artefact ───────────────
 
     private void GoldenContentCompanion(string relativePath, string body)

--- a/tests/D365FO.Core.Tests/Eval/EvalCompanionAndSeedTests.cs
+++ b/tests/D365FO.Core.Tests/Eval/EvalCompanionAndSeedTests.cs
@@ -150,6 +150,105 @@ public class EvalCompanionAndSeedTests : IDisposable
         Assert.True(score.GoldenMatch);
     }
 
+    // ── content companions: the non-XML half of an artefact ───────────────
+
+    private void GoldenContentCompanion(string relativePath, string body)
+    {
+        var path = Path.Combine(_goldensRoot, "L0-test", "_companions", relativePath);
+        Directory.CreateDirectory(Path.GetDirectoryName(path)!);
+        File.WriteAllText(path, body);
+    }
+
+    private string ProduceContent(string relativePath, string body)
+    {
+        var path = Path.Combine(_workDir, relativePath);
+        Directory.CreateDirectory(Path.GetDirectoryName(path)!);
+        File.WriteAllText(path, body);
+        return path;
+    }
+
+    private const string LabelContent = "LabelResources/en-US/ConFleet.en-US.label.txt";
+
+    [Fact]
+    public void A_content_companion_that_matches_keeps_the_case_passing()
+    {
+        Golden(Main);
+        GoldenContentCompanion(LabelContent, "Vehicles=Vehicles\r\n");
+        var actual = Produce("actual.xml", Main);
+        ProduceContent(LabelContent, "Vehicles=Vehicles\r\n");
+
+        var score = EvalScorer.Score(Case("L0-test"), actual, _goldensRoot, _repo, producedDir: _workDir);
+
+        Assert.True(score.GoldenMatch);
+    }
+
+    /// <summary>
+    /// The regression this exists for: <c>generate label-file --overwrite</c> with no
+    /// <c>--entry</c> emptied the <c>.label.txt</c> beside the manifest, and both the resource
+    /// and the label-file case stayed green because the scorer only ever diffed XML.
+    /// </summary>
+    [Fact]
+    public void A_content_companion_the_run_emptied_is_reported_as_changed()
+    {
+        Golden(Main);
+        GoldenContentCompanion(LabelContent, "Vehicles=Vehicles\r\nSetup=Setup\r\n");
+        var actual = Produce("actual.xml", Main);
+        ProduceContent(LabelContent, "");
+
+        var score = EvalScorer.Score(Case("L0-test"), actual, _goldensRoot, _repo, producedDir: _workDir);
+
+        Assert.False(score.GoldenMatch);
+        Assert.Contains(score.GoldenDiff.Changed, c => c.Path == $"_companions/{LabelContent}");
+    }
+
+    [Fact]
+    public void A_content_companion_the_run_did_not_write_at_all_is_missing()
+    {
+        Golden(Main);
+        GoldenContentCompanion(LabelContent, "Vehicles=Vehicles\r\n");
+        var actual = Produce("actual.xml", Main);
+
+        var score = EvalScorer.Score(Case("L0-test"), actual, _goldensRoot, _repo, producedDir: _workDir);
+
+        Assert.Contains($"_companions/{LabelContent}", score.GoldenDiff.Missing);
+    }
+
+    /// <summary>
+    /// Git decides the line endings and the BOM of a text file on its way to a checkout, so
+    /// neither can be evidence about what the tool wrote.
+    /// </summary>
+    [Fact]
+    public void A_content_companion_differing_only_in_BOM_and_line_endings_still_matches()
+    {
+        Golden(Main);
+        GoldenContentCompanion(LabelContent, "Vehicles=Vehicles\nSetup=Setup\n");
+        var actual = Produce("actual.xml", Main);
+        var path = Path.Combine(_workDir, LabelContent);
+        Directory.CreateDirectory(Path.GetDirectoryName(path)!);
+        File.WriteAllText(path, "Vehicles=Vehicles\r\nSetup=Setup\r\n",
+            new System.Text.UTF8Encoding(encoderShouldEmitUTF8Identifier: true));
+
+        var score = EvalScorer.Score(Case("L0-test"), actual, _goldensRoot, _repo, producedDir: _workDir);
+
+        Assert.True(score.GoldenMatch);
+    }
+
+    /// <summary>
+    /// The <c>.bak</c> an overwrite leaves behind is the writer's recovery copy, not an artefact
+    /// the command produced — every <c>apply_to_seed</c> case makes one.
+    /// </summary>
+    [Fact]
+    public void A_writer_sidecar_is_not_an_extra_companion()
+    {
+        Golden(Main);
+        var actual = Produce("actual.xml", Main);
+        Produce("actual.xml.bak", Main);
+
+        var score = EvalScorer.Score(Case("L0-test"), actual, _goldensRoot, _repo, producedDir: _workDir);
+
+        Assert.True(score.GoldenMatch);
+    }
+
     // ── the seeds themselves ──────────────────────────────────────────────
 
     /// <summary>

--- a/tests/D365FO.Core.Tests/PropertyHonestyTests.cs
+++ b/tests/D365FO.Core.Tests/PropertyHonestyTests.cs
@@ -97,6 +97,26 @@ public class PropertyHonestyTests
         Assert.Empty(PropertyHonesty.Reconcile([("--label", "  ")], Table));
     }
 
+    /// <summary>
+    /// The scaffolders omit a member whose value is the contract's default, because shipped
+    /// files omit it too — a tile's <c>Type</c> when it is Standard, a menu entry's
+    /// <c>MenuItemType</c> when it is Display. Asking for the default and getting the default is
+    /// the option working, so reporting it as a dropped value trains the reader to ignore this
+    /// check.
+    /// </summary>
+    [Fact]
+    public void A_contract_default_the_writer_omits_is_not_a_gap()
+    {
+        const string tile = "<AxTile><Name>ConFmTile</Name><MenuItemName>FMVehicle</MenuItemName></AxTile>";
+
+        Assert.Empty(PropertyHonesty.Reconcile(
+            [("--type", "Standard"), ("--menu-item-type", "Display"), ("--display", "Auto")], tile));
+
+        // A value that is not a default still is one.
+        var gaps = PropertyHonesty.Reconcile([("--type", "Count")], tile);
+        Assert.Equal("Count", Assert.Single(gaps).Missing);
+    }
+
     [Fact]
     public void An_unparseable_document_falls_back_to_its_raw_text()
     {

--- a/tests/D365FO.Core.Tests/SmallObjectScaffolderTests.cs
+++ b/tests/D365FO.Core.Tests/SmallObjectScaffolderTests.cs
@@ -100,6 +100,55 @@ public class SmallObjectScaffolderTests
         Assert.Throws<ArgumentException>(() => NavigationScaffolder.Tile("X", ""));
     }
 
+    /// <summary>
+    /// What a tile binds to follows from its type. 762 of the 770 the installation ships carry
+    /// <c>MenuItemName</c> and all of them are Standard or Count; the eight that do not are the
+    /// KPI and Link tiles, which carry <c>KPI</c> and <c>URL</c> instead
+    /// (<c>QMSCAPAAvgDaysToCloseAllCases</c>, <c>CTPTechDocumentation</c>). Requiring a menu
+    /// item on every tile made those two shapes unwritable while the command still offered them.
+    /// </summary>
+    [Fact]
+    public void Tile_binds_the_target_its_type_implies_and_not_a_menu_item_for_all_four()
+    {
+        var kpi = NavigationScaffolder.Tile("ConFmKpi", menuItemName: null, type: "KPI",
+            kpi: "QMSCAPAAvgDaysToCloseAllCases", size: "Wide");
+        Assert.Null(kpi.Root!.Element("MenuItemName"));
+        Assert.Equal("QMSCAPAAvgDaysToCloseAllCases", kpi.Root.Element("KPI")!.Value);
+
+        var link = NavigationScaffolder.Tile("ConFmLink", menuItemName: null, type: "Link",
+            url: "https://learn.microsoft.com/dynamics365/", tileDisplay: "TextOnly");
+        Assert.Null(link.Root!.Element("MenuItemName"));
+        Assert.Equal("https://learn.microsoft.com/dynamics365/", link.Root.Element("URL")!.Value);
+        Assert.Equal("Link", link.Root.Element("Type")!.Value);
+
+        // Standard and Count still have to open something, which is what 762 shipped files say.
+        Assert.Throws<ArgumentException>(() => NavigationScaffolder.Tile("X", null));
+        Assert.Throws<ArgumentException>(() => NavigationScaffolder.Tile("X", null, type: "Count", query: "FMVehicleQuery"));
+
+        // A Link tile with no address, and a URL on a type that has no member to hold it.
+        Assert.Throws<ArgumentException>(() => NavigationScaffolder.Tile("X", null, type: "Link"));
+        Assert.Throws<ArgumentException>(() => NavigationScaffolder.Tile("X", "FMVehicle", url: "https://example.com/"));
+    }
+
+    /// <summary>
+    /// A cycle among the embedded references resolves — every parent name exists — but the tree
+    /// is walked down from the roots, so nothing in the cycle is ever reached. The composite
+    /// came out with an empty <c>EmbeddedDataEntities</c> while the caller was told both
+    /// entities were bundled.
+    /// </summary>
+    [Fact]
+    public void Composite_entity_reports_embedded_references_whose_parent_chain_loops()
+    {
+        Assert.Empty(EntityShapeScaffolder.UnrootedEmbedded(
+            [("Lines", "Header"), ("Charges", "Lines")]));
+
+        Assert.Equal(["A", "B"], EntityShapeScaffolder.UnrootedEmbedded(
+            [("A", "B"), ("B", "A")]));
+
+        Assert.Equal(["Self"], EntityShapeScaffolder.UnrootedEmbedded(
+            [("Lines", "Header"), ("Self", "Self")]));
+    }
+
     [Fact]
     public void Menu_nests_entries_under_submenus_in_declaration_order_and_keeps_elements_unnamespaced()
     {


### PR DESCRIPTION
Reviewing #201 against the installation rather than against its own commit message. Every gate that commit claims reproduces here — 0 errors / 109 warnings, 1 857 tests, `eval run` 70/70, `eval coverage --check` 83/83, all ten new goldens `clean` under the real `xppc`. These are what was underneath them.

## The defects

**`generate label-file --overwrite` destroyed labels it was not asked about.** With no `--entry`, the content write ran anyway and put an empty string over an existing `.label.txt` — a 35-byte file became a 3-byte byte-order mark. The content file goes to disk outside `ScaffoldFileWriter`, so there was no `.bak` and no journal entry to recover from either: re-running the command to refresh a manifest silently emptied the label file beside it. An existing file with no `--entry` is now left alone (with a warning); `--entry` with `--overwrite` keeps the previous content as `.bak` and reports it as `contentBackup`.

**A KPI or Link tile could not be written at all.** `--menu-item` was required of every tile, justified as "every shipped tile has one". Counted on this installation: of **770** tiles, **762** carry `<MenuItemName>` and every one of those is `Standard` or `Count`. The eight that do not are the other two types — `QMSCAPAAvgDaysToCloseAllCases` binds `<KPI>`, `CTPTechDocumentation` binds `<URL>` — so the command offered `--type KPI` and `--type Link` while refusing to produce either shape, and had no `--url` option at all. The requirement follows the type now, `--url` exists, and both new shapes compile clean under the real `xppc`:

```xml
<AxTile …><Name>ConFixLink</Name><Label>Docs</Label>
  <TileDisplay>TextOnly</TileDisplay><Type>Link</Type>
  <URL>https://learn.microsoft.com/dynamics365/</URL></AxTile>
```

**A tile's `size` was unreachable over MCP.** One flat `generate_object` schema with `additionalProperties: false` declares `size` as an integer for `edt`, while the tile branch read the same key as a string: a validating client could not send `"Wide"`, and one that obeyed the declared type crashed the handler on `JsonElement.GetString()`. Tiles take `tileSize` now (`size` still accepted as an alias), and `Str` renders a number instead of throwing.

**A cyclic `--embedded` chain was reported as bundled and written as nothing.** `--embedded A:relA:B --embedded B:relB:A` passed every check — each parent name resolves — and produced an empty `<EmbeddedDataEntities />` while the payload and `requiredSymbols` listed both entities. Both surfaces now walk each parent chain to a root through the shared `EntityShapeScaffolder.UnrootedEmbedded`.

**Content companions were never scored.** `eval run` diffed `_companions/*.xml` non-recursively, so the `.label.txt` and `.png` added with the ten subcommands were invisible — `L1-label-file-basic` and `L1-resource-basic` would both have stayed green with the truncation above in place. The scorer walks companions recursively and compares non-XML ones as content (BOM and line endings normalised, since git owns both), and the replay writes its artefacts into a directory of its own so the temp index and the write journal are not read as output.

**`generate resource --source` failed a command that had half succeeded.** An existing content file without `--overwrite` threw out of `File.Copy` *after* the manifest was on disk, reporting `WRITE_FAILED` for a write that happened. It warns now, as the label-file path already did.

## Also

- Property honesty no longer reports a contract default the writer omits by design (`--type Standard`, `--menu-item-type Display`, `--display Auto`).
- The L3 provisioner no longer copies a golden's content companions into the throwaway model when the golden itself is skipped.
- The menu census in `forms-and-navigation` is **80 menus / 59 with inline sub-menus** as measured here, not 81 / 60. The structural claims it makes are exact: 0 files with `<SubMenu>`, 1 with `<MenuName>`. The `TileSize` correction that dropped `Small` is right — shipped values are Medium 8, Wide 244, ShortWide 37, Large 4.
- Two comments in `ObjectTypeRegistry` that #201 made false — "the null is the truth here" over a row whose null it had just filled in, "nothing generates" over nine rows that all name a command — say what their rows say.

## Gates

| | |
|---|---|
| Build | 0 errors, **109** warnings (ratchet holds) |
| Tests | **1 868** passed (was 1 857; +11) |
| `eval run --all` | 70/70 |
| `eval coverage --check` | 83/83 |
| `eval verify-build` | 70 × `clean`, 0 errors |

The new tests pin the regressions themselves: a truncated `.label.txt` now shows up as `changed` in `eval run`, a `.bak` sidecar is not an extra companion, and the tile bindings and the embedded cycle each have a case.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018X8AaWQfKTwnzNwVCcLAu6
