### PR TITLE
docs(copilot): VS 2022 does read .github/skills/ (#205)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,14 +21,21 @@ was ported from.
 
 ### Fixed — Copilot skill setup docs (#205)
 
-- SETUP.md, README and the installer header claimed Visual Studio 2022 / 2026 pick up
-  `.github/skills/` and that VS "searches upward from the `.sln`", so one copy in a parent
-  folder covers every solution beneath it. Neither holds: Agent Skills need Visual Studio 2026
-  18.5+ (VS 2022 ignores the folder), and VS discovers solution skills next to the `.sln` only.
-  The docs now say where the folder has to be, offer the personal-skill folder
-  (`%USERPROFILE%\.copilot\skills\`) when several solutions share a parent, point VS 2022
-  users at the legacy `.instructions.md` layout, and explain how to verify discovery in the
-  skills panel.
+- SETUP.md, README and the installer header claimed VS "searches upward from the `.sln`", so one
+  copy in a parent folder covers every solution beneath it. It does not: VS discovers solution
+  skills next to the `.sln` only. The docs now say where the folder has to be and offer the
+  personal-skill folder (`%USERPROFILE%\.copilot\skills\`) when several solutions share a parent.
+  TROUBLESHOOTING.md still carried the "walks upward" claim in two places and was missed by the
+  first pass; it is corrected and now ends with a verification step per host.
+- The same pass then claimed Agent Skills need VS 2026 18.5+ and that VS 2022 ignores
+  `.github/skills/`. That was wrong — it came from Microsoft's Agent Skills page, which is not
+  published for the VS 2022 moniker, while the agent-mode page gates only on 17.14.
+  `.github/skills/` is read on VS 2022 17.14+ with a current Copilot extension; what is
+  VS 2026-only is the skills *panel*, so the docs now give the VS 2022 way to verify (Copilot
+  names the skill in its reply).
+- Added the answer to "skill, instructions, or both?": the skill alone is the default, the
+  `.instructions.md` layout is the deterministic-by-glob fallback, and
+  `.github/copilot-instructions.md` is retired.
 
 ### Added — `generate extension Menu`, and menu items as symbols
 

--- a/README.md
+++ b/README.md
@@ -145,7 +145,7 @@ Ready to scaffold your first table, form, and CoC extension? Full walkthrough wi
 
 ### GitHub Copilot (VS Code / Visual Studio)
 
-The preferred method is the **one-command skill installer** — it deploys the bundled `d365fo-cli` Copilot skill (SKILL.md + 43 lazily-loaded topic references) into your X++ project's `.github/skills/d365fo-cli/` folder. Copilot auto-discovers skills in `.github/skills/` with no extra configuration. Point `-XppRepo` at the folder that holds the `.sln` you open: Visual Studio (2026 18.5+) discovers skills next to the solution, not in parent folders. See [SETUP.md](docs/SETUP.md#github-copilot--visual-studio-2026-185--vs-code-agent-mode) for the multi-solution and VS 2022 options.
+The preferred method is the **one-command skill installer** — it deploys the bundled `d365fo-cli` Copilot skill (SKILL.md + 43 lazily-loaded topic references) into your X++ project's `.github/skills/d365fo-cli/` folder. Copilot auto-discovers skills in `.github/skills/` with no extra configuration, on VS 2022 17.14+ as well as VS 2026. Point `-XppRepo` at the folder that holds the `.sln` you open: Visual Studio discovers skills next to the solution, not in parent folders. See [SETUP.md](docs/SETUP.md#github-copilot--visual-studio-2022-1714--2026--vs-code-agent-mode) for the multi-solution setup and the `.instructions.md` fallback.
 
 ```powershell
 # From the d365fo-cli repo's scripts folder:

--- a/docs/SETUP.md
+++ b/docs/SETUP.md
@@ -56,7 +56,7 @@ flowchart TD
 | .NET SDK | **10** (pinned in `global.json`) | building / running the CLI |
 | `git` | any | `d365fo review diff` |
 | Visual Studio 2022 / 2026 + Dynamics 365 F&O workload | latest | scenario A — `MSBuild.exe`, `SyncEngine.exe`, `SysTestRunner.exe`, `xppbp.exe` on `PATH` |
-| GitHub Copilot extension | latest | VS agent mode (optional) — Agent Skills need **VS 2026 18.5+**; VS 2022 gets the legacy `.instructions.md` layout |
+| GitHub Copilot extension | latest | VS agent mode (optional) — Agent Skills are read by **VS 2022 17.14+** and VS 2026; the `.instructions.md` layout is the fallback when a Copilot build does not discover skills |
 | .NET Framework 4.8 Developer Pack | 4.8 | bridge (`D365FO_BRIDGE_ENABLED=1`) — pre-installed on D365FO VMs |
 
 > Off-platform setups (B) only need .NET 10 + git. Everything else is gated by `UNSUPPORTED_PLATFORM` and never invoked.
@@ -177,7 +177,7 @@ Or run the daemon and forget about it — `d365fo daemon start` keeps the SQLite
 
 ```mermaid
 flowchart LR
-    Cop["GitHub Copilot<br/>VS 2026 18.5+ · VS Code"] -->|.github/skills/d365fo-cli/| Bin
+    Cop["GitHub Copilot<br/>VS 2022 17.14+ · VS 2026 · VS Code"] -->|.github/skills/d365fo-cli/| Bin
     Cla["Claude Code<br/>CLI · VS Code ext."]     -->|skills/anthropic/| Bin
     Other["Codex · Gemini · Cursor"]              -->|AGENTS.md| Bin
     Mcp["Claude Desktop · Continue<br/>(MCP host)"] -->|JSON-RPC stdio| Mbin["d365fo-mcp"]
@@ -185,7 +185,7 @@ flowchart LR
     Mbin --> Idx
 ```
 
-### GitHub Copilot — Visual Studio 2026 (18.5+) / VS Code (agent mode)
+### GitHub Copilot — Visual Studio (2022 17.14+ / 2026) / VS Code (agent mode)
 
 1. Place `d365fo` on `PATH` (either Option 1 alias or Option 2 binary above).
 2. Deploy the `d365fo-cli` Copilot skill into the folder that contains the `.sln` you open in Visual Studio:
@@ -210,9 +210,19 @@ flowchart LR
    Restart Visual Studio after either step — skills are discovered on solution load.
 3. **Agent mode (recommended).** Open Copilot Chat → mode dropdown (top-right) → **Agent**. Copilot now calls `d365fo` directly via its terminal tool — no copy-paste.
 4. **Chat mode (fallback).** Without agent tools, Copilot asks you to run `d365fo` commands in Developer PowerShell and paste the JSON back. The skill teaches Copilot to ask first — if it skips that step the `.github/skills/d365fo-cli/SKILL.md` file is not next to the `.sln` (or in `%USERPROFILE%\.copilot\skills\`).
-5. **Verify the skill is discovered.** In VS 2026 18.6+ select the **Tools** icon in the bottom-right corner of Copilot Chat — the skills panel lists every skill VS found, with diagnostics for frontmatter errors. `d365fo-cli` must appear there; if it does not, VS is not seeing the folder (wrong location, or VS 2022 — see the requirements note below). When the skill activates, VS names it in the chat reply. In VS Code, type `/skills` in the chat input to list discovered skills, and check that `chat.useAgentSkills` is enabled in Settings.
+5. **Verify the skill is discovered.** In VS 2026 18.6+ select the **Tools** icon in the bottom-right corner of Copilot Chat — the skills panel lists every skill VS found, with diagnostics for frontmatter errors. `d365fo-cli` must appear there; if it does not, VS is not seeing the folder (almost always the wrong location — see the requirements note below). VS 2022 has no skills panel, so verify it there the other way: restart VS, open Copilot Chat in **Agent** mode and ask for something D365FO-shaped ("add a CoC extension for `SalesTable.insert`"). Copilot names the skill it used in the reply. If it doesn't fire on its own, say *"use the d365fo-cli skill"* — if it then answers that it doesn't know that skill, the folder is still in the wrong place. In VS Code, type `/skills` in the chat input to list discovered skills, and check that `chat.useAgentSkills` is enabled in Settings.
 
-> **Requirements.** Agent Skills need **Visual Studio 2026 version 18.5 or later** (or VS Code with `chat.useAgentSkills` on). Visual Studio 2022 has no skill support — it silently ignores `.github/skills/`. On a VS 2022 machine (including UDE setups still on VS 2022) use the legacy layout instead: copy `skills/copilot/*.instructions.md` into `<XppRepo>\.github\instructions\` and enable **Tools → Options → GitHub → Copilot → Copilot Chat → Enable custom instructions**. VS 2022 17.10+ applies those deterministically through their `applyTo` globs.
+> **Requirements.** Microsoft's [Agent Skills page](https://learn.microsoft.com/en-us/visualstudio/ide/copilot-agent-skills?view=visualstudio) lists **Visual Studio 2026 version 18.5 or later**, and that page is not published for the VS 2022 moniker at all — but the [agent mode page](https://learn.microsoft.com/en-us/visualstudio/ide/copilot-agent-mode?view=visualstudio) requires only **17.14** and lists agent skills as an agent-mode tool with no version gate. In practice `.github/skills/` is read on **VS 2022 17.14+ with a current GitHub Copilot extension** (verified on a VS 2022 UDE box), so a VS 2022 machine does not need to upgrade — only the folder has to sit next to the `.sln`. What genuinely is VS 2026-only is the **skills panel** (the Tools icon UI); on VS 2022 you verify by whether Copilot names the skill in its reply. If your Copilot build turns out not to discover skills, fall back to the deterministic `.github/instructions/` layout below — it needs no skill support at all.
+
+> **Skill, instructions, or both?** The **skill** is all you need — install it and stop there. The other two layouts exist for specific reasons:
+>
+> | Layout | What it is | When you want it |
+> |---|---|---|
+> | `.github/skills/d365fo-cli/` | SKILL.md + 43 topic references, loaded on demand | **the default** — cheapest by far (see [TOKEN_ECONOMICS.md](TOKEN_ECONOMICS.md)), the agent decides when it is relevant |
+> | `.github/instructions/*.instructions.md` | the same 43 topics as per-file rules with `applyTo` globs | when you want rules to fire deterministically by file pattern, or your Copilot build doesn't discover skills |
+> | `.github/copilot-instructions.md` | the pre-skill single always-on file | **retired.** The skill replaced it; delete it if an older install left one behind |
+>
+> The first two coexist — they do not clobber each other — but running both means paying for the instruction files in every request. Start with the skill alone.
 
 > **How the skill decides to activate — and what to do when it doesn't.**
 >
@@ -336,7 +346,8 @@ The [one-line install](#one-line-install) at the top of this page **is** the qui
 | `NO_INDEX` | `d365fo index build && d365fo index extract` |
 | `stale-index` warning from `doctor` | `d365fo index refresh --model <Model>` (or just start the daemon) |
 | Copilot Chat says "There was an error executing code search" then writes generic X++ | VS Copilot Chat cannot search AOT XML — the `d365fo-cli` skill is not being picked up. Open the skills panel (Tools icon, bottom-right of Copilot Chat) and confirm `d365fo-cli` is listed; `.github/skills/d365fo-cli/` must sit next to the `.sln` (or in `%USERPROFILE%\.copilot\skills\`). Restart VS. For full automation switch Copilot Chat to **Agent** mode |
-| Copilot never mentions the `d365fo-cli` skill and the skills panel is missing or empty | Agent Skills need VS 2026 18.5+ (VS 2022 ignores `.github/skills/`). Upgrade, or deploy the legacy `.github/instructions/*.instructions.md` layout from `skills/copilot/` |
+| Copilot never mentions the `d365fo-cli` skill | The folder is not next to the `.sln` — VS does not search parent folders. Re-run the installer with `-XppRepo` = the solution folder, or copy the skill to `%USERPROFILE%\.copilot\skills\d365fo-cli`, then restart VS and ask in **Agent** mode. Say *"use the d365fo-cli skill"* to force it. Still nothing on an older Copilot build: deploy `skills/copilot/*.instructions.md` to `.github/instructions/`, which applies by glob and needs no skill support |
+| The skills panel (Tools icon in Copilot Chat) is missing | The panel is VS 2026 18.6+ only. On VS 2022 the skill still works — verify it by whether Copilot names `d365fo-cli` in its reply |
 | Index file appears locked | Stop any running `d365fo daemon` or `d365fo-mcp` process; `-wal` / `-shm` sidecar files are normal |
 | Settings differ between Developer PowerShell and PowerShell 7 | Re-run `d365fo init --persist-profile` — it writes both profiles and the JSON config |
 | Self-contained binary won't start on Linux | `chmod +x d365fo` after copying out of the publish folder |

--- a/docs/TROUBLESHOOTING.md
+++ b/docs/TROUBLESHOOTING.md
@@ -364,17 +364,21 @@ These are two completely unrelated concepts that happen to share the word "works
 | `D365FO_WORKSPACE_PATH`, `D365FO_PACKAGES_PATH`, `D365FO_CUSTOM_PACKAGES_PATH` (CLI env vars) | Where the `d365fo` CLI indexes metadata from / writes scaffolded output to |
 | The folder/`.sln` open in Visual Studio or VS Code ("workspace" in the IDE sense) | Where Copilot looks for `.github/skills/d365fo-cli/SKILL.md` |
 
-No `D365FO_*` environment variable or `settings.json` entry has any effect on Copilot's instruction discovery. Copilot (both in Visual Studio and VS Code) only walks **upward from the folder/solution you actually opened in the editor** looking for a `.github/` folder — it never reads CLI configuration.
+No `D365FO_*` environment variable or `settings.json` entry has any effect on Copilot's skill discovery — it never reads CLI configuration. Visual Studio looks for `.github/skills/` **in the solution folder itself**; it does not walk up to parent folders, so a copy one level above the `.sln` is invisible.
 
 Fix, in order:
 
-1. Confirm which folder is actually open in the editor (Visual Studio: the `.sln`'s folder; VS Code: File → Open Folder).
-2. Re-run `Install-D365FoCopilotSkills.ps1` targeting that exact folder (or a parent of it) as `-XppRepo`, not the `D365FO_WORKSPACE_PATH` / `D365FO_CUSTOM_PACKAGES_PATH` value.
-3. Visual Studio only: confirm the **GitHub Copilot** extension is enabled and skills auto-discovery is active (look for the `.github/skills/` folder being picked up in Copilot Chat's reference list).
-4. No shared parent solution/`.sln` above your projects? Copy the skill to a higher common ancestor folder:
-   - Run `Install-D365FoCopilotSkills.ps1 -XppRepo <common-parent>` to place `.github/skills/d365fo-cli/` where Copilot can walk up to it from any solution.
-   - Legacy fallback (pre-skill hosts): `skills/copilot/*.instructions.md` are still emitted and can be placed in `.github/instructions/` as before.
-5. Verify: after Copilot answers, expand **References / "Used N references"** in the reply — loaded instruction files are listed there. If your file isn't listed, it wasn't discovered.
+1. Confirm which folder is actually open in the editor (Visual Studio: the folder holding the `.sln`; VS Code: File → Open Folder).
+2. Re-run `Install-D365FoCopilotSkills.ps1` targeting that exact folder as `-XppRepo` — not the `D365FO_WORKSPACE_PATH` / `D365FO_CUSTOM_PACKAGES_PATH` value, and not a parent folder.
+3. Restart Visual Studio: skills are discovered on solution load. Then ask in Copilot Chat **Agent** mode — chat mode without agent tools does not load skills.
+4. Several solutions under one parent? There is no folder that covers them all. Either run the installer once per solution folder (and commit `.github/`, so teammates get it too), or install it as a personal skill, which applies to every solution but stays on your machine:
+
+   ```powershell
+   Copy-Item -Recurse -Force C:\source\d365fo-cli\skills\d365fo-cli "$env:USERPROFILE\.copilot\skills\d365fo-cli"
+   ```
+
+5. Verify. VS 2026 18.6+: the skills panel (Tools icon in Copilot Chat) lists every discovered skill. VS 2022 has no such panel — ask something D365FO-shaped and check that Copilot names `d365fo-cli` in its reply; force it with *"use the d365fo-cli skill"*. VS Code: type `/skills`, and check `chat.useAgentSkills` is enabled.
+6. Still nothing on an older Copilot build? Use the glob-scoped layout, which needs no skill support: copy `skills/copilot/*.instructions.md` into `<SolutionFolder>\.github\instructions\` and enable **Tools → Options → GitHub → Copilot → Copilot Chat → Enable custom instructions**. The two layouts coexist; `.github/copilot-instructions.md` is retired and can be deleted if an older install left one behind.
 
 ---
 

--- a/scripts/Install-D365FoCopilotSkills.ps1
+++ b/scripts/Install-D365FoCopilotSkills.ps1
@@ -7,14 +7,21 @@
       - skills/d365fo-cli/SKILL.md            (main rule canon + tool mapping)
       - skills/d365fo-cli/references/*.md      (lazily-loaded X++ topic files, one per knowledge topic)
     into <XppRepo>/.github/skills/d365fo-cli/ so that GitHub Copilot in
-    Visual Studio 2026 18.5+ (and VS Code) automatically picks up the skill.
+    Visual Studio (2022 17.14+ or 2026) and VS Code automatically picks up
+    the skill.
 
     Visual Studio discovers solution skills next to the .sln only - it never
     searches parent folders - so XppRepo must be the folder that holds the
     solution you open. To cover several solutions at once, copy
     skills/d365fo-cli to %USERPROFILE%\.copilot\skills\d365fo-cli instead:
-    a personal skill applies to every solution. Visual Studio 2022 has no
-    skill support; use skills/copilot/*.instructions.md there (see docs/SETUP.md).
+    a personal skill applies to every solution, at the cost of not travelling
+    to teammates through source control.
+
+    Verifying it worked: VS 2026 18.6+ lists discovered skills in the Copilot
+    Chat skills panel (Tools icon). VS 2022 has no such panel - ask something
+    D365FO-shaped in Agent mode and check that Copilot names the d365fo-cli
+    skill in its reply. If a Copilot build does not discover skills at all,
+    fall back to skills/copilot/*.instructions.md (see docs/SETUP.md).
 
     If the skill folder's references/ is empty (first run or clean clone), this
     script regenerates it first, using whichever host is available: pwsh,

--- a/skills/d365fo-cli/SKILL.md
+++ b/skills/d365fo-cli/SKILL.md
@@ -1,15 +1,16 @@
 ---
 name: d365fo-cli
 description: "D365 Finance & Operations X++ AI development skill powered by the d365fo CLI. Use whenever the user is working in a D365 F&O X++ project: writing classes, tables, forms, CoC extensions, event handlers, entities, security, batch jobs, business events, labels, or any AOT artifact. Loads topic-specific guidance lazily from references/."
-compatibility: Requires GitHub Copilot agent mode (Visual Studio 2026 18.5+ or VS Code) and d365fo CLI in PATH.
+compatibility: Requires GitHub Copilot agent mode (Visual Studio 2022 17.14+, Visual Studio 2026, or VS Code) and d365fo CLI in PATH.
 ---
 
 # D365 Finance & Operations X++ Development — `d365fo` CLI
 
 <!--
   Deployed to your X++ project via Install-D365FoCopilotSkills.ps1.
-  Primary target: GitHub Copilot in Visual Studio 2026 18.5+ (agent mode with built-in tools).
-  Visual Studio 2022 does not read .github/skills/; it gets skills/copilot/*.instructions.md instead.
+  Primary target: GitHub Copilot in Visual Studio (2022 17.14+ or 2026), agent mode with built-in tools.
+  The .instructions.md layout in skills/copilot/ is the fallback for Copilot builds that do not
+  discover skills; the two layouts coexist.
   Secondary target: VS Code with Copilot in agent mode (can run d365fo directly via terminal).
   References in the form `[learn:<page>]` link to Microsoft Learn pages
   (see "Authoritative X++ syntax source" at the bottom).
@@ -17,7 +18,7 @@ compatibility: Requires GitHub Copilot agent mode (Visual Studio 2026 18.5+ or V
 
 This skill gives **GitHub Copilot** the rules for assisting with D365 Finance & Operations X++ development. It is deployed to your X++ project's `.github/skills/d365fo-cli/` folder by `Install-D365FoCopilotSkills.ps1` and is loaded automatically by Copilot when you are working on D365 F&O tasks.
 
-> **Primary environment — VS 2026 agent mode (18.5+):** GitHub Copilot runs `d365fo` commands via the built-in terminal tool (`run_command_in_terminal`). Topic-specific rules in `references/` load on demand. No copy-paste, no MCP overhead.
+> **Primary environment — Visual Studio agent mode (2022 17.14+ or 2026):** GitHub Copilot runs `d365fo` commands via the built-in terminal tool (`run_command_in_terminal`). Topic-specific rules in `references/` load on demand. No copy-paste, no MCP overhead. (The skills panel that lists discovered skills is VS 2026 18.6+ only; on VS 2022 the skill still loads — Copilot names it in its reply.)
 >
 > **Secondary environment — VS Code agent mode:** Same approach, different terminal tool name (`run_in_terminal`). Identical experience.
 >


### PR DESCRIPTION
Closes #205.

Three things the thread turned up, none of them fixed by #206.

**1. The VS-version claim in #206 was wrong, and it is still in the repo.**
It came from Microsoft's [Agent Skills page](https://learn.microsoft.com/en-us/visualstudio/ide/copilot-agent-skills?view=visualstudio), which lists VS 2026 18.5+ and is not published for the VS 2022 doc moniker at all — while the [agent mode page](https://learn.microsoft.com/en-us/visualstudio/ide/copilot-agent-mode?view=visualstudio) requires only 17.14 and lists agent skills as an agent-mode tool with no version gate. `.github/skills/` is read on VS 2022 17.14+ with a current Copilot extension. What is genuinely VS 2026-only is the skills **panel** (the Tools icon), so the docs now give the VS 2022 way to verify: whether Copilot names the skill in its reply. Corrected in SETUP.md (requirements note, section heading, prerequisites table, mermaid diagram, troubleshooting table), README, `skills/d365fo-cli/SKILL.md` (frontmatter + header) and the installer header.

**2. TROUBLESHOOTING.md was missed by #206 entirely.**
Its "Copilot isn't finding the instruction files" section still said Copilot *"only walks upward from the folder/solution you actually opened"* and told readers to install the skill in a common ancestor folder — the exact advice that sent the reporter down the wrong path. Rewritten, with a per-host verification step and the personal-skills folder as the multi-solution answer.

**3. The reporter's remaining question had no answer anywhere: "do I need both skills and instructions?"**
SETUP.md now carries a table — the skill alone is the default; `.github/instructions/*.instructions.md` is the deterministic-by-glob fallback for Copilot builds that do not discover skills; `.github/copilot-instructions.md` is retired and can be deleted. They coexist, but running both means paying for the instruction files in every request.

Docs only — no behaviour change. `check-skill-frontmatter.py` passes on all 88 skill files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01R5UGLZGKmSUVkM33GDD8p9
