### PR TITLE
fix(build): probe the toolchain instead of trusting PATH (#207)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,27 @@ was ported from.
 
 ## [Unreleased]
 
+### Fixed — build tooling is probed instead of assumed (#207)
+
+- **`d365fo build` picked its MSBuild off `PATH`.** On a developer VM that is
+  `C:\Windows\Microsoft.NET\Framework\v4.0.30319\MSBuild.exe`, which cannot host
+  `Microsoft.Dynamics.Framework.Tools.BuildTasks` — the build then fails with `MSB4062`, which
+  reads like a compiler error and is not one. `BuildTooling.ResolveMsBuild` now prefers the
+  Visual Studio MSBuild (`vswhere`, then the known install roots) over `PATH`, honours
+  `D365FO_MSBUILD_PATH`, and reports the executable it used in `data.msbuild` — with the reason
+  when the resolved one cannot build X++.
+- **`explain-error` had nothing to say about environment failures.** `MSB4062`,
+  `MSB4019`/`MSB4066` and `MSB1003`/`MSB1009` now match four `ENV-…` rules that name the cause
+  and point at `build-error-triage`; the topic itself gained an "is it your code at all?"
+  section. MSBuild's own diagnostics carry those hints in the build payload too.
+- **`doctor` answered "is build tooling functional here?" with an OS check.** It now reports
+  `build.msbuild` (which executable, found how), `build.dynamicsTargets` (the
+  `BuildTasksDirectory` default an `.rnrproj` imports) and `build.tooling` for `xppc.exe`,
+  `xppbp.exe` and `SyncEngine.exe` under `<packages>\bin`.
+- **A build that never started reported zero errors.** MSBuild's position-less form
+  (`MSBUILD : error MSB1009: …`) matched neither diagnostic parser, and `stderr` was not scanned
+  at all. Both are parsed now, de-duplicated against the positional form.
+
 ### Fixed — Copilot skill setup docs (#205)
 
 - SETUP.md, README and the installer header claimed Visual Studio 2022 / 2026 pick up

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -24,6 +24,7 @@ Run `d365fo init` — in a terminal it's a wizard that asks for what you need an
 | `D365FO_BRIDGE_ENABLED` | `1`/`true` enables the metadata bridge (required for `generate --install-to` and `find refs --xref`) | `false` |
 | `D365FO_BRIDGE_PATH` | Path to `D365FO.Bridge.exe` (auto-detected next to `d365fo.exe` when unset) | *(auto)* |
 | `D365FO_BIN_PATH` | Folder containing `Microsoft.Dynamics.AX.Metadata.*.dll` (usually `<PackagesLocalDirectory>\bin`) | — |
+| `D365FO_MSBUILD_PATH` | MSBuild executable for `d365fo build`. Unset, the Visual Studio MSBuild is resolved through `vswhere` (then the known install roots) and only then `PATH` — the `msbuild.exe` first on `PATH` is usually the .NET Framework one, which cannot load the X++ build tasks and fails with `MSB4062`. `d365fo doctor` reports which one is resolved. | *(auto)* |
 | `D365FO_XREF_CONNECTIONSTRING` | Cross-reference DB connection string | — |
 | `D365FO_FORCE_JSON` | `1` forces machine-readable JSON output even on a TTY | — |
 | `D365FO_HOME` | Root for the provenance/grounding token store | `%USERPROFILE%\.d365fo` |

--- a/docs/TROUBLESHOOTING.md
+++ b/docs/TROUBLESHOOTING.md
@@ -113,6 +113,32 @@ d365fo index extract --model MyModel
 d365fo index history --model MyModel   # confirm no extraction errors
 ```
 
+### `d365fo build` fails with `MSB4062` / `MSB4019` before compiling anything
+
+An `MSB…` code means MSBuild failed before the X++ compiler ran, so nothing in the log says
+anything about your code:
+
+```
+error MSB4062: The "…BuildTasks.BuildTask" task could not be loaded from the assembly …
+error MSB4019: The imported project "…BuildTasks.17.0.targets" was not found.
+```
+
+An `.rnrproj` imports `$(BuildTasksDirectory)\Microsoft.Dynamics.Framework.Tools.BuildTasks[.17.0].targets`
+— defaulting to `%ProgramFiles(x86)%\MSBuild\Microsoft\Dynamics\AX` — and that file declares its
+tasks by `AssemblyName`, so only an MSBuild that can resolve the Dynamics dev-tools assembly can
+run them. The `msbuild.exe` first on `PATH` is normally
+`C:\Windows\Microsoft.NET\Framework\v4.0.30319\MSBuild.exe`, which cannot; `dotnet build` never can.
+
+```sh
+d365fo doctor --output json    # build.msbuild / build.dynamicsTargets / build.tooling
+d365fo explain-error --file build.log --output json
+```
+
+`d365fo build` resolves the Visual Studio MSBuild ahead of `PATH` and reports the executable it
+used in `data.msbuild`. Override it with `--msbuild <path>` or `D365FO_MSBUILD_PATH` when the box
+carries several Visual Studio installs. If `build.dynamicsTargets` is missing, the Dynamics 365
+dev tools are not installed on the host at all — no MSBuild choice will fix that.
+
 ### `.NET 4.8 bridge not found` on non-Windows systems
 
 The `D365FO.Bridge` child process requires the .NET Framework 4.8 runtime, which is Windows-only. On macOS or Linux the bridge is unavailable and the CLI falls back to the SQLite index automatically:

--- a/skills/_source/build-error-triage.md
+++ b/skills/_source/build-error-triage.md
@@ -30,6 +30,33 @@ each. A message that matches nothing is returned **verbatim** rather than
 answered with the nearest-looking rule — an unexplained message is information,
 a wrong explanation is not.
 
+## First question: is it your code at all?
+
+An `MSB…` code means MSBuild failed before the X++ compiler ever ran, so nothing in the
+log is a statement about your code. The three that actually happen:
+
+| Message | What it is | Fix |
+|---|---|---|
+| `MSB4062` "task could not be loaded from the assembly" | MSBuild cannot load `Microsoft.Dynamics.Framework.Tools.BuildTasks` | you are running the wrong MSBuild — see below |
+| `MSB4019` "the imported project … was not found" | `BuildTasksDirectory` resolves nowhere: the Dynamics 365 dev tools are not installed for this MSBuild | install the dev tools, or pass `/p:BuildTasksDirectory=<dir with the .targets>` |
+| `MSB1003` / `MSB1009` "specify a project", "project file does not exist" | the build was pointed at no project | `d365fo build --project <sln or rnrproj>`, or run it where one lives |
+
+The wrong MSBuild is the common one. An `.rnrproj` imports
+`$(BuildTasksDirectory)\Microsoft.Dynamics.Framework.Tools.BuildTasks[.17.0].targets`
+(defaulting to `%ProgramFiles(x86)%\MSBuild\Microsoft\Dynamics\AX`), and that file declares
+its tasks by `AssemblyName` — so only an MSBuild that can resolve the dev-tools assembly can
+run them. On a developer VM the first `msbuild.exe` on `PATH` is
+`C:\Windows\Microsoft.NET\Framework\v4.0.30319\MSBuild.exe`, which cannot, and `dotnet build`
+never can.
+
+```sh
+d365fo doctor --output json    # build.msbuild / build.dynamicsTargets / build.tooling
+```
+
+`d365fo build` resolves the Visual Studio MSBuild ahead of `PATH` for exactly this reason and
+reports the executable it used in `data.msbuild`. Override it with `--msbuild <path>` or
+`D365FO_MSBUILD_PATH` when the box has several installs.
+
 ## Before you trust any of it: stale symbols
 
 If the log says a package "has not been successfully compiled since it was last
@@ -54,6 +81,7 @@ Rebuild first (`d365fo build --full` on the VM) and re-read.
 | "unknown type", "could not be found" | invented identifier | `d365fo validate references --file <f>` — it proves every symbol before the compiler sees it |
 | "label … does not exist" | missing label id | `d365fo search label "<text>"`, then `d365fo label create` |
 | `';' expected` and friends | syntax | check the reported line — usually a CDATA method body edit |
+| `MSB4062`, `MSB4019`, `MSB1003`/`MSB1009` | the build never reached the compiler | see "is it your code at all?" above |
 
 Each row is a rule in the scored matcher, and each carries the knowledge topic
 that explains the underlying model: `d365fo explain-error` returns the topic id

--- a/skills/anthropic/build-error-triage/SKILL.md
+++ b/skills/anthropic/build-error-triage/SKILL.md
@@ -25,6 +25,33 @@ each. A message that matches nothing is returned **verbatim** rather than
 answered with the nearest-looking rule — an unexplained message is information,
 a wrong explanation is not.
 
+## First question: is it your code at all?
+
+An `MSB…` code means MSBuild failed before the X++ compiler ever ran, so nothing in the
+log is a statement about your code. The three that actually happen:
+
+| Message | What it is | Fix |
+|---|---|---|
+| `MSB4062` "task could not be loaded from the assembly" | MSBuild cannot load `Microsoft.Dynamics.Framework.Tools.BuildTasks` | you are running the wrong MSBuild — see below |
+| `MSB4019` "the imported project … was not found" | `BuildTasksDirectory` resolves nowhere: the Dynamics 365 dev tools are not installed for this MSBuild | install the dev tools, or pass `/p:BuildTasksDirectory=<dir with the .targets>` |
+| `MSB1003` / `MSB1009` "specify a project", "project file does not exist" | the build was pointed at no project | `d365fo build --project <sln or rnrproj>`, or run it where one lives |
+
+The wrong MSBuild is the common one. An `.rnrproj` imports
+`$(BuildTasksDirectory)\Microsoft.Dynamics.Framework.Tools.BuildTasks[.17.0].targets`
+(defaulting to `%ProgramFiles(x86)%\MSBuild\Microsoft\Dynamics\AX`), and that file declares
+its tasks by `AssemblyName` — so only an MSBuild that can resolve the dev-tools assembly can
+run them. On a developer VM the first `msbuild.exe` on `PATH` is
+`C:\Windows\Microsoft.NET\Framework\v4.0.30319\MSBuild.exe`, which cannot, and `dotnet build`
+never can.
+
+```sh
+d365fo doctor --output json    # build.msbuild / build.dynamicsTargets / build.tooling
+```
+
+`d365fo build` resolves the Visual Studio MSBuild ahead of `PATH` for exactly this reason and
+reports the executable it used in `data.msbuild`. Override it with `--msbuild <path>` or
+`D365FO_MSBUILD_PATH` when the box has several installs.
+
 ## Before you trust any of it: stale symbols
 
 If the log says a package "has not been successfully compiled since it was last
@@ -49,6 +76,7 @@ Rebuild first (`d365fo build --full` on the VM) and re-read.
 | "unknown type", "could not be found" | invented identifier | `d365fo validate references --file <f>` — it proves every symbol before the compiler sees it |
 | "label … does not exist" | missing label id | `d365fo search label "<text>"`, then `d365fo label create` |
 | `';' expected` and friends | syntax | check the reported line — usually a CDATA method body edit |
+| `MSB4062`, `MSB4019`, `MSB1003`/`MSB1009` | the build never reached the compiler | see "is it your code at all?" above |
 
 Each row is a rule in the scored matcher, and each carries the knowledge topic
 that explains the underlying model: `d365fo explain-error` returns the topic id

--- a/skills/copilot/build-error-triage.instructions.md
+++ b/skills/copilot/build-error-triage.instructions.md
@@ -24,6 +24,33 @@ each. A message that matches nothing is returned **verbatim** rather than
 answered with the nearest-looking rule — an unexplained message is information,
 a wrong explanation is not.
 
+## First question: is it your code at all?
+
+An `MSB…` code means MSBuild failed before the X++ compiler ever ran, so nothing in the
+log is a statement about your code. The three that actually happen:
+
+| Message | What it is | Fix |
+|---|---|---|
+| `MSB4062` "task could not be loaded from the assembly" | MSBuild cannot load `Microsoft.Dynamics.Framework.Tools.BuildTasks` | you are running the wrong MSBuild — see below |
+| `MSB4019` "the imported project … was not found" | `BuildTasksDirectory` resolves nowhere: the Dynamics 365 dev tools are not installed for this MSBuild | install the dev tools, or pass `/p:BuildTasksDirectory=<dir with the .targets>` |
+| `MSB1003` / `MSB1009` "specify a project", "project file does not exist" | the build was pointed at no project | `d365fo build --project <sln or rnrproj>`, or run it where one lives |
+
+The wrong MSBuild is the common one. An `.rnrproj` imports
+`$(BuildTasksDirectory)\Microsoft.Dynamics.Framework.Tools.BuildTasks[.17.0].targets`
+(defaulting to `%ProgramFiles(x86)%\MSBuild\Microsoft\Dynamics\AX`), and that file declares
+its tasks by `AssemblyName` — so only an MSBuild that can resolve the dev-tools assembly can
+run them. On a developer VM the first `msbuild.exe` on `PATH` is
+`C:\Windows\Microsoft.NET\Framework\v4.0.30319\MSBuild.exe`, which cannot, and `dotnet build`
+never can.
+
+```sh
+d365fo doctor --output json    # build.msbuild / build.dynamicsTargets / build.tooling
+```
+
+`d365fo build` resolves the Visual Studio MSBuild ahead of `PATH` for exactly this reason and
+reports the executable it used in `data.msbuild`. Override it with `--msbuild <path>` or
+`D365FO_MSBUILD_PATH` when the box has several installs.
+
 ## Before you trust any of it: stale symbols
 
 If the log says a package "has not been successfully compiled since it was last
@@ -48,6 +75,7 @@ Rebuild first (`d365fo build --full` on the VM) and re-read.
 | "unknown type", "could not be found" | invented identifier | `d365fo validate references --file <f>` — it proves every symbol before the compiler sees it |
 | "label … does not exist" | missing label id | `d365fo search label "<text>"`, then `d365fo label create` |
 | `';' expected` and friends | syntax | check the reported line — usually a CDATA method body edit |
+| `MSB4062`, `MSB4019`, `MSB1003`/`MSB1009` | the build never reached the compiler | see "is it your code at all?" above |
 
 Each row is a rule in the scored matcher, and each carries the knowledge topic
 that explains the underlying model: `d365fo explain-error` returns the topic id

--- a/skills/d365fo-cli/references/build-error-triage.md
+++ b/skills/d365fo-cli/references/build-error-triage.md
@@ -20,6 +20,33 @@ each. A message that matches nothing is returned **verbatim** rather than
 answered with the nearest-looking rule — an unexplained message is information,
 a wrong explanation is not.
 
+## First question: is it your code at all?
+
+An `MSB…` code means MSBuild failed before the X++ compiler ever ran, so nothing in the
+log is a statement about your code. The three that actually happen:
+
+| Message | What it is | Fix |
+|---|---|---|
+| `MSB4062` "task could not be loaded from the assembly" | MSBuild cannot load `Microsoft.Dynamics.Framework.Tools.BuildTasks` | you are running the wrong MSBuild — see below |
+| `MSB4019` "the imported project … was not found" | `BuildTasksDirectory` resolves nowhere: the Dynamics 365 dev tools are not installed for this MSBuild | install the dev tools, or pass `/p:BuildTasksDirectory=<dir with the .targets>` |
+| `MSB1003` / `MSB1009` "specify a project", "project file does not exist" | the build was pointed at no project | `d365fo build --project <sln or rnrproj>`, or run it where one lives |
+
+The wrong MSBuild is the common one. An `.rnrproj` imports
+`$(BuildTasksDirectory)\Microsoft.Dynamics.Framework.Tools.BuildTasks[.17.0].targets`
+(defaulting to `%ProgramFiles(x86)%\MSBuild\Microsoft\Dynamics\AX`), and that file declares
+its tasks by `AssemblyName` — so only an MSBuild that can resolve the dev-tools assembly can
+run them. On a developer VM the first `msbuild.exe` on `PATH` is
+`C:\Windows\Microsoft.NET\Framework\v4.0.30319\MSBuild.exe`, which cannot, and `dotnet build`
+never can.
+
+```sh
+d365fo doctor --output json    # build.msbuild / build.dynamicsTargets / build.tooling
+```
+
+`d365fo build` resolves the Visual Studio MSBuild ahead of `PATH` for exactly this reason and
+reports the executable it used in `data.msbuild`. Override it with `--msbuild <path>` or
+`D365FO_MSBUILD_PATH` when the box has several installs.
+
 ## Before you trust any of it: stale symbols
 
 If the log says a package "has not been successfully compiled since it was last
@@ -44,6 +71,7 @@ Rebuild first (`d365fo build --full` on the VM) and re-read.
 | "unknown type", "could not be found" | invented identifier | `d365fo validate references --file <f>` — it proves every symbol before the compiler sees it |
 | "label … does not exist" | missing label id | `d365fo search label "<text>"`, then `d365fo label create` |
 | `';' expected` and friends | syntax | check the reported line — usually a CDATA method body edit |
+| `MSB4062`, `MSB4019`, `MSB1003`/`MSB1009` | the build never reached the compiler | see "is it your code at all?" above |
 
 Each row is a rule in the scored matcher, and each carries the knowledge topic
 that explains the underlying model: `d365fo explain-error` returns the topic id

--- a/src/D365FO.Cli/Commands/Ops/BuildCommands.cs
+++ b/src/D365FO.Cli/Commands/Ops/BuildCommands.cs
@@ -18,6 +18,7 @@ public sealed class BuildCommand : Command<BuildCommand.Settings>
     public sealed class Settings : D365OutputSettings
     {
         [CommandOption("--msbuild <PATH>")]
+        [System.ComponentModel.Description("MSBuild executable. Defaults to the Visual Studio MSBuild (via vswhere) ahead of the one on PATH, because the .NET Framework MSBuild cannot load the X++ build tasks. `d365fo doctor` reports the resolved path.")]
         public string? MsBuildPath { get; init; }
 
         [CommandOption("--project <PATH>")]

--- a/src/D365FO.Cli/Commands/Ops/OpsCommands.cs
+++ b/src/D365FO.Cli/Commands/Ops/OpsCommands.cs
@@ -1,5 +1,6 @@
 using D365FO.Core;
 using D365FO.Core.Bridge;
+using D365FO.Core.Ops;
 using Spectre.Console;
 using Spectre.Console.Cli;
 
@@ -67,6 +68,34 @@ public sealed class DoctorCommand : Command<DoctorCommand.Settings>
         Add("platform.windows (build/sync/bp require it)",
             OperatingSystem.IsWindows() ? DoctorSeverity.Ok : DoctorSeverity.Warn,
             OperatingSystem.IsWindows() ? null : "Non-Windows host: write-ops (build, sync, bp, test) are unavailable.");
+
+        // Being on Windows is not the same as having a working X++ toolchain, and answering
+        // "is build tooling functional here?" with an OS check is how a broken MSBuild reached
+        // the user as an unexplained MSB4062 (issue #207). Probe the tools themselves.
+        if (OperatingSystem.IsWindows())
+        {
+            var msbuild = BuildTooling.ResolveMsBuild(null);
+            Add("build.msbuild (d365fo build)",
+                msbuild.Ok ? DoctorSeverity.Ok : DoctorSeverity.Warn,
+                msbuild.Ok
+                    ? $"{msbuild.Path} (from {msbuild.Source})"
+                    : msbuild.Path is null
+                        ? msbuild.Problem
+                        : $"{msbuild.Path} (from {msbuild.Source}) — {msbuild.Problem}");
+
+            var targets = BuildTooling.ResolveDynamicsTargets();
+            Add("build.dynamicsTargets (X++ MSBuild tasks)",
+                targets.Ok ? DoctorSeverity.Ok : DoctorSeverity.Warn,
+                targets.Ok ? targets.Path : targets.Problem);
+
+            foreach (var exe in BuildTooling.PackageBinTools)
+            {
+                var t = BuildTooling.ResolvePackageBinTool(exe, cfg.PackagesPath);
+                Add($"build.tooling ({exe})",
+                    t.Ok ? DoctorSeverity.Ok : DoctorSeverity.Warn,
+                    t.Ok ? t.Path : t.Problem);
+            }
+        }
 
         // Bridge — required for `generate --install-to <Model>` and `find refs --xref`.
         // Reports Warn (not Fail) when missing because read-only operations work

--- a/src/D365FO.Core/Ops/BuildTooling.cs
+++ b/src/D365FO.Core/Ops/BuildTooling.cs
@@ -1,0 +1,236 @@
+// <copyright file="BuildTooling.cs" company="d365fo-cli contributors">
+// MIT
+// </copyright>
+
+using System.Diagnostics;
+
+namespace D365FO.Core.Ops;
+
+/// <summary>One resolved developer tool: where it is, how it was found, what is wrong with it.</summary>
+/// <param name="Name">Display name of the tool (<c>msbuild</c>, <c>xppc.exe</c>, …).</param>
+/// <param name="Path">Absolute path when found, otherwise <c>null</c>.</param>
+/// <param name="Source">How the path was arrived at — <c>--msbuild</c>, <c>D365FO_MSBUILD_PATH</c>, <c>vswhere</c>, <c>PATH</c>, <c>packages\bin</c>.</param>
+/// <param name="Problem">
+/// Non-null when the path is unusable for X++ (missing, or an MSBuild that cannot host the
+/// Dynamics build tasks). A path plus a problem is still returned so the caller can say
+/// <i>which</i> wrong tool it found rather than only that something is missing.
+/// </param>
+public sealed record ToolPath(string Name, string? Path, string Source, string? Problem = null)
+{
+    /// <summary>True when the tool was found and nothing is wrong with it.</summary>
+    public bool Ok => Path is not null && Problem is null;
+}
+
+/// <summary>
+/// Where the Windows-only D365FO build tools actually are, and whether the MSBuild that
+/// <c>d365fo build</c> would run can build X++ at all.
+/// </summary>
+/// <remarks>
+/// <para>
+/// <c>SdlcRunner.Build</c> used to shell out to a bare <c>msbuild.exe</c> and let PATH decide.
+/// On a D365FO developer VM PATH resolves that to
+/// <c>C:\Windows\Microsoft.NET\Framework\v4.0.30319\MSBuild.exe</c> — the .NET Framework MSBuild,
+/// which cannot load <c>Microsoft.Dynamics.Framework.Tools.BuildTasks</c>. The build then fails
+/// with <c>MSB4062</c> ("task could not be loaded from the assembly"), which reads like a
+/// compiler error and is not one. That is the report behind issue #207: the environment is
+/// broken in a way nothing in the CLI could see, so the agent had to guess.
+/// </para>
+/// <para>
+/// The X++ project (<c>.rnrproj</c>) imports
+/// <c>$(BuildTasksDirectory)\Microsoft.Dynamics.Framework.Tools.BuildTasks[.17.0].targets</c>,
+/// defaulting <c>BuildTasksDirectory</c> to <c>%ProgramFiles(x86)%\MSBuild\Microsoft\Dynamics\AX</c>,
+/// and that targets file declares its tasks by <c>AssemblyName</c> — so MSBuild has to resolve
+/// the build-task assembly itself, which only the Visual Studio install carrying the
+/// Dynamics 365 dev tools extension can do. Both halves are probed here, separately, because
+/// they fail separately.
+/// </para>
+/// </remarks>
+public static class BuildTooling
+{
+    /// <summary>Override for the MSBuild executable (env var or settings.json).</summary>
+    public const string MsBuildEnvVar = "D365FO_MSBUILD_PATH";
+
+    /// <summary>The two names the Dynamics build targets ship under, newest first.</summary>
+    public static readonly string[] DynamicsTargetsFileNames =
+    [
+        "Microsoft.Dynamics.Framework.Tools.BuildTasks.17.0.targets",
+        "Microsoft.Dynamics.Framework.Tools.BuildTasks.targets",
+    ];
+
+    /// <summary>The tools <c>sync</c>, <c>test run</c> and <c>bp check</c> invoke, under <c>&lt;packages&gt;\bin</c>.</summary>
+    public static readonly string[] PackageBinTools =
+    [
+        "xppc.exe",
+        "xppbp.exe",
+        "SyncEngine.exe",
+    ];
+
+    /// <summary>
+    /// The .NET Framework MSBuild ships with Windows and is always on PATH; it is not a
+    /// Visual Studio MSBuild and cannot host the Dynamics build tasks.
+    /// </summary>
+    public static bool IsFrameworkMsBuild(string? path) =>
+        path is not null &&
+        path.Replace('/', '\\').Contains(@"\Microsoft.NET\Framework", StringComparison.OrdinalIgnoreCase);
+
+    /// <summary>
+    /// The MSBuild <c>d365fo build</c> will run: <c>--msbuild</c>, then
+    /// <see cref="MsBuildEnvVar"/>, then the newest Visual Studio install (via <c>vswhere</c>,
+    /// falling back to the well-known install roots), then PATH.
+    /// </summary>
+    public static ToolPath ResolveMsBuild(string? explicitPath = null)
+    {
+        if (!string.IsNullOrWhiteSpace(explicitPath))
+            return Judge("msbuild", explicitPath!, "--msbuild");
+
+        var configured = D365FoSettings.Resolve(MsBuildEnvVar);
+        if (!string.IsNullOrWhiteSpace(configured))
+            return Judge("msbuild", configured!, MsBuildEnvVar);
+
+        var vs = VisualStudioMsBuild();
+        if (vs is not null) return Judge("msbuild", vs, "vswhere");
+
+        var onPath = FindOnPath("msbuild.exe");
+        if (onPath is not null) return Judge("msbuild", onPath, "PATH");
+
+        return new ToolPath("msbuild", null, "PATH",
+            "msbuild.exe not found. Install the Visual Studio workload with the Dynamics 365 dev tools, or set D365FO_MSBUILD_PATH.");
+    }
+
+    /// <summary>
+    /// The directory an <c>.rnrproj</c> imports its targets from — <c>BuildTasksDirectory</c>,
+    /// which the project defaults to <c>%ProgramFiles(x86)%\MSBuild\Microsoft\Dynamics\AX</c>.
+    /// Missing means the Dynamics 365 dev tools were never installed on this host.
+    /// </summary>
+    public static ToolPath ResolveDynamicsTargets()
+    {
+        var root = Path.Combine(
+            Environment.GetFolderPath(Environment.SpecialFolder.ProgramFilesX86),
+            "MSBuild", "Microsoft", "Dynamics", "AX");
+
+        foreach (var name in DynamicsTargetsFileNames)
+        {
+            var candidate = Path.Combine(root, name);
+            if (File.Exists(candidate))
+                return new ToolPath("build targets", candidate, "BuildTasksDirectory default");
+        }
+
+        return new ToolPath("build targets", null, "BuildTasksDirectory default",
+            $"No Microsoft.Dynamics.Framework.Tools.BuildTasks*.targets under {root} — the Dynamics 365 dev tools are not installed for MSBuild on this host. Building an .rnrproj will fail with MSB4019/MSB4062.");
+    }
+
+    /// <summary>A tool under <c>&lt;packagesPath&gt;\bin</c> (<c>xppc.exe</c>, <c>xppbp.exe</c>, <c>SyncEngine.exe</c>).</summary>
+    public static ToolPath ResolvePackageBinTool(string exeName, string? packagesPath)
+    {
+        if (string.IsNullOrWhiteSpace(packagesPath))
+            return new ToolPath(exeName, null, @"packages\bin",
+                "D365FO_PACKAGES_PATH is not set, so <packages>\\bin cannot be probed.");
+
+        var candidate = Path.Combine(packagesPath!, "bin", exeName);
+        return File.Exists(candidate)
+            ? new ToolPath(exeName, candidate, @"packages\bin")
+            : new ToolPath(exeName, null, @"packages\bin", $"Not found at {candidate}.");
+    }
+
+    private static ToolPath Judge(string name, string path, string source)
+    {
+        if (!File.Exists(path))
+            return new ToolPath(name, path, source, $"Not found: {path}");
+
+        return IsFrameworkMsBuild(path)
+            ? new ToolPath(name, path, source,
+                "This is the .NET Framework MSBuild, which cannot load Microsoft.Dynamics.Framework.Tools.BuildTasks — an X++ build against it fails with MSB4062. Use the MSBuild from the Visual Studio install that has the Dynamics 365 dev tools extension.")
+            : new ToolPath(name, path, source);
+    }
+
+    /// <summary>
+    /// The newest Visual Studio MSBuild, asked of <c>vswhere</c> (which ships with every VS
+    /// installer since 2017) and, when that is unavailable, found by walking the known install
+    /// roots. Returns <c>null</c> off Windows or when no install is present.
+    /// </summary>
+    private static string? VisualStudioMsBuild()
+    {
+        if (!OperatingSystem.IsWindows()) return null;
+
+        var vswhere = Path.Combine(
+            Environment.GetFolderPath(Environment.SpecialFolder.ProgramFilesX86),
+            "Microsoft Visual Studio", "Installer", "vswhere.exe");
+
+        if (File.Exists(vswhere))
+        {
+            try
+            {
+                var psi = new ProcessStartInfo
+                {
+                    FileName = vswhere,
+                    RedirectStandardOutput = true,
+                    RedirectStandardError = true,
+                    UseShellExecute = false,
+                    CreateNoWindow = true,
+                };
+                foreach (var a in new[] { "-latest", "-prerelease", "-products", "*", "-find", @"MSBuild\**\Bin\MSBuild.exe" })
+                    psi.ArgumentList.Add(a);
+
+                using var p = Process.Start(psi);
+                if (p is not null)
+                {
+                    var stdout = p.StandardOutput.ReadToEnd();
+                    p.WaitForExit(15_000);
+                    var hit = stdout
+                        .Split('\n', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries)
+                        .FirstOrDefault(File.Exists);
+                    if (hit is not null) return hit;
+                }
+            }
+            catch
+            {
+                // vswhere is a convenience, never a requirement — fall through to the roots below.
+            }
+        }
+
+        foreach (var root in new[]
+                 {
+                     Environment.GetFolderPath(Environment.SpecialFolder.ProgramFiles),
+                     Environment.GetFolderPath(Environment.SpecialFolder.ProgramFilesX86),
+                 })
+        {
+            var vsRoot = Path.Combine(root, "Microsoft Visual Studio");
+            if (!Directory.Exists(vsRoot)) continue;
+
+            // <root>\<version>\<edition>\MSBuild\Current\Bin\MSBuild.exe — newest version first.
+            foreach (var version in Directory.EnumerateDirectories(vsRoot).OrderByDescending(d => d, StringComparer.OrdinalIgnoreCase))
+            {
+                foreach (var edition in SafeDirectories(version))
+                {
+                    var candidate = Path.Combine(edition, "MSBuild", "Current", "Bin", "MSBuild.exe");
+                    if (File.Exists(candidate)) return candidate;
+                }
+            }
+        }
+
+        return null;
+    }
+
+    private static IEnumerable<string> SafeDirectories(string path)
+    {
+        try { return Directory.EnumerateDirectories(path); }
+        catch { return []; }
+    }
+
+    /// <summary>First match for <paramref name="exeName"/> on PATH, or <c>null</c>.</summary>
+    internal static string? FindOnPath(string exeName)
+    {
+        var path = Environment.GetEnvironmentVariable("PATH");
+        if (string.IsNullOrEmpty(path)) return null;
+
+        foreach (var dir in path.Split(Path.PathSeparator, StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries))
+        {
+            string candidate;
+            try { candidate = Path.Combine(dir, exeName); }
+            catch { continue; } // an unparseable PATH entry is not a reason to fail resolution
+            if (File.Exists(candidate)) return candidate;
+        }
+
+        return null;
+    }
+}

--- a/src/D365FO.Core/Ops/SdlcRunner.cs
+++ b/src/D365FO.Core/Ops/SdlcRunner.cs
@@ -32,7 +32,11 @@ public static class SdlcRunner
 
     // ----------------------------------------------------------------- build
 
-    /// <param name="msbuildPath">MSBuild executable; defaults to <c>msbuild.exe</c> on PATH.</param>
+    /// <param name="msbuildPath">
+    /// MSBuild executable. Omitted, it is resolved by <see cref="BuildTooling.ResolveMsBuild"/>:
+    /// the Visual Studio MSBuild before the one on PATH, because on a developer VM PATH resolves
+    /// <c>msbuild.exe</c> to the .NET Framework build, which cannot host the Dynamics build tasks.
+    /// </param>
     /// <param name="projectPath">Project or solution to build; omitted builds whatever is in the working directory.</param>
     /// <param name="configuration">MSBuild configuration, <c>Debug</c> by default.</param>
     /// <param name="xppcLogPath">
@@ -42,15 +46,26 @@ public static class SdlcRunner
     public static ToolResult<object> Build(
         string? msbuildPath, string? projectPath, string configuration = "Debug", string? xppcLogPath = null)
     {
-        var msbuild = string.IsNullOrWhiteSpace(msbuildPath) ? "msbuild.exe" : msbuildPath!;
+        var tool = BuildTooling.ResolveMsBuild(msbuildPath);
+        if (tool.Path is null)
+        {
+            return ToolResult<object>.Fail("MSBUILD_NOT_FOUND",
+                tool.Problem ?? "msbuild.exe could not be resolved.",
+                "Run `d365fo doctor` to see every build tool path, then set D365FO_MSBUILD_PATH or pass --msbuild.");
+        }
+
+        var msbuild = tool.Path;
         var args = new List<string>();
         if (!string.IsNullOrEmpty(projectPath)) args.Add(projectPath!);
         args.Add($"/p:Configuration={configuration}");
         args.Add("/nologo");
 
         var (exit, stdout, stderr, elapsed) = Run(msbuild, args);
-        var errors = ParseMsBuildDiagnostics(stdout, "error");
-        var warnings = ParseMsBuildDiagnostics(stdout, "warning");
+        // stderr is scanned too: a toolchain failure (MSB1009, a missing targets import) is
+        // often all MSBuild writes, and reading only stdout reported it as zero errors.
+        var output = string.IsNullOrEmpty(stderr) ? stdout : stdout + "\n" + stderr;
+        var errors = ParseMsBuildDiagnostics(output, "error");
+        var warnings = ParseMsBuildDiagnostics(output, "warning");
 
         // Structured xppc diagnostics: the X++ compiler reports through its own
         // "Compile Error: … dynamics://Model/Object/member: [(l,c)]: msg" format,
@@ -70,6 +85,10 @@ public static class SdlcRunner
             buildSucceeded = exit == 0,
             exitCode = exit,
             elapsedMs = (long)elapsed.TotalMilliseconds,
+            // Which MSBuild ran, and whether it is one that can build X++ at all. A build that
+            // fails because PATH handed us the .NET Framework MSBuild reports MSB4062, which
+            // reads like a compiler error; naming the executable here makes it one question.
+            msbuild = new { path = tool.Path, source = tool.Source, problem = tool.Problem },
             errorCount = errors.Count,
             warningCount = warnings.Count,
             errors,
@@ -98,7 +117,11 @@ public static class SdlcRunner
         // A failed build keeps the full structured payload — the diagnostics are wanted exactly
         // when it fails — and says so in a warning rather than in an error envelope that would
         // throw the diagnostics away.
-        return ToolResult<object>.Success(payload, exit == 0 ? null : ["build-failed"]);
+        var buildWarnings = new List<string>();
+        if (exit != 0) buildWarnings.Add("build-failed");
+        if (tool.Problem is not null) buildWarnings.Add($"msbuild-unfit: {tool.Problem}");
+
+        return ToolResult<object>.Success(payload, buildWarnings.Count == 0 ? null : buildWarnings);
     }
 
     // ------------------------------------------------------------------ sync
@@ -262,22 +285,66 @@ public static class SdlcRunner
         @"(?<file>[^:()]+)\((?<line>\d+),(?<col>\d+)\):\s+(?<kind>error|warning)\s+(?<code>\S+):\s+(?<msg>.+)",
         RegexOptions.Compiled);
 
-    private static List<object> ParseMsBuildDiagnostics(string output, string kind)
+    // MSBuild's other diagnostic shape, with no file position: "MSBUILD : error MSB1009: …",
+    // "MSBUILD : error MSB4062: …". These are exactly the toolchain failures — a missing
+    // project, an unloadable build task — and matching only the positional form above dropped
+    // them, so a build that never reached the compiler reported zero errors.
+    private static readonly Regex GlobalDiagRx = new(
+        @"^\s*(?<src>[^\r\n:]*?)\s*:\s*(?<kind>error|warning)\s+(?<code>MSB\d+):\s+(?<msg>.+)$",
+        RegexOptions.Compiled | RegexOptions.Multiline | RegexOptions.IgnoreCase);
+
+    internal static List<object> ParseMsBuildDiagnostics(string output, string kind)
     {
         var list = new List<object>();
+        var seen = new HashSet<string>(StringComparer.Ordinal);
+
         foreach (Match m in DiagRx.Matches(output))
         {
             if (!string.Equals(m.Groups["kind"].Value, kind, StringComparison.OrdinalIgnoreCase)) continue;
+            var code = m.Groups["code"].Value;
+            var message = m.Groups["msg"].Value.Trim();
+            seen.Add(code + "|" + message);
             list.Add(new
             {
                 file = m.Groups["file"].Value.Trim(),
                 line = int.Parse(m.Groups["line"].Value),
                 column = int.Parse(m.Groups["col"].Value),
-                code = m.Groups["code"].Value,
-                message = m.Groups["msg"].Value.Trim(),
+                code,
+                message,
+                hint = HintFor(m.Value.Trim()),
             });
         }
+
+        foreach (Match m in GlobalDiagRx.Matches(output))
+        {
+            if (!string.Equals(m.Groups["kind"].Value, kind, StringComparison.OrdinalIgnoreCase)) continue;
+            var code = m.Groups["code"].Value;
+            var message = m.Groups["msg"].Value.Trim();
+            // The same MSB error is often echoed both with and without a file position.
+            if (!seen.Add(code + "|" + message)) continue;
+            list.Add(new
+            {
+                file = m.Groups["src"].Value.Trim(),
+                line = (int?)null,
+                column = (int?)null,
+                code,
+                message,
+                hint = HintFor(m.Value.Trim()),
+            });
+        }
+
         return list;
+    }
+
+    /// <summary>
+    /// The scored fix-hint rules, applied to MSBuild's own messages. An MSB4062 is an
+    /// environment failure that reads like a compiler error; without this the caller saw the
+    /// raw text and had to guess what it meant.
+    /// </summary>
+    private static object? HintFor(string line)
+    {
+        var hint = XppcFixHints.Best(line);
+        return hint is null ? null : new { rule = hint.RuleId, hint = hint.Hint, knowledge = hint.Knowledge };
     }
 
     private static string Tail(string text, int lines) =>

--- a/src/D365FO.Core/Validation/XppcFixHints.cs
+++ b/src/D365FO.Core/Validation/XppcFixHints.cs
@@ -54,6 +54,38 @@ public static class XppcFixHints
     /// </summary>
     internal static readonly Rule[] Rules =
     [
+        // --- environment / tooling: the build never reached the X++ compiler -----
+        // Not X++ defects at all. Without these rules a "MSBuild task assembly
+        // missing" failure matched nothing, so the only thing an agent could do
+        // with it was guess at the cause — the report behind issue #207.
+        new("ENV-MSBUILD-TASK-MISSING",
+            AllOf: [],
+            AnyOf: [@"\bMSB4062\b", @"task could not be loaded from the assembly", @"<UsingTask> declaration"],
+            NoneOf: [], Weight: 12,
+            Hint: "MSBuild could not load the D365FO build tasks — an environment failure, not an X++ error. The first `msbuild.exe` on PATH is usually the .NET Framework one (C:\\Windows\\Microsoft.NET\\Framework\\v4.0.30319), which cannot host Microsoft.Dynamics.Framework.Tools.BuildTasks: those load only under the Visual Studio MSBuild that carries the Dynamics 365 dev tools extension. `d365fo doctor` prints which MSBuild is resolved; override it with `d365fo build --msbuild <VS>\\MSBuild\\Current\\Bin\\MSBuild.exe` or D365FO_MSBUILD_PATH.",
+            Knowledge: "build-error-triage"),
+
+        new("ENV-MSBUILD-TARGETS-MISSING",
+            AllOf: [],
+            AnyOf: [@"\bMSB4019\b", @"imported project .* was not found", @"\bMSB4066\b", @"is not a supported project type", @"\bMSB4025\b"],
+            NoneOf: [], Weight: 12,
+            Hint: "MSBuild cannot read the X++ project — the imported Dynamics targets are missing, so this MSBuild has no Dynamics 365 dev tools extension behind it. Build with the Visual Studio MSBuild on the developer VM (`d365fo doctor` reports the one it resolves); `dotnet build` and the .NET Framework MSBuild cannot build a .rnrproj.",
+            Knowledge: "build-error-triage"),
+
+        new("ENV-PROJECT-NOT-FOUND",
+            AllOf: [],
+            AnyOf: [@"\bMSB1003\b", @"\bMSB1009\b", @"specify a project or solution file", @"project file does not exist"],
+            NoneOf: [], Weight: 12,
+            Hint: "MSBuild was pointed at no project: it builds whatever is in the working directory unless told otherwise. Pass `d365fo build --project <Solution.sln|Model.rnrproj>`, or run it from the folder that holds one.",
+            Knowledge: "build-error-triage"),
+
+        new("ENV-TOOL-NOT-FOUND",
+            AllOf: [@"\b(msbuild|xppc|xppbp|syncengine|systestconsole)(\.exe)?\b"],
+            AnyOf: [@"is not recognized as", @"command not found", @"could not find the file", @"cannot find the file", @"was not found"],
+            NoneOf: [@"\bMSB4062\b", @"task could not be loaded"], Weight: 11,
+            Hint: "A D365FO developer tool is not where the CLI looked. MSBuild comes from the Visual Studio install; SyncEngine.exe, SysTestConsole.exe and xppbp.exe live under <PackagesLocalDirectory>\\bin. `d365fo doctor` prints every tool path it resolves and which one is missing.",
+            Knowledge: "build-error-triage"),
+
         // --- named diagnostics: the message identifies the defect itself ----------
         new("XPPC-COC-MISSING-NEXT",
             AllOf: [], AnyOf: [@"\bSYS10028\b", @"must call next", @"missing next", @"call to next"],

--- a/tests/D365FO.Core.Tests/BuildToolingTests.cs
+++ b/tests/D365FO.Core.Tests/BuildToolingTests.cs
@@ -1,0 +1,146 @@
+using System.Text.Json;
+using D365FO.Core.Ops;
+using Xunit;
+
+namespace D365FO.Core.Tests;
+
+/// <summary>
+/// Cover for the build-tooling probe added for issue #207: a build that fails because the
+/// environment cannot host the X++ MSBuild tasks used to look exactly like a compiler error.
+/// </summary>
+public class BuildToolingTests
+{
+    [Theory]
+    [InlineData(@"C:\Windows\Microsoft.NET\Framework\v4.0.30319\MSBuild.exe", true)]
+    [InlineData(@"C:\Windows\Microsoft.NET\Framework64\v4.0.30319\MSBuild.exe", true)]
+    [InlineData(@"C:/Windows/Microsoft.NET/Framework/v4.0.30319/MSBuild.exe", true)]
+    [InlineData(@"C:\Program Files\Microsoft Visual Studio\18\Professional\MSBuild\Current\Bin\MSBuild.exe", false)]
+    [InlineData(@"C:\Program Files (x86)\Microsoft Visual Studio\2022\BuildTools\MSBuild\Current\Bin\MSBuild.exe", false)]
+    public void Framework_msbuild_is_recognised_by_its_path(string path, bool expected) =>
+        Assert.Equal(expected, BuildTooling.IsFrameworkMsBuild(path));
+
+    [Fact]
+    public void Null_path_is_not_a_framework_msbuild() =>
+        Assert.False(BuildTooling.IsFrameworkMsBuild(null));
+
+    [Fact]
+    public void An_explicit_msbuild_path_wins_and_is_reported_as_such()
+    {
+        var dir = Directory.CreateTempSubdirectory("d365fo-msbuild-");
+        try
+        {
+            var exe = Path.Combine(dir.FullName, "MSBuild.exe");
+            File.WriteAllText(exe, string.Empty);
+
+            var resolved = BuildTooling.ResolveMsBuild(exe);
+
+            Assert.True(resolved.Ok);
+            Assert.Equal(exe, resolved.Path);
+            Assert.Equal("--msbuild", resolved.Source);
+        }
+        finally
+        {
+            dir.Delete(recursive: true);
+        }
+    }
+
+    [Fact]
+    public void An_explicit_path_that_does_not_exist_is_reported_rather_than_silently_ignored()
+    {
+        var missing = Path.Combine(Path.GetTempPath(), "d365fo-no-such-msbuild", "MSBuild.exe");
+
+        var resolved = BuildTooling.ResolveMsBuild(missing);
+
+        Assert.False(resolved.Ok);
+        Assert.Equal(missing, resolved.Path);
+        Assert.Contains("Not found", resolved.Problem);
+    }
+
+    [Fact]
+    public void A_framework_msbuild_is_returned_with_the_reason_it_cannot_build_xpp()
+    {
+        // The path is what matters, not the file: an absent one already fails earlier.
+        var dir = Directory.CreateTempSubdirectory("Microsoft.NET-");
+        try
+        {
+            var nested = Path.Combine(dir.FullName, "Microsoft.NET", "Framework", "v4.0.30319");
+            Directory.CreateDirectory(nested);
+            var exe = Path.Combine(nested, "MSBuild.exe");
+            File.WriteAllText(exe, string.Empty);
+
+            var resolved = BuildTooling.ResolveMsBuild(exe);
+
+            Assert.False(resolved.Ok);
+            Assert.Equal(exe, resolved.Path);
+            Assert.Contains("MSB4062", resolved.Problem);
+        }
+        finally
+        {
+            dir.Delete(recursive: true);
+        }
+    }
+
+    [Fact]
+    public void Package_bin_tools_are_probed_under_the_packages_root()
+    {
+        var dir = Directory.CreateTempSubdirectory("d365fo-packages-");
+        try
+        {
+            Directory.CreateDirectory(Path.Combine(dir.FullName, "bin"));
+            var xppc = Path.Combine(dir.FullName, "bin", "xppc.exe");
+            File.WriteAllText(xppc, string.Empty);
+
+            var found = BuildTooling.ResolvePackageBinTool("xppc.exe", dir.FullName);
+            Assert.True(found.Ok);
+            Assert.Equal(xppc, found.Path);
+
+            var missing = BuildTooling.ResolvePackageBinTool("SyncEngine.exe", dir.FullName);
+            Assert.False(missing.Ok);
+            Assert.Contains("SyncEngine.exe", missing.Problem);
+        }
+        finally
+        {
+            dir.Delete(recursive: true);
+        }
+    }
+
+    [Fact]
+    public void Without_a_packages_path_the_probe_says_so_instead_of_throwing()
+    {
+        var resolved = BuildTooling.ResolvePackageBinTool("xppbp.exe", null);
+
+        Assert.False(resolved.Ok);
+        Assert.Contains("D365FO_PACKAGES_PATH", resolved.Problem);
+    }
+
+    [Fact]
+    public void A_toolchain_failure_without_a_file_position_is_still_reported_as_an_error()
+    {
+        // "MSBUILD : error MSB1009: …" carries no (line,col), so the positional parser
+        // dropped it and the build reported zero errors for a build that never started.
+        var output = string.Join('\n',
+            "Microsoft (R) Build Engine version 17.0",
+            "MSBUILD : error MSB1009: Project file does not exist.",
+            "Switch: MyModel.rnrproj");
+
+        var errors = SdlcRunner.ParseMsBuildDiagnostics(output, "error");
+
+        var json = JsonSerializer.Serialize(errors);
+        Assert.Single(errors);
+        Assert.Contains("MSB1009", json);
+        Assert.Contains("ENV-PROJECT-NOT-FOUND", json);
+    }
+
+    [Fact]
+    public void The_same_error_reported_twice_is_listed_once()
+    {
+        var output = string.Join('\n',
+            @"C:\Proj\MyModel.rnrproj(4,5): error MSB4062: The ""BuildTask"" task could not be loaded from the assembly.",
+            @"MSBUILD : error MSB4062: The ""BuildTask"" task could not be loaded from the assembly.");
+
+        var errors = SdlcRunner.ParseMsBuildDiagnostics(output, "error");
+
+        var single = Assert.Single(errors);
+        Assert.Contains("ENV-MSBUILD-TASK-MISSING", JsonSerializer.Serialize(single));
+    }
+}

--- a/tests/D365FO.Core.Tests/XppcFixHintsTests.cs
+++ b/tests/D365FO.Core.Tests/XppcFixHintsTests.cs
@@ -52,6 +52,13 @@ public class XppcFixHintsTests
     [InlineData("The number sequence for MyId is not set up for company USMF.", "XPPC-NUMBER-SEQUENCE")]
     [InlineData("The field 'CreditMaxx' does not exist on table CustTable.", "XPPC-FIELD-MISSING")]
     [InlineData("CSUV1: the value cannot be assigned to a variable of this type.", "XPPC-TYPE-MISMATCH")]
+    // Environment failures (issue #207): the build never reached the X++ compiler, and
+    // before these rules the whole family matched nothing at all.
+    [InlineData("MyModel.rnrproj(4,5): error MSB4062: The \"BuildTask\" task could not be loaded from the assembly Microsoft.Dynamics.Framework.Tools.BuildTasks.17.0.", "ENV-MSBUILD-TASK-MISSING")]
+    [InlineData("error MSB4019: The imported project \"\\Microsoft.Dynamics.Framework.Tools.BuildTasks.17.0.targets\" was not found.", "ENV-MSBUILD-TARGETS-MISSING")]
+    [InlineData("'msbuild.exe' is not recognized as an internal or external command.", "ENV-TOOL-NOT-FOUND")]
+    [InlineData("MSBUILD : error MSB1009: Project file does not exist.", "ENV-PROJECT-NOT-FOUND")]
+    [InlineData("MSBUILD : error MSB1003: Specify a project or solution file. The current working directory does not contain a project or solution file.", "ENV-PROJECT-NOT-FOUND")]
     public void Maps_known_messages_to_their_rule(string message, string expectedRule)
     {
         var best = XppcFixHints.Best(message);
@@ -134,5 +141,33 @@ public class XppcFixHintsTests
     {
         var matches = XppcFixHints.Match("The field 'Foo' does not exist on table CustTable.");
         Assert.Equal("XPPC-FIELD-MISSING", matches[0].RuleId);
+    }
+
+    [Fact]
+    public void Environment_rules_do_not_claim_ordinary_xpp_errors()
+    {
+        // The tooling rules sit at the top of the weight order, so a rule that matched
+        // loosely would shadow every compiler diagnostic below it.
+        foreach (var message in new[]
+                 {
+                     "The field 'CreditMaxx' does not exist on table CustTable.",
+                     "The label @SYS12345 does not exist.",
+                     "Unknown type 'CustTableXyz'.",
+                     "';' expected.",
+                 })
+        {
+            Assert.DoesNotContain(XppcFixHints.Match(message), h => h.RuleId.StartsWith("ENV-", StringComparison.Ordinal));
+        }
+    }
+
+    [Fact]
+    public void Task_load_failure_outranks_the_generic_tool_not_found_rule()
+    {
+        // MSB4062 names the assembly it could not find, so both rules can see it; the
+        // one that explains *why* the assembly is unreachable has to win.
+        var matches = XppcFixHints.Match(
+            "MSBUILD : error MSB4062: The \"BuildTask\" task could not be loaded from the assembly. The system cannot find the file specified.");
+        Assert.Equal("ENV-MSBUILD-TASK-MISSING", matches[0].RuleId);
+        Assert.DoesNotContain(matches, h => h.RuleId == "ENV-TOOL-NOT-FOUND");
     }
 }


### PR DESCRIPTION
Closes #207.

The report was a chat transcript: an agent hit *"MSBuild task assembly missing"*, correctly guessed it was environmental, and reached for `d365fo explain-error` and `d365fo doctor` — neither of which had anything to say about it. Both gaps are real, and there is a third behind them.

### What was actually wrong

`d365fo build` ran a bare `msbuild.exe`. On this D365FO VM, `where msbuild` answers:

```
C:\Windows\Microsoft.NET\Framework\v3.5\MSBuild.exe
C:\Windows\Microsoft.NET\Framework\v4.0.30319\MSBuild.exe
```

— the .NET Framework MSBuild, never a Visual Studio one. An `.rnrproj` imports
`$(BuildTasksDirectory)\Microsoft.Dynamics.Framework.Tools.BuildTasks[.17.0].targets` (default
`%ProgramFiles(x86)%\MSBuild\Microsoft\Dynamics\AX`, present on this box) and that file declares
its tasks by `AssemblyName`, so MSBuild has to resolve the dev-tools assembly itself — it ships in
the VS extension folder and `<PackagesLocalDirectory>\bin`, not the GAC. Hence `MSB4062`, which
looks like a compiler error and is not one.

### Changes

- **`BuildTooling`** (new) — resolves MSBuild as `--msbuild` → `D365FO_MSBUILD_PATH` → the VS
  MSBuild (`vswhere`, then the known install roots) → `PATH`, and reports *why* a resolved one
  cannot build X++. `d365fo build` uses it and names the executable in `data.msbuild`.
- **`explain-error`** — four `ENV-…` rules for `MSB4062`, `MSB4019`/`MSB4066` and
  `MSB1003`/`MSB1009`, each carrying the `build-error-triage` topic, which gained an
  "is it your code at all?" section. MSBuild's own diagnostics carry the hints in the build payload.
- **`doctor`** — `build.msbuild`, `build.dynamicsTargets` and `build.tooling` for `xppc.exe`,
  `xppbp.exe`, `SyncEngine.exe`. Previously "is build tooling functional here?" was answered by an
  OS check.
- **A build that never started reported zero errors** — `MSBUILD : error MSB1009: …` has no
  `(line,col)` and matched neither parser, and `stderr` was not scanned. Both fixed, de-duplicated.

### Verified on this VM

```
✓ build.msbuild (d365fo build) — C:\Program Files\Microsoft Visual Studio\18\Professional\MSBuild\Current\Bin\MSBuild.exe (from vswhere)
✓ build.dynamicsTargets (X++ MSBuild tasks) — C:\Program Files (x86)\MSBuild\Microsoft\Dynamics\AX\Microsoft.Dynamics.Framework.Tools.BuildTasks.17.0.targets
✓ build.tooling (xppc.exe) — K:\AosService\PackagesLocalDirectory\bin\xppc.exe
```

`d365fo build` in an empty folder now returns `errorCount: 1` with
`{"rule":"ENV-PROJECT-NOT-FOUND", …}` where it used to return zero errors and a text tail.

1896 tests pass (11 new).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01R5UGLZGKmSUVkM33GDD8p9
