### PR TITLE
docs(copilot): skills live next to the .sln and need VS 2026 18.5+ (#205)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,17 @@ was ported from.
 
 ## [Unreleased]
 
+### Fixed — Copilot skill setup docs (#205)
+
+- SETUP.md, README and the installer header claimed Visual Studio 2022 / 2026 pick up
+  `.github/skills/` and that VS "searches upward from the `.sln`", so one copy in a parent
+  folder covers every solution beneath it. Neither holds: Agent Skills need Visual Studio 2026
+  18.5+ (VS 2022 ignores the folder), and VS discovers solution skills next to the `.sln` only.
+  The docs now say where the folder has to be, offer the personal-skill folder
+  (`%USERPROFILE%\.copilot\skills\`) when several solutions share a parent, point VS 2022
+  users at the legacy `.instructions.md` layout, and explain how to verify discovery in the
+  skills panel.
+
 ### Added — `generate extension Menu`, and menu items as symbols
 
 - **`AxMenuExtension`** — the most common ISV navigation task, adding to a menu Microsoft owns,

--- a/README.md
+++ b/README.md
@@ -145,7 +145,7 @@ Ready to scaffold your first table, form, and CoC extension? Full walkthrough wi
 
 ### GitHub Copilot (VS Code / Visual Studio)
 
-The preferred method is the **one-command skill installer** — it deploys the bundled `d365fo-cli` Copilot skill (SKILL.md + 43 lazily-loaded topic references) into your X++ project's `.github/skills/d365fo-cli/` folder. Copilot auto-discovers skills in `.github/skills/` with no extra configuration.
+The preferred method is the **one-command skill installer** — it deploys the bundled `d365fo-cli` Copilot skill (SKILL.md + 43 lazily-loaded topic references) into your X++ project's `.github/skills/d365fo-cli/` folder. Copilot auto-discovers skills in `.github/skills/` with no extra configuration. Point `-XppRepo` at the folder that holds the `.sln` you open: Visual Studio (2026 18.5+) discovers skills next to the solution, not in parent folders. See [SETUP.md](docs/SETUP.md#github-copilot--visual-studio-2026-185--vs-code-agent-mode) for the multi-solution and VS 2022 options.
 
 ```powershell
 # From the d365fo-cli repo's scripts folder:

--- a/docs/SETUP.md
+++ b/docs/SETUP.md
@@ -56,7 +56,7 @@ flowchart TD
 | .NET SDK | **10** (pinned in `global.json`) | building / running the CLI |
 | `git` | any | `d365fo review diff` |
 | Visual Studio 2022 / 2026 + Dynamics 365 F&O workload | latest | scenario A — `MSBuild.exe`, `SyncEngine.exe`, `SysTestRunner.exe`, `xppbp.exe` on `PATH` |
-| GitHub Copilot extension | latest | VS agent mode (optional) |
+| GitHub Copilot extension | latest | VS agent mode (optional) — Agent Skills need **VS 2026 18.5+**; VS 2022 gets the legacy `.instructions.md` layout |
 | .NET Framework 4.8 Developer Pack | 4.8 | bridge (`D365FO_BRIDGE_ENABLED=1`) — pre-installed on D365FO VMs |
 
 > Off-platform setups (B) only need .NET 10 + git. Everything else is gated by `UNSUPPORTED_PLATFORM` and never invoked.
@@ -177,7 +177,7 @@ Or run the daemon and forget about it — `d365fo daemon start` keeps the SQLite
 
 ```mermaid
 flowchart LR
-    Cop["GitHub Copilot<br/>VS 2022/2026 · VS Code"] -->|.github/skills/d365fo-cli/| Bin
+    Cop["GitHub Copilot<br/>VS 2026 18.5+ · VS Code"] -->|.github/skills/d365fo-cli/| Bin
     Cla["Claude Code<br/>CLI · VS Code ext."]     -->|skills/anthropic/| Bin
     Other["Codex · Gemini · Cursor"]              -->|AGENTS.md| Bin
     Mcp["Claude Desktop · Continue<br/>(MCP host)"] -->|JSON-RPC stdio| Mbin["d365fo-mcp"]
@@ -185,20 +185,34 @@ flowchart LR
     Mbin --> Idx
 ```
 
-### GitHub Copilot — Visual Studio 2022 / 2026 / VS Code (agent mode)
+### GitHub Copilot — Visual Studio 2026 (18.5+) / VS Code (agent mode)
 
 1. Place `d365fo` on `PATH` (either Option 1 alias or Option 2 binary above).
-2. Deploy the `d365fo-cli` Copilot skill into a parent folder of your X++ solutions:
+2. Deploy the `d365fo-cli` Copilot skill into the folder that contains the `.sln` you open in Visual Studio:
 
    ```powershell
    .\scripts\Install-D365FoCopilotSkills.ps1 `
      -CliRepo C:\source\d365fo-cli `
-     -XppRepo K:\D365FO\MyProject
+     -XppRepo K:\D365FO\MyProject        # the folder holding MyProject.sln
    ```
 
-   The script deploys `skills/d365fo-cli/SKILL.md` and all `references/*.md` to `.github/skills/d365fo-cli/`. One copy in a common parent covers every solution beneath it — VS searches upward from the `.sln`. Copilot auto-discovers skills in `.github/skills/` with no extra configuration.
+   The script deploys `skills/d365fo-cli/SKILL.md` and all `references/*.md` to `<XppRepo>\.github\skills\d365fo-cli\`. Copilot auto-discovers skills in `.github/skills/` with no extra configuration.
+
+   **Where Visual Studio looks.** VS discovers solution skills in `.github/skills/` **next to the solution** — it does not walk up to parent folders. A copy in `C:\D365\Projects\.github\skills\` is invisible to a solution opened from `C:\D365\Projects\MyProject\MyProject.sln`. (Repo/workspace-root discovery was announced as "pending release" on the Visual Studio blog in June 2026, but has not appeared in the VS release notes as of September 2026.) When several solutions share a parent folder you have two options:
+
+   - run the installer once per solution folder, or
+   - install the skill as a **personal skill**, which applies to every solution regardless of location:
+
+     ```powershell
+     Copy-Item -Recurse -Force C:\source\d365fo-cli\skills\d365fo-cli "$env:USERPROFILE\.copilot\skills\d365fo-cli"
+     ```
+
+   Restart Visual Studio after either step — skills are discovered on solution load.
 3. **Agent mode (recommended).** Open Copilot Chat → mode dropdown (top-right) → **Agent**. Copilot now calls `d365fo` directly via its terminal tool — no copy-paste.
-4. **Chat mode (fallback).** Without agent tools, Copilot asks you to run `d365fo` commands in Developer PowerShell and paste the JSON back. The skill teaches Copilot to ask first — if it skips that step the `.github/skills/d365fo-cli/SKILL.md` file is missing from the parent folder.
+4. **Chat mode (fallback).** Without agent tools, Copilot asks you to run `d365fo` commands in Developer PowerShell and paste the JSON back. The skill teaches Copilot to ask first — if it skips that step the `.github/skills/d365fo-cli/SKILL.md` file is not next to the `.sln` (or in `%USERPROFILE%\.copilot\skills\`).
+5. **Verify the skill is discovered.** In VS 2026 18.6+ select the **Tools** icon in the bottom-right corner of Copilot Chat — the skills panel lists every skill VS found, with diagnostics for frontmatter errors. `d365fo-cli` must appear there; if it does not, VS is not seeing the folder (wrong location, or VS 2022 — see the requirements note below). When the skill activates, VS names it in the chat reply. In VS Code, type `/skills` in the chat input to list discovered skills, and check that `chat.useAgentSkills` is enabled in Settings.
+
+> **Requirements.** Agent Skills need **Visual Studio 2026 version 18.5 or later** (or VS Code with `chat.useAgentSkills` on). Visual Studio 2022 has no skill support — it silently ignores `.github/skills/`. On a VS 2022 machine (including UDE setups still on VS 2022) use the legacy layout instead: copy `skills/copilot/*.instructions.md` into `<XppRepo>\.github\instructions\` and enable **Tools → Options → GitHub → Copilot → Copilot Chat → Enable custom instructions**. VS 2022 17.10+ applies those deterministically through their `applyTo` globs.
 
 > **How the skill decides to activate — and what to do when it doesn't.**
 >
@@ -217,7 +231,7 @@ flowchart LR
 > | `D365FO_WORKSPACE_PATH` (CLI env var) | Where `d365fo generate` writes scaffolded X++ files | `d365fo init` / `settings.json` / env var |
 > | Editor "workspace" (VS solution root / VS Code opened folder) | Where Copilot looks for `.github/skills/d365fo-cli/SKILL.md` | Which folder/`.sln` you open in the IDE |
 >
-> Setting `D365FO_WORKSPACE_PATH` (or any `D365FO_*` env var) has **zero effect** on Copilot's skill discovery. If Copilot isn't finding your skill, the fix is always about **which folder is open in the editor**, never about CLI configuration — re-run `Install-D365FoCopilotSkills.ps1` against the actual parent folder you open, not against `D365FO_WORKSPACE_PATH`.
+> Setting `D365FO_WORKSPACE_PATH` (or any `D365FO_*` env var) has **zero effect** on Copilot's skill discovery. If Copilot isn't finding your skill, the fix is always about **which folder is open in the editor**, never about CLI configuration — re-run `Install-D365FoCopilotSkills.ps1` against the folder that holds the `.sln` you open (or use the personal-skill folder), not against `D365FO_WORKSPACE_PATH`.
 
 ### Claude Code (CLI or VS Code extension)
 
@@ -321,7 +335,8 @@ The [one-line install](#one-line-install) at the top of this page **is** the qui
 | `UNSUPPORTED_PLATFORM` | `build` / `sync` / `test` / `bp` require Windows + a D365FO dev VM. Everything else still works |
 | `NO_INDEX` | `d365fo index build && d365fo index extract` |
 | `stale-index` warning from `doctor` | `d365fo index refresh --model <Model>` (or just start the daemon) |
-| Copilot Chat says "There was an error executing code search" then writes generic X++ | VS Copilot Chat cannot search AOT XML — the `d365fo-cli` skill must be deployed in a parent folder. Re-run `Install-D365FoCopilotSkills.ps1` and restart VS. For full automation switch Copilot Chat to **Agent** mode |
+| Copilot Chat says "There was an error executing code search" then writes generic X++ | VS Copilot Chat cannot search AOT XML — the `d365fo-cli` skill is not being picked up. Open the skills panel (Tools icon, bottom-right of Copilot Chat) and confirm `d365fo-cli` is listed; `.github/skills/d365fo-cli/` must sit next to the `.sln` (or in `%USERPROFILE%\.copilot\skills\`). Restart VS. For full automation switch Copilot Chat to **Agent** mode |
+| Copilot never mentions the `d365fo-cli` skill and the skills panel is missing or empty | Agent Skills need VS 2026 18.5+ (VS 2022 ignores `.github/skills/`). Upgrade, or deploy the legacy `.github/instructions/*.instructions.md` layout from `skills/copilot/` |
 | Index file appears locked | Stop any running `d365fo daemon` or `d365fo-mcp` process; `-wal` / `-shm` sidecar files are normal |
 | Settings differ between Developer PowerShell and PowerShell 7 | Re-run `d365fo init --persist-profile` — it writes both profiles and the JSON config |
 | Self-contained binary won't start on Linux | `chmod +x d365fo` after copying out of the publish folder |

--- a/scripts/Install-D365FoCopilotSkills.ps1
+++ b/scripts/Install-D365FoCopilotSkills.ps1
@@ -7,7 +7,14 @@
       - skills/d365fo-cli/SKILL.md            (main rule canon + tool mapping)
       - skills/d365fo-cli/references/*.md      (lazily-loaded X++ topic files, one per knowledge topic)
     into <XppRepo>/.github/skills/d365fo-cli/ so that GitHub Copilot in
-    Visual Studio 2022 / 2026 (and VS Code) automatically picks up the skill.
+    Visual Studio 2026 18.5+ (and VS Code) automatically picks up the skill.
+
+    Visual Studio discovers solution skills next to the .sln only - it never
+    searches parent folders - so XppRepo must be the folder that holds the
+    solution you open. To cover several solutions at once, copy
+    skills/d365fo-cli to %USERPROFILE%\.copilot\skills\d365fo-cli instead:
+    a personal skill applies to every solution. Visual Studio 2022 has no
+    skill support; use skills/copilot/*.instructions.md there (see docs/SETUP.md).
 
     If the skill folder's references/ is empty (first run or clean clone), this
     script regenerates it first, using whichever host is available: pwsh,
@@ -33,7 +40,9 @@
 
 .PARAMETER XppRepo
     Absolute path to the root of your X++ project repository (the folder that
-    contains - or will contain - the .github/ directory).
+    contains - or will contain - the .github/ directory). This must be the
+    folder that contains the .sln you open in Visual Studio; VS does not look
+    for skills in parent folders.
 
 .EXAMPLE
     .\Install-D365FoCopilotSkills.ps1 `
@@ -171,7 +180,8 @@ Write-Host "$summary to:"
 Write-Host "  $dstSkill"
 Write-Host ""
 Write-Host "Next steps:"
-Write-Host "  1. Restart Visual Studio / VS Code to pick up the new skill."
+Write-Host "  1. Restart Visual Studio 2026 (18.5+) / VS Code to pick up the new skill."
+Write-Host "     Verify: Copilot Chat -> Tools icon (bottom-right) -> skills panel lists d365fo-cli."
 Write-Host "  2. Commit .github/ in your X++ project:"
 Write-Host "       git -C `"$XppRepo`" add .github/"
 Write-Host "       git -C `"$XppRepo`" commit -m `"chore: add d365fo Copilot skill`""

--- a/skills/d365fo-cli/SKILL.md
+++ b/skills/d365fo-cli/SKILL.md
@@ -1,14 +1,15 @@
 ---
 name: d365fo-cli
 description: "D365 Finance & Operations X++ AI development skill powered by the d365fo CLI. Use whenever the user is working in a D365 F&O X++ project: writing classes, tables, forms, CoC extensions, event handlers, entities, security, batch jobs, business events, labels, or any AOT artifact. Loads topic-specific guidance lazily from references/."
-compatibility: Requires GitHub Copilot agent mode (VS 2022/2026 or VS Code) and d365fo CLI in PATH.
+compatibility: Requires GitHub Copilot agent mode (Visual Studio 2026 18.5+ or VS Code) and d365fo CLI in PATH.
 ---
 
 # D365 Finance & Operations X++ Development — `d365fo` CLI
 
 <!--
   Deployed to your X++ project via Install-D365FoCopilotSkills.ps1.
-  Primary target: GitHub Copilot in Visual Studio 2022 / 2026 (agent mode with built-in tools).
+  Primary target: GitHub Copilot in Visual Studio 2026 18.5+ (agent mode with built-in tools).
+  Visual Studio 2022 does not read .github/skills/; it gets skills/copilot/*.instructions.md instead.
   Secondary target: VS Code with Copilot in agent mode (can run d365fo directly via terminal).
   References in the form `[learn:<page>]` link to Microsoft Learn pages
   (see "Authoritative X++ syntax source" at the bottom).
@@ -16,7 +17,7 @@ compatibility: Requires GitHub Copilot agent mode (VS 2022/2026 or VS Code) and 
 
 This skill gives **GitHub Copilot** the rules for assisting with D365 Finance & Operations X++ development. It is deployed to your X++ project's `.github/skills/d365fo-cli/` folder by `Install-D365FoCopilotSkills.ps1` and is loaded automatically by Copilot when you are working on D365 F&O tasks.
 
-> **Primary environment — VS 2022 / VS 2026 agent mode:** GitHub Copilot runs `d365fo` commands via the built-in terminal tool (`run_command_in_terminal`). Topic-specific rules in `references/` load on demand. No copy-paste, no MCP overhead.
+> **Primary environment — VS 2026 agent mode (18.5+):** GitHub Copilot runs `d365fo` commands via the built-in terminal tool (`run_command_in_terminal`). Topic-specific rules in `references/` load on demand. No copy-paste, no MCP overhead.
 >
 > **Secondary environment — VS Code agent mode:** Same approach, different terminal tool name (`run_in_terminal`). Identical experience.
 >
@@ -84,7 +85,7 @@ Examples:
 
 | Environment | How Copilot runs d365fo | Token cost |
 |---|---|---|
-| **VS 2022/2026 agent mode** | Built-in terminal tool → `d365fo` CLI | ~100 tokens |
+| **VS 2026 agent mode** | Built-in terminal tool → `d365fo` CLI | ~100 tokens |
 | **VS Code agent mode** | `run_in_terminal` → `d365fo` CLI | ~100 tokens |
 | **VS Chat mode** (no agent tools) | User runs manually, pastes JSON | collaborative |
 


### PR DESCRIPTION
Fixes the Copilot skill setup docs behind #205 (Copilot not reading `.github/skills/d365fo-cli` placed in a parent folder of the solutions).

## What was wrong

- **"VS searches upward from the `.sln`"** — carried over from the `copilot-instructions.md` era (commit b40a581) and never re-checked for skills. Visual Studio discovers solution skills in `.github/skills/` next to the `.sln` only; the VS blog author confirmed in June 2026 that repo/workspace-root discovery is still "pending release", and no VS 2026 release note (18.5–18.8) has shipped it.
- **"VS 2022 / 2026"** — Agent Skills need Visual Studio 2026 18.5+ per Microsoft Learn. VS 2022 (17.14 release notes) has no skill support and silently ignores the folder.

## What changed

- `docs/SETUP.md`: `-XppRepo` must be the folder holding the `.sln`; explains the two multi-solution options (installer per solution, or the personal-skill folder `%USERPROFILE%\.copilot\skills\`); new "verify the skill is discovered" step (skills panel via the Tools icon in Copilot Chat, `/skills` in VS Code); requirements note pointing VS 2022 users at the legacy `skills/copilot/*.instructions.md` layout; two troubleshooting rows updated/added.
- `README.md`, `skills/d365fo-cli/SKILL.md` (frontmatter `compatibility` + prose), `scripts/Install-D365FoCopilotSkills.ps1` (help block + "next steps" output): same corrections. No behavioural change to the script.
- `CHANGELOG.md`: Unreleased → Fixed entry.

`scripts/check-skill-frontmatter.py` passes; the PS1 parses and its help block resolves.

Sources: [Use Agent Skills with GitHub Copilot – Visual Studio](https://learn.microsoft.com/en-us/visualstudio/ide/copilot-agent-skills?view=visualstudio), [Agent Skills in Visual Studio (VS blog + comments)](https://devblogs.microsoft.com/visualstudio/agent-skills-in-visual-studio/), [VS 2026 release notes](https://learn.microsoft.com/en-us/visualstudio/releases/2026/release-notes).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01ARpdEtpuihruHn7wD9YEPk
